### PR TITLE
feat: show build number in settings and about modal

### DIFF
--- a/app/lib/features/settings/ui/about_sheet.dart
+++ b/app/lib/features/settings/ui/about_sheet.dart
@@ -16,7 +16,9 @@ class AboutSheet extends StatelessWidget {
       child: FutureBuilder<PackageInfo>(
         future: PackageInfo.fromPlatform(),
         builder: (context, snapshot) {
-          final version = snapshot.data?.version ?? '';
+          final info = snapshot.data;
+          final version = info?.version ?? '';
+          final build = info?.buildNumber ?? '';
           return Column(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -65,7 +67,7 @@ class AboutSheet extends StatelessWidget {
               ),
               const SizedBox(height: 4),
               Text(
-                'Version $version',
+                build.isNotEmpty ? 'Version $version ($build)' : 'Version $version',
                 style: const TextStyle(
                   color: AppTheme.textSecondary,
                   fontSize: 14,

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -22,7 +22,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   void initState() {
     super.initState();
     PackageInfo.fromPlatform().then((info) {
-      setState(() => _appVersion = info.version);
+      final build = info.buildNumber;
+      setState(() => _appVersion =
+          build.isNotEmpty ? '${info.version} ($build)' : info.version);
     });
   }
 


### PR DESCRIPTION
## Summary

- Shows the build number alongside the version in both the settings tile and the about sheet
- Format: "Version 0.1.0 (1)" where the build number comes from pubspec.yaml's `version: 0.1.0+1`
- Falls back to version-only display when build number is empty

## Test plan

- [ ] Open Settings → About tile shows "Version X.Y.Z (N)"
- [ ] Tap About → modal shows "Version X.Y.Z (N)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)