### PR TITLE
Remove dead invite code system

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Cantinarr makes it dead simple for your family and friends to discover and reque
 - **TMDB + Trakt for discovery** -- The best metadata, images, and trending data. Sonarr's TVDB dependency is invisible.
 - **The Rosetta Stone** -- Automatic TMDB-to-TVDB ID bridging with Trakt fallback. The #1 source of failed Sonarr adds, solved.
 - **AI assistant** -- "What should I watch tonight?" Claude searches your library, checks availability, and can request for you.
-- **Household-friendly** -- Invite codes, role-based access. Admins manage arr services, users just browse and request.
+- **Household-friendly** -- Connect links, role-based access. Admins manage arr services, users just browse and request.
 - **Single container** -- One Go binary, one port, serves API + web UI. Runs great on a Raspberry Pi or NAS.
 
 ## Quick Start
@@ -89,7 +89,7 @@ cantinarr/
 │   ├── internal/
 │   │   ├── ai/             # Claude AI chat with SSE streaming
 │   │   ├── api/            # Chi router, middleware, routes
-│   │   ├── auth/           # JWT, bcrypt, invite codes
+│   │   ├── auth/           # JWT, bcrypt, connect tokens
 │   │   ├── config/         # Environment variable loading
 │   │   ├── db/             # SQLite with WAL mode
 │   │   ├── mcp/            # 9 AI tools (search, request, status)
@@ -136,8 +136,8 @@ See [`server/README.md`](server/README.md) for the full configuration reference.
 ## How It Works
 
 ### For Users
-1. Admin gives you a 6-character invite code and a server URL
-2. Open the app, enter the URL and code, pick a username
+1. Admin sends you a connect link
+2. Open the link on your device -- it creates your account and connects automatically
 3. Browse movies and TV shows powered by TMDB and Trakt
 4. Tap "Request" on anything you want -- it just works
 5. Watch download progress in real-time via WebSocket updates
@@ -145,7 +145,7 @@ See [`server/README.md`](server/README.md) for the full configuration reference.
 
 ### For Admins
 1. Deploy the container, set your TMDB key and arr connections
-2. Log in as `admin`, generate invite codes for your household
+2. Log in as `admin`, generate connect links for your household
 3. Users' requests flow through the Rosetta Stone bridge to the correct arr service
 4. Manage Radarr/Sonarr from the app (admin tabs) without exposing API keys
 5. Optionally add an Anthropic key for AI chat features
@@ -174,7 +174,7 @@ Movies don't need bridging -- Radarr natively supports TMDB IDs.
 |---|---|
 | Server | Go, Chi router, SQLite (pure Go) |
 | Client | Flutter (Dart), Riverpod, GoRouter |
-| Auth | JWT (HS256), bcrypt, invite codes |
+| Auth | JWT (HS256), bcrypt, connect tokens |
 | AI | Anthropic Claude API, SSE streaming |
 | Real-time | gorilla/websocket |
 | Discovery | TMDB API v3, Trakt API v2 |

--- a/app/README.md
+++ b/app/README.md
@@ -58,7 +58,7 @@ Dark-first UI with warm gold accents, designed for couch browsing.
 
 ### Auth
 - **Server URL + login** -- point at your Cantinarr server, enter credentials
-- **Invite codes** -- new users register with a 6-character code from their admin
+- **Connect links** -- new users connect via a one-time link from their admin
 - **Automatic session restore** -- JWT stored in secure storage, auto-refreshes on 401
 
 ## Getting Started
@@ -148,7 +148,6 @@ app/
 │   │   │   ├── logic/auth_provider.dart       # Session state (AsyncNotifier)
 │   │   │   └── ui/
 │   │   │       ├── login_screen.dart          # Server URL + credentials
-│   │   │       └── invite_screen.dart         # Invite code registration
 │   │   │
 │   │   ├── discover/                          # Browse & search
 │   │   │   ├── data/
@@ -241,7 +240,7 @@ Four-tab bottom navigation with GoRouter:
 | TV Shows | `/sonarr` | Sonarr library | Backend proxy |
 | Assistant | `/assistant` | AI chat | Backend SSE |
 
-Full-screen routes: `/detail/:type/:id`, `/settings`, `/login`, `/invite`
+Full-screen routes: `/detail/:type/:id`, `/settings`, `/login`
 
 Auth guard redirects unauthenticated users to `/login`. Authenticated users on `/login` redirect to `/discover`.
 

