### PR TITLE
Fix web storage crash on HTTP (non-HTTPS) deployments

### DIFF
--- a/app/lib/core/storage/secure_storage.dart
+++ b/app/lib/core/storage/secure_storage.dart
@@ -1,11 +1,64 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-/// Provides access to encrypted key-value storage for API keys and tokens.
-final secureStorageProvider = Provider<FlutterSecureStorage>(
-  (_) => const FlutterSecureStorage(
+/// Platform-aware key-value storage.
+///
+/// On native platforms, uses FlutterSecureStorage (Keychain / EncryptedSharedPreferences).
+/// On web, uses SharedPreferences (localStorage) because FlutterSecureStorage's
+/// Web Crypto API requires HTTPS, which self-hosted LAN deployments often lack.
+abstract class StorageService {
+  Future<String?> read({required String key});
+  Future<void> write({required String key, required String? value});
+  Future<void> delete({required String key});
+}
+
+class _NativeStorageService implements StorageService {
+  final _storage = const FlutterSecureStorage(
     aOptions: AndroidOptions(encryptedSharedPreferences: true),
-  ),
+  );
+
+  @override
+  Future<String?> read({required String key}) => _storage.read(key: key);
+
+  @override
+  Future<void> write({required String key, required String? value}) =>
+      _storage.write(key: key, value: value);
+
+  @override
+  Future<void> delete({required String key}) => _storage.delete(key: key);
+}
+
+class _WebStorageService implements StorageService {
+  static const _prefix = 'cantinarr_';
+
+  @override
+  Future<String?> read({required String key}) async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString('$_prefix$key');
+  }
+
+  @override
+  Future<void> write({required String key, required String? value}) async {
+    final prefs = await SharedPreferences.getInstance();
+    if (value == null) {
+      await prefs.remove('$_prefix$key');
+    } else {
+      await prefs.setString('$_prefix$key', value);
+    }
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('$_prefix$key');
+  }
+}
+
+/// Provides access to token/credential storage.
+final storageServiceProvider = Provider<StorageService>(
+  (_) => kIsWeb ? _WebStorageService() : _NativeStorageService(),
 );
 
 /// Keys used in secure storage.

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import '../../../core/models/backend_connection.dart';
 import '../../../core/models/user_profile.dart';
 import '../../../core/storage/secure_storage.dart';
@@ -52,12 +51,12 @@ class AuthState {
 /// Manages authentication lifecycle: login, connect token, token refresh.
 class AuthNotifier extends AsyncNotifier<AuthState> {
   late final AuthService _authService;
-  late final FlutterSecureStorage _storage;
+  late final StorageService _storage;
 
   @override
   Future<AuthState> build() async {
     _authService = AuthService();
-    _storage = ref.read(secureStorageProvider);
+    _storage = ref.read(storageServiceProvider);
 
     // Try to restore session from secure storage
     return _tryRestoreSession();


### PR DESCRIPTION
## Summary
- **Root cause found**: `FlutterSecureStorage` on web uses `crypto.subtle` for encryption, which browsers only expose in secure contexts (HTTPS or localhost). Self-hosted LAN deployments over HTTP (`http://192.168.x.x:8585`) crash silently when saving auth tokens after a successful login/setup.
- Server logs confirmed all API calls returned 200/201 — the crash was client-side in `_saveTokens`
- Introduces a `StorageService` abstraction: `SharedPreferences` (plain localStorage) on web, `FlutterSecureStorage` on native
- Browser localStorage isn't truly "secure" regardless — the Web Crypto encryption layer was security theater

## Context
Fresh Unraid deployment showed "Setup failed" and "Connection failed" errors despite the server processing everything correctly. iOS app worked fine since it uses the Keychain (no HTTPS requirement).

## Test plan
- [ ] Deploy on Unraid/Docker over HTTP — setup and login should work
- [ ] iOS/Android app still works (uses FlutterSecureStorage natively)
- [ ] Session persists across page refreshes on web
- [ ] Logout clears stored tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)