### PR TITLE
feat: module system + multi-instance architecture

### DIFF
--- a/app/lib/core/models/app_module.dart
+++ b/app/lib/core/models/app_module.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// Types of modules available in the app.
+enum ModuleType { dashboard, radarr, sonarr, assistant }
+
+/// Represents a navigable module in the app (shown in drawer).
+class AppModule {
+  final ModuleType type;
+  final String label;
+  final IconData icon;
+  final String? instanceId;
+  final String? instanceName;
+
+  const AppModule({
+    required this.type,
+    required this.label,
+    required this.icon,
+    this.instanceId,
+    this.instanceName,
+  });
+}

--- a/app/lib/core/models/backend_connection.dart
+++ b/app/lib/core/models/backend_connection.dart
@@ -1,3 +1,33 @@
+/// Represents a configured service instance (Radarr or Sonarr).
+class ServiceInstance {
+  final String id;
+  final String serviceType;
+  final String name;
+  final bool isDefault;
+
+  const ServiceInstance({
+    required this.id,
+    required this.serviceType,
+    required this.name,
+    this.isDefault = false,
+  });
+
+  factory ServiceInstance.fromJson(Map<String, dynamic> json) =>
+      ServiceInstance(
+        id: json['id'] as String,
+        serviceType: json['service_type'] as String,
+        name: json['name'] as String,
+        isDefault: json['is_default'] as bool? ?? false,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'service_type': serviceType,
+        'name': name,
+        'is_default': isDefault,
+      };
+}
+
 /// Represents the active connection to a Cantinarr backend server.
 class BackendConnection {
   final String serverUrl;
@@ -5,6 +35,7 @@ class BackendConnection {
   final String refreshToken;
   final String? serverName;
   final AvailableServices services;
+  final List<ServiceInstance> instances;
 
   const BackendConnection({
     required this.serverUrl,
@@ -12,6 +43,7 @@ class BackendConnection {
     required this.refreshToken,
     this.serverName,
     this.services = const AvailableServices(),
+    this.instances = const [],
   });
 
   BackendConnection copyWith({
@@ -20,6 +52,7 @@ class BackendConnection {
     String? refreshToken,
     String? serverName,
     AvailableServices? services,
+    List<ServiceInstance>? instances,
   }) =>
       BackendConnection(
         serverUrl: serverUrl ?? this.serverUrl,
@@ -27,7 +60,30 @@ class BackendConnection {
         refreshToken: refreshToken ?? this.refreshToken,
         serverName: serverName ?? this.serverName,
         services: services ?? this.services,
+        instances: instances ?? this.instances,
       );
+
+  /// Get all Radarr instances.
+  List<ServiceInstance> get radarrInstances =>
+      instances.where((i) => i.serviceType == 'radarr').toList();
+
+  /// Get all Sonarr instances.
+  List<ServiceInstance> get sonarrInstances =>
+      instances.where((i) => i.serviceType == 'sonarr').toList();
+
+  /// Get the default Radarr instance, if any.
+  ServiceInstance? get defaultRadarrInstance {
+    final radarr = radarrInstances;
+    if (radarr.isEmpty) return null;
+    return radarr.firstWhere((i) => i.isDefault, orElse: () => radarr.first);
+  }
+
+  /// Get the default Sonarr instance, if any.
+  ServiceInstance? get defaultSonarrInstance {
+    final sonarr = sonarrInstances;
+    if (sonarr.isEmpty) return null;
+    return sonarr.firstWhere((i) => i.isDefault, orElse: () => sonarr.first);
+  }
 }
 
 /// Which services the backend has configured.

--- a/app/lib/core/providers/instance_provider.dart
+++ b/app/lib/core/providers/instance_provider.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../features/auth/logic/auth_provider.dart';
+import '../models/backend_connection.dart';
+
+/// Tracks available instances and which is currently active per service type.
+class InstanceState {
+  final List<ServiceInstance> radarrInstances;
+  final List<ServiceInstance> sonarrInstances;
+  final String? activeRadarrInstanceId;
+  final String? activeSonarrInstanceId;
+
+  const InstanceState({
+    this.radarrInstances = const [],
+    this.sonarrInstances = const [],
+    this.activeRadarrInstanceId,
+    this.activeSonarrInstanceId,
+  });
+
+  InstanceState copyWith({
+    List<ServiceInstance>? radarrInstances,
+    List<ServiceInstance>? sonarrInstances,
+    String? activeRadarrInstanceId,
+    String? activeSonarrInstanceId,
+  }) =>
+      InstanceState(
+        radarrInstances: radarrInstances ?? this.radarrInstances,
+        sonarrInstances: sonarrInstances ?? this.sonarrInstances,
+        activeRadarrInstanceId:
+            activeRadarrInstanceId ?? this.activeRadarrInstanceId,
+        activeSonarrInstanceId:
+            activeSonarrInstanceId ?? this.activeSonarrInstanceId,
+      );
+
+  /// Get the active Radarr instance, falling back to default.
+  ServiceInstance? get activeRadarrInstance {
+    if (radarrInstances.isEmpty) return null;
+    if (activeRadarrInstanceId != null) {
+      final found = radarrInstances
+          .where((i) => i.id == activeRadarrInstanceId)
+          .toList();
+      if (found.isNotEmpty) return found.first;
+    }
+    return radarrInstances.firstWhere((i) => i.isDefault,
+        orElse: () => radarrInstances.first);
+  }
+
+  /// Get the active Sonarr instance, falling back to default.
+  ServiceInstance? get activeSonarrInstance {
+    if (sonarrInstances.isEmpty) return null;
+    if (activeSonarrInstanceId != null) {
+      final found = sonarrInstances
+          .where((i) => i.id == activeSonarrInstanceId)
+          .toList();
+      if (found.isNotEmpty) return found.first;
+    }
+    return sonarrInstances.firstWhere((i) => i.isDefault,
+        orElse: () => sonarrInstances.first);
+  }
+}
+
+class InstanceNotifier extends Notifier<InstanceState> {
+  @override
+  InstanceState build() {
+    final auth = ref.watch(authProvider).valueOrNull;
+    final connection = auth?.connection;
+    if (connection == null) return const InstanceState();
+
+    final radarr = connection.radarrInstances;
+    final sonarr = connection.sonarrInstances;
+
+    return InstanceState(
+      radarrInstances: radarr,
+      sonarrInstances: sonarr,
+      activeRadarrInstanceId:
+          radarr.isNotEmpty ? (radarr.firstWhere((i) => i.isDefault, orElse: () => radarr.first)).id : null,
+      activeSonarrInstanceId:
+          sonarr.isNotEmpty ? (sonarr.firstWhere((i) => i.isDefault, orElse: () => sonarr.first)).id : null,
+    );
+  }
+
+  void setActiveRadarrInstance(String instanceId) {
+    state = state.copyWith(activeRadarrInstanceId: instanceId);
+  }
+
+  void setActiveSonarrInstance(String instanceId) {
+    state = state.copyWith(activeSonarrInstanceId: instanceId);
+  }
+}
+
+final instanceProvider =
+    NotifierProvider<InstanceNotifier, InstanceState>(InstanceNotifier.new);

--- a/app/lib/core/providers/module_provider.dart
+++ b/app/lib/core/providers/module_provider.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../features/auth/logic/auth_provider.dart';
+import '../models/app_module.dart';
+import '../models/backend_connection.dart';
+
+/// Derives the list of available modules from the current auth state.
+class ModuleState {
+  final List<AppModule> modules;
+  final ModuleType activeModuleType;
+  final String? activeInstanceId;
+
+  const ModuleState({
+    this.modules = const [],
+    this.activeModuleType = ModuleType.dashboard,
+    this.activeInstanceId,
+  });
+
+  ModuleState copyWith({
+    List<AppModule>? modules,
+    ModuleType? activeModuleType,
+    String? activeInstanceId,
+    bool clearInstanceId = false,
+  }) =>
+      ModuleState(
+        modules: modules ?? this.modules,
+        activeModuleType: activeModuleType ?? this.activeModuleType,
+        activeInstanceId:
+            clearInstanceId ? null : (activeInstanceId ?? this.activeInstanceId),
+      );
+
+  int get activeIndex {
+    for (int i = 0; i < modules.length; i++) {
+      final m = modules[i];
+      if (m.type == activeModuleType && m.instanceId == activeInstanceId) {
+        return i;
+      }
+    }
+    return 0;
+  }
+}
+
+class ModuleNotifier extends Notifier<ModuleState> {
+  @override
+  ModuleState build() {
+    final auth = ref.watch(authProvider).valueOrNull;
+    final connection = auth?.connection;
+    final modules = _buildModules(connection);
+
+    return ModuleState(modules: modules);
+  }
+
+  List<AppModule> _buildModules(BackendConnection? connection) {
+    final modules = <AppModule>[];
+
+    // Dashboard is always available
+    modules.add(const AppModule(
+      type: ModuleType.dashboard,
+      label: 'Dashboard',
+      icon: Icons.dashboard,
+    ));
+
+    if (connection != null) {
+      // Radarr instances
+      for (final inst in connection.radarrInstances) {
+        modules.add(AppModule(
+          type: ModuleType.radarr,
+          label: inst.name,
+          icon: Icons.movie,
+          instanceId: inst.id,
+          instanceName: inst.name,
+        ));
+      }
+
+      // Sonarr instances
+      for (final inst in connection.sonarrInstances) {
+        modules.add(AppModule(
+          type: ModuleType.sonarr,
+          label: inst.name,
+          icon: Icons.tv,
+          instanceId: inst.id,
+          instanceName: inst.name,
+        ));
+      }
+
+      // AI Assistant
+      if (connection.services.ai) {
+        modules.add(const AppModule(
+          type: ModuleType.assistant,
+          label: 'AI Assistant',
+          icon: Icons.smart_toy,
+        ));
+      }
+    }
+
+    return modules;
+  }
+
+  void setActiveModule(ModuleType type, {String? instanceId}) {
+    state = state.copyWith(
+      activeModuleType: type,
+      activeInstanceId: instanceId,
+      clearInstanceId: instanceId == null,
+    );
+  }
+}
+
+final moduleProvider =
+    NotifierProvider<ModuleNotifier, ModuleState>(ModuleNotifier.new);

--- a/app/lib/core/widgets/instance_dropdown.dart
+++ b/app/lib/core/widgets/instance_dropdown.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import '../models/backend_connection.dart';
+import '../theme/app_theme.dart';
+
+/// Dropdown for switching between service instances.
+/// Hidden when only one instance exists.
+class InstanceDropdown extends StatelessWidget {
+  final List<ServiceInstance> instances;
+  final String? activeInstanceId;
+  final ValueChanged<String> onChanged;
+
+  const InstanceDropdown({
+    super.key,
+    required this.instances,
+    required this.activeInstanceId,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (instances.length <= 1) return const SizedBox.shrink();
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: AppTheme.border),
+      ),
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<String>(
+          value: activeInstanceId,
+          isDense: true,
+          dropdownColor: AppTheme.surface,
+          style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
+          icon: const Icon(Icons.arrow_drop_down,
+              color: AppTheme.textSecondary, size: 20),
+          items: instances
+              .map((inst) => DropdownMenuItem(
+                    value: inst.id,
+                    child: Text(inst.name),
+                  ))
+              .toList(),
+          onChanged: (id) {
+            if (id != null) onChanged(id);
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/auth/data/auth_service.dart
+++ b/app/lib/features/auth/data/auth_service.dart
@@ -107,15 +107,26 @@ class AuthResponse {
 class ServerConfig {
   final String serverName;
   final AvailableServices services;
+  final List<ServiceInstance> instances;
 
   const ServerConfig({
     required this.serverName,
     required this.services,
+    this.instances = const [],
   });
 
-  factory ServerConfig.fromJson(Map<String, dynamic> json) => ServerConfig(
-        serverName: json['server_name'] as String? ?? 'Cantinarr',
-        services: AvailableServices.fromJson(
-            json['services'] as Map<String, dynamic>? ?? {}),
-      );
+  factory ServerConfig.fromJson(Map<String, dynamic> json) {
+    final instancesList = (json['instances'] as List<dynamic>?)
+            ?.map((i) =>
+                ServiceInstance.fromJson(i as Map<String, dynamic>))
+            .toList() ??
+        [];
+
+    return ServerConfig(
+      serverName: json['server_name'] as String? ?? 'Cantinarr',
+      services: AvailableServices.fromJson(
+          json['services'] as Map<String, dynamic>? ?? {}),
+      instances: instancesList,
+    );
+  }
 }

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -78,6 +78,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         refreshToken: authResp.refreshToken,
         serverName: config.serverName,
         services: config.services,
+        instances: config.instances,
       );
 
       return AuthState(connection: connection, user: authResp.user);
@@ -109,6 +110,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         refreshToken: authResp.refreshToken,
         serverName: config.serverName,
         services: config.services,
+        instances: config.instances,
       );
 
       state = AsyncData(
@@ -139,6 +141,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         refreshToken: authResp.refreshToken,
         serverName: config.serverName,
         services: config.services,
+        instances: config.instances,
       );
 
       state = AsyncData(

--- a/app/lib/features/dashboard/ui/dashboard_movies_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_movies_tab.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../../discover/ui/category_row.dart';
+import '../../radarr/data/radarr_api_service.dart';
+import '../../radarr/data/radarr_models.dart';
+import '../../radarr/logic/movie_discover_provider.dart';
+
+/// Dashboard Movies tab: discovery rows + simplified Radarr library sections.
+class DashboardMoviesTab extends ConsumerStatefulWidget {
+  const DashboardMoviesTab({super.key});
+
+  @override
+  ConsumerState<DashboardMoviesTab> createState() =>
+      _DashboardMoviesTabState();
+}
+
+class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
+  List<RadarrMovie> _recentlyDownloaded = [];
+  List<RadarrMovie> _missing = [];
+  bool _isLoadingLibrary = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(movieDiscoverProvider.notifier).bootstrap();
+      _loadLibraryPreview();
+    });
+  }
+
+  Future<void> _loadLibraryPreview() async {
+    final auth = ref.read(authProvider).valueOrNull;
+    final defaultRadarr = auth?.connection?.defaultRadarrInstance;
+    if (defaultRadarr == null) return;
+
+    setState(() => _isLoadingLibrary = true);
+    try {
+      final backendDio = ref.read(backendClientProvider);
+      final service = RadarrApiService(
+          backendDio: backendDio, instanceId: defaultRadarr.id);
+      final movies = await service.getMovies();
+
+      final downloaded = movies.where((m) => m.hasFile).toList()
+        ..sort((a, b) => (b.added ?? DateTime(0)).compareTo(a.added ?? DateTime(0)));
+      final missing = movies.where((m) => m.monitored && !m.hasFile).toList();
+
+      setState(() {
+        _recentlyDownloaded = downloaded.take(10).toList();
+        _missing = missing.take(10).toList();
+        _isLoadingLibrary = false;
+      });
+    } catch (_) {
+      setState(() => _isLoadingLibrary = false);
+    }
+  }
+
+  Future<void> _onRefresh() async {
+    await Future.wait([
+      ref.read(movieDiscoverProvider.notifier).bootstrap(),
+      _loadLibraryPreview(),
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final discover = ref.watch(movieDiscoverProvider);
+
+    return RefreshIndicator(
+      onRefresh: _onRefresh,
+      color: AppTheme.accent,
+      child: ListView(
+        padding: const EdgeInsets.only(bottom: 24),
+        children: [
+          // Discovery rows
+          CategoryRow(
+            title: 'Popular Movies',
+            items: discover.popularMovies,
+            isLoading: discover.isLoadingPopular,
+          ),
+          if (discover.topRated.isNotEmpty)
+            CategoryRow(
+              title: 'Top Rated',
+              items: discover.topRated,
+              isLoading: discover.isLoadingTopRated,
+            ),
+          if (discover.upcoming.isNotEmpty)
+            CategoryRow(
+              title: 'Coming Soon',
+              items: discover.upcoming,
+              isLoading: discover.isLoadingUpcoming,
+            ),
+          if (discover.anticipated.isNotEmpty)
+            CategoryRow(
+              title: 'Most Anticipated',
+              items: discover.anticipated,
+              isLoading: discover.isLoadingAnticipated,
+            ),
+
+          // Simplified library sections
+          if (_recentlyDownloaded.isNotEmpty || _missing.isNotEmpty) ...[
+            _SectionHeader(title: 'Your Library'),
+            if (_isLoadingLibrary)
+              const Padding(
+                padding: EdgeInsets.all(24),
+                child: Center(
+                    child:
+                        CircularProgressIndicator(color: AppTheme.accent)),
+              ),
+            if (_recentlyDownloaded.isNotEmpty)
+              _CompactMovieSection(
+                title: 'Recently Downloaded',
+                movies: _recentlyDownloaded,
+                color: AppTheme.available,
+              ),
+            if (_missing.isNotEmpty)
+              _CompactMovieSection(
+                title: 'Missing',
+                movies: _missing,
+                color: AppTheme.requested,
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  const _SectionHeader({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 28, 16, 8),
+      child: Row(
+        children: [
+          Expanded(child: Container(height: 1, color: AppTheme.border)),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              title,
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          Expanded(child: Container(height: 1, color: AppTheme.border)),
+        ],
+      ),
+    );
+  }
+}
+
+class _CompactMovieSection extends StatelessWidget {
+  final String title;
+  final List<RadarrMovie> movies;
+  final Color color;
+
+  const _CompactMovieSection({
+    required this.title,
+    required this.movies,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Row(
+            children: [
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '$title (${movies.length})',
+                style: const TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+        ...movies.map((movie) => ListTile(
+              dense: true,
+              leading: Icon(Icons.movie_outlined,
+                  color: color, size: 20),
+              title: Text(
+                movie.title,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary, fontSize: 14),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              subtitle: Text(
+                movie.year.toString(),
+                style: const TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 12),
+              ),
+            )),
+      ],
+    );
+  }
+}

--- a/app/lib/features/dashboard/ui/dashboard_shell.dart
+++ b/app/lib/features/dashboard/ui/dashboard_shell.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_theme.dart';
+
+/// Dashboard module shell with bottom nav: Movies | TV Shows.
+class DashboardShell extends StatefulWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTabChanged;
+  final Widget child;
+
+  const DashboardShell({
+    super.key,
+    required this.currentIndex,
+    required this.onTabChanged,
+    required this.child,
+  });
+
+  @override
+  State<DashboardShell> createState() => _DashboardShellState();
+}
+
+class _DashboardShellState extends State<DashboardShell> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: widget.child,
+      bottomNavigationBar: Container(
+        decoration: const BoxDecoration(
+          border:
+              Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
+        ),
+        child: BottomNavigationBar(
+          currentIndex: widget.currentIndex,
+          onTap: widget.onTabChanged,
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.movie_outlined),
+              activeIcon: Icon(Icons.movie),
+              label: 'Movies',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.tv_outlined),
+              activeIcon: Icon(Icons.tv),
+              label: 'TV Shows',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/dashboard/ui/dashboard_tv_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_tv_tab.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../../discover/ui/category_row.dart';
+import '../../sonarr/data/sonarr_api_service.dart';
+import '../../sonarr/data/sonarr_models.dart';
+import '../../sonarr/logic/tv_discover_provider.dart';
+
+/// Dashboard TV tab: discovery rows + simplified Sonarr library sections.
+class DashboardTvTab extends ConsumerStatefulWidget {
+  const DashboardTvTab({super.key});
+
+  @override
+  ConsumerState<DashboardTvTab> createState() => _DashboardTvTabState();
+}
+
+class _DashboardTvTabState extends ConsumerState<DashboardTvTab> {
+  List<SonarrSeries> _recentlyDownloaded = [];
+  List<SonarrSeries> _continuing = [];
+  bool _isLoadingLibrary = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(tvDiscoverProvider.notifier).bootstrap();
+      _loadLibraryPreview();
+    });
+  }
+
+  Future<void> _loadLibraryPreview() async {
+    final auth = ref.read(authProvider).valueOrNull;
+    final defaultSonarr = auth?.connection?.defaultSonarrInstance;
+    if (defaultSonarr == null) return;
+
+    setState(() => _isLoadingLibrary = true);
+    try {
+      final backendDio = ref.read(backendClientProvider);
+      final service = SonarrApiService(
+          backendDio: backendDio, instanceId: defaultSonarr.id);
+      final series = await service.getSeries();
+
+      final downloaded = series
+          .where((s) => s.percentComplete > 0)
+          .toList()
+        ..sort((a, b) =>
+            b.percentComplete.compareTo(a.percentComplete));
+      final continuing =
+          series.where((s) => s.status == 'continuing').toList();
+
+      setState(() {
+        _recentlyDownloaded = downloaded.take(10).toList();
+        _continuing = continuing.take(10).toList();
+        _isLoadingLibrary = false;
+      });
+    } catch (_) {
+      setState(() => _isLoadingLibrary = false);
+    }
+  }
+
+  Future<void> _onRefresh() async {
+    await Future.wait([
+      ref.read(tvDiscoverProvider.notifier).bootstrap(),
+      _loadLibraryPreview(),
+    ]);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final discover = ref.watch(tvDiscoverProvider);
+
+    return RefreshIndicator(
+      onRefresh: _onRefresh,
+      color: AppTheme.accent,
+      child: ListView(
+        padding: const EdgeInsets.only(bottom: 24),
+        children: [
+          CategoryRow(
+            title: 'Popular TV Shows',
+            items: discover.popularTV,
+            isLoading: discover.isLoadingPopular,
+          ),
+          if (discover.anticipated.isNotEmpty)
+            CategoryRow(
+              title: 'Most Anticipated',
+              items: discover.anticipated,
+              isLoading: discover.isLoadingAnticipated,
+            ),
+
+          if (_recentlyDownloaded.isNotEmpty || _continuing.isNotEmpty) ...[
+            _SectionHeader(title: 'Your Library'),
+            if (_isLoadingLibrary)
+              const Padding(
+                padding: EdgeInsets.all(24),
+                child: Center(
+                    child:
+                        CircularProgressIndicator(color: AppTheme.accent)),
+              ),
+            if (_continuing.isNotEmpty)
+              _CompactSeriesSection(
+                title: 'Airing Now',
+                series: _continuing,
+                color: AppTheme.downloading,
+              ),
+            if (_recentlyDownloaded.isNotEmpty)
+              _CompactSeriesSection(
+                title: 'Recently Downloaded',
+                series: _recentlyDownloaded,
+                color: AppTheme.available,
+              ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  const _SectionHeader({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 28, 16, 8),
+      child: Row(
+        children: [
+          Expanded(child: Container(height: 1, color: AppTheme.border)),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12),
+            child: Text(
+              title,
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                letterSpacing: 0.5,
+              ),
+            ),
+          ),
+          Expanded(child: Container(height: 1, color: AppTheme.border)),
+        ],
+      ),
+    );
+  }
+}
+
+class _CompactSeriesSection extends StatelessWidget {
+  final String title;
+  final List<SonarrSeries> series;
+  final Color color;
+
+  const _CompactSeriesSection({
+    required this.title,
+    required this.series,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Row(
+            children: [
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '$title (${series.length})',
+                style: const TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 14,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+        ...series.map((s) => ListTile(
+              dense: true,
+              leading: Icon(Icons.tv_outlined,
+                  color: color, size: 20),
+              title: Text(
+                s.title,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary, fontSize: 14),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+              subtitle: Text(
+                '${s.year != null ? s.year.toString() : ''} ${s.status == 'continuing' ? '• Continuing' : ''}',
+                style: const TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 12),
+              ),
+            )),
+      ],
+    );
+  }
+}

--- a/app/lib/features/radarr/data/radarr_api_service.dart
+++ b/app/lib/features/radarr/data/radarr_api_service.dart
@@ -3,15 +3,23 @@ import 'radarr_models.dart';
 
 /// Networking layer for Radarr, proxied through the Cantinarr backend.
 ///
-/// All requests go to /api/radarr/... which the backend forwards to
-/// the configured Radarr instance.
+/// Supports both instance-specific paths (/api/instances/{id}/...) and
+/// legacy paths (/api/radarr/...) for backward compatibility.
 class RadarrApiService {
   final Dio _dio;
+  final String? _instanceId;
 
-  RadarrApiService({required Dio backendDio}) : _dio = backendDio;
+  RadarrApiService({required Dio backendDio, String? instanceId})
+      : _dio = backendDio,
+        _instanceId = instanceId;
+
+  /// Returns the base path prefix for API calls.
+  String get _basePath => _instanceId != null
+      ? '/api/instances/$_instanceId/api/v3'
+      : '/api/radarr/api/v3';
 
   Future<RadarrSystemStatus> getSystemStatus() async {
-    final resp = await _dio.get('/api/radarr/api/v3/system/status');
+    final resp = await _dio.get('$_basePath/system/status');
     return RadarrSystemStatus.fromJson(resp.data as Map<String, dynamic>);
   }
 
@@ -21,27 +29,27 @@ class RadarrApiService {
       params['searchTerm'] = searchTerm;
     }
     final resp =
-        await _dio.get('/api/radarr/api/v3/movie', queryParameters: params);
+        await _dio.get('$_basePath/movie', queryParameters: params);
     return (resp.data as List<dynamic>)
         .map((m) => RadarrMovie.fromJson(m as Map<String, dynamic>))
         .toList();
   }
 
   Future<RadarrMovie> getMovie(int id) async {
-    final resp = await _dio.get('/api/radarr/api/v3/movie/$id');
+    final resp = await _dio.get('$_basePath/movie/$id');
     return RadarrMovie.fromJson(resp.data as Map<String, dynamic>);
   }
 
   Future<List<RadarrMovie>> lookupMovies(String term) async {
     final resp = await _dio
-        .get('/api/radarr/api/v3/movie/lookup', queryParameters: {'term': term});
+        .get('$_basePath/movie/lookup', queryParameters: {'term': term});
     return (resp.data as List<dynamic>)
         .map((m) => RadarrMovie.fromJson(m as Map<String, dynamic>))
         .toList();
   }
 
   Future<List<RadarrQualityProfile>> getQualityProfiles() async {
-    final resp = await _dio.get('/api/radarr/api/v3/qualityprofile');
+    final resp = await _dio.get('$_basePath/qualityprofile');
     return (resp.data as List<dynamic>)
         .map((p) =>
             RadarrQualityProfile.fromJson(p as Map<String, dynamic>))
@@ -49,36 +57,53 @@ class RadarrApiService {
   }
 
   Future<List<RadarrRootFolder>> getRootFolders() async {
-    final resp = await _dio.get('/api/radarr/api/v3/rootfolder');
+    final resp = await _dio.get('$_basePath/rootfolder');
     return (resp.data as List<dynamic>)
         .map((f) => RadarrRootFolder.fromJson(f as Map<String, dynamic>))
         .toList();
   }
 
   Future<RadarrMovie> addMovie(Map<String, dynamic> movieData) async {
-    final resp = await _dio.post('/api/radarr/api/v3/movie', data: movieData);
+    final resp = await _dio.post('$_basePath/movie', data: movieData);
     return RadarrMovie.fromJson(resp.data as Map<String, dynamic>);
   }
 
   Future<RadarrMovie> updateMovie(
       int id, Map<String, dynamic> movieData) async {
     final resp =
-        await _dio.put('/api/radarr/api/v3/movie/$id', data: movieData);
+        await _dio.put('$_basePath/movie/$id', data: movieData);
     return RadarrMovie.fromJson(resp.data as Map<String, dynamic>);
   }
 
   Future<void> deleteMovie(int id,
       {bool deleteFiles = false, bool addExclusion = false}) async {
-    await _dio.delete('/api/radarr/api/v3/movie/$id', queryParameters: {
+    await _dio.delete('$_basePath/movie/$id', queryParameters: {
       'deleteFiles': deleteFiles,
       'addImportListExclusion': addExclusion,
     });
   }
 
   Future<void> searchMovie(int movieId) async {
-    await _dio.post('/api/radarr/api/v3/command', data: {
+    await _dio.post('$_basePath/command', data: {
       'name': 'MoviesSearch',
       'movieIds': [movieId],
     });
+  }
+
+  Future<List<Map<String, dynamic>>> getQueue() async {
+    final resp = await _dio.get('$_basePath/queue',
+        queryParameters: {'includeMovie': true, 'pageSize': 50});
+    final records =
+        (resp.data as Map<String, dynamic>)['records'] as List<dynamic>?;
+    return records?.cast<Map<String, dynamic>>() ?? [];
+  }
+
+  Future<List<Map<String, dynamic>>> getCalendar({
+    required String start,
+    required String end,
+  }) async {
+    final resp = await _dio.get('$_basePath/calendar',
+        queryParameters: {'start': start, 'end': end});
+    return (resp.data as List<dynamic>).cast<Map<String, dynamic>>();
   }
 }

--- a/app/lib/features/radarr/ui/radarr_calendar_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_calendar_screen.dart
@@ -1,0 +1,137 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/radarr_api_service.dart';
+
+/// Shows upcoming movie releases from Radarr's calendar.
+class RadarrCalendarScreen extends ConsumerStatefulWidget {
+  const RadarrCalendarScreen({super.key});
+
+  @override
+  ConsumerState<RadarrCalendarScreen> createState() =>
+      _RadarrCalendarScreenState();
+}
+
+class _RadarrCalendarScreenState extends ConsumerState<RadarrCalendarScreen> {
+  List<Map<String, dynamic>> _events = [];
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadCalendar());
+  }
+
+  Future<void> _loadCalendar() async {
+    final instanceState = ref.read(instanceProvider);
+    final instanceId = instanceState.activeRadarrInstance?.id;
+    if (instanceId == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Radarr instance configured';
+      });
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      final backendDio = ref.read(backendClientProvider);
+      final service =
+          RadarrApiService(backendDio: backendDio, instanceId: instanceId);
+      final now = DateTime.now();
+      final start = now.subtract(const Duration(days: 7));
+      final end = now.add(const Duration(days: 30));
+      final events = await service.getCalendar(
+        start: start.toIso8601String(),
+        end: end.toIso8601String(),
+      );
+      setState(() {
+        _events = events;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load calendar: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(instanceProvider.select((s) => s.activeRadarrInstanceId),
+        (_, __) => _loadCalendar());
+
+    if (_isLoading) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!,
+                style: const TextStyle(color: AppTheme.textSecondary)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+                onPressed: _loadCalendar, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+    if (_events.isEmpty) {
+      return const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.calendar_today_outlined,
+                size: 48, color: AppTheme.textSecondary),
+            SizedBox(height: 12),
+            Text('No upcoming releases',
+                style: TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 16)),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _loadCalendar,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _events.length,
+        itemBuilder: (context, index) {
+          final event = _events[index];
+          final title = event['title'] as String? ?? 'Unknown';
+          final date = event['inCinemas'] as String? ??
+              event['digitalRelease'] as String? ??
+              event['physicalRelease'] as String? ??
+              '';
+          final hasFile = event['hasFile'] as bool? ?? false;
+
+          return ListTile(
+            leading: Icon(
+              hasFile ? Icons.check_circle : Icons.calendar_today,
+              color: hasFile ? AppTheme.available : AppTheme.accent,
+            ),
+            title: Text(title,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontWeight: FontWeight.w500)),
+            subtitle: Text(
+              date.isNotEmpty ? date.substring(0, 10) : 'TBA',
+              style: const TextStyle(
+                  color: AppTheme.textSecondary, fontSize: 13),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/app/lib/features/radarr/ui/radarr_home_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_home_screen.dart
@@ -1,14 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../data/radarr_api_service.dart';
-import '../data/radarr_models.dart';
 import '../logic/radarr_movies_provider.dart';
 import 'radarr_movie_list.dart';
 
-/// Admin view for Radarr movie management.
+/// Radarr library management screen (used in the Radarr module).
+/// Instance-aware: uses the active Radarr instance from the instance provider.
 class RadarrHomeScreen extends ConsumerStatefulWidget {
   const RadarrHomeScreen({super.key});
 
@@ -17,16 +18,27 @@ class RadarrHomeScreen extends ConsumerStatefulWidget {
 }
 
 class _RadarrHomeScreenState extends ConsumerState<RadarrHomeScreen> {
-  late final RadarrMoviesNotifier _notifier;
+  RadarrMoviesNotifier? _notifier;
   final _searchController = TextEditingController();
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _initNotifier());
+  }
+
+  void _initNotifier() {
+    final instanceState = ref.read(instanceProvider);
+    final activeInstance = instanceState.activeRadarrInstance;
+
     final backendDio = ref.read(backendClientProvider);
-    final service = RadarrApiService(backendDio: backendDio);
+    final service = RadarrApiService(
+      backendDio: backendDio,
+      instanceId: activeInstance?.id,
+    );
     _notifier = RadarrMoviesNotifier(service);
-    _notifier.loadMovies();
+    _notifier!.loadMovies();
+    setState(() {});
   }
 
   @override
@@ -37,114 +49,121 @@ class _RadarrHomeScreenState extends ConsumerState<RadarrHomeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // Rebuild when active instance changes
+    ref.listen(instanceProvider.select((s) => s.activeRadarrInstanceId),
+        (_, __) => _initNotifier());
+
+    if (_notifier == null) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+
     return ListenableBuilder(
-      listenable: _notifier,
+      listenable: _notifier!,
       builder: (context, _) {
-        final state = _notifier.state;
+        final state = _notifier!.state;
 
-        return Scaffold(
-          body: Column(
-            children: [
-              // Stats bar
-              Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                color: AppTheme.surface,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceAround,
-                  children: [
-                    _StatChip(
-                        label: 'Total',
-                        count: state.movies.length,
+        return Column(
+          children: [
+            // Stats bar
+            Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              color: AppTheme.surface,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  _StatChip(
+                      label: 'Total',
+                      count: state.movies.length,
+                      color: AppTheme.textPrimary),
+                  _StatChip(
+                      label: 'Downloaded',
+                      count: state.downloadedCount,
+                      color: AppTheme.available),
+                  _StatChip(
+                      label: 'Missing',
+                      count: state.missingCount,
+                      color: AppTheme.requested),
+                ],
+              ),
+            ),
+
+            // Search + filter
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _searchController,
+                      onChanged: _notifier!.search,
+                      decoration: InputDecoration(
+                        hintText: 'Search movies...',
+                        prefixIcon: const Icon(Icons.search),
+                        suffixIcon: _searchController.text.isNotEmpty
+                            ? IconButton(
+                                icon: const Icon(Icons.close),
+                                onPressed: () {
+                                  _searchController.clear();
+                                  _notifier!.search('');
+                                },
+                              )
+                            : null,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  PopupMenuButton<RadarrFilter>(
+                    icon: const Icon(Icons.filter_list,
                         color: AppTheme.textPrimary),
-                    _StatChip(
-                        label: 'Downloaded',
-                        count: state.downloadedCount,
-                        color: AppTheme.available),
-                    _StatChip(
-                        label: 'Missing',
-                        count: state.missingCount,
-                        color: AppTheme.requested),
-                  ],
-                ),
+                    onSelected: _notifier!.setFilter,
+                    itemBuilder: (_) => RadarrFilter.values
+                        .map((f) => PopupMenuItem(
+                              value: f,
+                              child: Row(
+                                children: [
+                                  if (f == state.filter)
+                                    const Icon(Icons.check,
+                                        size: 18, color: AppTheme.accent),
+                                  if (f != state.filter)
+                                    const SizedBox(width: 18),
+                                  const SizedBox(width: 8),
+                                  Text(f.name[0].toUpperCase() +
+                                      f.name.substring(1)),
+                                ],
+                              ),
+                            ))
+                        .toList(),
+                  ),
+                ],
+              ),
+            ),
+
+            if (state.error != null)
+              ErrorBanner(
+                message: state.error!,
+                onRetry: _notifier!.loadMovies,
               ),
 
-              // Search + filter
-              Padding(
-                padding: const EdgeInsets.all(12),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: TextField(
-                        controller: _searchController,
-                        onChanged: _notifier.search,
-                        decoration: InputDecoration(
-                          hintText: 'Search movies...',
-                          prefixIcon: const Icon(Icons.search),
-                          suffixIcon: _searchController.text.isNotEmpty
-                              ? IconButton(
-                                  icon: const Icon(Icons.close),
-                                  onPressed: () {
-                                    _searchController.clear();
-                                    _notifier.search('');
-                                  },
-                                )
-                              : null,
-                        ),
+            // Movie list
+            Expanded(
+              child: state.isLoading && state.movies.isEmpty
+                  ? const Center(
+                      child:
+                          CircularProgressIndicator(color: AppTheme.accent))
+                  : RefreshIndicator(
+                      onRefresh: _notifier!.loadMovies,
+                      color: AppTheme.accent,
+                      child: RadarrMovieList(
+                        movies: state.filtered,
+                        onDelete: (id) =>
+                            _notifier!.deleteMovie(id, deleteFiles: false),
+                        onSearch: _notifier!.searchForMovie,
                       ),
                     ),
-                    const SizedBox(width: 8),
-                    PopupMenuButton<RadarrFilter>(
-                      icon: const Icon(Icons.filter_list,
-                          color: AppTheme.textPrimary),
-                      onSelected: _notifier.setFilter,
-                      itemBuilder: (_) => RadarrFilter.values
-                          .map((f) => PopupMenuItem(
-                                value: f,
-                                child: Row(
-                                  children: [
-                                    if (f == state.filter)
-                                      const Icon(Icons.check,
-                                          size: 18, color: AppTheme.accent),
-                                    if (f != state.filter)
-                                      const SizedBox(width: 18),
-                                    const SizedBox(width: 8),
-                                    Text(f.name[0].toUpperCase() +
-                                        f.name.substring(1)),
-                                  ],
-                                ),
-                              ))
-                          .toList(),
-                    ),
-                  ],
-                ),
-              ),
-
-              if (state.error != null)
-                ErrorBanner(
-                  message: state.error!,
-                  onRetry: _notifier.loadMovies,
-                ),
-
-              // Movie list
-              Expanded(
-                child: state.isLoading && state.movies.isEmpty
-                    ? const Center(
-                        child:
-                            CircularProgressIndicator(color: AppTheme.accent))
-                    : RefreshIndicator(
-                        onRefresh: _notifier.loadMovies,
-                        color: AppTheme.accent,
-                        child: RadarrMovieList(
-                          movies: state.filtered,
-                          onDelete: (id) =>
-                              _notifier.deleteMovie(id, deleteFiles: false),
-                          onSearch: _notifier.searchForMovie,
-                        ),
-                      ),
-              ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );

--- a/app/lib/features/radarr/ui/radarr_module_shell.dart
+++ b/app/lib/features/radarr/ui/radarr_module_shell.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/instance_dropdown.dart';
+
+/// Radarr module shell with bottom nav: Library | Queue | Calendar.
+/// Shows instance dropdown in the header when 2+ instances exist.
+class RadarrModuleShell extends ConsumerWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTabChanged;
+  final Widget child;
+
+  const RadarrModuleShell({
+    super.key,
+    required this.currentIndex,
+    required this.onTabChanged,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final instanceState = ref.watch(instanceProvider);
+
+    return Scaffold(
+      appBar: instanceState.radarrInstances.length > 1
+          ? AppBar(
+              title: InstanceDropdown(
+                instances: instanceState.radarrInstances,
+                activeInstanceId: instanceState.activeRadarrInstanceId,
+                onChanged: (id) => ref
+                    .read(instanceProvider.notifier)
+                    .setActiveRadarrInstance(id),
+              ),
+              backgroundColor: AppTheme.background,
+              elevation: 0,
+            )
+          : null,
+      body: child,
+      bottomNavigationBar: Container(
+        decoration: const BoxDecoration(
+          border:
+              Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
+        ),
+        child: BottomNavigationBar(
+          currentIndex: currentIndex,
+          onTap: onTabChanged,
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.video_library_outlined),
+              activeIcon: Icon(Icons.video_library),
+              label: 'Library',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.downloading_outlined),
+              activeIcon: Icon(Icons.downloading),
+              label: 'Queue',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.calendar_month_outlined),
+              activeIcon: Icon(Icons.calendar_month),
+              label: 'Calendar',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/radarr/ui/radarr_queue_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_queue_screen.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/radarr_api_service.dart';
+
+/// Shows the current Radarr download queue.
+class RadarrQueueScreen extends ConsumerStatefulWidget {
+  const RadarrQueueScreen({super.key});
+
+  @override
+  ConsumerState<RadarrQueueScreen> createState() => _RadarrQueueScreenState();
+}
+
+class _RadarrQueueScreenState extends ConsumerState<RadarrQueueScreen> {
+  List<Map<String, dynamic>> _queue = [];
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadQueue());
+  }
+
+  Future<void> _loadQueue() async {
+    final instanceState = ref.read(instanceProvider);
+    final instanceId = instanceState.activeRadarrInstance?.id;
+    if (instanceId == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Radarr instance configured';
+      });
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      final backendDio = ref.read(backendClientProvider);
+      final service =
+          RadarrApiService(backendDio: backendDio, instanceId: instanceId);
+      final queue = await service.getQueue();
+      setState(() {
+        _queue = queue;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load queue: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Rebuild when instance changes
+    ref.listen(instanceProvider.select((s) => s.activeRadarrInstanceId),
+        (_, __) => _loadQueue());
+
+    if (_isLoading) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!,
+                style: const TextStyle(color: AppTheme.textSecondary)),
+            const SizedBox(height: 16),
+            ElevatedButton(onPressed: _loadQueue, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+    if (_queue.isEmpty) {
+      return const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.check_circle_outline,
+                size: 48, color: AppTheme.available),
+            SizedBox(height: 12),
+            Text('Queue is empty',
+                style: TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 16)),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _loadQueue,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _queue.length,
+        itemBuilder: (context, index) {
+          final item = _queue[index];
+          final title = item['title'] as String? ?? 'Unknown';
+          final status = item['status'] as String? ?? '';
+          final size = (item['size'] as num?)?.toDouble() ?? 0;
+          final sizeLeft = (item['sizeleft'] as num?)?.toDouble() ?? 0;
+          final progress = size > 0 ? ((size - sizeLeft) / size) : 0.0;
+
+          return ListTile(
+            leading: CircularProgressIndicator(
+              value: progress,
+              color: AppTheme.accent,
+              backgroundColor: AppTheme.border,
+              strokeWidth: 3,
+            ),
+            title: Text(title,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontWeight: FontWeight.w500)),
+            subtitle: Text(
+              '${(progress * 100).toStringAsFixed(1)}% - $status',
+              style: const TextStyle(
+                  color: AppTheme.textSecondary, fontSize: 13),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/app/lib/features/settings/data/instance_api_service.dart
+++ b/app/lib/features/settings/data/instance_api_service.dart
@@ -1,0 +1,70 @@
+import 'package:dio/dio.dart';
+import '../../../core/models/backend_connection.dart';
+
+/// Calls the backend instance CRUD API endpoints.
+class InstanceApiService {
+  final Dio _dio;
+
+  InstanceApiService({required Dio backendDio}) : _dio = backendDio;
+
+  Future<List<ServiceInstance>> listInstances() async {
+    final resp = await _dio.get('/api/instances');
+    return (resp.data as List<dynamic>)
+        .map((i) => ServiceInstance.fromJson(i as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<ServiceInstance> createInstance({
+    required String serviceType,
+    required String name,
+    required String url,
+    required String apiKey,
+    bool isDefault = false,
+  }) async {
+    final resp = await _dio.post('/api/instances', data: {
+      'service_type': serviceType,
+      'name': name,
+      'url': url,
+      'api_key': apiKey,
+      'is_default': isDefault,
+    });
+    return ServiceInstance.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<ServiceInstance> updateInstance({
+    required String id,
+    required String name,
+    required String url,
+    required String apiKey,
+    bool isDefault = false,
+  }) async {
+    final resp = await _dio.put('/api/instances/$id', data: {
+      'name': name,
+      'url': url,
+      'api_key': apiKey,
+      'is_default': isDefault,
+    });
+    return ServiceInstance.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<void> deleteInstance(String id) async {
+    await _dio.delete('/api/instances/$id');
+  }
+
+  /// Test connection to a service URL.
+  Future<bool> testConnection(String url, String apiKey) async {
+    try {
+      final testDio = Dio(BaseOptions(
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+      ));
+      final resp = await testDio.get(
+        '$url/api/v3/system/status',
+        options: Options(headers: {'X-Api-Key': apiKey}),
+      );
+      return resp.statusCode == 200;
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -1,0 +1,310 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/instance_api_service.dart';
+
+/// Form for creating or editing a service instance.
+class InstanceEditScreen extends ConsumerStatefulWidget {
+  final String? instanceId;
+  final String? initialServiceType;
+  final String? initialName;
+  final String? initialUrl;
+  final String? initialApiKey;
+  final bool initialIsDefault;
+
+  const InstanceEditScreen({
+    super.key,
+    this.instanceId,
+    this.initialServiceType,
+    this.initialName,
+    this.initialUrl,
+    this.initialApiKey,
+    this.initialIsDefault = false,
+  });
+
+  bool get isEditing => instanceId != null;
+
+  @override
+  ConsumerState<InstanceEditScreen> createState() =>
+      _InstanceEditScreenState();
+}
+
+class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _urlController;
+  late final TextEditingController _apiKeyController;
+  String _serviceType = 'radarr';
+  bool _isDefault = false;
+  bool _isSaving = false;
+  bool _isTesting = false;
+  String? _testResult;
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.initialName ?? '');
+    _urlController = TextEditingController(text: widget.initialUrl ?? '');
+    _apiKeyController =
+        TextEditingController(text: widget.initialApiKey ?? '');
+    _serviceType = widget.initialServiceType ?? 'radarr';
+    _isDefault = widget.initialIsDefault;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _urlController.dispose();
+    _apiKeyController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _testConnection() async {
+    setState(() {
+      _isTesting = true;
+      _testResult = null;
+    });
+
+    final backendDio = ref.read(backendClientProvider);
+    final service = InstanceApiService(backendDio: backendDio);
+    final success = await service.testConnection(
+      _urlController.text.trim(),
+      _apiKeyController.text.trim(),
+    );
+
+    setState(() {
+      _isTesting = false;
+      _testResult = success ? 'Connection successful!' : 'Connection failed';
+    });
+  }
+
+  Future<void> _save() async {
+    if (_nameController.text.trim().isEmpty ||
+        _urlController.text.trim().isEmpty ||
+        _apiKeyController.text.trim().isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('All fields are required')),
+      );
+      return;
+    }
+
+    setState(() => _isSaving = true);
+
+    try {
+      final backendDio = ref.read(backendClientProvider);
+      final service = InstanceApiService(backendDio: backendDio);
+
+      if (widget.isEditing) {
+        await service.updateInstance(
+          id: widget.instanceId!,
+          name: _nameController.text.trim(),
+          url: _urlController.text.trim(),
+          apiKey: _apiKeyController.text.trim(),
+          isDefault: _isDefault,
+        );
+      } else {
+        await service.createInstance(
+          serviceType: _serviceType,
+          name: _nameController.text.trim(),
+          url: _urlController.text.trim(),
+          apiKey: _apiKeyController.text.trim(),
+          isDefault: _isDefault,
+        );
+      }
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+              content: Text(widget.isEditing
+                  ? 'Instance updated'
+                  : 'Instance created')),
+        );
+        context.pop(true); // Return true to signal refresh needed
+      }
+    } catch (e) {
+      setState(() => _isSaving = false);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to save: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _delete() async {
+    if (!widget.isEditing) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Instance'),
+        content: const Text('Are you sure you want to delete this instance?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Delete',
+                style: TextStyle(color: AppTheme.error)),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      final backendDio = ref.read(backendClientProvider);
+      final service = InstanceApiService(backendDio: backendDio);
+      await service.deleteInstance(widget.instanceId!);
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Instance deleted')),
+        );
+        context.pop(true);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to delete: $e')),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.isEditing ? 'Edit Instance' : 'Add Instance'),
+        actions: [
+          if (widget.isEditing)
+            IconButton(
+              icon: const Icon(Icons.delete_outline, color: AppTheme.error),
+              onPressed: _delete,
+            ),
+        ],
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // Service type (only for new instances)
+          if (!widget.isEditing) ...[
+            const Text('Service Type',
+                style: TextStyle(
+                    color: AppTheme.textSecondary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600)),
+            const SizedBox(height: 8),
+            SegmentedButton<String>(
+              segments: const [
+                ButtonSegment(value: 'radarr', label: Text('Radarr')),
+                ButtonSegment(value: 'sonarr', label: Text('Sonarr')),
+              ],
+              selected: {_serviceType},
+              onSelectionChanged: (value) =>
+                  setState(() => _serviceType = value.first),
+            ),
+            const SizedBox(height: 24),
+          ],
+
+          TextField(
+            controller: _nameController,
+            decoration: const InputDecoration(
+              labelText: 'Name',
+              hintText: 'e.g. Movies, 4K Movies',
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          TextField(
+            controller: _urlController,
+            decoration: const InputDecoration(
+              labelText: 'URL',
+              hintText: 'http://192.168.1.100:7878',
+            ),
+            keyboardType: TextInputType.url,
+          ),
+          const SizedBox(height: 16),
+
+          TextField(
+            controller: _apiKeyController,
+            decoration: const InputDecoration(
+              labelText: 'API Key',
+              hintText: 'Your Radarr/Sonarr API key',
+            ),
+            obscureText: true,
+          ),
+          const SizedBox(height: 16),
+
+          SwitchListTile(
+            title: const Text('Default Instance',
+                style: TextStyle(color: AppTheme.textPrimary)),
+            subtitle: const Text(
+                'Use this as the default for media requests',
+                style: TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 13)),
+            value: _isDefault,
+            onChanged: (value) => setState(() => _isDefault = value),
+            activeTrackColor: AppTheme.accent,
+          ),
+
+          const SizedBox(height: 24),
+
+          // Test connection button
+          OutlinedButton.icon(
+            onPressed: _isTesting ? null : _testConnection,
+            icon: _isTesting
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(
+                        strokeWidth: 2, color: AppTheme.accent),
+                  )
+                : const Icon(Icons.wifi_tethering),
+            label: const Text('Test Connection'),
+          ),
+          if (_testResult != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              _testResult!,
+              style: TextStyle(
+                color: _testResult!.contains('successful')
+                    ? AppTheme.available
+                    : AppTheme.error,
+                fontSize: 13,
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+
+          const SizedBox(height: 32),
+
+          // Save button
+          ElevatedButton(
+            onPressed: _isSaving ? null : _save,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppTheme.accent,
+              foregroundColor: Colors.black,
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            child: _isSaving
+                ? const SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                        strokeWidth: 2, color: Colors.black),
+                  )
+                : Text(widget.isEditing ? 'Save Changes' : 'Add Instance'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -24,6 +24,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final auth = authState.valueOrNull;
     final connection = auth?.connection;
     final user = auth?.user;
+    final instances = connection?.instances ?? [];
 
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
@@ -64,36 +65,30 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
           const SizedBox(height: 16),
 
-          // Services
-          _SectionHeader(title: 'Services'),
-          _SettingsTile(
-            icon: Icons.movie_outlined,
-            title: 'Radarr',
-            subtitle: connection?.services.radarr == true
-                ? 'Available'
-                : 'Not configured',
-            trailing: Icon(
-              Icons.circle,
-              size: 12,
-              color: connection?.services.radarr == true
-                  ? AppTheme.available
-                  : AppTheme.unavailable,
+          // Modules (dynamic, instance-based)
+          _SectionHeader(title: 'Modules'),
+          if (instances.isEmpty)
+            _SettingsTile(
+              icon: Icons.info_outline,
+              title: 'No instances configured',
+              subtitle: 'Add a Radarr or Sonarr instance to get started',
             ),
-          ),
-          _SettingsTile(
-            icon: Icons.tv_outlined,
-            title: 'Sonarr',
-            subtitle: connection?.services.sonarr == true
-                ? 'Available'
-                : 'Not configured',
-            trailing: Icon(
-              Icons.circle,
-              size: 12,
-              color: connection?.services.sonarr == true
-                  ? AppTheme.available
-                  : AppTheme.unavailable,
-            ),
-          ),
+          ...instances.map((inst) => _SettingsTile(
+                icon: inst.serviceType == 'radarr'
+                    ? Icons.movie_outlined
+                    : Icons.tv_outlined,
+                title: inst.name,
+                subtitle:
+                    '${inst.serviceType == 'radarr' ? 'Radarr' : 'Sonarr'}${inst.isDefault ? ' (Default)' : ''}',
+                trailing: Icon(
+                  Icons.circle,
+                  size: 12,
+                  color: AppTheme.available,
+                ),
+                onTap: user?.isAdmin == true
+                    ? () => context.push('/settings/instance/${inst.id}')
+                    : null,
+              )),
           _SettingsTile(
             icon: Icons.smart_toy_outlined,
             title: 'AI Assistant',
@@ -108,6 +103,27 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   : AppTheme.unavailable,
             ),
           ),
+          if (user?.isAdmin == true)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              child: OutlinedButton.icon(
+                onPressed: () async {
+                  final result =
+                      await context.push<bool>('/settings/instance/new');
+                  if (result == true && mounted) {
+                    // Trigger a config refresh by re-logging in
+                    // (the auth provider will refetch config on next session restore)
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                          content: Text(
+                              'Instance added. Restart the app to see changes.')),
+                    );
+                  }
+                },
+                icon: const Icon(Icons.add),
+                label: const Text('Add Instance'),
+              ),
+            ),
 
           // Admin section
           if (user?.isAdmin == true) ...[

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../core/models/app_module.dart';
 import '../../../core/network/backend_client.dart';
+import '../../../core/providers/module_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/search_bar.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -12,18 +15,14 @@ import '../../sonarr/data/sonarr_api_service.dart';
 import '../../sonarr/logic/sonarr_series_provider.dart';
 import '../logic/shell_search_provider.dart';
 
-/// The root shell widget with persistent search bar, bottom navigation,
-/// and a drawer. 3 tabs: Movies | TV Shows | Assistant.
+/// The root shell widget with persistent search bar and drawer.
+/// Each module provides its own bottom nav via inner StatefulShellRoutes.
 class AppShell extends ConsumerStatefulWidget {
-  final int currentIndex;
   final Widget child;
-  final ValueChanged<int> onTabChanged;
 
   const AppShell({
     super.key,
-    required this.currentIndex,
     required this.child,
-    required this.onTabChanged,
   });
 
   @override
@@ -57,14 +56,32 @@ class _AppShellState extends ConsumerState<AppShell>
   void _initLibraries() {
     final auth = ref.read(authProvider).valueOrNull;
     final backendDio = ref.read(backendClientProvider);
-    if (auth?.connection?.services.radarr ?? false) {
+
+    // Use instance-aware API services
+    final defaultRadarr = auth?.connection?.defaultRadarrInstance;
+    if (defaultRadarr != null) {
+      _radarrNotifier = RadarrMoviesNotifier(
+        RadarrApiService(backendDio: backendDio, instanceId: defaultRadarr.id),
+      );
+      _radarrNotifier!.addListener(_onLibraryChanged);
+      _radarrNotifier!.loadMovies();
+    } else if (auth?.connection?.services.radarr ?? false) {
+      // Legacy fallback
       _radarrNotifier = RadarrMoviesNotifier(
         RadarrApiService(backendDio: backendDio),
       );
       _radarrNotifier!.addListener(_onLibraryChanged);
       _radarrNotifier!.loadMovies();
     }
-    if (auth?.connection?.services.sonarr ?? false) {
+
+    final defaultSonarr = auth?.connection?.defaultSonarrInstance;
+    if (defaultSonarr != null) {
+      _sonarrNotifier = SonarrSeriesNotifier(
+        SonarrApiService(backendDio: backendDio, instanceId: defaultSonarr.id),
+      );
+      _sonarrNotifier!.addListener(_onLibraryChanged);
+      _sonarrNotifier!.loadSeries();
+    } else if (auth?.connection?.services.sonarr ?? false) {
       _sonarrNotifier = SonarrSeriesNotifier(
         SonarrApiService(backendDio: backendDio),
       );
@@ -187,7 +204,7 @@ class _AppShellState extends ConsumerState<AppShell>
       body: SafeArea(
         child: Stack(
           children: [
-            // Base layer: search bar + tab content
+            // Base layer: search bar + module content
             Column(
               children: [
                 // Search bar: collapses on scroll (mobile only)
@@ -199,7 +216,7 @@ class _AppShellState extends ConsumerState<AppShell>
                   )
                 else
                   searchBar,
-                // Tab content
+                // Module content (includes its own bottom nav)
                 Expanded(
                   child: NotificationListener<ScrollNotification>(
                     onNotification: mobile && !searchState.isSearching
@@ -251,41 +268,13 @@ class _AppShellState extends ConsumerState<AppShell>
           ],
         ),
       ),
-      bottomNavigationBar: _buildBottomNav(),
       drawer: _buildDrawer(context),
     );
   }
 
-  Widget _buildBottomNav() {
-    return Container(
-      decoration: const BoxDecoration(
-        border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
-      ),
-      child: BottomNavigationBar(
-        currentIndex: widget.currentIndex,
-        onTap: widget.onTabChanged,
-        items: const [
-          BottomNavigationBarItem(
-            icon: Icon(Icons.movie_outlined),
-            activeIcon: Icon(Icons.movie),
-            label: 'Movies',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.tv_outlined),
-            activeIcon: Icon(Icons.tv),
-            label: 'TV Shows',
-          ),
-          BottomNavigationBarItem(
-            icon: Icon(Icons.smart_toy_outlined),
-            activeIcon: Icon(Icons.smart_toy),
-            label: 'Assistant',
-          ),
-        ],
-      ),
-    );
-  }
-
   Widget _buildDrawer(BuildContext context) {
+    final moduleState = ref.watch(moduleProvider);
+
     return Drawer(
       backgroundColor: AppTheme.surface,
       child: SafeArea(
@@ -327,34 +316,25 @@ class _AppShellState extends ConsumerState<AppShell>
             ),
             const Divider(color: AppTheme.border),
 
-            // Navigation items
-            _DrawerItem(
-              icon: Icons.movie,
-              title: 'Movies',
-              selected: widget.currentIndex == 0,
-              onTap: () {
-                Navigator.pop(context);
-                widget.onTabChanged(0);
-              },
-            ),
-            _DrawerItem(
-              icon: Icons.tv,
-              title: 'TV Shows',
-              selected: widget.currentIndex == 1,
-              onTap: () {
-                Navigator.pop(context);
-                widget.onTabChanged(1);
-              },
-            ),
-            _DrawerItem(
-              icon: Icons.smart_toy,
-              title: 'AI Assistant',
-              selected: widget.currentIndex == 2,
-              onTap: () {
-                Navigator.pop(context);
-                widget.onTabChanged(2);
-              },
-            ),
+            // Module navigation items
+            ...moduleState.modules.asMap().entries.map((entry) {
+              final module = entry.value;
+              final isActive = entry.key == moduleState.activeIndex;
+
+              return _DrawerItem(
+                icon: module.icon,
+                title: module.label,
+                selected: isActive,
+                onTap: () {
+                  Navigator.pop(context);
+                  _navigateToModule(context, module);
+                  ref.read(moduleProvider.notifier).setActiveModule(
+                        module.type,
+                        instanceId: module.instanceId,
+                      );
+                },
+              );
+            }),
 
             const Spacer(),
             const Divider(color: AppTheme.border),
@@ -362,18 +342,37 @@ class _AppShellState extends ConsumerState<AppShell>
             _DrawerItem(
               icon: Icons.play_circle_outline,
               title: 'Plex Setup Guide',
-              onTap: () => Navigator.pop(context),
+              onTap: () {
+                Navigator.pop(context);
+                context.push('/plex-guide');
+              },
             ),
             _DrawerItem(
               icon: Icons.settings,
               title: 'Settings',
-              onTap: () => Navigator.pop(context),
+              onTap: () {
+                Navigator.pop(context);
+                context.push('/settings');
+              },
             ),
             const SizedBox(height: 8),
           ],
         ),
       ),
     );
+  }
+
+  void _navigateToModule(BuildContext context, AppModule module) {
+    switch (module.type) {
+      case ModuleType.dashboard:
+        context.go('/dashboard/movies');
+      case ModuleType.radarr:
+        context.go('/radarr/library');
+      case ModuleType.sonarr:
+        context.go('/sonarr/library');
+      case ModuleType.assistant:
+        context.go('/assistant');
+    }
   }
 }
 

--- a/app/lib/features/sonarr/data/sonarr_api_service.dart
+++ b/app/lib/features/sonarr/data/sonarr_api_service.dart
@@ -3,32 +3,40 @@ import 'sonarr_models.dart';
 
 /// Networking layer for Sonarr, proxied through the Cantinarr backend.
 ///
-/// All requests go to /api/sonarr/... which the backend forwards to
-/// the configured Sonarr instance.
+/// Supports both instance-specific paths (/api/instances/{id}/...) and
+/// legacy paths (/api/sonarr/...) for backward compatibility.
 class SonarrApiService {
   final Dio _dio;
+  final String? _instanceId;
 
-  SonarrApiService({required Dio backendDio}) : _dio = backendDio;
+  SonarrApiService({required Dio backendDio, String? instanceId})
+      : _dio = backendDio,
+        _instanceId = instanceId;
+
+  /// Returns the base path prefix for API calls.
+  String get _basePath => _instanceId != null
+      ? '/api/instances/$_instanceId/api/v3'
+      : '/api/sonarr/api/v3';
 
   Future<SonarrSystemStatus> getSystemStatus() async {
-    final resp = await _dio.get('/api/sonarr/api/v3/system/status');
+    final resp = await _dio.get('$_basePath/system/status');
     return SonarrSystemStatus.fromJson(resp.data as Map<String, dynamic>);
   }
 
   Future<List<SonarrSeries>> getSeries() async {
-    final resp = await _dio.get('/api/sonarr/api/v3/series');
+    final resp = await _dio.get('$_basePath/series');
     return (resp.data as List<dynamic>)
         .map((s) => SonarrSeries.fromJson(s as Map<String, dynamic>))
         .toList();
   }
 
   Future<SonarrSeries> getSeriesById(int id) async {
-    final resp = await _dio.get('/api/sonarr/api/v3/series/$id');
+    final resp = await _dio.get('$_basePath/series/$id');
     return SonarrSeries.fromJson(resp.data as Map<String, dynamic>);
   }
 
   Future<List<SonarrSeries>> lookupSeries(String term) async {
-    final resp = await _dio.get('/api/sonarr/api/v3/series/lookup',
+    final resp = await _dio.get('$_basePath/series/lookup',
         queryParameters: {'term': term});
     return (resp.data as List<dynamic>)
         .map((s) => SonarrSeries.fromJson(s as Map<String, dynamic>))
@@ -36,7 +44,7 @@ class SonarrApiService {
   }
 
   Future<List<SonarrEpisode>> getEpisodes(int seriesId) async {
-    final resp = await _dio.get('/api/sonarr/api/v3/episode',
+    final resp = await _dio.get('$_basePath/episode',
         queryParameters: {'seriesId': seriesId});
     return (resp.data as List<dynamic>)
         .map((e) => SonarrEpisode.fromJson(e as Map<String, dynamic>))
@@ -44,7 +52,7 @@ class SonarrApiService {
   }
 
   Future<List<SonarrQualityProfile>> getQualityProfiles() async {
-    final resp = await _dio.get('/api/sonarr/api/v3/qualityprofile');
+    final resp = await _dio.get('$_basePath/qualityprofile');
     return (resp.data as List<dynamic>)
         .map((p) =>
             SonarrQualityProfile.fromJson(p as Map<String, dynamic>))
@@ -52,7 +60,7 @@ class SonarrApiService {
   }
 
   Future<List<SonarrRootFolder>> getRootFolders() async {
-    final resp = await _dio.get('/api/sonarr/api/v3/rootfolder');
+    final resp = await _dio.get('$_basePath/rootfolder');
     return (resp.data as List<dynamic>)
         .map((f) => SonarrRootFolder.fromJson(f as Map<String, dynamic>))
         .toList();
@@ -60,34 +68,51 @@ class SonarrApiService {
 
   Future<SonarrSeries> addSeries(Map<String, dynamic> seriesData) async {
     final resp =
-        await _dio.post('/api/sonarr/api/v3/series', data: seriesData);
+        await _dio.post('$_basePath/series', data: seriesData);
     return SonarrSeries.fromJson(resp.data as Map<String, dynamic>);
   }
 
   Future<SonarrSeries> updateSeries(
       int id, Map<String, dynamic> data) async {
     final resp =
-        await _dio.put('/api/sonarr/api/v3/series/$id', data: data);
+        await _dio.put('$_basePath/series/$id', data: data);
     return SonarrSeries.fromJson(resp.data as Map<String, dynamic>);
   }
 
   Future<void> deleteSeries(int id, {bool deleteFiles = false}) async {
-    await _dio.delete('/api/sonarr/api/v3/series/$id',
+    await _dio.delete('$_basePath/series/$id',
         queryParameters: {'deleteFiles': deleteFiles});
   }
 
   Future<void> searchSeries(int seriesId) async {
-    await _dio.post('/api/sonarr/api/v3/command', data: {
+    await _dio.post('$_basePath/command', data: {
       'name': 'SeriesSearch',
       'seriesId': seriesId,
     });
   }
 
   Future<void> searchSeason(int seriesId, int seasonNumber) async {
-    await _dio.post('/api/sonarr/api/v3/command', data: {
+    await _dio.post('$_basePath/command', data: {
       'name': 'SeasonSearch',
       'seriesId': seriesId,
       'seasonNumber': seasonNumber,
     });
+  }
+
+  Future<List<Map<String, dynamic>>> getQueue() async {
+    final resp = await _dio.get('$_basePath/queue',
+        queryParameters: {'includeSeries': true, 'pageSize': 50});
+    final records =
+        (resp.data as Map<String, dynamic>)['records'] as List<dynamic>?;
+    return records?.cast<Map<String, dynamic>>() ?? [];
+  }
+
+  Future<List<Map<String, dynamic>>> getCalendar({
+    required String start,
+    required String end,
+  }) async {
+    final resp = await _dio.get('$_basePath/calendar',
+        queryParameters: {'start': start, 'end': end});
+    return (resp.data as List<dynamic>).cast<Map<String, dynamic>>();
   }
 }

--- a/app/lib/features/sonarr/ui/sonarr_calendar_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_calendar_screen.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/sonarr_api_service.dart';
+
+/// Shows upcoming episode releases from Sonarr's calendar.
+class SonarrCalendarScreen extends ConsumerStatefulWidget {
+  const SonarrCalendarScreen({super.key});
+
+  @override
+  ConsumerState<SonarrCalendarScreen> createState() =>
+      _SonarrCalendarScreenState();
+}
+
+class _SonarrCalendarScreenState extends ConsumerState<SonarrCalendarScreen> {
+  List<Map<String, dynamic>> _events = [];
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadCalendar());
+  }
+
+  Future<void> _loadCalendar() async {
+    final instanceState = ref.read(instanceProvider);
+    final instanceId = instanceState.activeSonarrInstance?.id;
+    if (instanceId == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Sonarr instance configured';
+      });
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      final backendDio = ref.read(backendClientProvider);
+      final service =
+          SonarrApiService(backendDio: backendDio, instanceId: instanceId);
+      final now = DateTime.now();
+      final start = now.subtract(const Duration(days: 7));
+      final end = now.add(const Duration(days: 14));
+      final events = await service.getCalendar(
+        start: start.toIso8601String(),
+        end: end.toIso8601String(),
+      );
+      setState(() {
+        _events = events;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load calendar: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(instanceProvider.select((s) => s.activeSonarrInstanceId),
+        (_, __) => _loadCalendar());
+
+    if (_isLoading) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!,
+                style: const TextStyle(color: AppTheme.textSecondary)),
+            const SizedBox(height: 16),
+            ElevatedButton(
+                onPressed: _loadCalendar, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+    if (_events.isEmpty) {
+      return const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.calendar_today_outlined,
+                size: 48, color: AppTheme.textSecondary),
+            SizedBox(height: 12),
+            Text('No upcoming episodes',
+                style: TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 16)),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _loadCalendar,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _events.length,
+        itemBuilder: (context, index) {
+          final event = _events[index];
+          final seriesTitle = (event['series'] as Map<String, dynamic>?)?['title'] as String? ?? '';
+          final episodeTitle = event['title'] as String? ?? '';
+          final season = event['seasonNumber'] as int? ?? 0;
+          final episode = event['episodeNumber'] as int? ?? 0;
+          final airDate = event['airDateUtc'] as String? ?? '';
+          final hasFile = event['hasFile'] as bool? ?? false;
+
+          return ListTile(
+            leading: Icon(
+              hasFile ? Icons.check_circle : Icons.schedule,
+              color: hasFile ? AppTheme.available : AppTheme.accent,
+            ),
+            title: Text(seriesTitle,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontWeight: FontWeight.w500)),
+            subtitle: Text(
+              'S${season.toString().padLeft(2, '0')}E${episode.toString().padLeft(2, '0')} - $episodeTitle'
+              '${airDate.isNotEmpty ? '\n${airDate.substring(0, 10)}' : ''}',
+              style: const TextStyle(
+                  color: AppTheme.textSecondary, fontSize: 13),
+            ),
+            isThreeLine: airDate.isNotEmpty,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/app/lib/features/sonarr/ui/sonarr_home_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_home_screen.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../data/sonarr_api_service.dart';
 import '../logic/sonarr_series_provider.dart';
 import 'sonarr_series_list.dart';
 
-/// Admin view for Sonarr series management.
+/// Sonarr library management screen (used in the Sonarr module).
+/// Instance-aware: uses the active Sonarr instance from the instance provider.
 class SonarrHomeScreen extends ConsumerStatefulWidget {
   const SonarrHomeScreen({super.key});
 
@@ -16,16 +18,27 @@ class SonarrHomeScreen extends ConsumerStatefulWidget {
 }
 
 class _SonarrHomeScreenState extends ConsumerState<SonarrHomeScreen> {
-  late final SonarrSeriesNotifier _notifier;
+  SonarrSeriesNotifier? _notifier;
   final _searchController = TextEditingController();
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _initNotifier());
+  }
+
+  void _initNotifier() {
+    final instanceState = ref.read(instanceProvider);
+    final activeInstance = instanceState.activeSonarrInstance;
+
     final backendDio = ref.read(backendClientProvider);
-    final service = SonarrApiService(backendDio: backendDio);
+    final service = SonarrApiService(
+      backendDio: backendDio,
+      instanceId: activeInstance?.id,
+    );
     _notifier = SonarrSeriesNotifier(service);
-    _notifier.loadSeries();
+    _notifier!.loadSeries();
+    setState(() {});
   }
 
   @override
@@ -36,113 +49,120 @@ class _SonarrHomeScreenState extends ConsumerState<SonarrHomeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // Rebuild when active instance changes
+    ref.listen(instanceProvider.select((s) => s.activeSonarrInstanceId),
+        (_, __) => _initNotifier());
+
+    if (_notifier == null) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+
     return ListenableBuilder(
-      listenable: _notifier,
+      listenable: _notifier!,
       builder: (context, _) {
-        final state = _notifier.state;
+        final state = _notifier!.state;
 
-        return Scaffold(
-          body: Column(
-            children: [
-              // Stats bar
-              Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                color: AppTheme.surface,
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceAround,
-                  children: [
-                    _StatChip(
-                        label: 'Total',
-                        count: state.series.length,
+        return Column(
+          children: [
+            // Stats bar
+            Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              color: AppTheme.surface,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  _StatChip(
+                      label: 'Total',
+                      count: state.series.length,
+                      color: AppTheme.textPrimary),
+                  _StatChip(
+                      label: 'Complete',
+                      count: state.completeCount,
+                      color: AppTheme.available),
+                  _StatChip(
+                      label: 'Partial',
+                      count: state.partialCount,
+                      color: AppTheme.requested),
+                ],
+              ),
+            ),
+
+            // Search + filter
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _searchController,
+                      onChanged: _notifier!.search,
+                      decoration: InputDecoration(
+                        hintText: 'Search series...',
+                        prefixIcon: const Icon(Icons.search),
+                        suffixIcon: _searchController.text.isNotEmpty
+                            ? IconButton(
+                                icon: const Icon(Icons.close),
+                                onPressed: () {
+                                  _searchController.clear();
+                                  _notifier!.search('');
+                                },
+                              )
+                            : null,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  PopupMenuButton<SonarrFilter>(
+                    icon: const Icon(Icons.filter_list,
                         color: AppTheme.textPrimary),
-                    _StatChip(
-                        label: 'Complete',
-                        count: state.completeCount,
-                        color: AppTheme.available),
-                    _StatChip(
-                        label: 'Partial',
-                        count: state.partialCount,
-                        color: AppTheme.requested),
-                  ],
-                ),
+                    onSelected: _notifier!.setFilter,
+                    itemBuilder: (_) => SonarrFilter.values
+                        .map((f) => PopupMenuItem(
+                              value: f,
+                              child: Row(
+                                children: [
+                                  if (f == state.filter)
+                                    const Icon(Icons.check,
+                                        size: 18, color: AppTheme.accent),
+                                  if (f != state.filter)
+                                    const SizedBox(width: 18),
+                                  const SizedBox(width: 8),
+                                  Text(f.name[0].toUpperCase() +
+                                      f.name.substring(1)),
+                                ],
+                              ),
+                            ))
+                        .toList(),
+                  ),
+                ],
+              ),
+            ),
+
+            if (state.error != null)
+              ErrorBanner(
+                message: state.error!,
+                onRetry: _notifier!.loadSeries,
               ),
 
-              // Search + filter
-              Padding(
-                padding: const EdgeInsets.all(12),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: TextField(
-                        controller: _searchController,
-                        onChanged: _notifier.search,
-                        decoration: InputDecoration(
-                          hintText: 'Search series...',
-                          prefixIcon: const Icon(Icons.search),
-                          suffixIcon: _searchController.text.isNotEmpty
-                              ? IconButton(
-                                  icon: const Icon(Icons.close),
-                                  onPressed: () {
-                                    _searchController.clear();
-                                    _notifier.search('');
-                                  },
-                                )
-                              : null,
-                        ),
+            Expanded(
+              child: state.isLoading && state.series.isEmpty
+                  ? const Center(
+                      child:
+                          CircularProgressIndicator(color: AppTheme.accent))
+                  : RefreshIndicator(
+                      onRefresh: _notifier!.loadSeries,
+                      color: AppTheme.accent,
+                      child: SonarrSeriesList(
+                        series: state.filtered,
+                        onDelete: (id) =>
+                            _notifier!.deleteSeries(id, deleteFiles: false),
+                        onSearch: _notifier!.searchForSeries,
                       ),
                     ),
-                    const SizedBox(width: 8),
-                    PopupMenuButton<SonarrFilter>(
-                      icon: const Icon(Icons.filter_list,
-                          color: AppTheme.textPrimary),
-                      onSelected: _notifier.setFilter,
-                      itemBuilder: (_) => SonarrFilter.values
-                          .map((f) => PopupMenuItem(
-                                value: f,
-                                child: Row(
-                                  children: [
-                                    if (f == state.filter)
-                                      const Icon(Icons.check,
-                                          size: 18, color: AppTheme.accent),
-                                    if (f != state.filter)
-                                      const SizedBox(width: 18),
-                                    const SizedBox(width: 8),
-                                    Text(f.name[0].toUpperCase() +
-                                        f.name.substring(1)),
-                                  ],
-                                ),
-                              ))
-                          .toList(),
-                    ),
-                  ],
-                ),
-              ),
-
-              if (state.error != null)
-                ErrorBanner(
-                  message: state.error!,
-                  onRetry: _notifier.loadSeries,
-                ),
-
-              Expanded(
-                child: state.isLoading && state.series.isEmpty
-                    ? const Center(
-                        child:
-                            CircularProgressIndicator(color: AppTheme.accent))
-                    : RefreshIndicator(
-                        onRefresh: _notifier.loadSeries,
-                        color: AppTheme.accent,
-                        child: SonarrSeriesList(
-                          series: state.filtered,
-                          onDelete: (id) =>
-                              _notifier.deleteSeries(id, deleteFiles: false),
-                          onSearch: _notifier.searchForSeries,
-                        ),
-                      ),
-              ),
-            ],
-          ),
+            ),
+          ],
         );
       },
     );

--- a/app/lib/features/sonarr/ui/sonarr_module_shell.dart
+++ b/app/lib/features/sonarr/ui/sonarr_module_shell.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/instance_dropdown.dart';
+
+/// Sonarr module shell with bottom nav: Library | Queue | Calendar.
+/// Shows instance dropdown in the header when 2+ instances exist.
+class SonarrModuleShell extends ConsumerWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTabChanged;
+  final Widget child;
+
+  const SonarrModuleShell({
+    super.key,
+    required this.currentIndex,
+    required this.onTabChanged,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final instanceState = ref.watch(instanceProvider);
+
+    return Scaffold(
+      appBar: instanceState.sonarrInstances.length > 1
+          ? AppBar(
+              title: InstanceDropdown(
+                instances: instanceState.sonarrInstances,
+                activeInstanceId: instanceState.activeSonarrInstanceId,
+                onChanged: (id) => ref
+                    .read(instanceProvider.notifier)
+                    .setActiveSonarrInstance(id),
+              ),
+              backgroundColor: AppTheme.background,
+              elevation: 0,
+            )
+          : null,
+      body: child,
+      bottomNavigationBar: Container(
+        decoration: const BoxDecoration(
+          border:
+              Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
+        ),
+        child: BottomNavigationBar(
+          currentIndex: currentIndex,
+          onTap: onTabChanged,
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.video_library_outlined),
+              activeIcon: Icon(Icons.video_library),
+              label: 'Library',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.downloading_outlined),
+              activeIcon: Icon(Icons.downloading),
+              label: 'Queue',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.calendar_month_outlined),
+              activeIcon: Icon(Icons.calendar_month),
+              label: 'Calendar',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/sonarr/ui/sonarr_queue_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_queue_screen.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/sonarr_api_service.dart';
+
+/// Shows the current Sonarr download queue.
+class SonarrQueueScreen extends ConsumerStatefulWidget {
+  const SonarrQueueScreen({super.key});
+
+  @override
+  ConsumerState<SonarrQueueScreen> createState() => _SonarrQueueScreenState();
+}
+
+class _SonarrQueueScreenState extends ConsumerState<SonarrQueueScreen> {
+  List<Map<String, dynamic>> _queue = [];
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadQueue());
+  }
+
+  Future<void> _loadQueue() async {
+    final instanceState = ref.read(instanceProvider);
+    final instanceId = instanceState.activeSonarrInstance?.id;
+    if (instanceId == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Sonarr instance configured';
+      });
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      final backendDio = ref.read(backendClientProvider);
+      final service =
+          SonarrApiService(backendDio: backendDio, instanceId: instanceId);
+      final queue = await service.getQueue();
+      setState(() {
+        _queue = queue;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load queue: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(instanceProvider.select((s) => s.activeSonarrInstanceId),
+        (_, __) => _loadQueue());
+
+    if (_isLoading) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!,
+                style: const TextStyle(color: AppTheme.textSecondary)),
+            const SizedBox(height: 16),
+            ElevatedButton(onPressed: _loadQueue, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+    if (_queue.isEmpty) {
+      return const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.check_circle_outline,
+                size: 48, color: AppTheme.available),
+            SizedBox(height: 12),
+            Text('Queue is empty',
+                style: TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 16)),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _loadQueue,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _queue.length,
+        itemBuilder: (context, index) {
+          final item = _queue[index];
+          final title = item['title'] as String? ?? 'Unknown';
+          final status = item['status'] as String? ?? '';
+          final size = (item['size'] as num?)?.toDouble() ?? 0;
+          final sizeLeft = (item['sizeleft'] as num?)?.toDouble() ?? 0;
+          final progress = size > 0 ? ((size - sizeLeft) / size) : 0.0;
+
+          return ListTile(
+            leading: CircularProgressIndicator(
+              value: progress,
+              color: AppTheme.accent,
+              backgroundColor: AppTheme.border,
+              strokeWidth: 3,
+            ),
+            title: Text(title,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontWeight: FontWeight.w500)),
+            subtitle: Text(
+              '${(progress * 100).toStringAsFixed(1)}% - $status',
+              style: const TextStyle(
+                  color: AppTheme.textSecondary, fontSize: 13),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -5,25 +5,36 @@ import '../features/ai_assistant/ui/ai_chat_screen.dart';
 import '../features/auth/logic/auth_provider.dart';
 import '../features/auth/ui/invite_screen.dart';
 import '../features/auth/ui/login_screen.dart';
+import '../features/dashboard/ui/dashboard_movies_tab.dart';
+import '../features/dashboard/ui/dashboard_shell.dart';
+import '../features/dashboard/ui/dashboard_tv_tab.dart';
 import '../features/discover/data/tmdb_models.dart';
 import '../features/media_detail/ui/media_detail_screen.dart';
-import '../features/radarr/ui/movies_tab_screen.dart';
+import '../features/radarr/ui/radarr_calendar_screen.dart';
+import '../features/radarr/ui/radarr_home_screen.dart';
+import '../features/radarr/ui/radarr_module_shell.dart';
+import '../features/radarr/ui/radarr_queue_screen.dart';
+import '../features/settings/ui/instance_edit_screen.dart';
 import '../features/settings/ui/settings_screen.dart';
 import '../features/setup_wizard/ui/plex_setup_guide.dart';
 import '../features/setup_wizard/ui/setup_wizard_screen.dart';
-import '../features/sonarr/ui/tv_shows_tab_screen.dart';
 import '../features/shell/ui/app_shell.dart';
+import '../features/sonarr/ui/sonarr_calendar_screen.dart';
+import '../features/sonarr/ui/sonarr_home_screen.dart';
+import '../features/sonarr/ui/sonarr_module_shell.dart';
+import '../features/sonarr/ui/sonarr_queue_screen.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 
-/// Central router configuration using GoRouter with ShellRoute for tabs.
-/// Redirects unauthenticated users to /login.
+/// Central router configuration using GoRouter with module-based navigation.
+/// Outer ShellRoute provides the drawer + search bar.
+/// Inner StatefulShellRoutes provide per-module bottom nav.
 final appRouterProvider = Provider<GoRouter>((ref) {
   final authState = ref.watch(authProvider);
 
   return GoRouter(
     navigatorKey: _rootNavigatorKey,
-    initialLocation: '/radarr',
+    initialLocation: '/dashboard/movies',
     redirect: (context, state) {
       final auth = authState.valueOrNull;
       final isAuthenticated = auth?.isAuthenticated ?? false;
@@ -31,7 +42,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           state.matchedLocation == '/invite';
 
       if (!isAuthenticated && !isAuthRoute) return '/login';
-      if (isAuthenticated && isAuthRoute) return '/radarr';
+      if (isAuthenticated && isAuthRoute) return '/dashboard/movies';
       return null;
     },
     routes: [
@@ -49,47 +60,123 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         ),
       ),
 
-      // Shell route with bottom navigation
-      StatefulShellRoute.indexedStack(
-        builder: (context, state, navigationShell) {
-          return AppShell(
-            currentIndex: navigationShell.currentIndex,
-            onTabChanged: (index) => navigationShell.goBranch(index),
-            child: navigationShell,
-          );
+      // Module shell (provides drawer + search bar, no bottom nav)
+      ShellRoute(
+        builder: (context, state, child) {
+          return AppShell(child: child);
         },
-        branches: [
-          // Tab 0: Movies (discovery + Radarr library)
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/radarr',
-                builder: (context, state) => const MoviesTabScreen(),
+        routes: [
+          // Dashboard module (Movies/TV tabs)
+          StatefulShellRoute.indexedStack(
+            builder: (context, state, navigationShell) {
+              return DashboardShell(
+                currentIndex: navigationShell.currentIndex,
+                onTabChanged: (index) => navigationShell.goBranch(index),
+                child: navigationShell,
+              );
+            },
+            branches: [
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/dashboard/movies',
+                    builder: (_, __) => const DashboardMoviesTab(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/dashboard/tv',
+                    builder: (_, __) => const DashboardTvTab(),
+                  ),
+                ],
               ),
             ],
           ),
-          // Tab 1: TV Shows (discovery + Sonarr library)
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/sonarr',
-                builder: (context, state) => const TvShowsTabScreen(),
+
+          // Radarr module (Library/Queue/Calendar tabs)
+          StatefulShellRoute.indexedStack(
+            builder: (context, state, navigationShell) {
+              return RadarrModuleShell(
+                currentIndex: navigationShell.currentIndex,
+                onTabChanged: (index) => navigationShell.goBranch(index),
+                child: navigationShell,
+              );
+            },
+            branches: [
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/radarr/library',
+                    builder: (_, __) => const RadarrHomeScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/radarr/queue',
+                    builder: (_, __) => const RadarrQueueScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/radarr/calendar',
+                    builder: (_, __) => const RadarrCalendarScreen(),
+                  ),
+                ],
               ),
             ],
           ),
-          // Tab 2: AI Assistant
-          StatefulShellBranch(
-            routes: [
-              GoRoute(
-                path: '/assistant',
-                builder: (context, state) {
-                  final auth = ref.read(authProvider).valueOrNull;
-                  final hasAi =
-                      auth?.connection?.services.ai ?? false;
-                  return AiChatScreen(aiAvailable: hasAi);
-                },
+
+          // Sonarr module (Library/Queue/Calendar tabs)
+          StatefulShellRoute.indexedStack(
+            builder: (context, state, navigationShell) {
+              return SonarrModuleShell(
+                currentIndex: navigationShell.currentIndex,
+                onTabChanged: (index) => navigationShell.goBranch(index),
+                child: navigationShell,
+              );
+            },
+            branches: [
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/sonarr/library',
+                    builder: (_, __) => const SonarrHomeScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/sonarr/queue',
+                    builder: (_, __) => const SonarrQueueScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/sonarr/calendar',
+                    builder: (_, __) => const SonarrCalendarScreen(),
+                  ),
+                ],
               ),
             ],
+          ),
+
+          // AI Assistant module (single route, no bottom nav)
+          GoRoute(
+            path: '/assistant',
+            builder: (_, __) {
+              final auth = ref.read(authProvider).valueOrNull;
+              final hasAi = auth?.connection?.services.ai ?? false;
+              return AiChatScreen(aiAvailable: hasAi);
+            },
           ),
         ],
       ),
@@ -113,6 +200,26 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         path: '/settings',
         parentNavigatorKey: _rootNavigatorKey,
         builder: (_, __) => const SettingsScreen(),
+      ),
+      GoRoute(
+        path: '/settings/instance/new',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (_, __) => const InstanceEditScreen(),
+      ),
+      GoRoute(
+        path: '/settings/instance/:id',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) {
+          final extra = state.extra as Map<String, dynamic>?;
+          return InstanceEditScreen(
+            instanceId: state.pathParameters['id'],
+            initialServiceType: extra?['service_type'] as String?,
+            initialName: extra?['name'] as String?,
+            initialUrl: extra?['url'] as String?,
+            initialApiKey: extra?['api_key'] as String?,
+            initialIsDefault: extra?['is_default'] as bool? ?? false,
+          );
+        },
       ),
       GoRoute(
         path: '/setup',

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/config"
 	"github.com/windoze95/cantinarr-server/internal/db"
 	"github.com/windoze95/cantinarr-server/internal/discover"
+	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/mcp"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
@@ -65,27 +66,31 @@ func main() {
 	// Bridge
 	bridge := tmdb.NewBridge(tmdbClient, traktClient, database)
 
-	// Radarr (optional)
+	// Instance store and registry
+	instanceStore := instance.NewStore(database)
+	seedInstancesFromEnv(instanceStore, cfg)
+	registry := instance.NewRegistry(instanceStore)
+	instanceHandler := instance.NewHandler(instanceStore, registry)
+
+	// Legacy direct clients (for backward compat, also used as fallback)
 	var radarrClient *radarr.Client
 	if cfg.RadarrEnabled() {
 		radarrClient = radarr.NewClient(cfg.RadarrURL, cfg.RadarrKey)
 	}
-
-	// Sonarr (optional)
 	var sonarrClient *sonarr.Client
 	if cfg.SonarrEnabled() {
 		sonarrClient = sonarr.NewClient(cfg.SonarrURL, cfg.SonarrKey)
 	}
 
 	// Request service
-	requestService := request.NewService(database, radarrClient, sonarrClient, bridge)
+	requestService := request.NewService(database, registry, radarrClient, sonarrClient, bridge)
 	requestHandler := request.NewHandler(requestService)
 
 	// Proxy handler
-	proxyHandler := proxy.NewHandler(cfg.RadarrURL, cfg.RadarrKey, cfg.SonarrURL, cfg.SonarrKey)
+	proxyHandler := proxy.NewHandler(cfg.RadarrURL, cfg.RadarrKey, cfg.SonarrURL, cfg.SonarrKey, instanceStore)
 
 	// MCP tool server
-	toolServer := mcp.NewToolServer(tmdbClient, requestService, radarrClient, sonarrClient)
+	toolServer := mcp.NewToolServer(tmdbClient, requestService, registry, radarrClient, sonarrClient)
 
 	// AI service
 	var aiService *ai.Service
@@ -103,15 +108,62 @@ func main() {
 	}
 
 	// WebSocket hub
-	wsHub := ws.NewHub(authService, radarrClient, sonarrClient)
+	wsHub := ws.NewHub(authService, registry, instanceStore, radarrClient, sonarrClient)
 	go wsHub.Run(context.Background())
 
 	// Router
-	router := api.NewRouter(cfg, authHandler, authService, requestHandler, proxyHandler, wsHub, aiHandler, discoverHandler)
+	router := api.NewRouter(cfg, authHandler, authService, requestHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore)
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	log.Printf("Cantinarr server starting on %s", addr)
 	if err := http.ListenAndServe(addr, router); err != nil {
 		log.Fatalf("Server failed: %v", err)
+	}
+}
+
+// seedInstancesFromEnv creates default service instances from environment variables
+// if the service_instances table is empty and env vars are set.
+func seedInstancesFromEnv(store *instance.Store, cfg *config.Config) {
+	all, err := store.ListAll()
+	if err != nil {
+		log.Printf("Warning: could not check existing instances: %v", err)
+		return
+	}
+	if len(all) > 0 {
+		return // Already have instances, don't seed
+	}
+
+	if cfg.RadarrEnabled() {
+		inst := &instance.Instance{
+			ID:          "radarr-default",
+			ServiceType: "radarr",
+			Name:        "Movies",
+			URL:         cfg.RadarrURL,
+			APIKey:      cfg.RadarrKey,
+			IsDefault:   true,
+			SortOrder:   0,
+		}
+		if err := store.Create(inst); err != nil {
+			log.Printf("Warning: failed to seed Radarr instance: %v", err)
+		} else {
+			log.Println("Seeded default Radarr instance from env vars")
+		}
+	}
+
+	if cfg.SonarrEnabled() {
+		inst := &instance.Instance{
+			ID:          "sonarr-default",
+			ServiceType: "sonarr",
+			Name:        "TV Shows",
+			URL:         cfg.SonarrURL,
+			APIKey:      cfg.SonarrKey,
+			IsDefault:   true,
+			SortOrder:   0,
+		}
+		if err := store.Create(inst); err != nil {
+			log.Printf("Warning: failed to seed Sonarr instance: %v", err)
+		} else {
+			log.Println("Seeded default Sonarr instance from env vars")
+		}
 	}
 }

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -11,6 +11,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/auth"
 	"github.com/windoze95/cantinarr-server/internal/config"
 	"github.com/windoze95/cantinarr-server/internal/discover"
+	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/request"
 	"github.com/windoze95/cantinarr-server/internal/web"
@@ -26,6 +27,8 @@ func NewRouter(
 	wsHub *ws.Hub,
 	aiHandler *ai.Handler,
 	discoverHandler *discover.Handler,
+	instanceHandler *instance.Handler,
+	instanceStore *instance.Store,
 ) http.Handler {
 	r := chi.NewRouter()
 
@@ -77,7 +80,7 @@ func NewRouter(
 		// Config route (authenticated)
 		r.Group(func(r chi.Router) {
 			r.Use(authService.AuthMiddleware)
-			r.Get("/config", configHandler(cfg))
+			r.Get("/config", configHandler(cfg, instanceStore))
 		})
 
 		// Request routes (authenticated)
@@ -139,7 +142,21 @@ func NewRouter(
 			r.Get("/ai/available", aiHandler.Available)
 		})
 
-		// Arr proxy routes (admin only)
+		// Instance CRUD routes (admin only)
+		r.Group(func(r chi.Router) {
+			r.Use(authService.AuthMiddleware)
+			r.Use(auth.AdminMiddleware)
+
+			r.Get("/instances", instanceHandler.List)
+			r.Post("/instances", instanceHandler.Create)
+			r.Put("/instances/{instanceID}", instanceHandler.Update)
+			r.Delete("/instances/{instanceID}", instanceHandler.Delete)
+
+			// Instance proxy — forward to specific instance
+			r.HandleFunc("/instances/{instanceID}/*", proxyHandler.InstanceProxy())
+		})
+
+		// Legacy arr proxy routes (admin only, backward compat)
 		r.Group(func(r chi.Router) {
 			r.Use(authService.AuthMiddleware)
 			r.Use(auth.AdminMiddleware)
@@ -155,18 +172,63 @@ func NewRouter(
 	return r
 }
 
-func configHandler(cfg *config.Config) http.HandlerFunc {
+func configHandler(cfg *config.Config, store *instance.Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Build instances list
+		type instanceInfo struct {
+			ID          string `json:"id"`
+			ServiceType string `json:"service_type"`
+			Name        string `json:"name"`
+			IsDefault   bool   `json:"is_default"`
+		}
+
+		var instances []instanceInfo
+		allInstances, err := store.ListAll()
+		if err == nil {
+			for _, inst := range allInstances {
+				instances = append(instances, instanceInfo{
+					ID:          inst.ID,
+					ServiceType: inst.ServiceType,
+					Name:        inst.Name,
+					IsDefault:   inst.IsDefault,
+				})
+			}
+		}
+		if instances == nil {
+			instances = []instanceInfo{}
+		}
+
+		// Derive radarr/sonarr availability from instances
+		hasRadarr := false
+		hasSonarr := false
+		for _, inst := range instances {
+			if inst.ServiceType == "radarr" {
+				hasRadarr = true
+			}
+			if inst.ServiceType == "sonarr" {
+				hasSonarr = true
+			}
+		}
+
+		// Fall back to env var config if no instances
+		if !hasRadarr {
+			hasRadarr = cfg.RadarrEnabled()
+		}
+		if !hasSonarr {
+			hasSonarr = cfg.SonarrEnabled()
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"server_name": cfg.ServerName,
 			"services": map[string]bool{
-				"radarr": cfg.RadarrEnabled(),
-				"sonarr": cfg.SonarrEnabled(),
+				"radarr": hasRadarr,
+				"sonarr": hasSonarr,
 				"ai":     cfg.AIEnabled(),
 				"tmdb":   cfg.TMDBEnabled(),
 				"trakt":  cfg.TraktEnabled(),
 			},
+			"instances": instances,
 		})
 	}
 }

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -42,6 +42,17 @@ CREATE TABLE IF NOT EXISTS tmdb_tvdb_cache (
     imdb_id TEXT,
     cached_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS service_instances (
+    id TEXT PRIMARY KEY,
+    service_type TEXT NOT NULL,
+    name TEXT NOT NULL,
+    url TEXT NOT NULL,
+    api_key TEXT NOT NULL,
+    is_default BOOLEAN DEFAULT 0,
+    sort_order INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
 `
 
 func Open(dbPath string) (*sql.DB, error) {

--- a/server/internal/instance/handler.go
+++ b/server/internal/instance/handler.go
@@ -1,0 +1,144 @@
+package instance
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Handler provides REST endpoints for instance CRUD.
+type Handler struct {
+	store    *Store
+	registry *Registry
+}
+
+// NewHandler creates a new instance handler.
+func NewHandler(store *Store, registry *Registry) *Handler {
+	return &Handler{store: store, registry: registry}
+}
+
+// List returns all service instances.
+func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
+	instances, err := h.store.ListAll()
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+		return
+	}
+	if instances == nil {
+		instances = []Instance{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(instances)
+}
+
+// Create adds a new service instance.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	var inst Instance
+	if err := json.NewDecoder(r.Body).Decode(&inst); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	if inst.ServiceType != "radarr" && inst.ServiceType != "sonarr" {
+		http.Error(w, `{"error":"service_type must be 'radarr' or 'sonarr'"}`, http.StatusBadRequest)
+		return
+	}
+	if inst.Name == "" || inst.URL == "" || inst.APIKey == "" {
+		http.Error(w, `{"error":"name, url, and api_key are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	// Normalize URL
+	inst.URL = strings.TrimRight(inst.URL, "/")
+
+	// Validate URL reachability
+	if err := validateInstanceURL(inst.URL, inst.APIKey); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"connection test failed: %s"}`, err), http.StatusBadRequest)
+		return
+	}
+
+	if err := h.store.Create(&inst); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(inst)
+}
+
+// Update modifies an existing service instance.
+func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
+	instanceID := chi.URLParam(r, "instanceID")
+
+	var inst Instance
+	if err := json.NewDecoder(r.Body).Decode(&inst); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+	inst.ID = instanceID
+
+	if inst.Name == "" || inst.URL == "" || inst.APIKey == "" {
+		http.Error(w, `{"error":"name, url, and api_key are required"}`, http.StatusBadRequest)
+		return
+	}
+
+	inst.URL = strings.TrimRight(inst.URL, "/")
+
+	if err := validateInstanceURL(inst.URL, inst.APIKey); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"connection test failed: %s"}`, err), http.StatusBadRequest)
+		return
+	}
+
+	if err := h.store.Update(&inst); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+		return
+	}
+
+	h.registry.InvalidateClient(instanceID)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(inst)
+}
+
+// Delete removes a service instance.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	instanceID := chi.URLParam(r, "instanceID")
+
+	if err := h.store.Delete(instanceID); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+		return
+	}
+
+	h.registry.InvalidateClient(instanceID)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// validateInstanceURL checks that the instance is reachable by hitting its system/status endpoint.
+func validateInstanceURL(baseURL, apiKey string) error {
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest("GET", baseURL+"/api/v3/system/status", nil)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	req.Header.Set("X-Api-Key", apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("could not reach server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 401 {
+		return fmt.Errorf("invalid API key")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("server returned status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/server/internal/instance/registry.go
+++ b/server/internal/instance/registry.go
@@ -1,0 +1,118 @@
+package instance
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/windoze95/cantinarr-server/internal/radarr"
+	"github.com/windoze95/cantinarr-server/internal/sonarr"
+)
+
+// Registry lazily creates and caches Radarr/Sonarr clients keyed by instance ID.
+type Registry struct {
+	store         *Store
+	mu            sync.RWMutex
+	radarrClients map[string]*radarr.Client
+	sonarrClients map[string]*sonarr.Client
+}
+
+// NewRegistry creates a new client registry.
+func NewRegistry(store *Store) *Registry {
+	return &Registry{
+		store:         store,
+		radarrClients: make(map[string]*radarr.Client),
+		sonarrClients: make(map[string]*sonarr.Client),
+	}
+}
+
+// GetRadarrClient returns a cached or new Radarr client for the given instance ID.
+func (r *Registry) GetRadarrClient(instanceID string) (*radarr.Client, error) {
+	r.mu.RLock()
+	if client, ok := r.radarrClients[instanceID]; ok {
+		r.mu.RUnlock()
+		return client, nil
+	}
+	r.mu.RUnlock()
+
+	inst, err := r.store.Get(instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("get instance: %w", err)
+	}
+	if inst == nil {
+		return nil, fmt.Errorf("instance not found: %s", instanceID)
+	}
+	if inst.ServiceType != "radarr" {
+		return nil, fmt.Errorf("instance %s is not a radarr instance", instanceID)
+	}
+
+	client := radarr.NewClient(inst.URL, inst.APIKey)
+
+	r.mu.Lock()
+	r.radarrClients[instanceID] = client
+	r.mu.Unlock()
+
+	return client, nil
+}
+
+// GetSonarrClient returns a cached or new Sonarr client for the given instance ID.
+func (r *Registry) GetSonarrClient(instanceID string) (*sonarr.Client, error) {
+	r.mu.RLock()
+	if client, ok := r.sonarrClients[instanceID]; ok {
+		r.mu.RUnlock()
+		return client, nil
+	}
+	r.mu.RUnlock()
+
+	inst, err := r.store.Get(instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("get instance: %w", err)
+	}
+	if inst == nil {
+		return nil, fmt.Errorf("instance not found: %s", instanceID)
+	}
+	if inst.ServiceType != "sonarr" {
+		return nil, fmt.Errorf("instance %s is not a sonarr instance", instanceID)
+	}
+
+	client := sonarr.NewClient(inst.URL, inst.APIKey)
+
+	r.mu.Lock()
+	r.sonarrClients[instanceID] = client
+	r.mu.Unlock()
+
+	return client, nil
+}
+
+// GetDefaultRadarrClient returns the client for the default Radarr instance.
+func (r *Registry) GetDefaultRadarrClient() (*radarr.Client, string, error) {
+	inst, err := r.store.GetDefault("radarr")
+	if err != nil {
+		return nil, "", fmt.Errorf("get default radarr: %w", err)
+	}
+	if inst == nil {
+		return nil, "", nil
+	}
+	client, err := r.GetRadarrClient(inst.ID)
+	return client, inst.ID, err
+}
+
+// GetDefaultSonarrClient returns the client for the default Sonarr instance.
+func (r *Registry) GetDefaultSonarrClient() (*sonarr.Client, string, error) {
+	inst, err := r.store.GetDefault("sonarr")
+	if err != nil {
+		return nil, "", fmt.Errorf("get default sonarr: %w", err)
+	}
+	if inst == nil {
+		return nil, "", nil
+	}
+	client, err := r.GetSonarrClient(inst.ID)
+	return client, inst.ID, err
+}
+
+// InvalidateClient removes a cached client, forcing recreation on next access.
+func (r *Registry) InvalidateClient(instanceID string) {
+	r.mu.Lock()
+	delete(r.radarrClients, instanceID)
+	delete(r.sonarrClients, instanceID)
+	r.mu.Unlock()
+}

--- a/server/internal/instance/store.go
+++ b/server/internal/instance/store.go
@@ -1,0 +1,160 @@
+package instance
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Instance represents a configured Radarr or Sonarr service instance.
+type Instance struct {
+	ID          string    `json:"id"`
+	ServiceType string    `json:"service_type"` // "radarr" or "sonarr"
+	Name        string    `json:"name"`
+	URL         string    `json:"url"`
+	APIKey      string    `json:"api_key"`
+	IsDefault   bool      `json:"is_default"`
+	SortOrder   int       `json:"sort_order"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// Store provides CRUD operations for service instances.
+type Store struct {
+	db *sql.DB
+}
+
+// NewStore creates a new instance store.
+func NewStore(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// List returns all instances of the given service type, ordered by sort_order.
+func (s *Store) List(serviceType string) ([]Instance, error) {
+	rows, err := s.db.Query(
+		"SELECT id, service_type, name, url, api_key, is_default, sort_order, created_at FROM service_instances WHERE service_type = ? ORDER BY sort_order, name",
+		serviceType,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list instances: %w", err)
+	}
+	defer rows.Close()
+	return scanInstances(rows)
+}
+
+// ListAll returns all instances across all service types.
+func (s *Store) ListAll() ([]Instance, error) {
+	rows, err := s.db.Query(
+		"SELECT id, service_type, name, url, api_key, is_default, sort_order, created_at FROM service_instances ORDER BY service_type, sort_order, name",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list all instances: %w", err)
+	}
+	defer rows.Close()
+	return scanInstances(rows)
+}
+
+// Get returns a single instance by ID.
+func (s *Store) Get(id string) (*Instance, error) {
+	var inst Instance
+	err := s.db.QueryRow(
+		"SELECT id, service_type, name, url, api_key, is_default, sort_order, created_at FROM service_instances WHERE id = ?",
+		id,
+	).Scan(&inst.ID, &inst.ServiceType, &inst.Name, &inst.URL, &inst.APIKey, &inst.IsDefault, &inst.SortOrder, &inst.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get instance: %w", err)
+	}
+	return &inst, nil
+}
+
+// Create inserts a new instance and returns it with a generated ID.
+func (s *Store) Create(inst *Instance) error {
+	if inst.ID == "" {
+		inst.ID = inst.ServiceType + "-" + uuid.New().String()[:8]
+	}
+	inst.CreatedAt = time.Now()
+
+	_, err := s.db.Exec(
+		"INSERT INTO service_instances (id, service_type, name, url, api_key, is_default, sort_order, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		inst.ID, inst.ServiceType, inst.Name, inst.URL, inst.APIKey, inst.IsDefault, inst.SortOrder, inst.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("create instance: %w", err)
+	}
+	return nil
+}
+
+// Update modifies an existing instance.
+func (s *Store) Update(inst *Instance) error {
+	result, err := s.db.Exec(
+		"UPDATE service_instances SET name = ?, url = ?, api_key = ?, is_default = ?, sort_order = ? WHERE id = ?",
+		inst.Name, inst.URL, inst.APIKey, inst.IsDefault, inst.SortOrder, inst.ID,
+	)
+	if err != nil {
+		return fmt.Errorf("update instance: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("instance not found: %s", inst.ID)
+	}
+	return nil
+}
+
+// Delete removes an instance by ID.
+func (s *Store) Delete(id string) error {
+	result, err := s.db.Exec("DELETE FROM service_instances WHERE id = ?", id)
+	if err != nil {
+		return fmt.Errorf("delete instance: %w", err)
+	}
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return fmt.Errorf("instance not found: %s", id)
+	}
+	return nil
+}
+
+// GetDefault returns the default instance for a service type.
+func (s *Store) GetDefault(serviceType string) (*Instance, error) {
+	var inst Instance
+	err := s.db.QueryRow(
+		"SELECT id, service_type, name, url, api_key, is_default, sort_order, created_at FROM service_instances WHERE service_type = ? AND is_default = 1 LIMIT 1",
+		serviceType,
+	).Scan(&inst.ID, &inst.ServiceType, &inst.Name, &inst.URL, &inst.APIKey, &inst.IsDefault, &inst.SortOrder, &inst.CreatedAt)
+	if err == sql.ErrNoRows {
+		// Fall back to first instance
+		err = s.db.QueryRow(
+			"SELECT id, service_type, name, url, api_key, is_default, sort_order, created_at FROM service_instances WHERE service_type = ? ORDER BY sort_order LIMIT 1",
+			serviceType,
+		).Scan(&inst.ID, &inst.ServiceType, &inst.Name, &inst.URL, &inst.APIKey, &inst.IsDefault, &inst.SortOrder, &inst.CreatedAt)
+	}
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get default instance: %w", err)
+	}
+	return &inst, nil
+}
+
+// Count returns the number of instances for a service type.
+func (s *Store) Count(serviceType string) (int, error) {
+	var count int
+	err := s.db.QueryRow("SELECT COUNT(*) FROM service_instances WHERE service_type = ?", serviceType).Scan(&count)
+	return count, err
+}
+
+func scanInstances(rows *sql.Rows) ([]Instance, error) {
+	var instances []Instance
+	for rows.Next() {
+		var inst Instance
+		if err := rows.Scan(&inst.ID, &inst.ServiceType, &inst.Name, &inst.URL, &inst.APIKey, &inst.IsDefault, &inst.SortOrder, &inst.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan instance: %w", err)
+		}
+		instances = append(instances, inst)
+	}
+	return instances, rows.Err()
+}

--- a/server/internal/mcp/server.go
+++ b/server/internal/mcp/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
 	"github.com/windoze95/cantinarr-server/internal/request"
 	"github.com/windoze95/cantinarr-server/internal/sonarr"
@@ -20,19 +21,45 @@ type Tool struct {
 
 // ToolServer executes tools in-process on behalf of the AI.
 type ToolServer struct {
-	tmdb    *tmdb.Client
-	request *request.Service
-	radarr  *radarr.Client
-	sonarr  *sonarr.Client
+	tmdb     *tmdb.Client
+	request  *request.Service
+	registry *instance.Registry
+
+	// Legacy direct clients (used when registry is nil)
+	radarr *radarr.Client
+	sonarr *sonarr.Client
 }
 
-func NewToolServer(tmdbClient *tmdb.Client, requestSvc *request.Service, radarrClient *radarr.Client, sonarrClient *sonarr.Client) *ToolServer {
+func NewToolServer(tmdbClient *tmdb.Client, requestSvc *request.Service, registry *instance.Registry, radarrClient *radarr.Client, sonarrClient *sonarr.Client) *ToolServer {
 	return &ToolServer{
-		tmdb:    tmdbClient,
-		request: requestSvc,
-		radarr:  radarrClient,
-		sonarr:  sonarrClient,
+		tmdb:     tmdbClient,
+		request:  requestSvc,
+		registry: registry,
+		radarr:   radarrClient,
+		sonarr:   sonarrClient,
 	}
+}
+
+// GetRadarr returns the default Radarr client.
+func (s *ToolServer) GetRadarr() *radarr.Client {
+	if s.registry != nil {
+		client, _, err := s.registry.GetDefaultRadarrClient()
+		if err == nil && client != nil {
+			return client
+		}
+	}
+	return s.radarr
+}
+
+// GetSonarr returns the default Sonarr client.
+func (s *ToolServer) GetSonarr() *sonarr.Client {
+	if s.registry != nil {
+		client, _, err := s.registry.GetDefaultSonarrClient()
+		if err == nil && client != nil {
+			return client
+		}
+	}
+	return s.sonarr
 }
 
 // GetTools returns the list of tools available to the AI.

--- a/server/internal/proxy/handler.go
+++ b/server/internal/proxy/handler.go
@@ -5,6 +5,9 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/instance"
 )
 
 type Handler struct {
@@ -12,12 +15,14 @@ type Handler struct {
 	radarrKey string
 	sonarrURL *url.URL
 	sonarrKey string
+	store     *instance.Store
 }
 
-func NewHandler(radarrURL, radarrKey, sonarrURL, sonarrKey string) *Handler {
+func NewHandler(radarrURL, radarrKey, sonarrURL, sonarrKey string, store *instance.Store) *Handler {
 	h := &Handler{
 		radarrKey: radarrKey,
 		sonarrKey: sonarrKey,
+		store:     store,
 	}
 	if radarrURL != "" {
 		h.radarrURL, _ = url.Parse(radarrURL)
@@ -45,6 +50,36 @@ func (h *Handler) SonarrProxy() http.HandlerFunc {
 			return
 		}
 		h.proxyRequest(w, r, h.sonarrURL, h.sonarrKey, "/api/sonarr")
+	}
+}
+
+// InstanceProxy proxies requests to a specific service instance by ID.
+func (h *Handler) InstanceProxy() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		instanceID := chi.URLParam(r, "instanceID")
+		if instanceID == "" {
+			http.Error(w, `{"error":"instance ID required"}`, http.StatusBadRequest)
+			return
+		}
+
+		inst, err := h.store.Get(instanceID)
+		if err != nil {
+			http.Error(w, `{"error":"failed to get instance"}`, http.StatusInternalServerError)
+			return
+		}
+		if inst == nil {
+			http.Error(w, `{"error":"instance not found"}`, http.StatusNotFound)
+			return
+		}
+
+		target, err := url.Parse(inst.URL)
+		if err != nil {
+			http.Error(w, `{"error":"invalid instance URL"}`, http.StatusInternalServerError)
+			return
+		}
+
+		stripPrefix := "/api/instances/" + instanceID
+		h.proxyRequest(w, r, target, inst.APIKey, stripPrefix)
 	}
 }
 

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -5,25 +5,52 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
 	"github.com/windoze95/cantinarr-server/internal/sonarr"
 	"github.com/windoze95/cantinarr-server/internal/tmdb"
 )
 
 type Service struct {
-	db     *sql.DB
+	db       *sql.DB
+	registry *instance.Registry
+	bridge   *tmdb.Bridge
+
+	// Legacy direct clients (nil when using registry)
 	radarr *radarr.Client
 	sonarr *sonarr.Client
-	bridge *tmdb.Bridge
 }
 
-func NewService(db *sql.DB, radarrClient *radarr.Client, sonarrClient *sonarr.Client, bridge *tmdb.Bridge) *Service {
+func NewService(db *sql.DB, registry *instance.Registry, radarrClient *radarr.Client, sonarrClient *sonarr.Client, bridge *tmdb.Bridge) *Service {
 	return &Service{
-		db:     db,
-		radarr: radarrClient,
-		sonarr: sonarrClient,
-		bridge: bridge,
+		db:       db,
+		registry: registry,
+		radarr:   radarrClient,
+		sonarr:   sonarrClient,
+		bridge:   bridge,
 	}
+}
+
+// getRadarr returns the default Radarr client, preferring registry over legacy.
+func (s *Service) getRadarr() *radarr.Client {
+	if s.registry != nil {
+		client, _, err := s.registry.GetDefaultRadarrClient()
+		if err == nil && client != nil {
+			return client
+		}
+	}
+	return s.radarr
+}
+
+// getSonarr returns the default Sonarr client, preferring registry over legacy.
+func (s *Service) getSonarr() *sonarr.Client {
+	if s.registry != nil {
+		client, _, err := s.registry.GetDefaultSonarrClient()
+		if err == nil && client != nil {
+			return client
+		}
+	}
+	return s.sonarr
 }
 
 type CreateRequest struct {
@@ -64,12 +91,13 @@ func (s *Service) CreateMediaRequest(userID int64, req *CreateRequest) (*CreateR
 }
 
 func (s *Service) requestMovie(userID int64, tmdbID int) (*CreateResponse, error) {
-	if s.radarr == nil {
+	radarrClient := s.getRadarr()
+	if radarrClient == nil {
 		return nil, fmt.Errorf("radarr is not configured")
 	}
 
 	// Check if already in Radarr
-	existing, err := s.radarr.GetMovieByTMDB(tmdbID)
+	existing, err := radarrClient.GetMovieByTMDB(tmdbID)
 	if err == nil && existing != nil {
 		status := "requested"
 		if existing.HasFile {
@@ -80,17 +108,17 @@ func (s *Service) requestMovie(userID int64, tmdbID int) (*CreateResponse, error
 	}
 
 	// Lookup movie
-	lookup, err := s.radarr.LookupByTMDB(tmdbID)
+	lookup, err := radarrClient.LookupByTMDB(tmdbID)
 	if err != nil {
 		return nil, fmt.Errorf("movie lookup failed: %w", err)
 	}
 
 	// Get defaults
-	profiles, err := s.radarr.GetQualityProfiles()
+	profiles, err := radarrClient.GetQualityProfiles()
 	if err != nil || len(profiles) == 0 {
 		return nil, fmt.Errorf("no quality profiles available")
 	}
-	folders, err := s.radarr.GetRootFolders()
+	folders, err := radarrClient.GetRootFolders()
 	if err != nil || len(folders) == 0 {
 		return nil, fmt.Errorf("no root folders available")
 	}
@@ -105,7 +133,7 @@ func (s *Service) requestMovie(userID int64, tmdbID int) (*CreateResponse, error
 	}
 	addReq.AddOptions.SearchForMovie = true
 
-	if err := s.radarr.AddMovie(addReq); err != nil {
+	if err := radarrClient.AddMovie(addReq); err != nil {
 		return nil, fmt.Errorf("add movie failed: %w", err)
 	}
 
@@ -114,7 +142,8 @@ func (s *Service) requestMovie(userID int64, tmdbID int) (*CreateResponse, error
 }
 
 func (s *Service) requestTV(userID int64, req *CreateRequest) (*CreateResponse, error) {
-	if s.sonarr == nil {
+	sonarrClient := s.getSonarr()
+	if sonarrClient == nil {
 		return nil, fmt.Errorf("sonarr is not configured")
 	}
 
@@ -131,7 +160,7 @@ func (s *Service) requestTV(userID int64, req *CreateRequest) (*CreateResponse, 
 
 	// Check if already in Sonarr
 	if tvdbID != 0 {
-		existing, err := s.sonarr.GetSeriesByTVDB(tvdbID)
+		existing, err := sonarrClient.GetSeriesByTVDB(tvdbID)
 		if err == nil && existing != nil {
 			status := "requested"
 			if existing.Statistics != nil && existing.Statistics.PercentOfEpisodes >= 100 {
@@ -148,14 +177,14 @@ func (s *Service) requestTV(userID int64, req *CreateRequest) (*CreateResponse, 
 	var lookup *sonarr.LookupResult
 	var err error
 	if tvdbID != 0 {
-		lookup, err = s.sonarr.LookupByTVDB(tvdbID)
+		lookup, err = sonarrClient.LookupByTVDB(tvdbID)
 	}
 	if lookup == nil || err != nil {
 		// Fallback to title search
 		if title == "" {
 			return nil, fmt.Errorf("series lookup failed: no TVDB ID or title provided")
 		}
-		lookup, err = s.sonarr.LookupByTitle(title)
+		lookup, err = sonarrClient.LookupByTitle(title)
 		if err != nil {
 			return nil, fmt.Errorf("series lookup failed: %w", err)
 		}
@@ -163,11 +192,11 @@ func (s *Service) requestTV(userID int64, req *CreateRequest) (*CreateResponse, 
 	}
 
 	// Get defaults
-	profiles, err := s.sonarr.GetQualityProfiles()
+	profiles, err := sonarrClient.GetQualityProfiles()
 	if err != nil || len(profiles) == 0 {
 		return nil, fmt.Errorf("no quality profiles available")
 	}
-	folders, err := s.sonarr.GetRootFolders()
+	folders, err := sonarrClient.GetRootFolders()
 	if err != nil || len(folders) == 0 {
 		return nil, fmt.Errorf("no root folders available")
 	}
@@ -183,7 +212,7 @@ func (s *Service) requestTV(userID int64, req *CreateRequest) (*CreateResponse, 
 	}
 	addReq.AddOptions.SearchForMissingEpisodes = true
 
-	if err := s.sonarr.AddSeries(addReq); err != nil {
+	if err := sonarrClient.AddSeries(addReq); err != nil {
 		return nil, fmt.Errorf("add series failed: %w", err)
 	}
 
@@ -203,11 +232,12 @@ func (s *Service) GetStatus(tmdbID int, mediaType string) (*StatusResponse, erro
 }
 
 func (s *Service) getMovieStatus(tmdbID int) (*StatusResponse, error) {
-	if s.radarr == nil {
+	radarrClient := s.getRadarr()
+	if radarrClient == nil {
 		return &StatusResponse{Status: "unavailable"}, nil
 	}
 
-	movie, err := s.radarr.GetMovieByTMDB(tmdbID)
+	movie, err := radarrClient.GetMovieByTMDB(tmdbID)
 	if err != nil || movie == nil {
 		return &StatusResponse{Status: "unavailable"}, nil
 	}
@@ -217,7 +247,7 @@ func (s *Service) getMovieStatus(tmdbID int) (*StatusResponse, error) {
 	}
 
 	// Check queue for download progress
-	queue, err := s.radarr.GetQueue()
+	queue, err := radarrClient.GetQueue()
 	if err == nil {
 		for _, item := range queue {
 			if item.MovieID == movie.ID {
@@ -238,7 +268,8 @@ func (s *Service) getMovieStatus(tmdbID int) (*StatusResponse, error) {
 }
 
 func (s *Service) getTVStatus(tmdbID int) (*StatusResponse, error) {
-	if s.sonarr == nil {
+	sonarrClient := s.getSonarr()
+	if sonarrClient == nil {
 		return &StatusResponse{Status: "unavailable"}, nil
 	}
 
@@ -254,7 +285,7 @@ func (s *Service) getTVStatus(tmdbID int) (*StatusResponse, error) {
 		tvdbID = bridgeResult.TVDBID
 	}
 
-	series, err := s.sonarr.GetSeriesByTVDB(tvdbID)
+	series, err := sonarrClient.GetSeriesByTVDB(tvdbID)
 	if err != nil || series == nil {
 		return &StatusResponse{Status: "unavailable"}, nil
 	}

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
 	"github.com/windoze95/cantinarr-server/internal/sonarr"
 )
@@ -44,12 +45,16 @@ type Hub struct {
 	mu         sync.RWMutex
 
 	authService *auth.Service
-	radarr      *radarr.Client
-	sonarr      *sonarr.Client
+	registry    *instance.Registry
+	store       *instance.Store
+
+	// Legacy direct clients (used when registry is nil)
+	radarr *radarr.Client
+	sonarr *sonarr.Client
 
 	// Previous polling state for detecting transitions
-	prevRadarrQueue map[int]float64 // movieId -> progress
-	prevSonarrQueue map[int]float64 // seriesId -> progress
+	prevRadarrQueue map[string]map[int]float64 // instanceID -> movieId -> progress
+	prevSonarrQueue map[string]map[int]float64 // instanceID -> seriesId -> progress
 }
 
 var upgrader = websocket.Upgrader{
@@ -57,17 +62,19 @@ var upgrader = websocket.Upgrader{
 }
 
 // NewHub creates a new WebSocket hub.
-func NewHub(authService *auth.Service, radarrClient *radarr.Client, sonarrClient *sonarr.Client) *Hub {
+func NewHub(authService *auth.Service, registry *instance.Registry, store *instance.Store, radarrClient *radarr.Client, sonarrClient *sonarr.Client) *Hub {
 	return &Hub{
 		clients:         make(map[*Client]bool),
 		broadcast:       make(chan []byte, 256),
 		register:        make(chan *Client),
 		unregister:      make(chan *Client),
 		authService:     authService,
+		registry:        registry,
+		store:           store,
 		radarr:          radarrClient,
 		sonarr:          sonarrClient,
-		prevRadarrQueue: make(map[int]float64),
-		prevSonarrQueue: make(map[int]float64),
+		prevRadarrQueue: make(map[string]map[int]float64),
+		prevSonarrQueue: make(map[string]map[int]float64),
 	}
 }
 
@@ -205,20 +212,66 @@ func (h *Hub) pollLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			h.pollRadarr()
-			h.pollSonarr()
+			h.pollAllRadarr()
+			h.pollAllSonarr()
 		}
 	}
 }
 
-func (h *Hub) pollRadarr() {
-	if h.radarr == nil {
-		return
+func (h *Hub) pollAllRadarr() {
+	// Poll via registry (all instances)
+	if h.store != nil {
+		instances, err := h.store.List("radarr")
+		if err == nil {
+			for _, inst := range instances {
+				if h.registry == nil {
+					continue
+				}
+				client, err := h.registry.GetRadarrClient(inst.ID)
+				if err != nil {
+					continue
+				}
+				h.pollRadarrInstance(inst.ID, client)
+			}
+			return
+		}
 	}
 
-	queue, err := h.radarr.GetQueue()
+	// Legacy fallback
+	if h.radarr != nil {
+		h.pollRadarrInstance("legacy", h.radarr)
+	}
+}
+
+func (h *Hub) pollAllSonarr() {
+	// Poll via registry (all instances)
+	if h.store != nil {
+		instances, err := h.store.List("sonarr")
+		if err == nil {
+			for _, inst := range instances {
+				if h.registry == nil {
+					continue
+				}
+				client, err := h.registry.GetSonarrClient(inst.ID)
+				if err != nil {
+					continue
+				}
+				h.pollSonarrInstance(inst.ID, client)
+			}
+			return
+		}
+	}
+
+	// Legacy fallback
+	if h.sonarr != nil {
+		h.pollSonarrInstance("legacy", h.sonarr)
+	}
+}
+
+func (h *Hub) pollRadarrInstance(instanceID string, client *radarr.Client) {
+	queue, err := client.GetQueue()
 	if err != nil {
-		log.Printf("websocket: poll radarr queue: %v", err)
+		log.Printf("websocket: poll radarr queue (%s): %v", instanceID, err)
 		return
 	}
 
@@ -231,7 +284,7 @@ func (h *Hub) pollRadarr() {
 		currentQueue[item.MovieID] = progress
 
 		// Look up TMDB ID for this movie
-		movie, err := h.radarr.GetMovie(item.MovieID)
+		movie, err := client.GetMovie(item.MovieID)
 		if err != nil {
 			log.Printf("websocket: get radarr movie %d: %v", item.MovieID, err)
 			continue
@@ -240,46 +293,47 @@ func (h *Hub) pollRadarr() {
 		h.Broadcast(Event{
 			Type: "download_progress",
 			Data: map[string]interface{}{
-				"tmdb_id":    movie.TmdbID,
-				"media_type": "movie",
-				"progress":   progress,
-				"status":     "downloading",
+				"tmdb_id":     movie.TmdbID,
+				"media_type":  "movie",
+				"progress":    progress,
+				"status":      "downloading",
+				"instance_id": instanceID,
 			},
 		})
 	}
 
 	// Check for items that were previously downloading but are no longer in queue
-	for movieID := range h.prevRadarrQueue {
-		if _, stillInQueue := currentQueue[movieID]; !stillInQueue {
-			movie, err := h.radarr.GetMovie(movieID)
-			if err != nil {
-				log.Printf("websocket: get completed radarr movie %d: %v", movieID, err)
-				continue
-			}
-			if movie.HasFile {
-				h.Broadcast(Event{
-					Type: "request_status_changed",
-					Data: map[string]interface{}{
-						"tmdb_id":    movie.TmdbID,
-						"media_type": "movie",
-						"status":     "available",
-					},
-				})
+	prevQueue := h.prevRadarrQueue[instanceID]
+	if prevQueue != nil {
+		for movieID := range prevQueue {
+			if _, stillInQueue := currentQueue[movieID]; !stillInQueue {
+				movie, err := client.GetMovie(movieID)
+				if err != nil {
+					log.Printf("websocket: get completed radarr movie %d: %v", movieID, err)
+					continue
+				}
+				if movie.HasFile {
+					h.Broadcast(Event{
+						Type: "request_status_changed",
+						Data: map[string]interface{}{
+							"tmdb_id":     movie.TmdbID,
+							"media_type":  "movie",
+							"status":      "available",
+							"instance_id": instanceID,
+						},
+					})
+				}
 			}
 		}
 	}
 
-	h.prevRadarrQueue = currentQueue
+	h.prevRadarrQueue[instanceID] = currentQueue
 }
 
-func (h *Hub) pollSonarr() {
-	if h.sonarr == nil {
-		return
-	}
-
-	queue, err := h.sonarr.GetQueue()
+func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
+	queue, err := client.GetQueue()
 	if err != nil {
-		log.Printf("websocket: poll sonarr queue: %v", err)
+		log.Printf("websocket: poll sonarr queue (%s): %v", instanceID, err)
 		return
 	}
 
@@ -291,7 +345,7 @@ func (h *Hub) pollSonarr() {
 		}
 		currentQueue[item.SeriesID] = progress
 
-		series, err := h.sonarr.GetSeries(item.SeriesID)
+		series, err := client.GetSeries(item.SeriesID)
 		if err != nil {
 			log.Printf("websocket: get sonarr series %d: %v", item.SeriesID, err)
 			continue
@@ -300,36 +354,41 @@ func (h *Hub) pollSonarr() {
 		h.Broadcast(Event{
 			Type: "download_progress",
 			Data: map[string]interface{}{
-				"tmdb_id":    series.TmdbID,
-				"media_type": "tv",
-				"progress":   progress,
-				"status":     "downloading",
+				"tmdb_id":     series.TmdbID,
+				"media_type":  "tv",
+				"progress":    progress,
+				"status":      "downloading",
+				"instance_id": instanceID,
 			},
 		})
 	}
 
 	// Check for items that left the queue
-	for seriesID := range h.prevSonarrQueue {
-		if _, stillInQueue := currentQueue[seriesID]; !stillInQueue {
-			series, err := h.sonarr.GetSeries(seriesID)
-			if err != nil {
-				log.Printf("websocket: get completed sonarr series %d: %v", seriesID, err)
-				continue
+	prevQueue := h.prevSonarrQueue[instanceID]
+	if prevQueue != nil {
+		for seriesID := range prevQueue {
+			if _, stillInQueue := currentQueue[seriesID]; !stillInQueue {
+				series, err := client.GetSeries(seriesID)
+				if err != nil {
+					log.Printf("websocket: get completed sonarr series %d: %v", seriesID, err)
+					continue
+				}
+				status := "available"
+				if series.Statistics != nil && series.Statistics.PercentOfEpisodes < 100 {
+					status = "partially_available"
+				}
+				h.Broadcast(Event{
+					Type: "request_status_changed",
+					Data: map[string]interface{}{
+						"tmdb_id":     series.TmdbID,
+						"media_type":  "tv",
+						"status":      status,
+						"instance_id": instanceID,
+					},
+				})
 			}
-			status := "available"
-			if series.Statistics != nil && series.Statistics.PercentOfEpisodes < 100 {
-				status = "partially_available"
-			}
-			h.Broadcast(Event{
-				Type: "request_status_changed",
-				Data: map[string]interface{}{
-					"tmdb_id":    series.TmdbID,
-					"media_type": "tv",
-					"status":     status,
-				},
-			})
 		}
 	}
 
-	h.prevSonarrQueue = currentQueue
+	h.prevSonarrQueue[instanceID] = currentQueue
 }


### PR DESCRIPTION
## Summary

- Restructures app from flat 3-tab layout into **module-based architecture** with drawer navigation
- Each module (Dashboard, Radarr, Sonarr, AI Assistant) has its own bottom nav
- Adds **multi-instance support**: multiple Radarr/Sonarr instances configurable via backend CRUD API
- Env var seeding + legacy route backward compatibility preserved

### Backend (3 new files, 7 modified)
- `service_instances` DB table with CRUD store, lazy client registry, and REST handler
- Instance-aware proxy (`/api/instances/{id}/*`), updated config endpoint with instances array
- All consumers (request service, websocket hub, MCP) use registry with legacy fallback

### Frontend (15 new files, 10 modified)
- `ServiceInstance` model, instance/module Riverpod providers
- Module-based GoRouter: outer `ShellRoute` (drawer + search) → inner `StatefulShellRoute` per module
- Dashboard module with discovery rows + simplified library sections
- Radarr/Sonarr modules with Library/Queue/Calendar tabs
- Instance dropdown widget (visible when 2+ instances)
- Settings: dynamic modules section, instance add/edit/delete screen

## Test plan

- [ ] Start server with env vars → verify `service_instances` table seeded
- [ ] `GET /api/config` returns `instances` array
- [ ] `ANY /api/instances/{id}/api/v3/movie` proxies correctly
- [ ] Legacy `/api/radarr/*` and `/api/sonarr/*` still work
- [ ] Launch app → drawer shows Dashboard, Radarr instances, Sonarr instances, AI Assistant
- [ ] Tap Dashboard → Movies/TV tabs with discovery + simplified library lists
- [ ] Tap Radarr module → Library/Queue/Calendar tabs load data
- [ ] Tap Sonarr module → Library/Queue/Calendar tabs load data
- [ ] Settings shows configured instances with status indicators
- [ ] Add Instance screen: create/edit/delete with connection test
- [ ] Instance dropdown visible in module headers when 2+ instances exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)