### PR TITLE
Add PR container builds and cleanup workflow

### DIFF
--- a/.github/workflows/docker-cleanup.yml
+++ b/.github/workflows/docker-cleanup.yml
@@ -1,0 +1,30 @@
+name: Cleanup PR Docker Image
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete PR container image
+        env:
+          PR_TAG: pr-${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PACKAGE="cantinarr"
+
+          VERSION_ID=$(gh api \
+            "/users/windoze95/packages/container/${PACKAGE}/versions" \
+            --paginate --jq ".[] | select(.metadata.container.tags[] == \"${PR_TAG}\") | .id")
+
+          if [ -n "$VERSION_ID" ]; then
+            echo "Deleting image tagged ${PR_TAG} (version ID: ${VERSION_ID})"
+            gh api --method DELETE \
+              "/users/windoze95/packages/container/${PACKAGE}/versions/${VERSION_ID}"
+          else
+            echo "No image found with tag ${PR_TAG}, skipping."
+          fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,7 +9,23 @@ on:
       - "server/**"
       - "Dockerfile"
       - ".github/workflows/docker.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "app/**"
+      - "server/**"
+      - "Dockerfile"
+      - ".github/workflows/docker.yml"
   workflow_dispatch:
+    inputs:
+      multi-arch:
+        description: "Build for arm64 in addition to amd64"
+        type: boolean
+        default: false
+
+concurrency:
+  group: docker-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -22,6 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
+        if: startsWith(github.ref, 'refs/tags/v') || inputs.multi-arch
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -44,12 +61,13 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha
+            type=raw,value=pr-${{ github.event.pull_request.number }},enable=${{ github.event_name == 'pull_request' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ (startsWith(github.ref, 'refs/tags/v') || inputs.multi-arch) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- PRs that modify `app/**`, `server/**`, or `Dockerfile` now build and push a container image tagged `pr-<number>` to GHCR for testing
- PR images are automatically deleted from GHCR when the PR closes
- Multi-arch (arm64) builds now only run for release tags (`v*`) or on-demand via workflow_dispatch checkbox
- Added concurrency control to cancel stale Docker builds on the same PR

## Test plan
- [ ] Open a PR that modifies server code, verify `pr-<number>` image is pushed to GHCR
- [ ] Push another commit to that PR, verify the previous build is cancelled and a new image is pushed
- [ ] Close/merge the PR, verify the `pr-<number>` image is deleted from GHCR
- [ ] Verify push to main still builds amd64-only and tags `latest`
- [ ] Verify manual dispatch with multi-arch checkbox builds both platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)