--- a/app/lib/features/auth/data/auth_service.dart
+++ b/app/lib/features/auth/data/auth_service.dart
@@ -51,22 +51,6 @@ class AuthService {
     return AuthResponse.fromJson(resp.data as Map<String, dynamic>);
   }
 
-  /// Register a new account using an invite code.
-  Future<AuthResponse> register(
-    String serverUrl,
-    String username,
-    String password,
-    String inviteCode,
-  ) async {
-    final dio = _createDio(serverUrl);
-    final resp = await dio.post('/api/auth/register', data: {
-      'username': username,
-      'password': password,
-      'invite_code': inviteCode,
-    });
-    return AuthResponse.fromJson(resp.data as Map<String, dynamic>);
-  }
-
   /// Refresh an expired access token.
   Future<AuthResponse> refreshToken(
     String serverUrl,

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -457,7 +457,6 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         return 'Could not connect to server';
       }
       if (statusCode == 409) return 'Username already taken';
-      if (statusCode == 400) return 'Invalid invite code';
     }
     if (e is Exception) {
       final msg = e.toString();

--- a/app/lib/features/auth/ui/login_screen.dart
+++ b/app/lib/features/auth/ui/login_screen.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import '../../../core/theme/app_theme.dart';
 import '../logic/auth_provider.dart';
 
@@ -151,17 +150,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                             ),
                           )
                         : const Text('Sign In'),
-                  ),
-                ),
-                const SizedBox(height: 16),
-
-                // Invite link
-                TextButton(
-                  onPressed: () => context.go('/invite',
-                      extra: _serverUrlController.text.trim()),
-                  child: const Text(
-                    'Have an invite code?',
-                    style: TextStyle(color: AppTheme.accent),
                   ),
                 ),
               ],

