### PR TITLE
Refactor dashboard library sections to use horizontal card rows

### DIFF
--- a/app/lib/features/dashboard/ui/dashboard_movies_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_movies_tab.dart
@@ -41,21 +41,35 @@ class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
     if (defaultRadarr == null) return;
 
     setState(() => _isLoadingLibrary = true);
+
+    final backendDio = ref.read(backendClientProvider);
+    final service = RadarrApiService(
+        backendDio: backendDio, instanceId: defaultRadarr.id);
+
+    List<RadarrMovie> movies = [];
     try {
-      final backendDio = ref.read(backendClientProvider);
-      final service = RadarrApiService(
-          backendDio: backendDio, instanceId: defaultRadarr.id);
-      final movies = await service.getMovies();
+      movies = await service.getMovies();
+      if (!mounted) return;
+
+      final downloaded = movies.where((m) => m.hasFile).toList()
+        ..sort((a, b) => (b.added ?? DateTime(0)).compareTo(a.added ?? DateTime(0)));
+
+      setState(() {
+        _recentlyDownloaded = downloaded.take(10).toList();
+      });
+    } catch (_) {
+      // Movie fetch failed; leave _recentlyDownloaded empty.
+    }
+
+    try {
       final queue = await service.getQueue();
+      if (!mounted) return;
 
       // Track which movies are actively downloading
       final downloadingIds = queue
           .map((r) => r['movieId'] as int?)
           .whereType<int>()
           .toSet();
-
-      final downloaded = movies.where((m) => m.hasFile).toList()
-        ..sort((a, b) => (b.added ?? DateTime(0)).compareTo(a.added ?? DateTime(0)));
 
       // "Downloading Soon" includes both actively downloading and monitored-waiting;
       // actively downloading items are shown first.
@@ -65,14 +79,20 @@ class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
       final downloadingSoon = [...downloading, ...monitored];
 
       setState(() {
-        _recentlyDownloaded = downloaded.take(10).toList();
         _downloadingSoon = downloadingSoon.take(10).toList();
         _downloadingMovieIds = downloadingIds;
-        _isLoadingLibrary = false;
       });
     } catch (_) {
-      setState(() => _isLoadingLibrary = false);
+      if (!mounted) return;
+      // Queue fetch failed; still show monitored-but-missing movies without download status.
+      final waitingMovies = movies.where((m) => m.monitored && !m.hasFile).toList();
+      setState(() {
+        _downloadingSoon = waitingMovies.take(10).toList();
+        _downloadingMovieIds = {};
+      });
     }
+
+    if (mounted) setState(() => _isLoadingLibrary = false);
   }
 
   Future<void> _onRefresh() async {

--- a/app/lib/features/dashboard/ui/dashboard_movies_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_movies_tab.dart
@@ -23,6 +23,7 @@ class DashboardMoviesTab extends ConsumerStatefulWidget {
 class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
   List<RadarrMovie> _recentlyDownloaded = [];
   List<RadarrMovie> _downloadingSoon = [];
+  Set<int> _downloadingMovieIds = {};
   bool _isLoadingLibrary = false;
 
   @override
@@ -45,14 +46,28 @@ class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
       final service = RadarrApiService(
           backendDio: backendDio, instanceId: defaultRadarr.id);
       final movies = await service.getMovies();
+      final queue = await service.getQueue();
+
+      // Track which movies are actively downloading
+      final downloadingIds = queue
+          .map((r) => r['movieId'] as int?)
+          .whereType<int>()
+          .toSet();
 
       final downloaded = movies.where((m) => m.hasFile).toList()
         ..sort((a, b) => (b.added ?? DateTime(0)).compareTo(a.added ?? DateTime(0)));
-      final downloadingSoon = movies.where((m) => m.monitored && !m.hasFile).toList();
+
+      // "Downloading Soon" includes both actively downloading and monitored-waiting;
+      // actively downloading items are shown first.
+      final waitingMovies = movies.where((m) => m.monitored && !m.hasFile).toList();
+      final downloading = waitingMovies.where((m) => downloadingIds.contains(m.id)).toList();
+      final monitored = waitingMovies.where((m) => !downloadingIds.contains(m.id)).toList();
+      final downloadingSoon = [...downloading, ...monitored];
 
       setState(() {
         _recentlyDownloaded = downloaded.take(10).toList();
         _downloadingSoon = downloadingSoon.take(10).toList();
+        _downloadingMovieIds = downloadingIds;
         _isLoadingLibrary = false;
       });
     } catch (_) {
@@ -107,15 +122,16 @@ class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
             _buildRow(
               title: 'Downloading Soon',
               items: _downloadingSoon,
-              statusLabel: 'Monitored',
-              statusColor: AppTheme.requested,
+              badgeBuilder: (movie) => _downloadingMovieIds.contains(movie.id)
+                  ? (label: 'Downloading', color: AppTheme.downloading)
+                  : (label: 'Monitored', color: AppTheme.requested),
             ),
           if (_recentlyDownloaded.isNotEmpty || _isLoadingLibrary)
             _buildRow(
               title: 'Recently Downloaded',
               items: _recentlyDownloaded,
-              statusLabel: 'Downloaded',
-              statusColor: AppTheme.available,
+              badgeBuilder: (_) =>
+                  (label: 'Downloaded', color: AppTheme.available),
             ),
         ],
       ),
