### PR TITLE
Fix search bar styling and app shell safe area padding

### DIFF
--- a/app/lib/core/widgets/search_bar.dart
+++ b/app/lib/core/widgets/search_bar.dart
@@ -44,6 +44,7 @@ class CantinarrSearchBar extends StatelessWidget {
                   },
                 )
               : null,
+          filled: false,
           border: InputBorder.none,
           contentPadding:
               const EdgeInsets.symmetric(horizontal: 16, vertical: 14),

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -202,6 +202,7 @@ class _AppShellState extends ConsumerState<AppShell>
 
     return Scaffold(
       body: SafeArea(
+        bottom: false,
         child: Stack(
           children: [
             // Base layer: search bar + module content


### PR DESCRIPTION
## Summary
This PR adjusts UI styling in the search bar and app shell to improve visual consistency and layout behavior.

## Key Changes
- **Search Bar**: Set `filled: false` on the search bar input decoration to remove the background fill
- **App Shell**: Set `bottom: false` on the SafeArea widget to prevent bottom padding from being applied to the main content stack

## Implementation Details
These changes ensure that:
1. The search bar maintains a cleaner, unfilled appearance consistent with the design
2. The app shell's main content area extends to the bottom of the screen without unnecessary SafeArea padding, while still respecting top and side safe areas

https://claude.ai/code/session_01BB3zmyZhBhmMioqQKWmLgp