### PR TITLE
Integrate AI chat into search bar

### DIFF
--- a/app/lib/core/widgets/search_bar.dart
+++ b/app/lib/core/widgets/search_bar.dart
@@ -1,13 +1,27 @@
 import 'package:flutter/material.dart';
 import '../theme/app_theme.dart';
 
-/// An animated search bar with focus handling and clear button.
+/// An animated search bar with focus handling, clear button,
+/// and optional AI mode (sparkle hint, multiline input, glow effect).
 class CantinarrSearchBar extends StatelessWidget {
   final TextEditingController controller;
   final FocusNode focusNode;
   final String hintText;
   final ValueChanged<String>? onChanged;
   final VoidCallback? onClear;
+
+  /// When true, shows a sparkle icon hinting at AI capability.
+  final bool aiEnabled;
+
+  /// When true, the text field expands to 3 lines with a send button.
+  final bool multiline;
+
+  /// Called when the send button is tapped (AI multiline mode).
+  final VoidCallback? onSend;
+
+  /// Glow intensity (0.0–1.0) for the gold accent border/shadow.
+  /// Driven by the parent's animation controller.
+  final double glowIntensity;
 
   const CantinarrSearchBar({
     super.key,
@@ -16,34 +30,49 @@ class CantinarrSearchBar extends StatelessWidget {
     this.hintText = 'Search movies & TV shows...',
     this.onChanged,
     this.onClear,
+    this.aiEnabled = false,
+    this.multiline = false,
+    this.onSend,
+    this.glowIntensity = 0.0,
   });
 
   @override
   Widget build(BuildContext context) {
+    final hasGlow = glowIntensity > 0.0;
+    final borderColor = hasGlow
+        ? Color.lerp(AppTheme.border, AppTheme.accent, glowIntensity)!
+        : AppTheme.border;
+
     return Container(
       decoration: BoxDecoration(
         color: AppTheme.surfaceVariant,
         borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: AppTheme.border, width: 1),
+        border: Border.all(color: borderColor, width: hasGlow ? 1.5 : 1),
+        boxShadow: hasGlow
+            ? [
+                BoxShadow(
+                  color: AppTheme.accent.withValues(alpha: glowIntensity * 0.2),
+                  blurRadius: 20,
+                  spreadRadius: 1,
+                ),
+              ]
+            : null,
       ),
       child: TextField(
         controller: controller,
         focusNode: focusNode,
         onChanged: onChanged,
+        onSubmitted: multiline ? null : null,
+        textInputAction:
+            multiline ? TextInputAction.newline : TextInputAction.search,
+        maxLines: multiline ? 3 : 1,
+        minLines: multiline ? 2 : 1,
         style: const TextStyle(color: AppTheme.textPrimary, fontSize: 16),
         decoration: InputDecoration(
           hintText: hintText,
           hintStyle: const TextStyle(color: AppTheme.textSecondary),
-          prefixIcon: const Icon(Icons.search, color: AppTheme.textSecondary),
-          suffixIcon: controller.text.isNotEmpty
-              ? IconButton(
-                  icon: const Icon(Icons.close, color: AppTheme.textSecondary),
-                  onPressed: () {
-                    controller.clear();
-                    onClear?.call();
-                  },
-                )
-              : null,
+          prefixIcon: _buildPrefixIcon(),
+          suffixIcon: _buildSuffixIcon(),
           filled: false,
           border: InputBorder.none,
           contentPadding:
@@ -51,5 +80,67 @@ class CantinarrSearchBar extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget _buildPrefixIcon() {
+    if (aiEnabled) {
+      return Padding(
+        padding: const EdgeInsets.only(left: 12, right: 4),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.auto_awesome,
+              size: 18,
+              color: AppTheme.accent.withValues(alpha: 0.7),
+            ),
+            const SizedBox(width: 6),
+            const Icon(Icons.search, size: 22, color: AppTheme.textSecondary),
+          ],
+        ),
+      );
+    }
+    return const Icon(Icons.search, color: AppTheme.textSecondary);
+  }
+
+  Widget? _buildSuffixIcon() {
+    if (multiline && controller.text.isNotEmpty) {
+      return Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.close, size: 20, color: AppTheme.textSecondary),
+            onPressed: () {
+              controller.clear();
+              onClear?.call();
+            },
+          ),
+          IconButton(
+            icon: const Icon(Icons.send_rounded, color: AppTheme.accent),
+            onPressed: onSend,
+          ),
+        ],
+      );
+    }
+
+    if (controller.text.isNotEmpty) {
+      return IconButton(
+        icon: const Icon(Icons.close, color: AppTheme.textSecondary),
+        onPressed: () {
+          controller.clear();
+          onClear?.call();
+        },
+      );
+    }
+
+    if (multiline) {
+      return IconButton(
+        icon: Icon(Icons.send_rounded,
+            color: AppTheme.textSecondary.withValues(alpha: 0.5)),
+        onPressed: null,
+      );
+    }
+
+    return null;
   }
 }