@@ -125,8 +141,7 @@ class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
   Widget _buildRow({
     required String title,
     required List<RadarrMovie> items,
-    required String statusLabel,
-    required Color statusColor,
+    required ({String label, Color color}) Function(RadarrMovie) badgeBuilder,
   }) {
     return Padding(
       padding: const EdgeInsets.only(top: 20),
@@ -148,17 +163,20 @@ class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
           HorizontalItemRow<RadarrMovie>(
             items: items,
             isLoading: _isLoadingLibrary,
-            itemBuilder: (movie) => MediaCard(
-              id: movie.id,
-              title: movie.title,
-              posterPath: movie.posterUrl,
-              statusLabel: statusLabel,
-              statusColor: statusColor,
-              width: 100,
-              onTap: movie.tmdbId != null
-                  ? () => context.push('/detail/movie/${movie.tmdbId}')
-                  : null,
-            ),
+            itemBuilder: (movie) {
+              final badge = badgeBuilder(movie);
+              return MediaCard(
+                id: movie.id,
+                title: movie.title,
+                posterPath: movie.posterUrl,
+                statusLabel: badge.label,
+                statusColor: badge.color,
+                width: 100,
+                onTap: movie.tmdbId != null
+                    ? () => context.push('/detail/movie/${movie.tmdbId}')
+                    : null,
+              );
+            },
           ),
         ],
       ),

--- a/app/lib/features/dashboard/ui/dashboard_movies_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_movies_tab.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/horizontal_item_row.dart';
+import '../../../core/widgets/media_card.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../discover/ui/category_row.dart';
 import '../../radarr/data/radarr_api_service.dart';
 import '../../radarr/data/radarr_models.dart';
 import '../../radarr/logic/movie_discover_provider.dart';
 