--- a/server/README.md
+++ b/server/README.md
@@ -2,7 +2,7 @@
 
 The backend brain for [Cantinarr](https://github.com/windoze95/cantinarr) -- a self-hosted media request app for Plex and Jellyfin households.
 
-A single Go binary that bridges your arr stack, serves the web UI, and keeps API keys off user devices. Drop it on your NAS, point it at Radarr/Sonarr, and hand out invite codes to family and friends.
+A single Go binary that bridges your arr stack, serves the web UI, and keeps API keys off user devices. Drop it on your NAS, point it at Radarr/Sonarr, and generate connect links for family and friends.
 
 ```
                         Cantinarr Server (:8585)
@@ -26,7 +26,7 @@ A single Go binary that bridges your arr stack, serves the web UI, and keeps API
 
 - **One-tap requests** -- Users browse TMDB/Trakt on the app, tap request, and the server handles everything: ID bridging, arr lookups, quality profiles, root folders.
 - **TMDB-to-TVDB Rosetta Stone** -- Transparently translates TMDB IDs to TVDB IDs for Sonarr. Falls back to Trakt cross-references, then title+year search. Results cached in SQLite for 30 days.
-- **Invite code auth** -- Admin generates 6-character codes for household members. JWT-based sessions with 7-day access / 30-day refresh tokens.
+- **Connect link auth** -- Admin generates one-time connect links for household members. JWT-based sessions with 7-day access / 30-day refresh tokens.
 - **AI assistant** -- Claude-powered chat with server-side tool execution (search, recommendations, request status, make requests). Streams responses via SSE.
 - **Real-time updates** -- WebSocket hub polls arr queues every 30 seconds and pushes download progress to connected clients.
 - **Arr proxy** -- Admins get full passthrough to Radarr/Sonarr APIs for management without exposing keys.
@@ -102,10 +102,8 @@ All configuration is via environment variables with the `CANTINARR_` prefix.
 ### Authentication
 ```
 POST   /api/auth/login          # { username, password } -> tokens + user
-POST   /api/auth/register       # { username, password, invite_code } -> tokens + user
 POST   /api/auth/refresh        # { refresh_token } -> new tokens
 GET    /api/auth/me             # current user profile
-POST   /api/auth/invite         # (admin) generate invite code
 ```
 
 ### Configuration
@@ -191,7 +189,6 @@ The AI assistant has 9 server-side tools:
 SQLite with WAL mode for concurrent reads. Four tables:
 
 - `users` -- accounts with bcrypt password hashes
-- `invite_codes` -- single-use registration codes (7-day expiry)
 - `request_log` -- audit trail of all requests
 - `tmdb_tvdb_cache` -- ID bridge cache (30-day TTL)
 
@@ -206,7 +203,7 @@ server/
 │   │   └── service.go              # Anthropic API client + tool loop
 │   ├── api/router.go               # Chi router, CORS, middleware, routes
 │   ├── auth/
-│   │   ├── handler.go              # Login, register, refresh, invite
+│   │   ├── handler.go              # Login, refresh, connect token
 │   │   ├── middleware.go           # JWT validation + admin gate
 │   │   ├── models.go              # User, tokens, request/response types
 │   │   └── service.go             # Auth business logic, JWT signing

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -75,7 +75,6 @@ func NewRouter(
 			r.Get("/status", authHandler.AuthStatus)
 			r.With(authLimiter.Middleware).Post("/setup", authHandler.HandleSetup)
 			r.With(authLimiter.Middleware).Post("/login", authHandler.Login)
-			r.With(authLimiter.Middleware).Post("/register", authHandler.Register)
 			r.Post("/refresh", authHandler.Refresh)
 			r.With(authLimiter.Middleware).Post("/connect", authHandler.HandleRedeemConnectToken)
 
@@ -93,12 +92,6 @@ func NewRouter(
 				r.Post("/passkey/register/finish", authHandler.FinishPasskeyRegistration)
 				r.Get("/passkeys", authHandler.ListPasskeys)
 				r.Delete("/passkeys/{credentialID}", authHandler.DeletePasskey)
-
-				// Admin-only
-				r.Group(func(r chi.Router) {
-					r.Use(auth.AdminMiddleware)
-					r.Post("/invite", authHandler.CreateInvite)
-				})
 			})
 		})
 

--- a/server/internal/auth/handler.go
+++ b/server/internal/auth/handler.go
@@ -41,34 +41,6 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
-func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
-	var req RegisterRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
-		return
-	}
-
-	if req.Username == "" || req.Password == "" || req.InviteCode == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "username, password, and invite_code required"})
-		return
-	}
-
-	resp, err := h.service.Register(req.Username, req.Password, req.InviteCode)
-	if err != nil {
-		switch {
-		case errors.Is(err, ErrInviteRequired), errors.Is(err, ErrInviteExpired):
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		case errors.Is(err, ErrUserExists):
-			writeJSON(w, http.StatusConflict, map[string]string{"error": "username already taken"})
-		default:
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
-		}
-		return
-	}
-
-	writeJSON(w, http.StatusCreated, resp)
-}
-
 func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
 	var req RefreshRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -92,22 +64,6 @@ func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, resp)
-}
-
-func (h *Handler) CreateInvite(w http.ResponseWriter, r *http.Request) {
-	claims := GetClaims(r.Context())
-	if claims == nil {
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
-		return
-	}
-
-	resp, err := h.service.CreateInvite(claims.UserID)
-	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to create invite"})
-		return
-	}
-
-	writeJSON(w, http.StatusCreated, resp)
 }
 
 func (h *Handler) HandleCreateConnectToken(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/auth/models.go
+++ b/server/internal/auth/models.go
@@ -10,14 +10,6 @@ type User struct {
 	CreatedAt    time.Time `json:"created_at"`
 }
 
-type InviteCode struct {
-	Code      string     `json:"code"`
-	CreatedBy int64      `json:"created_by"`
-	UsedBy    *int64     `json:"used_by,omitempty"`
-	ExpiresAt time.Time  `json:"expires_at"`
-	UsedAt    *time.Time `json:"used_at,omitempty"`
-}
-
 type Device struct {
 	ID         string     `json:"id"`
 	UserID     int64      `json:"user_id"`
@@ -40,12 +32,6 @@ type LoginRequest struct {
 	Password string `json:"password"`
 }
 
-type RegisterRequest struct {
-	Username   string `json:"username"`
-	Password   string `json:"password"`
-	InviteCode string `json:"invite_code"`
-}
-
 type RefreshRequest struct {
 	RefreshToken string `json:"refresh_token"`
 }
@@ -55,11 +41,6 @@ type TokenResponse struct {
 	RefreshToken string `json:"refresh_token"`
 	User         User   `json:"user"`
 	DeviceID     string `json:"device_id,omitempty"`
-}
-
-type InviteResponse struct {
-	Code      string    `json:"code"`
-	ExpiresAt time.Time `json:"expires_at"`
 }
 
 type CreateConnectTokenRequest struct {

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -23,8 +23,6 @@ func hashToken(token string) string {
 
 var (
 	ErrInvalidCredentials  = errors.New("invalid credentials")
-	ErrInviteRequired      = errors.New("valid invite code required")
-	ErrInviteExpired       = errors.New("invite code expired or already used")
 	ErrUserExists          = errors.New("username already taken")
 	ErrTokenExpired        = errors.New("connect token has expired")
 	ErrTokenRedeemed       = errors.New("connect token has already been used")
@@ -203,44 +201,6 @@ func (s *Service) Login(username, password string) (*TokenResponse, error) {
 	return resp, nil
 }
 
-func (s *Service) Register(username, password, inviteCode string) (*TokenResponse, error) {
-	// Validate invite code
-	var code InviteCode
-	err := s.db.QueryRow(
-		"SELECT code, created_by, expires_at, used_at FROM invite_codes WHERE code = ?", inviteCode,
-	).Scan(&code.Code, &code.CreatedBy, &code.ExpiresAt, &code.UsedAt)
-	if err != nil {
-		return nil, ErrInviteRequired
-	}
-	if code.UsedAt != nil || time.Now().After(code.ExpiresAt) {
-		return nil, ErrInviteExpired
-	}
-
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	if err != nil {
-		return nil, fmt.Errorf("hash password: %w", err)
-	}
-
-	result, err := s.db.Exec("INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)", username, string(hash), "user")
-	if err != nil {
-		return nil, ErrUserExists
-	}
-	userID, _ := result.LastInsertId()
-
-	now := time.Now()
-	_, err = s.db.Exec("UPDATE invite_codes SET used_by = ?, used_at = ? WHERE code = ?", userID, now, inviteCode)
-	if err != nil {
-		return nil, fmt.Errorf("mark invite used: %w", err)
-	}
-
-	user := &User{
-		ID:       userID,
-		Username: username,
-		Role:     "user",
-	}
-	return s.generateTokens(user, "")
-}
-
 func (s *Service) Refresh(refreshToken string) (*TokenResponse, error) {
 	claims, err := s.ValidateToken(refreshToken)
 	if err != nil {
@@ -297,19 +257,6 @@ func (s *Service) Refresh(refreshToken string) (*TokenResponse, error) {
 
 func (s *Service) GetUser(userID int64) (*User, error) {
 	return s.getUserByID(userID)
-}
-
-func (s *Service) CreateInvite(createdBy int64) (*InviteResponse, error) {
-	code, err := generateCode(6)
-	if err != nil {
-		return nil, fmt.Errorf("generate code: %w", err)
-	}
-	expiresAt := time.Now().Add(7 * 24 * time.Hour)
-	_, err = s.db.Exec("INSERT INTO invite_codes (code, created_by, expires_at) VALUES (?, ?, ?)", code, createdBy, expiresAt)
-	if err != nil {
-		return nil, fmt.Errorf("insert invite: %w", err)
-	}
-	return &InviteResponse{Code: code, ExpiresAt: expiresAt}, nil
 }
 
 func (s *Service) CreateConnectToken(createdBy int64, name, serverURL string) (*CreateConnectTokenResponse, error) {

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -17,14 +17,6 @@ CREATE TABLE IF NOT EXISTS users (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE IF NOT EXISTS invite_codes (
-    code TEXT PRIMARY KEY,
-    created_by INTEGER REFERENCES users(id),
-    used_by INTEGER REFERENCES users(id),
-    expires_at DATETIME NOT NULL,
-    used_at DATETIME
-);
-
 CREATE TABLE IF NOT EXISTS request_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER REFERENCES users(id),

--- a/server/migrations/001_init.sql
+++ b/server/migrations/001_init.sql
@@ -6,14 +6,6 @@ CREATE TABLE IF NOT EXISTS users (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE TABLE IF NOT EXISTS invite_codes (
-    code TEXT PRIMARY KEY,
-    created_by INTEGER REFERENCES users(id),
-    used_by INTEGER REFERENCES users(id),
-    expires_at DATETIME NOT NULL,
-    used_at DATETIME
-);
-
 CREATE TABLE IF NOT EXISTS request_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER REFERENCES users(id),


### PR DESCRIPTION
## Summary
- Removes the invite code registration flow (server routes, handlers, service methods, models, DB schema) which was superseded by the connect token/link system
- Removes the "Have an invite code?" button from the app login screen and the unused `register()` method from the Dart auth service
- Updates all documentation (README, server/README, app/README) to reference connect links instead of invite codes

## Test plan
- [ ] `rg -i "invite.?code"` returns no results
- [ ] `go build ./...` succeeds from `server/`
- [ ] App compiles without errors
- [ ] Admin can still generate connect links and users can redeem them
- [ ] Login flow works as before (no regressions from removed dead UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)