--- a/app/lib/features/shell/logic/shell_ai_chat_provider.dart
+++ b/app/lib/features/shell/logic/shell_ai_chat_provider.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../ai_assistant/data/ai_chat_service.dart';
+import '../../ai_assistant/logic/ai_chat_provider.dart';
+
+/// Provides an [AiChatNotifier] scoped to the shell's inline AI mode.
+///
+/// Created lazily on first access, persists until the provider is disposed.
+/// Reuses the existing [AiChatService] and [AiChatNotifier] classes.
+final shellAiChatProvider = Provider<AiChatNotifier>((ref) {
+  final backendDio = ref.watch(backendClientProvider);
+  final notifier = AiChatNotifier(
+    chatService: AiChatService(backendDio: backendDio),
+  );
+  ref.onDispose(() => notifier.dispose());
+  return notifier;
+});

--- a/app/lib/features/shell/logic/shell_search_provider.dart
+++ b/app/lib/features/shell/logic/shell_search_provider.dart
@@ -1,9 +1,22 @@
 import 'dart:async';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/config/app_config.dart';
+import '../../auth/logic/auth_provider.dart';
 import '../../discover/data/discover_api_service.dart';
 import '../../discover/data/tmdb_models.dart';
 import '../../discover/logic/paged_loader.dart';
