### PR TITLE
Update search hint when AI is not configured

### DIFF
--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -334,7 +334,7 @@ class _AppShellState extends ConsumerState<AppShell>
           focusNode: _searchFocusNode,
           hintText: isAiReady
               ? 'Edit your question or press send...'
-              : (hasAi ? 'Search or ask AI...' : 'Search movies & TV shows...'),
+              : (hasAi ? 'Search or ask AI...' : 'Search by title or person...'),
           aiEnabled: hasAi,
           onSend: isAiReady ? _submitFromAiReady : null,
           onChanged: isAiMode ? null : (q) => searchNotifier.updateSearch(q),


### PR DESCRIPTION
## Summary
- Changes no-AI hint from "Search movies & TV shows..." to "Search by title or person..."

## Test plan
- [ ] With AI configured: hint shows "Search or ask AI..."
- [ ] Without AI configured: hint shows "Search by title or person..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)