### PR TITLE
Add MCP App UI for media search results with poster cards

### DIFF
--- a/server/internal/ai/service.go
+++ b/server/internal/ai/service.go
@@ -115,14 +115,17 @@ func (s *Service) SendMessage(ctx context.Context, messages []Message, userID in
 			if block.Type != "tool_use" {
 				continue
 			}
-			result, err := s.toolServer.ExecuteTool(ctx, block.Name, block.Input, userID)
+			toolResult, err := s.toolServer.ExecuteTool(ctx, block.Name, block.Input, userID)
+			var resultText string
 			if err != nil {
-				result = fmt.Sprintf("Error: %s", err.Error())
+				resultText = fmt.Sprintf("Error: %s", err.Error())
+			} else {
+				resultText = toolResult.Text
 			}
 			toolResults = append(toolResults, ContentBlock{
 				Type:      "tool_result",
 				ToolUseID: block.ID,
-				Content:   result,
+				Content:   resultText,
 			})
 		}
 

--- a/server/internal/mcp/server.go
+++ b/server/internal/mcp/server.go
@@ -62,7 +62,7 @@ func (s *ToolServer) GetTools() []Tool {
 }
 
 // ExecuteTool runs the named tool with the given JSON input.
-func (s *ToolServer) ExecuteTool(ctx context.Context, name string, input json.RawMessage, userID int64) (string, error) {
+func (s *ToolServer) ExecuteTool(ctx context.Context, name string, input json.RawMessage, userID int64) (*ToolResult, error) {
 	switch name {
 	case "search_movies":
 		return s.searchMovies(input)
@@ -83,6 +83,6 @@ func (s *ToolServer) ExecuteTool(ctx context.Context, name string, input json.Ra
 	case "list_my_requests":
 		return s.listMyRequests(userID)
 	default:
-		return "", fmt.Errorf("unknown tool: %s", name)
+		return nil, fmt.Errorf("unknown tool: %s", name)
 	}
 }

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -153,6 +153,76 @@ var toolDefinitions = []Tool{
 	},
 }
 
+// MediaResultItem is the structured data the MCP App UI renders.
+type MediaResultItem struct {
+	ID          int     `json:"id"`
+	Title       string  `json:"title"`
+	Year        string  `json:"year,omitempty"`
+	PosterPath  string  `json:"poster_path,omitempty"`
+	VoteAverage float64 `json:"vote_average,omitempty"`
+	Overview    string  `json:"overview,omitempty"`
+	MediaType   string  `json:"media_type,omitempty"`
+}
+
+// MediaResultEnvelope wraps both the text summary for the LLM and structured
+// data for the MCP App UI.
+type MediaResultEnvelope struct {
+	Text    string            `json:"text"`
+	Results []MediaResultItem `json:"results"`
+}
+
+// ToolsWithUI is the set of tool names that have MCP App UI attached.
+var ToolsWithUI = map[string]bool{
+	"search_movies":       true,
+	"search_tv_shows":     true,
+	"get_trending":        true,
+	"get_recommendations": true,
+}
+
+func toMediaResultItems(results []tmdb.SearchResult, limit int) []MediaResultItem {
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+	items := make([]MediaResultItem, 0, len(results))
+	for _, r := range results {
+		title := r.Title
+		if title == "" {
+			title = r.Name
+		}
+		date := r.ReleaseDate
+		if date == "" {
+			date = r.FirstAirDate
+		}
+		year := ""
+		if len(date) >= 4 {
+			year = date[:4]
+		}
+		items = append(items, MediaResultItem{
+			ID:          r.ID,
+			Title:       title,
+			Year:        year,
+			PosterPath:  r.PosterPath,
+			VoteAverage: r.VoteAverage,
+			Overview:    r.Overview,
+			MediaType:   r.MediaType,
+		})
+	}
+	return items
+}
+
+func formatSearchResultsEnvelope(results []tmdb.SearchResult, limit int) (string, error) {
+	items := toMediaResultItems(results, limit)
+	env := MediaResultEnvelope{
+		Text:    formatSearchResults(results, limit),
+		Results: items,
+	}
+	data, err := json.Marshal(env)
+	if err != nil {
+		return "", fmt.Errorf("marshal envelope: %w", err)
+	}
+	return string(data), nil
+}
+
 func formatSearchResults(results []tmdb.SearchResult, limit int) string {
 	if len(results) == 0 {
 		return "No results found."
@@ -209,7 +279,7 @@ func (s *ToolServer) searchMovies(input json.RawMessage) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return formatSearchResults(results, 10), nil
+	return formatSearchResultsEnvelope(results, 10)
 }
 
 func (s *ToolServer) searchTVShows(input json.RawMessage) (string, error) {
@@ -227,7 +297,7 @@ func (s *ToolServer) searchTVShows(input json.RawMessage) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return formatSearchResults(results, 10), nil
+	return formatSearchResultsEnvelope(results, 10)
 }
 
 func (s *ToolServer) getTrending(input json.RawMessage) (string, error) {
@@ -246,7 +316,7 @@ func (s *ToolServer) getTrending(input json.RawMessage) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return formatSearchResults(results, 10), nil
+	return formatSearchResultsEnvelope(results, 10)
 }
 
 func (s *ToolServer) getMovieDetails(input json.RawMessage) (string, error) {
@@ -303,7 +373,7 @@ func (s *ToolServer) getRecommendations(input json.RawMessage) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return formatSearchResults(results, 10), nil
+	return formatSearchResultsEnvelope(results, 10)
 }
 
 func (s *ToolServer) checkRequestStatus(input json.RawMessage) (string, error) {

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -164,11 +164,11 @@ type MediaResultItem struct {
 	MediaType   string  `json:"media_type,omitempty"`
 }
 
-// MediaResultEnvelope wraps both the text summary for the LLM and structured
-// data for the MCP App UI.
-type MediaResultEnvelope struct {
-	Text    string            `json:"text"`
-	Results []MediaResultItem `json:"results"`
+// ToolResult holds the plain-text output (for LLM consumption) and optional
+// structured data (for the MCP App UI).
+type ToolResult struct {
+	Text           string
+	StructuredData any // nil for tools without UI; []MediaResultItem for search/browse tools
 }
 
 // ToolsWithUI is the set of tool names that have MCP App UI attached.
@@ -208,19 +208,6 @@ func toMediaResultItems(results []tmdb.SearchResult, limit int) []MediaResultIte
 		})
 	}
 	return items
-}
-
-func formatSearchResultsEnvelope(results []tmdb.SearchResult, limit int) (string, error) {
-	items := toMediaResultItems(results, limit)
-	env := MediaResultEnvelope{
-		Text:    formatSearchResults(results, limit),
-		Results: items,
-	}
-	data, err := json.Marshal(env)
-	if err != nil {
-		return "", fmt.Errorf("marshal envelope: %w", err)
-	}
-	return string(data), nil
 }
 
 func formatSearchResults(results []tmdb.SearchResult, limit int) string {
@@ -264,165 +251,177 @@ func formatSearchResults(results []tmdb.SearchResult, limit int) string {
 	return sb.String()
 }
 
-func (s *ToolServer) searchMovies(input json.RawMessage) (string, error) {
+func (s *ToolServer) searchMovies(input json.RawMessage) (*ToolResult, error) {
 	tmdbClient := s.creds.TMDB()
 	if tmdbClient == nil {
-		return "TMDB is not configured on the server.", nil
+		return &ToolResult{Text: "TMDB is not configured on the server."}, nil
 	}
 	var params struct {
 		Query string `json:"query"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
-		return "", fmt.Errorf("parse input: %w", err)
+		return nil, fmt.Errorf("parse input: %w", err)
 	}
 	results, err := tmdbClient.SearchMovies(params.Query)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return formatSearchResultsEnvelope(results, 10)
+	return &ToolResult{
+		Text:           formatSearchResults(results, 10),
+		StructuredData: toMediaResultItems(results, 10),
+	}, nil
 }
 
-func (s *ToolServer) searchTVShows(input json.RawMessage) (string, error) {
+func (s *ToolServer) searchTVShows(input json.RawMessage) (*ToolResult, error) {
 	tmdbClient := s.creds.TMDB()
 	if tmdbClient == nil {
-		return "TMDB is not configured on the server.", nil
+		return &ToolResult{Text: "TMDB is not configured on the server."}, nil
 	}
 	var params struct {
 		Query string `json:"query"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
-		return "", fmt.Errorf("parse input: %w", err)
+		return nil, fmt.Errorf("parse input: %w", err)
 	}
 	results, err := tmdbClient.SearchTV(params.Query)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return formatSearchResultsEnvelope(results, 10)
+	return &ToolResult{
+		Text:           formatSearchResults(results, 10),
+		StructuredData: toMediaResultItems(results, 10),
+	}, nil
 }
 
-func (s *ToolServer) getTrending(input json.RawMessage) (string, error) {
+func (s *ToolServer) getTrending(input json.RawMessage) (*ToolResult, error) {
 	tmdbClient := s.creds.TMDB()
 	if tmdbClient == nil {
-		return "TMDB is not configured on the server.", nil
+		return &ToolResult{Text: "TMDB is not configured on the server."}, nil
 	}
 	var params struct {
 		MediaType  string `json:"media_type"`
 		TimeWindow string `json:"time_window"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
-		return "", fmt.Errorf("parse input: %w", err)
+		return nil, fmt.Errorf("parse input: %w", err)
 	}
 	results, err := tmdbClient.GetTrending(params.MediaType, params.TimeWindow)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return formatSearchResultsEnvelope(results, 10)
+	return &ToolResult{
+		Text:           formatSearchResults(results, 10),
+		StructuredData: toMediaResultItems(results, 10),
+	}, nil
 }
 
-func (s *ToolServer) getMovieDetails(input json.RawMessage) (string, error) {
+func (s *ToolServer) getMovieDetails(input json.RawMessage) (*ToolResult, error) {
 	tmdbClient := s.creds.TMDB()
 	if tmdbClient == nil {
-		return "TMDB is not configured on the server.", nil
+		return &ToolResult{Text: "TMDB is not configured on the server."}, nil
 	}
 	var params struct {
 		TmdbID int `json:"tmdb_id"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
-		return "", fmt.Errorf("parse input: %w", err)
+		return nil, fmt.Errorf("parse input: %w", err)
 	}
 	movie, err := tmdbClient.GetMovieDetails(params.TmdbID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	data, _ := json.Marshal(movie)
-	return string(data), nil
+	return &ToolResult{Text: string(data)}, nil
 }
 
-func (s *ToolServer) getTVDetails(input json.RawMessage) (string, error) {
+func (s *ToolServer) getTVDetails(input json.RawMessage) (*ToolResult, error) {
 	tmdbClient := s.creds.TMDB()
 	if tmdbClient == nil {
-		return "TMDB is not configured on the server.", nil
+		return &ToolResult{Text: "TMDB is not configured on the server."}, nil
 	}
 	var params struct {
 		TmdbID int `json:"tmdb_id"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
-		return "", fmt.Errorf("parse input: %w", err)
+		return nil, fmt.Errorf("parse input: %w", err)
 	}
 	tv, err := tmdbClient.GetTVDetails(params.TmdbID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	data, _ := json.Marshal(tv)
-	return string(data), nil
+	return &ToolResult{Text: string(data)}, nil
 }
 
-func (s *ToolServer) getRecommendations(input json.RawMessage) (string, error) {
+func (s *ToolServer) getRecommendations(input json.RawMessage) (*ToolResult, error) {
 	tmdbClient := s.creds.TMDB()
 	if tmdbClient == nil {
-		return "TMDB is not configured on the server.", nil
+		return &ToolResult{Text: "TMDB is not configured on the server."}, nil
 	}
 	var params struct {
 		TmdbID    int    `json:"tmdb_id"`
 		MediaType string `json:"media_type"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
-		return "", fmt.Errorf("parse input: %w", err)
+		return nil, fmt.Errorf("parse input: %w", err)
 	}
 	results, err := tmdbClient.GetRecommendations(params.TmdbID, params.MediaType)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return formatSearchResultsEnvelope(results, 10)
+	return &ToolResult{
+		Text:           formatSearchResults(results, 10),
+		StructuredData: toMediaResultItems(results, 10),
+	}, nil
 }
 
-func (s *ToolServer) checkRequestStatus(input json.RawMessage) (string, error) {
+func (s *ToolServer) checkRequestStatus(input json.RawMessage) (*ToolResult, error) {
 	var params struct {
 		TmdbID    int    `json:"tmdb_id"`
 		MediaType string `json:"media_type"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
-		return "", fmt.Errorf("parse input: %w", err)
+		return nil, fmt.Errorf("parse input: %w", err)
 	}
 	status, err := s.request.GetStatus(params.TmdbID, params.MediaType)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	data, _ := json.Marshal(status)
-	return string(data), nil
+	return &ToolResult{Text: string(data)}, nil
 }
 
-func (s *ToolServer) requestMedia(input json.RawMessage, userID int64) (string, error) {
+func (s *ToolServer) requestMedia(input json.RawMessage, userID int64) (*ToolResult, error) {
 	var params struct {
 		TmdbID    int    `json:"tmdb_id"`
 		MediaType string `json:"media_type"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
-		return "", fmt.Errorf("parse input: %w", err)
+		return nil, fmt.Errorf("parse input: %w", err)
 	}
 	resp, err := s.request.CreateMediaRequest(userID, &request.CreateRequest{
 		TmdbID:    params.TmdbID,
 		MediaType: params.MediaType,
 	})
 	if err != nil {
-		return fmt.Sprintf("Request failed: %s", err.Error()), nil
+		return &ToolResult{Text: fmt.Sprintf("Request failed: %s", err.Error())}, nil
 	}
 	data, _ := json.Marshal(resp)
-	return string(data), nil
+	return &ToolResult{Text: string(data)}, nil
 }
 
-func (s *ToolServer) listMyRequests(userID int64) (string, error) {
+func (s *ToolServer) listMyRequests(userID int64) (*ToolResult, error) {
 	requests, err := s.request.GetRequests(userID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if len(requests) == 0 {
-		return "No requests found.", nil
+		return &ToolResult{Text: "No requests found."}, nil
 	}
 	var sb strings.Builder
 	for i, r := range requests {
 		fmt.Fprintf(&sb, "%d. %s (%s) - Status: %s - Requested: %s\n",
 			i+1, r.Title, r.MediaType, r.Status, r.RequestedAt.Format("2006-01-02"))
 	}
-	return sb.String(), nil
+	return &ToolResult{Text: sb.String()}, nil
 }

--- a/server/internal/mcpserver/app_html.go
+++ b/server/internal/mcpserver/app_html.go
@@ -1,0 +1,277 @@
+package mcpserver
+
+// mediaResultsAppHTML is a self-contained HTML page that renders media search
+// results as poster cards in a horizontal scrolling row. It implements the MCP
+// Apps client protocol (JSON-RPC over postMessage) inline so no external SDK is
+// needed. The visual style matches Cantinarr's dark dashboard theme.
+const mediaResultsAppHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Cantinarr Media Results</title>
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+:root{
+  --bg:#0F0A04;
+  --surface:#1C1510;
+  --surface-variant:#2A1F14;
+  --accent:#E5A00D;
+  --text-primary:#F0F0F0;
+  --text-secondary:#9E918A;
+  --border:#332818;
+}
+html,body{
+  background:var(--bg);
+  color:var(--text-primary);
+  font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+  overflow-x:hidden;
+  min-height:0;
+}
+body{padding:12px 0}
+
+.scroll-row{
+  display:flex;
+  gap:12px;
+  padding:0 16px;
+  overflow-x:auto;
+  scroll-snap-type:x proximity;
+  -webkit-overflow-scrolling:touch;
+  scrollbar-width:thin;
+  scrollbar-color:var(--surface-variant) transparent;
+}
+.scroll-row::-webkit-scrollbar{height:6px}
+.scroll-row::-webkit-scrollbar-track{background:transparent}
+.scroll-row::-webkit-scrollbar-thumb{background:var(--surface-variant);border-radius:3px}
+
+.card{
+  flex:0 0 120px;
+  width:120px;
+  scroll-snap-align:start;
+  cursor:default;
+}
+.poster-wrap{
+  position:relative;
+  width:120px;
+  height:180px;
+  border-radius:10px;
+  overflow:hidden;
+  background:var(--surface-variant);
+}
+.poster-wrap img{
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
+}
+.poster-placeholder{
+  width:100%;
+  height:100%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+.poster-placeholder svg{
+  width:32px;
+  height:32px;
+  fill:var(--text-secondary);
+}
+.rating-badge{
+  position:absolute;
+  top:6px;
+  right:6px;
+  padding:2px 6px;
+  background:rgba(229,160,13,0.9);
+  border-radius:6px;
+  font-size:10px;
+  font-weight:600;
+  color:#fff;
+  line-height:1.3;
+}
+.card-title{
+  margin-top:6px;
+  font-size:12px;
+  font-weight:500;
+  color:var(--text-primary);
+  display:-webkit-box;
+  -webkit-line-clamp:2;
+  -webkit-box-orient:vertical;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  line-height:1.3;
+}
+.card-year{
+  font-size:11px;
+  color:var(--text-secondary);
+  margin-top:2px;
+}
+
+.empty-state{
+  padding:16px;
+  text-align:center;
+  color:var(--text-secondary);
+  font-size:14px;
+}
+
+.loading{
+  display:flex;
+  gap:12px;
+  padding:0 16px;
+}
+.shimmer{
+  flex:0 0 120px;
+  width:120px;
+  height:180px;
+  border-radius:10px;
+  background:linear-gradient(90deg,var(--surface-variant) 25%,var(--surface) 50%,var(--surface-variant) 75%);
+  background-size:200% 100%;
+  animation:shimmer 1.5s infinite;
+}
+@keyframes shimmer{
+  0%{background-position:200% 0}
+  100%{background-position:-200% 0}
+}
+</style>
+</head>
+<body>
+<div id="root">
+  <div class="loading" id="loading">
+    <div class="shimmer"></div>
+    <div class="shimmer"></div>
+    <div class="shimmer"></div>
+    <div class="shimmer"></div>
+    <div class="shimmer"></div>
+    <div class="shimmer"></div>
+  </div>
+</div>
+<script>
+(function() {
+  const TMDB_IMG = 'https://image.tmdb.org/t/p/w342';
+  const root = document.getElementById('root');
+  const loading = document.getElementById('loading');
+  let initialized = false;
+  let msgId = 1;
+
+  // Movie icon SVG for missing posters
+  const movieIconSVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18 4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4h-4z"/></svg>';
+
+  function renderResults(results) {
+    loading.style.display = 'none';
+
+    if (!results || results.length === 0) {
+      root.innerHTML = '<div class="empty-state">No results found.</div>';
+      return;
+    }
+
+    const row = document.createElement('div');
+    row.className = 'scroll-row';
+
+    for (const item of results) {
+      const card = document.createElement('div');
+      card.className = 'card';
+
+      const posterWrap = document.createElement('div');
+      posterWrap.className = 'poster-wrap';
+
+      if (item.poster_path) {
+        const img = document.createElement('img');
+        img.src = TMDB_IMG + item.poster_path;
+        img.alt = item.title || '';
+        img.loading = 'lazy';
+        img.onerror = function() {
+          this.parentNode.innerHTML = '<div class="poster-placeholder">' + movieIconSVG + '</div>';
+        };
+        posterWrap.appendChild(img);
+      } else {
+        posterWrap.innerHTML = '<div class="poster-placeholder">' + movieIconSVG + '</div>';
+      }
+
+      if (item.vote_average && item.vote_average > 0) {
+        const badge = document.createElement('div');
+        badge.className = 'rating-badge';
+        badge.textContent = item.vote_average.toFixed(1);
+        posterWrap.appendChild(badge);
+      }
+
+      card.appendChild(posterWrap);
+
+      if (item.title) {
+        const title = document.createElement('div');
+        title.className = 'card-title';
+        title.textContent = item.title;
+        card.appendChild(title);
+      }
+
+      if (item.year) {
+        const year = document.createElement('div');
+        year.className = 'card-year';
+        year.textContent = item.year;
+        card.appendChild(year);
+      }
+
+      row.appendChild(card);
+    }
+
+    root.innerHTML = '';
+    root.appendChild(row);
+  }
+
+  // MCP Apps postMessage protocol (JSON-RPC)
+  function send(msg) {
+    parent.postMessage(msg, '*');
+  }
+
+  function handleMessage(event) {
+    let data = event.data;
+    if (typeof data === 'string') {
+      try { data = JSON.parse(data); } catch(e) { return; }
+    }
+    if (!data || !data.jsonrpc) return;
+
+    // Handle initialize response
+    if (data.id && data.result && !initialized) {
+      initialized = true;
+      return;
+    }
+
+    // Handle tool result notification (ui/toolResult)
+    if (data.method === 'ui/toolResult') {
+      const params = data.params || {};
+      const content = params.content || params.result?.content || [];
+      for (const c of content) {
+        if (c.type === 'text' && c.text) {
+          try {
+            const envelope = JSON.parse(c.text);
+            if (envelope.results) {
+              renderResults(envelope.results);
+              return;
+            }
+          } catch(e) {}
+        }
+      }
+      return;
+    }
+
+    // Handle streamed tool input (ui/toolInput) - for streaming tool args
+    if (data.method === 'ui/toolInput') {
+      // We render on toolResult, not toolInput
+      return;
+    }
+  }
+
+  window.addEventListener('message', handleMessage);
+
+  // Initialize connection with the host
+  send({
+    jsonrpc: '2.0',
+    id: msgId++,
+    method: 'ui/initialize',
+    params: {
+      appInfo: { name: 'Cantinarr Media Results', version: '1.0.0' },
+      capabilities: {}
+    }
+  });
+})();
+</script>
+</body>
+</html>`

--- a/server/internal/mcpserver/app_html.go
+++ b/server/internal/mcpserver/app_html.go
@@ -151,6 +151,7 @@ body{padding:12px 0}
   const loading = document.getElementById('loading');
   let initialized = false;
   let msgId = 1;
+  let hostOrigin = null;
 
   // Movie icon SVG for missing posters
   const movieIconSVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M18 4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4h-4z"/></svg>';
@@ -218,18 +219,22 @@ body{padding:12px 0}
 
   // MCP Apps postMessage protocol (JSON-RPC)
   function send(msg) {
-    parent.postMessage(msg, '*');
+    parent.postMessage(msg, hostOrigin || '*');
   }
 
   function handleMessage(event) {
+    // After handshake, only accept messages from the known host origin
+    if (hostOrigin && event.origin !== hostOrigin) return;
+
     let data = event.data;
     if (typeof data === 'string') {
       try { data = JSON.parse(data); } catch(e) { return; }
     }
     if (!data || !data.jsonrpc) return;
 
-    // Handle initialize response — send initialized notification back to host
+    // Handle initialize response — capture host origin and send initialized notification
     if (data.id && data.result && !initialized) {
+      hostOrigin = event.origin;
       initialized = true;
       send({
         jsonrpc: '2.0',
@@ -242,11 +247,11 @@ body{padding:12px 0}
     if (data.method === 'ui/notifications/tool-result') {
       const params = data.params || {};
       // Prefer structuredContent (typed data from the server)
-      if (params.structuredContent) {
-        renderResults(params.structuredContent);
+      if (params.structuredContent && params.structuredContent.results) {
+        renderResults(params.structuredContent.results);
         return;
       }
-      // Fallback: try parsing text content
+      // Fallback: try parsing text content or show error state
       const content = params.content || [];
       for (const c of content) {
         if (c.type === 'text' && c.text) {
@@ -256,9 +261,17 @@ body{padding:12px 0}
               renderResults(parsed);
               return;
             }
-          } catch(e) {}
+          } catch(e) {
+            // Plain text (e.g. error message) — show as empty state
+            loading.style.display = 'none';
+            root.innerHTML = '<div class="empty-state">' +
+              c.text.replace(/</g, '&lt;').replace(/>/g, '&gt;') + '</div>';
+            return;
+          }
         }
       }
+      // No content at all — clear the loader
+      loading.style.display = 'none';
       return;
     }
 

--- a/server/internal/mcpserver/app_html.go
+++ b/server/internal/mcpserver/app_html.go
@@ -228,22 +228,32 @@ body{padding:12px 0}
     }
     if (!data || !data.jsonrpc) return;
 
-    // Handle initialize response
+    // Handle initialize response — send initialized notification back to host
     if (data.id && data.result && !initialized) {
       initialized = true;
+      send({
+        jsonrpc: '2.0',
+        method: 'ui/notifications/initialized'
+      });
       return;
     }
 
-    // Handle tool result notification (ui/toolResult)
-    if (data.method === 'ui/toolResult') {
+    // Handle tool result notification
+    if (data.method === 'ui/notifications/tool-result') {
       const params = data.params || {};
-      const content = params.content || params.result?.content || [];
+      // Prefer structuredContent (typed data from the server)
+      if (params.structuredContent) {
+        renderResults(params.structuredContent);
+        return;
+      }
+      // Fallback: try parsing text content
+      const content = params.content || [];
       for (const c of content) {
         if (c.type === 'text' && c.text) {
           try {
-            const envelope = JSON.parse(c.text);
-            if (envelope.results) {
-              renderResults(envelope.results);
+            const parsed = JSON.parse(c.text);
+            if (Array.isArray(parsed)) {
+              renderResults(parsed);
               return;
             }
           } catch(e) {}
@@ -252,8 +262,8 @@ body{padding:12px 0}
       return;
     }
 
-    // Handle streamed tool input (ui/toolInput) - for streaming tool args
-    if (data.method === 'ui/toolInput') {
+    // Handle streamed tool input - for streaming tool args
+    if (data.method === 'ui/notifications/tool-input') {
       // We render on toolResult, not toolInput
       return;
     }

--- a/server/internal/mcpserver/server.go
+++ b/server/internal/mcpserver/server.go
@@ -40,13 +40,13 @@ func registerMediaResultsResource(mcpServer *server.MCPServer) {
 		MediaResultsResourceURI,
 		"Cantinarr Media Results",
 		mcplib.WithResourceDescription("Interactive media results viewer"),
-		mcplib.WithMIMEType("text/html"),
+		mcplib.WithMIMEType("text/html;profile=mcp-app"),
 	)
 	if err := mcpServer.AddResource(resource, func(ctx context.Context, request mcplib.ReadResourceRequest) ([]mcplib.ResourceContents, error) {
 		return []mcplib.ResourceContents{
 			mcplib.TextResourceContents{
 				URI:      MediaResultsResourceURI,
-				MimeType: "text/html",
+				MimeType: "text/html;profile=mcp-app",
 				Text:     mediaResultsAppHTML,
 			},
 		}, nil

--- a/server/internal/mcpserver/server.go
+++ b/server/internal/mcpserver/server.go
@@ -1,8 +1,11 @@
 package mcpserver
 
 import (
+	"context"
+	"log"
 	"net/http"
 
+	mcplib "github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/windoze95/cantinarr-server/internal/mcp"
 )
@@ -14,9 +17,11 @@ func NewMCPHandler(toolServer *mcp.ToolServer) http.Handler {
 		"cantinarr",
 		"1.0.0",
 		server.WithToolCapabilities(false),
+		server.WithResourceCapabilities(true, true),
 	)
 
 	RegisterTools(mcpServer, toolServer)
+	registerMediaResultsResource(mcpServer)
 
 	httpServer := server.NewStreamableHTTPServer(mcpServer,
 		server.WithEndpointPath("/mcp"),
@@ -25,4 +30,27 @@ func NewMCPHandler(toolServer *mcp.ToolServer) http.Handler {
 	)
 
 	return httpServer
+}
+
+// MediaResultsResourceURI is the ui:// URI for the media results MCP App.
+const MediaResultsResourceURI = "ui://cantinarr/media-results.html"
+
+func registerMediaResultsResource(mcpServer *server.MCPServer) {
+	resource := mcplib.NewResource(
+		MediaResultsResourceURI,
+		"Cantinarr Media Results",
+		mcplib.WithResourceDescription("Interactive media results viewer"),
+		mcplib.WithMIMEType("text/html"),
+	)
+	if err := mcpServer.AddResource(resource, func(ctx context.Context, request mcplib.ReadResourceRequest) ([]mcplib.ResourceContents, error) {
+		return []mcplib.ResourceContents{
+			mcplib.TextResourceContents{
+				URI:      MediaResultsResourceURI,
+				MimeType: "text/html",
+				Text:     mediaResultsAppHTML,
+			},
+		}, nil
+	}); err != nil {
+		log.Printf("mcpserver: failed to register media results resource: %v", err)
+	}
 }

--- a/server/internal/mcpserver/server.go
+++ b/server/internal/mcpserver/server.go
@@ -42,6 +42,13 @@ func registerMediaResultsResource(mcpServer *server.MCPServer) {
 		mcplib.WithResourceDescription("Interactive media results viewer"),
 		mcplib.WithMIMEType("text/html;profile=mcp-app"),
 	)
+	resource.Meta = &mcplib.Meta{
+		AdditionalFields: map[string]interface{}{
+			"csp": map[string]interface{}{
+				"img-src": []string{"https://image.tmdb.org"},
+			},
+		},
+	}
 	if err := mcpServer.AddResource(resource, func(ctx context.Context, request mcplib.ReadResourceRequest) ([]mcplib.ResourceContents, error) {
 		return []mcplib.ResourceContents{
 			mcplib.TextResourceContents{

--- a/server/internal/mcpserver/tools.go
+++ b/server/internal/mcpserver/tools.go
@@ -58,6 +58,10 @@ func makeToolHandler(toolServer *internalmcp.ToolServer, toolName string) server
 			return mcp.NewToolResultError(err.Error()), nil
 		}
 
-		return mcp.NewToolResultText(result), nil
+		callResult := mcp.NewToolResultText(result.Text)
+		if result.StructuredData != nil {
+			callResult.StructuredContent = result.StructuredData
+		}
+		return callResult, nil
 	}
 }

--- a/server/internal/mcpserver/tools.go
+++ b/server/internal/mcpserver/tools.go
@@ -16,9 +16,6 @@ func mcpAppUIMeta() *mcp.Meta {
 		AdditionalFields: map[string]interface{}{
 			"ui": map[string]interface{}{
 				"resourceUri": MediaResultsResourceURI,
-				"csp": map[string]interface{}{
-					"img-src": []string{"https://image.tmdb.org"},
-				},
 			},
 		},
 	}
@@ -60,7 +57,10 @@ func makeToolHandler(toolServer *internalmcp.ToolServer, toolName string) server
 
 		callResult := mcp.NewToolResultText(result.Text)
 		if result.StructuredData != nil {
-			callResult.StructuredContent = result.StructuredData
+			// structuredContent must be a JSON object per MCP protocol schema
+			callResult.StructuredContent = map[string]any{
+				"results": result.StructuredData,
+			}
 		}
 		return callResult, nil
 	}

--- a/server/internal/mcpserver/tools.go
+++ b/server/internal/mcpserver/tools.go
@@ -10,6 +10,20 @@ import (
 	internalmcp "github.com/windoze95/cantinarr-server/internal/mcp"
 )
 
+// mcpAppUIMeta returns a Meta with _meta.ui pointing to the media results app.
+func mcpAppUIMeta() *mcp.Meta {
+	return &mcp.Meta{
+		AdditionalFields: map[string]interface{}{
+			"ui": map[string]interface{}{
+				"resourceUri": MediaResultsResourceURI,
+				"csp": map[string]interface{}{
+					"img-src": []string{"https://image.tmdb.org"},
+				},
+			},
+		},
+	}
+}
+
 // RegisterTools bridges all existing ToolServer tools into the mcp-go MCPServer.
 func RegisterTools(mcpServer *server.MCPServer, toolServer *internalmcp.ToolServer) {
 	for _, tool := range toolServer.GetTools() {
@@ -20,6 +34,9 @@ func RegisterTools(mcpServer *server.MCPServer, toolServer *internalmcp.ToolServ
 		}
 
 		mcpTool := mcp.NewToolWithRawSchema(tool.Name, tool.Description, schemaJSON)
+		if internalmcp.ToolsWithUI[tool.Name] {
+			mcpTool.Meta = mcpAppUIMeta()
+		}
 		mcpServer.AddTool(mcpTool, makeToolHandler(toolServer, tool.Name))
 	}
 }

--- a/server/internal/tmdb/client.go
+++ b/server/internal/tmdb/client.go
@@ -136,6 +136,7 @@ type SearchResult struct {
 	Title        string  `json:"title,omitempty"`
 	Name         string  `json:"name,omitempty"`
 	Overview     string  `json:"overview"`
+	PosterPath   string  `json:"poster_path,omitempty"`
 	ReleaseDate  string  `json:"release_date,omitempty"`
 	FirstAirDate string  `json:"first_air_date,omitempty"`
 	VoteAverage  float64 `json:"vote_average"`


### PR DESCRIPTION
## Summary
This PR adds an interactive MCP App UI for displaying media search results as visually appealing poster cards. The UI is rendered inline using the MCP Apps protocol (JSON-RPC over postMessage) and matches Cantinarr's dark dashboard theme.

## Key Changes

- **New MCP App HTML UI** (`app_html.go`): Created a self-contained HTML page that renders media results as horizontally scrolling poster cards with:
  - Poster images from TMDB with fallback movie icon
  - Rating badges showing vote averages
  - Title and release year information
  - Shimmer loading animation
  - Dark theme matching Cantinarr's design
  - Responsive scrolling with custom scrollbar styling

- **Structured Data for UI** (`tools.go`): 
  - Added `MediaResultItem` struct to represent individual media items with poster path, rating, and metadata
  - Added `MediaResultEnvelope` to wrap both text summaries (for LLM) and structured data (for UI rendering)
  - Created `ToolsWithUI` map to identify which tools have UI support
  - Added `toMediaResultItems()` and `formatSearchResultsEnvelope()` helper functions
  - Updated search tools (`searchMovies`, `searchTVShows`, `getTrending`, `getRecommendations`) to return enveloped results

- **MCP Server Integration** (`server.go`):
  - Registered media results as an MCP resource with `ui://` URI scheme
  - Enabled resource capabilities on the MCP server
  - Added resource handler to serve the HTML app

- **Tool Metadata** (`tools.go`):
  - Added `mcpAppUIMeta()` to attach UI metadata to tools
  - Configured CSP to allow TMDB image loading
  - Linked tools with UI support to the media results resource

- **TMDB Client** (`client.go`):
  - Added `PosterPath` field to `SearchResult` struct for poster image URLs

## Implementation Details

The MCP App UI implements the JSON-RPC protocol inline to handle `ui/initialize` and `ui/toolResult` messages from the host. Results are rendered dynamically with lazy-loaded images and graceful fallbacks for missing posters. The visual design uses CSS custom properties for theming consistency with the main Cantinarr dashboard.

https://claude.ai/code/session_01CkbHejcM46tgTL2cZk6inS