+
+/// The current mode of the shell search bar.
+enum SearchMode {
+  /// Normal search — bar at top, results overlay below.
+  search,
+
+  /// No results found and AI is available — glow transition state.
+  noResults,
+
+  /// AI chat mode — bar at bottom (multiline), chat messages above.
+  aiChat,
+}
 
 /// Shell-level search state visible across all tabs.
 class ShellSearchState {
@@ -11,12 +24,14 @@ class ShellSearchState {
   final List<MediaItem> searchResults;
   final bool isLoadingSearch;
   final String? error;
+  final SearchMode searchMode;
 
   const ShellSearchState({
     this.searchQuery = '',
     this.searchResults = const [],
     this.isLoadingSearch = false,
     this.error,
+    this.searchMode = SearchMode.search,
   });
 
   ShellSearchState copyWith({
@@ -24,12 +39,14 @@ class ShellSearchState {
     List<MediaItem>? searchResults,
     bool? isLoadingSearch,
     String? error,
+    SearchMode? searchMode,
   }) =>
       ShellSearchState(
         searchQuery: searchQuery ?? this.searchQuery,
         searchResults: searchResults ?? this.searchResults,
         isLoadingSearch: isLoadingSearch ?? this.isLoadingSearch,
         error: error,
+        searchMode: searchMode ?? this.searchMode,
       );
 
   bool get isSearching => searchQuery.isNotEmpty;
@@ -38,22 +55,32 @@ class ShellSearchState {
 /// Manages TMDB multi-search from the shell search bar.
 class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
   final DiscoverApiService _api;
+  final bool aiAvailable;
   final PagedLoader _searchLoader = PagedLoader();
   Timer? _searchDebounce;
 
-  ShellSearchNotifier(this._api) : super(const ShellSearchState());
+  ShellSearchNotifier(this._api, {this.aiAvailable = false})
+      : super(const ShellSearchState());
 
   void updateSearch(String query) {
-    state = state.copyWith(searchQuery: query);
     _searchDebounce?.cancel();
 
     if (query.isEmpty) {
-      state = state.copyWith(searchResults: [], isLoadingSearch: false);
+      state = state.copyWith(
+        searchQuery: '',
+        searchResults: [],
+        isLoadingSearch: false,
+        searchMode: SearchMode.search,
+      );
       _searchLoader.reset();
       return;
     }
 
-    state = state.copyWith(isLoadingSearch: true);
+    state = state.copyWith(
+      searchQuery: query,
+      isLoadingSearch: true,
+      searchMode: SearchMode.search,
+    );
     _searchDebounce = Timer(AppConfig.searchDebounce, () => _executeSearch());
   }
 
@@ -66,7 +93,19 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
         query: state.searchQuery,
         page: _searchLoader.page,
       );
-      state = state.copyWith(searchResults: page.results, isLoadingSearch: false);
+
+      if (page.results.isEmpty && aiAvailable) {
+        state = state.copyWith(
+          searchResults: [],
+          isLoadingSearch: false,
+          searchMode: SearchMode.noResults,
+        );
+      } else {
+        state = state.copyWith(
+          searchResults: page.results,
+          isLoadingSearch: false,
+        );
+      }
       _searchLoader.endLoading(page.totalPages);
     } catch (e) {
       _searchLoader.cancelLoading();
@@ -75,6 +114,24 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
         error: 'Search failed: $e',
       );
     }
+  }
+
+  /// Transition from noResults to AI chat mode.
+  void activateAiChat() {
+    if (state.searchMode == SearchMode.noResults) {
+      state = state.copyWith(searchMode: SearchMode.aiChat);
+    }
+  }
+
+  /// Exit AI mode and return to normal search.
+  void exitAiMode() {
+    state = state.copyWith(
+      searchMode: SearchMode.search,
+      searchQuery: '',
+      searchResults: [],
+      isLoadingSearch: false,
+    );
+    _searchLoader.reset();
   }
 
   void loadMoreSearch(MediaItem current) {
@@ -117,6 +174,8 @@ final shellSearchProvider =
     StateNotifierProvider<ShellSearchNotifier, ShellSearchState>(
   (ref) {
     final api = ref.watch(discoverServiceProvider);
-    return ShellSearchNotifier(api);
+    final auth = ref.watch(authProvider).valueOrNull;
+    final hasAi = auth?.connection?.services.ai ?? false;
+    return ShellSearchNotifier(api, aiAvailable: hasAi);
   },
 );

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -6,6 +7,10 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/providers/module_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/search_bar.dart';
+import '../../ai_assistant/data/ai_chat_service.dart';
+import '../../ai_assistant/data/ai_models.dart';
+import '../../ai_assistant/logic/ai_chat_provider.dart';
+import '../../ai_assistant/ui/chat_bubble.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../discover/data/tmdb_models.dart';
 import '../../discover/ui/search_results_view.dart';
@@ -30,13 +35,29 @@ class AppShell extends ConsumerStatefulWidget {
 }
 
 class _AppShellState extends ConsumerState<AppShell>
-    with SingleTickerProviderStateMixin {
+    with TickerProviderStateMixin {
   final _searchController = TextEditingController();
   final _searchFocusNode = FocusNode();
+  final _chatScrollController = ScrollController();
   RadarrMoviesNotifier? _radarrNotifier;
   SonarrSeriesNotifier? _sonarrNotifier;
+
+  // Search bar collapse on scroll (mobile)
   late final AnimationController _searchBarAnim;
   late final Animation<double> _searchBarCurve;
+
+  // AI mode layout flip
+  late final AnimationController _aiModeAnim;
+  late final Animation<double> _aiModeCurve;
+
+  // Glow pulse for no-results state
+  late final AnimationController _glowAnim;
+
+  // Shell-scoped AI chat notifier (lazy)
+  AiChatNotifier? _aiChatNotifier;
+  Timer? _aiTransitionTimer;
+  SearchMode _prevMode = SearchMode.search;
+  bool _hasAi = false;
 
   @override
   void initState() {
@@ -50,12 +71,25 @@ class _AppShellState extends ConsumerState<AppShell>
       parent: _searchBarAnim,
       curve: Curves.easeOut,
     );
+    _aiModeAnim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 500),
+    );
+    _aiModeCurve = CurvedAnimation(
+      parent: _aiModeAnim,
+      curve: Curves.easeInOutCubic,
+    );
+    _glowAnim = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    );
     WidgetsBinding.instance.addPostFrameCallback((_) => _initLibraries());
   }
 
   void _initLibraries() {
     final auth = ref.read(authProvider).valueOrNull;
     final backendDio = ref.read(backendClientProvider);
+    _hasAi = auth?.connection?.services.ai ?? false;
 
     // Use instance-aware API services
     final defaultRadarr = auth?.connection?.defaultRadarrInstance;
@@ -79,6 +113,84 @@ class _AppShellState extends ConsumerState<AppShell>
 
   void _onLibraryChanged() {
     if (mounted) setState(() {});
+  }
+
+  /// Lazily create the shell-scoped AI chat notifier.
+  AiChatNotifier _getOrCreateAiChat() {
+    if (_aiChatNotifier == null) {
+      final backendDio = ref.read(backendClientProvider);
+      _aiChatNotifier = AiChatNotifier(
+        chatService: AiChatService(backendDio: backendDio),
+      );
+      _aiChatNotifier!.addListener(_onAiChatChanged);
+    }
+    return _aiChatNotifier!;
+  }
+
+  void _onAiChatChanged() {
+    if (mounted) {
+      setState(() {});
+      // Auto-scroll chat to bottom
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (_chatScrollController.hasClients) {
+          _chatScrollController.animateTo(
+            _chatScrollController.position.maxScrollExtent,
+            duration: const Duration(milliseconds: 200),
+            curve: Curves.easeOut,
+          );
+        }
+      });
+    }
+  }
+
+  /// React to search mode changes and drive animations.
+  void _onSearchModeChanged(SearchMode mode) {
+    if (mode == _prevMode) return;
+    _prevMode = mode;
+
+    switch (mode) {
+      case SearchMode.noResults:
+        _glowAnim.repeat(reverse: true);
+        // Auto-transition to AI chat after glow delay
+        _aiTransitionTimer?.cancel();
+        _aiTransitionTimer = Timer(const Duration(milliseconds: 800), () {
+          if (mounted) {
+            ref.read(shellSearchProvider.notifier).activateAiChat();
+          }
+        });
+
+      case SearchMode.aiChat:
+        _aiTransitionTimer?.cancel();
+        _glowAnim.stop();
+        _glowAnim.value = 0;
+        _aiModeAnim.forward();
+        // Auto-send the original query to AI
+        final query = ref.read(shellSearchProvider).searchQuery;
+        if (query.isNotEmpty) {
+          final chat = _getOrCreateAiChat();
+          chat.sendMessage(query);
+          _searchController.clear();
+        }
+
+      case SearchMode.search:
+        _aiTransitionTimer?.cancel();
+        _glowAnim.stop();
+        _glowAnim.value = 0;
+        _aiModeAnim.reverse();
+    }
+  }
+
+  void _exitAiMode() {
+    _searchController.clear();
+    ref.read(shellSearchProvider.notifier).exitAiMode();
+    _searchFocusNode.unfocus();
+  }
+
+  void _sendAiMessage() {
+    final text = _searchController.text.trim();
+    if (text.isEmpty || _aiChatNotifier == null) return;
+    _searchController.clear();
+    _aiChatNotifier!.sendMessage(text);
   }
 
   Map<int, LibraryStatus> _buildLibraryStatus(
@@ -159,7 +271,13 @@ class _AppShellState extends ConsumerState<AppShell>
 
   @override
   void dispose() {
+    _aiTransitionTimer?.cancel();
     _searchBarAnim.dispose();
+    _aiModeAnim.dispose();
+    _glowAnim.dispose();
+    _chatScrollController.dispose();
+    _aiChatNotifier?.removeListener(_onAiChatChanged);
+    _aiChatNotifier?.dispose();
     _radarrNotifier?.removeListener(_onLibraryChanged);
     _sonarrNotifier?.removeListener(_onLibraryChanged);
     _searchController.dispose();
@@ -171,19 +289,27 @@ class _AppShellState extends ConsumerState<AppShell>
   Widget build(BuildContext context) {
     final searchState = ref.watch(shellSearchProvider);
     final searchNotifier = ref.read(shellSearchProvider.notifier);
-    final libraryStatus = searchState.isSearching
+    final libraryStatus = searchState.isSearching &&
+            searchState.searchMode == SearchMode.search
         ? _buildLibraryStatus(searchState.searchResults)
         : const <int, LibraryStatus>{};
 
     final mobile = _isMobile(context);
+
+    // Drive animations from state changes
+    _onSearchModeChanged(searchState.searchMode);
+
+    final isAiMode = searchState.searchMode == SearchMode.aiChat;
 
     final searchBar = Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: CantinarrSearchBar(
         controller: _searchController,
         focusNode: _searchFocusNode,
-        onChanged: (q) => searchNotifier.updateSearch(q),
-        onClear: () => searchNotifier.updateSearch(''),
+        hintText: _hasAi ? 'Search or ask AI...' : 'Search movies & TV shows...',
+        aiEnabled: _hasAi,
+        onChanged: isAiMode ? null : (q) => searchNotifier.updateSearch(q),
+        onClear: isAiMode ? _exitAiMode : () => searchNotifier.updateSearch(''),
       ),
     );
 
@@ -195,29 +321,33 @@ class _AppShellState extends ConsumerState<AppShell>
             // Base layer: search bar + module content
             Column(
               children: [
-                // Search bar: collapses on scroll (mobile only)
-                if (mobile)
-                  SizeTransition(
-                    sizeFactor: _searchBarCurve,
-                    axisAlignment: -1,
-                    child: searchBar,
-                  )
-                else
-                  searchBar,
+                // Search bar at top (hidden during AI mode)
+                if (!isAiMode) ...[
+                  if (mobile)
+                    SizeTransition(
+                      sizeFactor: _searchBarCurve,
+                      axisAlignment: -1,
+                      child: searchBar,
+                    )
+                  else
+                    searchBar,
+                ],
                 // Module content (includes its own bottom nav)
                 Expanded(
                   child: NotificationListener<ScrollNotification>(
-                    onNotification: mobile && !searchState.isSearching
-                        ? _handleScrollNotification
-                        : null,
+                    onNotification:
+                        mobile && !searchState.isSearching && !isAiMode
+                            ? _handleScrollNotification
+                            : null,
                     child: widget.child,
                   ),
                 ),
               ],
             ),
 
-            // Overlay: search results when searching
-            if (searchState.isSearching)
+            // Overlay: search results (normal search mode)
+            if (searchState.searchMode == SearchMode.search &&
+                searchState.isSearching)
               Positioned.fill(
                 top: 60, // below the search bar
                 child: Container(
@@ -232,31 +362,241 @@ class _AppShellState extends ConsumerState<AppShell>
                 ),
               ),
 
-            // Bottom fade gradient
-            Positioned(
-              left: 0,
-              right: 0,
-              bottom: 0,
-              height: 32,
-              child: IgnorePointer(
-                child: DecoratedBox(
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topCenter,
-                      end: Alignment.bottomCenter,
-                      colors: [
-                        AppTheme.accent.withValues(alpha: 0),
-                        AppTheme.accent.withValues(alpha: 0.08),
-                      ],
+            // Overlay: no-results glow transition
+            if (searchState.searchMode == SearchMode.noResults)
+              Positioned.fill(
+                top: 60,
+                child: _buildNoResultsGlow(searchState.searchQuery),
+              ),
+
+            // Overlay: AI chat mode
+            if (isAiMode) _buildAiChatOverlay(),
+
+            // Bottom fade gradient (only when not in AI mode)
+            if (!isAiMode)
+              Positioned(
+                left: 0,
+                right: 0,
+                bottom: 0,
+                height: 32,
+                child: IgnorePointer(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.topCenter,
+                        end: Alignment.bottomCenter,
+                        colors: [
+                          AppTheme.accent.withValues(alpha: 0),
+                          AppTheme.accent.withValues(alpha: 0.08),
+                        ],
+                      ),
                     ),
                   ),
                 ),
               ),
-            ),
           ],
         ),
       ),
       drawer: _buildDrawer(context),
