### PR TITLE
Fix mcp-go API compatibility in MCP resource registration

### DIFF
--- a/server/internal/mcpserver/server.go
+++ b/server/internal/mcpserver/server.go
@@ -2,7 +2,6 @@ package mcpserver
 
 import (
 	"context"
-	"log"
 	"net/http"
 
 	mcplib "github.com/mark3labs/mcp-go/mcp"
@@ -49,15 +48,13 @@ func registerMediaResultsResource(mcpServer *server.MCPServer) {
 			},
 		},
 	}
-	if err := mcpServer.AddResource(resource, func(ctx context.Context, request mcplib.ReadResourceRequest) ([]mcplib.ResourceContents, error) {
+	mcpServer.AddResource(resource, func(ctx context.Context, request mcplib.ReadResourceRequest) ([]mcplib.ResourceContents, error) {
 		return []mcplib.ResourceContents{
 			mcplib.TextResourceContents{
 				URI:      MediaResultsResourceURI,
-				MimeType: "text/html;profile=mcp-app",
+				MIMEType: "text/html;profile=mcp-app",
 				Text:     mediaResultsAppHTML,
 			},
 		}, nil
-	}); err != nil {
-		log.Printf("mcpserver: failed to register media results resource: %v", err)
-	}
+	})
 }


### PR DESCRIPTION
## Summary
- Fix `AddResource` call that no longer returns a value in latest mcp-go
- Rename `MimeType` field to `MIMEType` on `TextResourceContents` to match updated struct definition
- Remove unused `log` import

## Test plan
- [x] Local `go build ./cmd/server` passes
- [ ] CI Docker build succeeds on linux/amd64 and linux/arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)