### PR TITLE
fix: bump Dockerfile Go image from 1.22 to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY app/ .
 RUN flutter pub get && flutter build web --release
 
 # Stage 2: Build Go binary
-FROM golang:1.22-alpine AS go-builder
+FROM golang:1.25-alpine AS go-builder
 WORKDIR /build
 COPY server/go.mod server/go.sum ./
 RUN go mod download

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine AS builder
+FROM golang:1.25-alpine AS builder
 WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Summary
- `go.mod` requires `go 1.25.0` but both Dockerfiles used `golang:1.22-alpine`, causing `go mod download` to fail in CI with: `go.mod requires go >= 1.25.0 (running go 1.22.12; GOTOOLCHAIN=local)`
- Bumps `golang:1.22-alpine` → `golang:1.25-alpine` in both `Dockerfile` and `server/Dockerfile`

## Test plan
- [ ] Docker CI workflow passes (`go mod download` succeeds)
- [ ] Image builds and pushes to GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)