### PR TITLE
Fix AI chat agent loop crash and add rich media cards

### DIFF
--- a/app/lib/features/ai_assistant/data/ai_chat_service.dart
+++ b/app/lib/features/ai_assistant/data/ai_chat_service.dart
@@ -11,8 +11,8 @@ class AiChatService {
 
   AiChatService({required Dio backendDio}) : _backendDio = backendDio;
 
-  /// Send messages and stream the response text chunks via SSE.
-  Stream<String> sendMessage({
+  /// Send messages and stream response events (text chunks + media results) via SSE.
+  Stream<ChatStreamEvent> sendMessage({
     required List<ChatMessage> messages,
   }) async* {
     final apiMessages = messages
@@ -48,13 +48,23 @@ class AiChatService {
 
             try {
               final json = jsonDecode(data) as Map<String, dynamic>;
-              final text = json['text'] as String?;
-              if (text != null && text.isNotEmpty) {
-                yield text;
+              if (json.containsKey('text')) {
+                final text = json['text'] as String?;
+                if (text != null && text.isNotEmpty) {
+                  yield TextChunkEvent(text);
+                }
+              } else if (json.containsKey('media_results')) {
+                final items = (json['media_results'] as List)
+                    .map((e) =>
+                        MediaResultItem.fromJson(e as Map<String, dynamic>))
+                    .toList();
+                if (items.isNotEmpty) {
+                  yield MediaResultsEvent(items);
+                }
               }
             } catch (_) {
               // If it's not JSON, yield the raw data as text
-              if (data.isNotEmpty) yield data;
+              if (data.isNotEmpty) yield TextChunkEvent(data);
             }
           }
         }

--- a/app/lib/features/ai_assistant/data/ai_models.dart
+++ b/app/lib/features/ai_assistant/data/ai_models.dart
@@ -4,13 +4,27 @@ class ChatMessage {
   final ChatRole role;
   final String content;
   final DateTime timestamp;
+  final List<MediaResultItem> mediaResults;
 
   const ChatMessage({
     required this.id,
     required this.role,
     required this.content,
     required this.timestamp,
+    this.mediaResults = const [],
   });
+
+  ChatMessage copyWith({
+    String? content,
+    List<MediaResultItem>? mediaResults,
+  }) =>
+      ChatMessage(
+        id: id,
+        role: role,
+        content: content ?? this.content,
+        timestamp: timestamp,
+        mediaResults: mediaResults ?? this.mediaResults,
+      );
 
   Map<String, dynamic> toApiMessage() => {
         'role': role == ChatRole.user ? 'user' : 'assistant',
@@ -19,3 +33,48 @@ class ChatMessage {
 }
 
 enum ChatRole { user, assistant, system }
+
+/// A media item returned from tool execution for rich UI display.
+class MediaResultItem {
+  final int id;
+  final String title;
+  final String? year;
+  final String? posterPath;
+  final double? voteAverage;
+  final String? overview;
+  final String? mediaType;
+
+  const MediaResultItem({
+    required this.id,
+    required this.title,
+    this.year,
+    this.posterPath,
+    this.voteAverage,
+    this.overview,
+    this.mediaType,
+  });
+
+  factory MediaResultItem.fromJson(Map<String, dynamic> json) =>
+      MediaResultItem(
+        id: json['id'] as int,
+        title: json['title'] as String,
+        year: json['year'] as String?,
+        posterPath: json['poster_path'] as String?,
+        voteAverage: (json['vote_average'] as num?)?.toDouble(),
+        overview: json['overview'] as String?,
+        mediaType: json['media_type'] as String?,
+      );
+}
+
+/// Events emitted from the SSE chat stream.
+sealed class ChatStreamEvent {}
+
+class TextChunkEvent extends ChatStreamEvent {
+  final String text;
+  TextChunkEvent(this.text);
+}
+
+class MediaResultsEvent extends ChatStreamEvent {
+  final List<MediaResultItem> items;
+  MediaResultsEvent(this.items);
+}

--- a/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
+++ b/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
@@ -74,16 +74,21 @@ class AiChatNotifier extends ChangeNotifier {
           .toList();
 
       final buffer = StringBuffer();
+      final mediaItems = <MediaResultItem>[];
       final responseId = _uuid.v4();
 
-      await for (final chunk
+      await for (final event
           in _chatService.sendMessage(messages: conversationMessages)) {
-        buffer.write(chunk);
+        switch (event) {
+          case TextChunkEvent(:final text):
+            buffer.write(text);
+          case MediaResultsEvent(:final items):
+            mediaItems.addAll(items);
+        }
 
         // Update the assistant message in-place for streaming effect
         final updatedMessages = List<ChatMessage>.from(state.messages);
 
-        // Find or create the streaming message
         final existingIdx =
             updatedMessages.indexWhere((m) => m.id == responseId);
         final streamingMessage = ChatMessage(
@@ -91,6 +96,7 @@ class AiChatNotifier extends ChangeNotifier {
           role: ChatRole.assistant,
           content: buffer.toString(),
           timestamp: DateTime.now(),
+          mediaResults: List.unmodifiable(mediaItems),
         );
 
         if (existingIdx >= 0) {
@@ -103,7 +109,7 @@ class AiChatNotifier extends ChangeNotifier {
       }
 
       // If no content was streamed, the response was empty
-      if (buffer.isEmpty) {
+      if (buffer.isEmpty && mediaItems.isEmpty) {
         _addMessage(ChatMessage(
           id: responseId,
           role: ChatRole.assistant,

--- a/app/lib/features/ai_assistant/ui/chat_bubble.dart
+++ b/app/lib/features/ai_assistant/ui/chat_bubble.dart
@@ -1,8 +1,10 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import '../../../core/config/app_config.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/ai_models.dart';
 
-/// A single chat message bubble.
+/// A single chat message bubble with optional media result cards.
 class ChatBubble extends StatelessWidget {
   final ChatMessage message;
 
@@ -33,35 +35,163 @@ class ChatBubble extends StatelessWidget {
             const SizedBox(width: 8),
           ],
           Flexible(
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-              decoration: BoxDecoration(
-                color:
-                    isUser ? AppTheme.accent.withValues(alpha: 0.15) : AppTheme.surfaceVariant,
-                borderRadius: BorderRadius.only(
-                  topLeft: const Radius.circular(16),
-                  topRight: const Radius.circular(16),
-                  bottomLeft: Radius.circular(isUser ? 16 : 4),
-                  bottomRight: Radius.circular(isUser ? 4 : 16),
-                ),
-                border: Border.all(
-                  color: isUser
-                      ? AppTheme.accent.withValues(alpha: 0.3)
-                      : AppTheme.border,
-                ),
-              ),
-              child: SelectableText(
-                message.content,
-                style: TextStyle(
-                  color: AppTheme.textPrimary,
-                  fontSize: 15,
-                  height: 1.4,
-                  fontWeight: isUser ? FontWeight.w400 : FontWeight.w400,
-                ),
-              ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Text bubble
+                if (message.content.isNotEmpty)
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 14, vertical: 10),
+                    decoration: BoxDecoration(
+                      color: isUser
+                          ? AppTheme.accent.withValues(alpha: 0.15)
+                          : AppTheme.surfaceVariant,
+                      borderRadius: BorderRadius.only(
+                        topLeft: const Radius.circular(16),
+                        topRight: const Radius.circular(16),
+                        bottomLeft: Radius.circular(isUser ? 16 : 4),
+                        bottomRight: Radius.circular(isUser ? 4 : 16),
+                      ),
+                      border: Border.all(
+                        color: isUser
+                            ? AppTheme.accent.withValues(alpha: 0.3)
+                            : AppTheme.border,
+                      ),
+                    ),
+                    child: SelectableText(
+                      message.content,
+                      style: TextStyle(
+                        color: AppTheme.textPrimary,
+                        fontSize: 15,
+                        height: 1.4,
+                        fontWeight: isUser ? FontWeight.w400 : FontWeight.w400,
+                      ),
+                    ),
+                  ),
+
+                // Media result cards
+                if (message.mediaResults.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    height: 200,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: message.mediaResults.length,
+                      separatorBuilder: (_, __) => const SizedBox(width: 8),
+                      itemBuilder: (context, index) {
+                        return _MediaResultCard(
+                            item: message.mediaResults[index]);
+                      },
+                    ),
+                  ),
+                ],
+              ],
             ),
           ),
           if (isUser) const SizedBox(width: 8),
+        ],
+      ),
+    );
+  }
+}
+
+/// A compact media card for chat results showing poster, title, year, and rating.
+class _MediaResultCard extends StatelessWidget {
+  final MediaResultItem item;
+
+  const _MediaResultCard({required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    final imageUrl = AppConfig.tmdbPoster(item.posterPath, width: 342);
+
+    return SizedBox(
+      width: 110,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Poster
+          AspectRatio(
+            aspectRatio: 2 / 3,
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(8),
+              child: Stack(
+                fit: StackFit.expand,
+                children: [
+                  if (item.posterPath != null)
+                    CachedNetworkImage(
+                      imageUrl: imageUrl,
+                      fit: BoxFit.cover,
+                      placeholder: (_, __) => Container(
+                        color: AppTheme.surfaceVariant,
+                        child: const Center(
+                          child: Icon(Icons.movie_outlined,
+                              color: AppTheme.textSecondary, size: 28),
+                        ),
+                      ),
+                      errorWidget: (_, __, ___) => Container(
+                        color: AppTheme.surfaceVariant,
+                        child: const Center(
+                          child: Icon(Icons.broken_image_outlined,
+                              color: AppTheme.textSecondary, size: 28),
+                        ),
+                      ),
+                    )
+                  else
+                    Container(
+                      color: AppTheme.surfaceVariant,
+                      child: const Center(
+                        child: Icon(Icons.movie_outlined,
+                            color: AppTheme.textSecondary, size: 28),
+                      ),
+                    ),
+                  // Rating badge
+                  if (item.voteAverage != null && item.voteAverage! > 0)
+                    Positioned(
+                      top: 4,
+                      right: 4,
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 5, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: Colors.black.withValues(alpha: 0.7),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Icon(Icons.star_rounded,
+                                color: AppTheme.accent, size: 12),
+                            const SizedBox(width: 2),
+                            Text(
+                              item.voteAverage!.toStringAsFixed(1),
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 4),
+          // Title + year
+          Text(
+            item.year != null ? '${item.title} (${item.year})' : item.title,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 11,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
         ],
       ),
     );

--- a/server/internal/ai/handler.go
+++ b/server/internal/ai/handler.go
@@ -68,7 +68,15 @@ func (h *Handler) Chat(w http.ResponseWriter, r *http.Request) {
 		flusher.Flush()
 	}
 
-	err := service.SendMessage(r.Context(), req.Messages, claims.UserID, onText)
+	onToolResult := func(toolName string, structuredData any) {
+		data, _ := json.Marshal(map[string]interface{}{
+			"media_results": structuredData,
+		})
+		fmt.Fprintf(w, "data: %s\n\n", data)
+		flusher.Flush()
+	}
+
+	err := service.SendMessage(r.Context(), req.Messages, claims.UserID, onText, onToolResult)
 	if err != nil {
 		log.Printf("ai chat error: %v", err)
 		errData, _ := json.Marshal(map[string]string{"error": err.Error()})

--- a/server/internal/ai/service.go
+++ b/server/internal/ai/service.go
@@ -88,8 +88,8 @@ type streamEvent struct {
 }
 
 // SendMessage handles the full conversation loop with tool execution.
-// It streams text back via the onText callback.
-func (s *Service) SendMessage(ctx context.Context, messages []Message, userID int64, onText func(string)) error {
+// It streams text back via onText and structured tool results via onToolResult.
+func (s *Service) SendMessage(ctx context.Context, messages []Message, userID int64, onText func(string), onToolResult func(string, any)) error {
 	tools := s.toolServer.GetTools()
 
 	for {
@@ -121,6 +121,10 @@ func (s *Service) SendMessage(ctx context.Context, messages []Message, userID in
 				resultText = fmt.Sprintf("Error: %s", err.Error())
 			} else {
 				resultText = toolResult.Text
+				// Send structured data to the frontend for rich UI rendering
+				if toolResult.StructuredData != nil && mcp.ToolsWithUI[block.Name] {
+					onToolResult(block.Name, toolResult.StructuredData)
+				}
 			}
 			toolResults = append(toolResults, ContentBlock{
 				Type:      "tool_result",
@@ -209,6 +213,11 @@ func (s *Service) parseSSEStream(reader io.Reader, onText func(string)) (*anthro
 		case "content_block_start":
 			if event.ContentBlock != nil {
 				block := *event.ContentBlock
+				// Clear the initial empty input from tool_use blocks;
+				// the real input arrives via input_json_delta events.
+				if block.Type == "tool_use" {
+					block.Input = nil
+				}
 				currentBlock = &block
 			}
 


### PR DESCRIPTION
## Summary
- **Fix crash**: The AI agent loop crashed with `invalid character '{' after top-level value` when Claude used tools. The `content_block_start` SSE event includes `Input:{}` for tool_use blocks, and streaming `input_json_delta` chunks were appended to it, producing invalid JSON like `{}{"query":"..."}`. Fixed by clearing `Input` on tool_use block start so deltas build fresh.
- **Stream structured data**: Wired up `StructuredData` from tool results as `media_results` SSE events so the frontend receives poster images, ratings, and metadata alongside text.
- **Render media cards**: Added `MediaResultItem` model, `ChatStreamEvent` sealed class, and poster card rendering in chat bubbles using existing `CachedNetworkImage` + `AppConfig.tmdbPoster()` patterns.

## Test plan
- [x] Confirmed marshaling bug on live instance (reproducible with "search for movies with keanu reeves")
- [x] Built fixed Docker image, verified agent loop completes without errors
- [x] Verified multi-tool flows (trending → recommendations) work with multiple loop iterations
- [x] Verified `media_results` SSE events contain full structured data (IDs, titles, years, poster paths, ratings, overviews)
- [ ] Verify Flutter app renders media cards in chat bubbles on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)