-/// Dashboard Movies tab: discovery rows + simplified Radarr library sections.
+/// Dashboard Movies tab: discovery rows + Radarr library rows.
 class DashboardMoviesTab extends ConsumerStatefulWidget {
   const DashboardMoviesTab({super.key});
 
@@ -19,7 +22,7 @@ class DashboardMoviesTab extends ConsumerStatefulWidget {
 
 class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
   List<RadarrMovie> _recentlyDownloaded = [];
-  List<RadarrMovie> _missing = [];
+  List<RadarrMovie> _downloadingSoon = [];
   bool _isLoadingLibrary = false;
 
   @override
@@ -45,11 +48,11 @@ class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
 
       final downloaded = movies.where((m) => m.hasFile).toList()
         ..sort((a, b) => (b.added ?? DateTime(0)).compareTo(a.added ?? DateTime(0)));
-      final missing = movies.where((m) => m.monitored && !m.hasFile).toList();
+      final downloadingSoon = movies.where((m) => m.monitored && !m.hasFile).toList();
 
       setState(() {
         _recentlyDownloaded = downloaded.take(10).toList();
-        _missing = missing.take(10).toList();
+        _downloadingSoon = downloadingSoon.take(10).toList();
         _isLoadingLibrary = false;
       });
     } catch (_) {
@@ -99,120 +102,66 @@ class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab> {
               isLoading: discover.isLoadingAnticipated,
             ),
 
-          // Simplified library sections
-          if (_recentlyDownloaded.isNotEmpty || _missing.isNotEmpty) ...[
-            _SectionHeader(title: 'Your Library'),
-            if (_isLoadingLibrary)
-              const Padding(
-                padding: EdgeInsets.all(24),
-                child: Center(
-                    child:
-                        CircularProgressIndicator(color: AppTheme.accent)),
-              ),
-            if (_recentlyDownloaded.isNotEmpty)
-              _CompactMovieSection(
-                title: 'Recently Downloaded',
-                movies: _recentlyDownloaded,
-                color: AppTheme.available,
-              ),
-            if (_missing.isNotEmpty)
-              _CompactMovieSection(
-                title: 'Missing',
-                movies: _missing,
-                color: AppTheme.requested,
-              ),
-          ],
+          // Radarr library rows (same style as discovery)
+          if (_downloadingSoon.isNotEmpty || _isLoadingLibrary)
+            _buildRow(
+              title: 'Downloading Soon',
+              items: _downloadingSoon,
+              statusLabel: 'Monitored',
+              statusColor: AppTheme.requested,
+            ),
+          if (_recentlyDownloaded.isNotEmpty || _isLoadingLibrary)
+            _buildRow(
+              title: 'Recently Downloaded',
+              items: _recentlyDownloaded,
+              statusLabel: 'Downloaded',
+              statusColor: AppTheme.available,
+            ),
         ],
       ),
     );
   }
-}
 
-class _SectionHeader extends StatelessWidget {
-  final String title;
-  const _SectionHeader({required this.title});
-
-  @override
-  Widget build(BuildContext context) {
+  Widget _buildRow({
+    required String title,
+    required List<RadarrMovie> items,
+    required String statusLabel,
+    required Color statusColor,
+  }) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 28, 16, 8),
-      child: Row(
+      padding: const EdgeInsets.only(top: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Expanded(child: Container(height: 1, color: AppTheme.border)),
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
+            padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Text(
               title,
               style: const TextStyle(
-                color: AppTheme.textSecondary,
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                letterSpacing: 0.5,
+                color: AppTheme.textPrimary,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
               ),
             ),
           ),
-          Expanded(child: Container(height: 1, color: AppTheme.border)),
+          const SizedBox(height: 12),
+          HorizontalItemRow<RadarrMovie>(
+            items: items,
+            isLoading: _isLoadingLibrary,
+            itemBuilder: (movie) => MediaCard(
+              id: movie.id,
+              title: movie.title,
+              posterPath: movie.posterUrl,
+              statusLabel: statusLabel,
+              statusColor: statusColor,
+              width: 100,
+              onTap: movie.tmdbId != null
+                  ? () => context.push('/detail/movie/${movie.tmdbId}')
+                  : null,
+            ),
+          ),
         ],
       ),
