### PR TITLE
Add ITSAppUsesNonExemptEncryption flag to iOS Info.plist

### DIFF
--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -81,5 +81,7 @@
 		</array>
 		<key>UIStatusBarHidden</key>
 		<false/>
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
 	</dict>
 </plist>


### PR DESCRIPTION
## Summary
Added the `ITSAppUsesNonExemptEncryption` configuration flag to the iOS app's Info.plist file to comply with App Store requirements.

## Key Changes
- Added `ITSAppUsesNonExemptEncryption` key set to `false` in Info.plist

## Details
This flag is required by Apple's App Store Connect for all app submissions. Setting it to `false` indicates that the app does not use non-exempt encryption, which is necessary for proper app store compliance and submission processing.

https://claude.ai/code/session_01FVMEEmqY5KXdbyFVgm5KUi