### PR TITLE
Fix focus loss when search bar transitions to AI chat mode

### DIFF
--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -173,6 +173,14 @@ class _AppShellState extends ConsumerState<AppShell>
           );
         }
         _getOrCreateAiChat();
+        // Re-request focus after the frame rebuilds so the new AI chat
+        // text field picks it up seamlessly (the old search bar is removed
+        // from the tree, which drops focus on the shared FocusNode).
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted && !_searchFocusNode.hasFocus) {
+            _searchFocusNode.requestFocus();
+          }
+        });
 
       case SearchMode.search:
         _aiTransitionTimer?.cancel();


### PR DESCRIPTION
## Summary
- When the search bar transitions to AI chat mode, the shared `FocusNode` loses focus because the original search bar widget is removed from the tree and a new one is created in the AI overlay
- Added a `postFrameCallback` to re-request focus after the rebuild, so the keyboard stays open and the transition is seamless

## Test plan
- [ ] Type a search query that returns no results and has AI enabled
- [ ] Verify the transition to AI chat mode keeps the keyboard open without needing to tap the input again
- [ ] Verify normal search mode focus behavior is unaffected
- [ ] Test on both mobile and desktop layouts

https://claude.ai/code/session_01M59DjkVmeU9yx2v8LmNWrY