-    );
-  }
-}
-
-class _CompactMovieSection extends StatelessWidget {
-  final String title;
-  final List<RadarrMovie> movies;
-  final Color color;
-
-  const _CompactMovieSection({
-    required this.title,
-    required this.movies,
-    required this.color,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-          child: Row(
-            children: [
-              Container(
-                width: 8,
-                height: 8,
-                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-              ),
-              const SizedBox(width: 8),
-              Text(
-                '$title (${movies.length})',
-                style: const TextStyle(
-                  color: AppTheme.textPrimary,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-        ),
-        ...movies.map((movie) => ListTile(
-              dense: true,
-              leading: Icon(Icons.movie_outlined,
-                  color: color, size: 20),
-              title: Text(
-                movie.title,
-                style: const TextStyle(
-                    color: AppTheme.textPrimary, fontSize: 14),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              subtitle: Text(
-                movie.year.toString(),
-                style: const TextStyle(
-                    color: AppTheme.textSecondary, fontSize: 12),
-              ),
-            )),
-      ],
     );
   }
 }

--- a/app/lib/features/dashboard/ui/dashboard_tv_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_tv_tab.dart
@@ -1,14 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/horizontal_item_row.dart';
+import '../../../core/widgets/media_card.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../discover/ui/category_row.dart';
 import '../../sonarr/data/sonarr_api_service.dart';
 import '../../sonarr/data/sonarr_models.dart';
 import '../../sonarr/logic/tv_discover_provider.dart';
 
-/// Dashboard TV tab: discovery rows + simplified Sonarr library sections.
+/// Dashboard TV tab: discovery rows + Sonarr library rows.
 class DashboardTvTab extends ConsumerStatefulWidget {
   const DashboardTvTab({super.key});
 
@@ -18,7 +21,7 @@ class DashboardTvTab extends ConsumerStatefulWidget {
 
 class _DashboardTvTabState extends ConsumerState<DashboardTvTab> {
   List<SonarrSeries> _recentlyDownloaded = [];
-  List<SonarrSeries> _continuing = [];
+  List<SonarrSeries> _airingNext = [];
   bool _isLoadingLibrary = false;
 
   @override
@@ -40,19 +43,34 @@ class _DashboardTvTabState extends ConsumerState<DashboardTvTab> {
       final backendDio = ref.read(backendClientProvider);
       final service = SonarrApiService(
           backendDio: backendDio, instanceId: defaultSonarr.id);
+
       final series = await service.getSeries();
 
+      final now = DateTime.now();
+      final calendarEntries = await service.getCalendar(
+        start: now.toIso8601String(),
+        end: now.add(const Duration(days: 7)).toIso8601String(),
+      );
+
+      // "Airing Next" = unique series from calendar entries
+      final airingSeriesIds = calendarEntries
+          .map((e) => e['seriesId'] as int?)
+          .whereType<int>()
+          .toSet();
+      final airingNext = series
+          .where((s) => airingSeriesIds.contains(s.id))
+          .toList();
+
+      // "Recently Downloaded" = series with downloaded episodes, sorted by percent complete
       final downloaded = series
           .where((s) => s.percentComplete > 0)
           .toList()
         ..sort((a, b) =>
             b.percentComplete.compareTo(a.percentComplete));
-      final continuing =
-          series.where((s) => s.status == 'continuing').toList();
 
       setState(() {
         _recentlyDownloaded = downloaded.take(10).toList();
-        _continuing = continuing.take(10).toList();
+        _airingNext = airingNext.take(10).toList();
         _isLoadingLibrary = false;
       });
     } catch (_) {
@@ -89,119 +107,66 @@ class _DashboardTvTabState extends ConsumerState<DashboardTvTab> {
               isLoading: discover.isLoadingAnticipated,
             ),
 
-          if (_recentlyDownloaded.isNotEmpty || _continuing.isNotEmpty) ...[
-            _SectionHeader(title: 'Your Library'),
-            if (_isLoadingLibrary)
-              const Padding(
-                padding: EdgeInsets.all(24),
-                child: Center(
-                    child:
-                        CircularProgressIndicator(color: AppTheme.accent)),
-              ),
-            if (_continuing.isNotEmpty)
-              _CompactSeriesSection(
-                title: 'Airing Now',
-                series: _continuing,
-                color: AppTheme.downloading,
-              ),
-            if (_recentlyDownloaded.isNotEmpty)
-              _CompactSeriesSection(
-                title: 'Recently Downloaded',
-                series: _recentlyDownloaded,
-                color: AppTheme.available,
-              ),
-          ],
+          // Sonarr library rows (same style as discovery)
+          if (_recentlyDownloaded.isNotEmpty || _isLoadingLibrary)
+            _buildRow(
+              title: 'Recently Downloaded',
+              items: _recentlyDownloaded,
+              statusLabel: 'Downloaded',
+              statusColor: AppTheme.available,
+            ),
+          if (_airingNext.isNotEmpty || _isLoadingLibrary)
+            _buildRow(
+              title: 'Airing Next',
+              items: _airingNext,
+              statusLabel: 'Airing',
+              statusColor: AppTheme.downloading,
+            ),
         ],
       ),
     );
   }
-}
 
-class _SectionHeader extends StatelessWidget {
-  final String title;
-  const _SectionHeader({required this.title});
-
-  @override
-  Widget build(BuildContext context) {
+  Widget _buildRow({
+    required String title,
+    required List<SonarrSeries> items,
+    required String statusLabel,
+    required Color statusColor,
+  }) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 28, 16, 8),
-      child: Row(
+      padding: const EdgeInsets.only(top: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Expanded(child: Container(height: 1, color: AppTheme.border)),
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12),
+            padding: const EdgeInsets.symmetric(horizontal: 16),
             child: Text(
               title,
               style: const TextStyle(
-                color: AppTheme.textSecondary,
-                fontSize: 13,
-                fontWeight: FontWeight.w600,
-                letterSpacing: 0.5,
+                color: AppTheme.textPrimary,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
               ),
             ),
           ),
-          Expanded(child: Container(height: 1, color: AppTheme.border)),
+          const SizedBox(height: 12),
+          HorizontalItemRow<SonarrSeries>(
+            items: items,
+            isLoading: _isLoadingLibrary,
+            itemBuilder: (series) => MediaCard(
+              id: series.id,
+              title: series.title,
+              posterPath: series.posterUrl,
+              statusLabel: statusLabel,
+              statusColor: statusColor,
+              width: 100,
+              onTap: series.tvdbId != null
+                  ? () => context.push('/detail/tv/${series.tvdbId}')
+                  : null,
+            ),
+          ),
         ],
       ),
-    );
-  }
-}
-
-class _CompactSeriesSection extends StatelessWidget {
-  final String title;
-  final List<SonarrSeries> series;
-  final Color color;
-
-  const _CompactSeriesSection({
-    required this.title,
-    required this.series,
-    required this.color,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-          child: Row(
-            children: [
-              Container(
-                width: 8,
-                height: 8,
-                decoration: BoxDecoration(color: color, shape: BoxShape.circle),
-              ),
-              const SizedBox(width: 8),
-              Text(
-                '$title (${series.length})',
-                style: const TextStyle(
-                  color: AppTheme.textPrimary,
-                  fontSize: 14,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-        ),
-        ...series.map((s) => ListTile(
-              dense: true,
-              leading: Icon(Icons.tv_outlined,
-                  color: color, size: 20),
-              title: Text(
-                s.title,
-                style: const TextStyle(
-                    color: AppTheme.textPrimary, fontSize: 14),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              subtitle: Text(
-                '${s.year != null ? s.year.toString() : ''} ${s.status == 'continuing' ? '• Continuing' : ''}',
-                style: const TextStyle(
-                    color: AppTheme.textSecondary, fontSize: 12),
-              ),
-            )),
-      ],
     );
   }
 }

--- a/app/lib/features/dashboard/ui/dashboard_tv_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_tv_tab.dart
@@ -39,27 +39,15 @@ class _DashboardTvTabState extends ConsumerState<DashboardTvTab> {
     if (defaultSonarr == null) return;
 
     setState(() => _isLoadingLibrary = true);
+
+    final backendDio = ref.read(backendClientProvider);
+    final service = SonarrApiService(
+        backendDio: backendDio, instanceId: defaultSonarr.id);
+
+    List<SonarrSeries> series = [];
     try {
-      final backendDio = ref.read(backendClientProvider);
-      final service = SonarrApiService(
-          backendDio: backendDio, instanceId: defaultSonarr.id);
-
-      final series = await service.getSeries();
-
-      final now = DateTime.now();
-      final calendarEntries = await service.getCalendar(
-        start: now.toIso8601String(),
-        end: now.add(const Duration(days: 7)).toIso8601String(),
-      );
-
-      // "Airing Next" = unique series from calendar entries
-      final airingSeriesIds = calendarEntries
-          .map((e) => e['seriesId'] as int?)
-          .whereType<int>()
-          .toSet();
-      final airingNext = series
-          .where((s) => airingSeriesIds.contains(s.id))
-          .toList();
+      series = await service.getSeries();
+      if (!mounted) return;
 
       // "Recently Downloaded" = series with downloaded episodes, sorted by percent complete
       final downloaded = series
@@ -70,12 +58,36 @@ class _DashboardTvTabState extends ConsumerState<DashboardTvTab> {
 
       setState(() {
         _recentlyDownloaded = downloaded.take(10).toList();
-        _airingNext = airingNext.take(10).toList();
-        _isLoadingLibrary = false;
       });
     } catch (_) {
-      setState(() => _isLoadingLibrary = false);
+      // Series fetch failed; leave _recentlyDownloaded empty.
     }
+
+    try {
+      final now = DateTime.now();
+      final calendarEntries = await service.getCalendar(
+        start: now.toIso8601String(),
+        end: now.add(const Duration(days: 7)).toIso8601String(),
+      );
+      if (!mounted) return;
+
+      // "Airing Next" = unique series from calendar entries
+      final airingSeriesIds = calendarEntries
+          .map((e) => e['seriesId'] as int?)
+          .whereType<int>()
+          .toSet();
+      final airingNext = series
+          .where((s) => airingSeriesIds.contains(s.id))
+          .toList();
+
+      setState(() {
+        _airingNext = airingNext.take(10).toList();
+      });
+    } catch (_) {
+      // Calendar fetch failed; leave _airingNext empty.
+    }
+
+    if (mounted) setState(() => _isLoadingLibrary = false);
   }
 
   Future<void> _onRefresh() async {
@@ -160,8 +172,8 @@ class _DashboardTvTabState extends ConsumerState<DashboardTvTab> {
               statusLabel: statusLabel,
               statusColor: statusColor,
               width: 100,
-              onTap: series.tvdbId != null
-                  ? () => context.push('/detail/tv/${series.tvdbId}')
+              onTap: series.tmdbId != null
+                  ? () => context.push('/detail/tv/${series.tmdbId}')
                   : null,
             ),
           ),

--- a/app/lib/features/sonarr/data/sonarr_models.dart
+++ b/app/lib/features/sonarr/data/sonarr_models.dart
@@ -3,6 +3,7 @@ class SonarrSeries {
   final int id;
   final String title;
   final int? tvdbId;
+  final int? tmdbId;
   final int? year;
   final String? overview;
   final String? titleSlug;
@@ -19,6 +20,7 @@ class SonarrSeries {
     required this.id,
     required this.title,
     this.tvdbId,
+    this.tmdbId,
     this.year,
     this.overview,
     this.titleSlug,
@@ -36,6 +38,7 @@ class SonarrSeries {
         id: json['id'] as int? ?? 0,
         title: json['title'] as String? ?? 'Untitled',
         tvdbId: json['tvdbId'] as int?,
+        tmdbId: json['tmdbId'] as int?,
         year: json['year'] as int?,
         overview: json['overview'] as String?,
         titleSlug: json['titleSlug'] as String?,
@@ -62,6 +65,7 @@ class SonarrSeries {
         'id': id,
         'title': title,
         'tvdbId': tvdbId,
+        'tmdbId': tmdbId,
         'year': year,
         'overview': overview,
         'titleSlug': titleSlug,


### PR DESCRIPTION
## Summary
Refactored the dashboard Movies and TV tabs to display library content using horizontal scrollable card rows (matching the discovery section style) instead of vertical list tiles. This provides a more consistent and visually appealing UI across the dashboard.

## Key Changes

**Dashboard Movies Tab:**
- Replaced vertical list-based "Recently Downloaded" and "Missing" sections with horizontal `MediaCard` rows
- Renamed "Missing" section to "Downloading Soon" with improved categorization:
  - Fetches Radarr queue to identify actively downloading movies
  - Displays actively downloading movies first, followed by monitored-waiting movies
  - Shows dynamic badges: "Downloading" (blue) for active items, "Monitored" (orange) for waiting items
- Removed `_SectionHeader` and `_CompactMovieSection` widgets in favor of reusable `_buildRow()` method
- Added navigation to movie detail pages via `go_router`

**Dashboard TV Tab:**
- Replaced vertical list-based "Airing Now" and "Recently Downloaded" sections with horizontal `MediaCard` rows
- Renamed "Airing Now" to "Airing Next" with improved data source:
  - Fetches Sonarr calendar for the next 7 days
  - Filters series to only those with upcoming episodes
  - Replaces the previous "continuing status" filter with calendar-based logic
- Removed `_SectionHeader` and `_CompactSeriesSection` widgets in favor of reusable `_buildRow()` method
- Added navigation to TV detail pages via `go_router`

## Implementation Details
- Both tabs now use `HorizontalItemRow` and `MediaCard` components for consistent presentation
- Library sections use the same visual style and spacing as discovery rows (20pt top padding, bold 20pt titles)
- Status badges are color-coded and dynamically set based on content type
- Loading state is handled uniformly across all library rows
- Improved data fetching logic with better filtering and sorting strategies

https://claude.ai/code/session_01NCkTatnJLyizCgLfuk2ek8