### PR TITLE
feat: add About modal and fix TestFlight build numbering

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -20,22 +20,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Calculate build number
         id: build_number
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_B64: ${{ secrets.APP_STORE_CONNECT_API_KEY_B64 }}
         run: |
           VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
-          FIRST_COMMIT=$(git log --all --reverse -S "version: ${VERSION}" --format="%H" -- app/pubspec.yaml | head -1)
-          if [ -z "$FIRST_COMMIT" ]; then
-            COMMIT_COUNT=1
-          else
-            COMMIT_COUNT=$(( $(git rev-list --count ${FIRST_COMMIT}..HEAD) + 1 ))
-          fi
-          BUILD_NUMBER=$(( 38 + COMMIT_COUNT ))
-          echo "build_number=${BUILD_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Building ${VERSION}+${BUILD_NUMBER}"
+          cd ios
+          gem install fastlane
+          APP_VERSION=$VERSION fastlane get_build_number
 
       - name: Setup Xcode 16
         uses: maxim-lobanov/setup-xcode@v1
@@ -49,12 +47,6 @@ jobs:
 
       - name: Install dependencies
         run: flutter pub get
-
-      - name: Install Fastlane
-        run: |
-          cd ios
-          gem install bundler
-          gem install fastlane
 
       - name: Import distribution certificate
         env:

--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -1,6 +1,27 @@
 default_platform(:ios)
 
 platform :ios do
+  desc "Get next build number from TestFlight"
+  lane :get_build_number do
+    api_key = app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
+      key_content: Base64.decode64(ENV["APP_STORE_CONNECT_API_KEY_B64"]),
+      is_key_content_base64: false,
+    )
+
+    version = ENV["APP_VERSION"]
+    current = latest_testflight_build_number(
+      api_key: api_key,
+      version: version,
+      initial_build_number: 0,
+    )
+    next_build = current + 1
+
+    UI.message("Latest TestFlight build: #{current}, next: #{next_build}")
+    File.write(ENV['GITHUB_OUTPUT'], "build_number=#{next_build}\n", mode: "a") if ENV['GITHUB_OUTPUT']
+  end
+
   desc "Upload to TestFlight"
   lane :beta do
     api_key = app_store_connect_api_key(


### PR DESCRIPTION
## Summary
- Add About modal with Greedo image
- Fix TestFlight build number auto-increment by replacing fragile commit-counting logic with fastlane's `latest_testflight_build_number`, which queries App Store Connect directly and resets automatically on version bumps

## Test plan
- [ ] Verify About modal displays correctly
- [ ] Trigger a TestFlight deploy and confirm the build number increments past 39

🤖 Generated with [Claude Code](https://claude.com/claude-code)