### PR TITLE
Show single prefix icon in search bar

### DIFF
--- a/app/lib/core/widgets/search_bar.dart
+++ b/app/lib/core/widgets/search_bar.dart
@@ -89,20 +89,10 @@ class CantinarrSearchBar extends StatelessWidget {
 
   Widget _buildPrefixIcon() {
     if (aiEnabled) {
-      return Padding(
-        padding: const EdgeInsets.only(left: 12, right: 4),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              Icons.auto_awesome,
-              size: 18,
-              color: AppTheme.accent.withValues(alpha: 0.7),
-            ),
-            const SizedBox(width: 6),
-            const Icon(Icons.search, size: 22, color: AppTheme.textSecondary),
-          ],
-        ),
+      return Icon(
+        Icons.auto_awesome,
+        size: 20,
+        color: AppTheme.accent.withValues(alpha: 0.7),
       );
     }
     return const Icon(Icons.search, color: AppTheme.textSecondary);


### PR DESCRIPTION
## Summary
- Replaces the two side-by-side icons (sparkle + search) with a single icon
- AI enabled: gold sparkle (`auto_awesome`), no AI: plain search icon
- Reduces visual clutter

## Test plan
- [ ] With AI enabled: search bar shows single gold sparkle icon
- [ ] Without AI: search bar shows normal search icon
- [ ] No layout shift or extra padding from the removed Row

🤖 Generated with [Claude Code](https://claude.com/claude-code)