### PR TITLE
Make AI agent media result cards clickable

### DIFF
--- a/app/lib/features/ai_assistant/ui/chat_bubble.dart
+++ b/app/lib/features/ai_assistant/ui/chat_bubble.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import '../../../core/config/app_config.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/ai_models.dart';
@@ -106,9 +107,13 @@ class _MediaResultCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final imageUrl = AppConfig.tmdbPoster(item.posterPath, width: 342);
 
-    return SizedBox(
-      width: 110,
-      child: Column(
+    final mediaType = item.mediaType ?? 'movie';
+
+    return GestureDetector(
+      onTap: () => context.push('/detail/$mediaType/${item.id}'),
+      child: SizedBox(
+        width: 110,
+        child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           // Poster
@@ -194,6 +199,7 @@ class _MediaResultCard extends StatelessWidget {
           ),
         ],
       ),
+    ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Wrap `_MediaResultCard` in `chat_bubble.dart` with a `GestureDetector` that navigates to `/detail/{mediaType}/{id}` on tap
- Uses the existing `go_router` detail page route, matching the same pattern used by recommendation/similar cards elsewhere in the app
- Defaults to `movie` media type when `mediaType` is null

## Test plan
- [ ] Send a chat message that triggers a tool returning media results (e.g. "search for sci-fi movies")
- [ ] Verify each result card in the horizontal scroll is tappable
- [ ] Verify tapping a movie card opens the movie detail page
- [ ] Verify tapping a TV show card opens the TV show detail page
- [ ] Verify the back button from the detail page returns to the chat

https://claude.ai/code/session_01JZ2Emvo6zn4yzz8fJtESdT