### PR TITLE
fix: prevent login screen flash on app startup

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -52,8 +52,19 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp> {
 
   @override
   Widget build(BuildContext context) {
-    final router = ref.watch(appRouterProvider);
+    final authState = ref.watch(authProvider);
 
+    // Show blank screen while restoring session to prevent login flash
+    if (authState.isLoading) {
+      return MaterialApp(
+        title: 'Cantinarr',
+        theme: AppTheme.dark,
+        debugShowCheckedModeBanner: false,
+        home: const Scaffold(),
+      );
+    }
+
+    final router = ref.watch(appRouterProvider);
     return MaterialApp.router(
       title: 'Cantinarr',
       theme: AppTheme.dark,


### PR DESCRIPTION
## Summary
- Show a blank dark-themed `Scaffold` while `authProvider` is loading to prevent the router from briefly rendering the login page during session restore
- Once auth resolves, the normal router takes over and navigates to the dashboard or login as appropriate

## Test plan
- [ ] Boot app with existing saved session — should see dark background, then dashboard (no login flash)
- [ ] Fresh install / cleared session — should go directly to login page
- [ ] Expired refresh token — should show login page after brief loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)