### PR TITLE
Keep search bar single-line in aiReady mode

### DIFF
--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -336,7 +336,6 @@ class _AppShellState extends ConsumerState<AppShell>
               ? 'Edit your question or press send...'
               : (hasAi ? 'Search or ask AI...' : 'Search movies & TV shows...'),
           aiEnabled: hasAi,
-          maxLines: isAiReady ? 5 : null,
           onSend: isAiReady ? _submitFromAiReady : null,
           onChanged: isAiMode ? null : (q) => searchNotifier.updateSearch(q),
           onClear: isAiReady || isAiMode


### PR DESCRIPTION
## Summary
- Removes the `maxLines: 5` override when entering aiReady mode
- Existing text no longer wraps to 2 lines — stays single-line with horizontal scroll
- Shimmer glow and send button still appear, just no height change

## Test plan
- [ ] Search for a long query that returns no results
- [ ] Verify: search bar stays exactly 1 line tall when shimmer appears
- [ ] Verify: send button still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)