### PR TITLE
fix: add server binary to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Go
 server/cantinarr
+server/server
 *.exe
 
 # Flutter


### PR DESCRIPTION
## Summary
- Add `server/server` to `.gitignore` — the Go binary was being tracked as untracked

## Test plan
- [x] `git status` no longer shows `server/server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)