### PR TITLE
fix: add app_identifier and rename fastlane lane

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -33,7 +33,7 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           cd ios
           gem install fastlane
-          APP_VERSION=$VERSION fastlane get_build_number
+          APP_VERSION=$VERSION fastlane next_build_number
 
       - name: Setup Xcode 16
         uses: maxim-lobanov/setup-xcode@v1

--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -2,7 +2,7 @@ default_platform(:ios)
 
 platform :ios do
   desc "Get next build number from TestFlight"
-  lane :get_build_number do
+  lane :next_build_number do
     api_key = app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_ISSUER_ID"],
@@ -13,6 +13,7 @@ platform :ios do
     version = ENV["APP_VERSION"]
     current = latest_testflight_build_number(
       api_key: api_key,
+      app_identifier: "codes.julian.cantinarr",
       version: version,
       initial_build_number: 0,
     )


### PR DESCRIPTION
## Summary
- Add missing `app_identifier` param to `latest_testflight_build_number` call
- Rename `get_build_number` lane to `next_build_number` to avoid conflict with built-in fastlane action

## Test plan
- [ ] Trigger TestFlight deploy and confirm build number is fetched and incremented correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)