+    );
+  }
+
+  /// Glow state: pulsing gold container with "Asking AI..." label.
+  Widget _buildNoResultsGlow(String query) {
+    return AnimatedBuilder(
+      animation: _glowAnim,
+      builder: (context, _) {
+        final glowValue = _glowAnim.value;
+        return Container(
+          decoration: BoxDecoration(
+            color: AppTheme.background,
+            border: Border(
+              top: BorderSide(
+                color: AppTheme.accent.withValues(alpha: 0.3 + glowValue * 0.5),
+                width: 1.5,
+              ),
+            ),
+            boxShadow: [
+              BoxShadow(
+                color: AppTheme.accent.withValues(alpha: glowValue * 0.15),
+                blurRadius: 24,
+                spreadRadius: 0,
+                offset: const Offset(0, -4),
+              ),
+            ],
+          ),
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.auto_awesome,
+                  size: 40,
+                  color: AppTheme.accent.withValues(alpha: 0.6 + glowValue * 0.4),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'No results for "$query"',
+                  style: const TextStyle(
+                    color: AppTheme.textSecondary,
+                    fontSize: 16,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                AnimatedOpacity(
+                  opacity: glowValue > 0.3 ? 1.0 : 0.0,
+                  duration: const Duration(milliseconds: 300),
+                  child: Text(
+                    'Asking AI...',
+                    style: TextStyle(
+                      color: AppTheme.accent.withValues(alpha: 0.8),
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  /// AI chat overlay: messages above, multiline input at bottom.
+  Widget _buildAiChatOverlay() {
+    final chatState = _aiChatNotifier?.state;
+    final messages = chatState?.messages ?? [];
+    final isLoading = chatState?.isLoading ?? false;
+
+    return AnimatedBuilder(
+      animation: _aiModeCurve,
+      builder: (context, _) {
+        return Positioned.fill(
+          child: FadeTransition(
+            opacity: _aiModeCurve,
+            child: Container(
+              color: AppTheme.background,
+              child: Column(
+                children: [
+                  // Header
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 8),
+                    decoration: const BoxDecoration(
+                      border: Border(
+                        bottom: BorderSide(color: AppTheme.border),
+                      ),
+                    ),
+                    child: Row(
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.arrow_back,
+                              color: AppTheme.textSecondary, size: 22),
+                          onPressed: _exitAiMode,
+                          tooltip: 'Back to search',
+                        ),
+                        Icon(
+                          Icons.auto_awesome,
+                          size: 18,
+                          color: AppTheme.accent.withValues(alpha: 0.8),
+                        ),
+                        const SizedBox(width: 8),
+                        const Text(
+                          'AI',
+                          style: TextStyle(
+                            color: AppTheme.textPrimary,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const Spacer(),
+                        if (messages.length > 1)
+                          IconButton(
+                            icon: const Icon(Icons.delete_outline,
+                                color: AppTheme.textSecondary, size: 20),
+                            onPressed: () {
+                              _aiChatNotifier?.clearChat();
+                            },
+                            tooltip: 'Clear chat',
+                          ),
+                      ],
+                    ),
+                  ),
+
+                  // Chat messages
+                  Expanded(
+                    child: ListView.builder(
+                      controller: _chatScrollController,
+                      padding: const EdgeInsets.all(16),
+                      itemCount: messages.length +
+                          (isLoading && (messages.isEmpty ||
+                                  messages.last.role != ChatRole.assistant)
+                              ? 1
+                              : 0),
+                      itemBuilder: (context, index) {
+                        if (index >= messages.length) {
+                          return const _TypingIndicator();
+                        }
+                        // Skip the initial welcome message
+                        final msg = messages[index];
+                        if (index == 0 && msg.role == ChatRole.assistant) {
+                          return const SizedBox.shrink();
+                        }
+                        return ChatBubble(message: msg);
+                      },
+                    ),
+                  ),
+
+                  // Error
+                  if (chatState?.error != null)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 4),
+                      child: Text(
+                        chatState!.error!,
+                        style: const TextStyle(
+                            color: AppTheme.error, fontSize: 12),
+                        maxLines: 2,
+                      ),
+                    ),
+
+                  // Bottom input bar
+                  Container(
+                    decoration: BoxDecoration(
+                      color: AppTheme.surface,
+                      border: const Border(
+                        top: BorderSide(color: AppTheme.border),
+                      ),
+                      boxShadow: [
+                        BoxShadow(
+                          color: AppTheme.accent.withValues(alpha: 0.05),
+                          blurRadius: 12,
+                          offset: const Offset(0, -2),
+                        ),
+                      ],
+                    ),
+                    padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
+                    child: SafeArea(
+                      top: false,
+                      child: CantinarrSearchBar(
+                        controller: _searchController,
+                        focusNode: _searchFocusNode,
+                        hintText: 'Ask about movies, shows...',
+                        aiEnabled: true,
+                        multiline: true,
+                        onSend: _sendAiMessage,
+                        onChanged: (_) => setState(() {}),
+                        onClear: _exitAiMode,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -393,6 +733,90 @@ class _DrawerItem extends StatelessWidget {
       selectedTileColor: AppTheme.accent.withValues(alpha: 0.08),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
       onTap: onTap,
+    );
+  }
+}
+
+/// Typing indicator with animated dots.
+class _TypingIndicator extends StatelessWidget {
+  const _TypingIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 8),
+      child: Row(
+        children: [
+          Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            decoration: BoxDecoration(
+              color: AppTheme.surfaceVariant,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: List.generate(
+                3,
+                (i) => Padding(
+                  padding: EdgeInsets.only(left: i > 0 ? 4 : 0),
+                  child: _Dot(delay: i * 200),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Dot extends StatefulWidget {
+  final int delay;
+  const _Dot({required this.delay});
+
+  @override
+  State<_Dot> createState() => _DotState();
+}
+
+class _DotState extends State<_Dot> with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 600),
+      vsync: this,
+    );
+    _animation = Tween(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+    Future.delayed(Duration(milliseconds: widget.delay), () {
+      if (mounted) _controller.repeat(reverse: true);
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _animation,
+      builder: (_, __) => Container(
+        width: 8,
+        height: 8,
+        decoration: BoxDecoration(
+          color: AppTheme.textSecondary
+              .withValues(alpha: 0.3 + _animation.value * 0.7),
+          shape: BoxShape.circle,
+        ),
+      ),
     );
   }
 }

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -57,7 +57,6 @@ class _AppShellState extends ConsumerState<AppShell>
   AiChatNotifier? _aiChatNotifier;
   Timer? _aiTransitionTimer;
   SearchMode _prevMode = SearchMode.search;
-  bool _hasAi = false;
 
   @override
   void initState() {
@@ -89,7 +88,6 @@ class _AppShellState extends ConsumerState<AppShell>
   void _initLibraries() {
     final auth = ref.read(authProvider).valueOrNull;
     final backendDio = ref.read(backendClientProvider);
-    _hasAi = auth?.connection?.services.ai ?? false;
 
     // Use instance-aware API services
     final defaultRadarr = auth?.connection?.defaultRadarrInstance;
@@ -164,12 +162,16 @@ class _AppShellState extends ConsumerState<AppShell>
         _glowAnim.stop();
         _glowAnim.value = 0;
         _aiModeAnim.forward();
-        // Auto-send the original query to AI
+        // Defer auto-send to after the current build frame to avoid
+        // setState() during build (sendMessage triggers notifyListeners).
         final query = ref.read(shellSearchProvider).searchQuery;
         if (query.isNotEmpty) {
-          final chat = _getOrCreateAiChat();
-          chat.sendMessage(query);
-          _searchController.clear();
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            if (!mounted) return;
+            final chat = _getOrCreateAiChat();
+            chat.sendMessage(query);
+            _searchController.clear();
+          });
         }
 
       case SearchMode.search:
@@ -289,6 +291,7 @@ class _AppShellState extends ConsumerState<AppShell>
   Widget build(BuildContext context) {
     final searchState = ref.watch(shellSearchProvider);
     final searchNotifier = ref.read(shellSearchProvider.notifier);
+    final hasAi = ref.watch(authProvider).valueOrNull?.connection?.services.ai ?? false;
     final libraryStatus = searchState.isSearching &&
             searchState.searchMode == SearchMode.search
         ? _buildLibraryStatus(searchState.searchResults)
@@ -306,8 +309,8 @@ class _AppShellState extends ConsumerState<AppShell>
       child: CantinarrSearchBar(
         controller: _searchController,
         focusNode: _searchFocusNode,
-        hintText: _hasAi ? 'Search or ask AI...' : 'Search movies & TV shows...',
-        aiEnabled: _hasAi,
+        hintText: hasAi ? 'Search or ask AI...' : 'Search movies & TV shows...',
+        aiEnabled: hasAi,
         onChanged: isAiMode ? null : (q) => searchNotifier.updateSearch(q),
         onClear: isAiMode ? _exitAiMode : () => searchNotifier.updateSearch(''),
       ),


### PR DESCRIPTION
## Summary
- When search returns no results and AI is configured, the results container pulses with a gold glow then auto-transitions into an inline AI chat
- Search bar drops to the bottom and expands into a multiline input; the original query is automatically sent to the AI
- Search bar hints at AI capability with a sparkle icon and "Search or ask AI..." placeholder when AI is available
- Reuses existing `AiChatService`, `AiChatNotifier`, and `ChatBubble` with zero changes to the AI infrastructure

## Test plan
- [ ] Search a popular movie name — results appear as before, no changes
- [ ] Search gibberish with AI configured — glow pulses, then layout auto-flips to chat with AI response streaming
- [ ] Type follow-up messages in AI chat mode — conversation continues
- [ ] Tap back arrow or clear — smooth reverse animation back to search mode
- [ ] Verify sparkle icon and "Search or ask AI..." hint when AI is configured
- [ ] Verify no glow/transition when AI is not configured (standard "No results" empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)