### PR TITLE
Defer media result cards until streaming completes

### DIFF
--- a/app/lib/features/ai_assistant/data/ai_models.dart
+++ b/app/lib/features/ai_assistant/data/ai_models.dart
@@ -5,6 +5,7 @@ class ChatMessage {
   final String content;
   final DateTime timestamp;
   final List<MediaResultItem> mediaResults;
+  final bool isStreaming;
 
   const ChatMessage({
     required this.id,
@@ -12,11 +13,13 @@ class ChatMessage {
     required this.content,
     required this.timestamp,
     this.mediaResults = const [],
+    this.isStreaming = false,
   });
 
   ChatMessage copyWith({
     String? content,
     List<MediaResultItem>? mediaResults,
+    bool? isStreaming,
   }) =>
       ChatMessage(
         id: id,
@@ -24,6 +27,7 @@ class ChatMessage {
         content: content ?? this.content,
         timestamp: timestamp,
         mediaResults: mediaResults ?? this.mediaResults,
+        isStreaming: isStreaming ?? this.isStreaming,
       );
 
   Map<String, dynamic> toApiMessage() => {

--- a/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
+++ b/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
@@ -97,6 +97,7 @@ class AiChatNotifier extends ChangeNotifier {
           content: buffer.toString(),
           timestamp: DateTime.now(),
           mediaResults: List.unmodifiable(mediaItems),
+          isStreaming: true,
         );
 
         if (existingIdx >= 0) {
@@ -106,6 +107,15 @@ class AiChatNotifier extends ChangeNotifier {
         }
 
         state = state.copyWith(messages: updatedMessages);
+      }
+
+      // Mark the streamed message as complete
+      final finalMessages = List<ChatMessage>.from(state.messages);
+      final doneIdx = finalMessages.indexWhere((m) => m.id == responseId);
+      if (doneIdx >= 0) {
+        finalMessages[doneIdx] =
+            finalMessages[doneIdx].copyWith(isStreaming: false);
+        state = state.copyWith(messages: finalMessages);
       }
 
       // If no content was streamed, the response was empty

--- a/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
+++ b/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
@@ -66,6 +66,8 @@ class AiChatNotifier extends ChangeNotifier {
 
     state = state.copyWith(isLoading: true, error: null);
 
+    final responseId = _uuid.v4();
+
     try {
       // Build conversation history (skip welcome message)
       final conversationMessages = state.messages
@@ -75,7 +77,6 @@ class AiChatNotifier extends ChangeNotifier {
 
       final buffer = StringBuffer();
       final mediaItems = <MediaResultItem>[];
-      final responseId = _uuid.v4();
 
       await for (final event
           in _chatService.sendMessage(messages: conversationMessages)) {
@@ -130,7 +131,16 @@ class AiChatNotifier extends ChangeNotifier {
 
       state = state.copyWith(isLoading: false);
     } catch (e) {
+      // Clear streaming flag on any partial message so media cards are shown
+      final errMessages = List<ChatMessage>.from(state.messages);
+      final errIdx = errMessages.indexWhere((m) => m.id == responseId);
+      if (errIdx >= 0) {
+        errMessages[errIdx] =
+            errMessages[errIdx].copyWith(isStreaming: false);
+      }
+
       state = state.copyWith(
+        messages: errIdx >= 0 ? errMessages : null,
         isLoading: false,
         error:
             'Failed to get response: ${e.toString().length > 100 ? '${e.toString().substring(0, 100)}...' : e}',

--- a/app/lib/features/ai_assistant/ui/chat_bubble.dart
+++ b/app/lib/features/ai_assistant/ui/chat_bubble.dart
@@ -39,24 +39,6 @@ class ChatBubble extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                // Media result cards (rendered first so interactive
-                // content isn't pushed down while text streams in)
-                if (message.mediaResults.isNotEmpty) ...[
-                  SizedBox(
-                    height: 200,
-                    child: ListView.separated(
-                      scrollDirection: Axis.horizontal,
-                      itemCount: message.mediaResults.length,
-                      separatorBuilder: (_, __) => const SizedBox(width: 8),
-                      itemBuilder: (context, index) {
-                        return _MediaResultCard(
-                            item: message.mediaResults[index]);
-                      },
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                ],
-
                 // Text bubble
                 if (message.content.isNotEmpty)
                   Container(
@@ -88,6 +70,24 @@ class ChatBubble extends StatelessWidget {
                       ),
                     ),
                   ),
+
+                // Media result cards (deferred until streaming completes)
+                if (message.mediaResults.isNotEmpty &&
+                    !message.isStreaming) ...[
+                  const SizedBox(height: 8),
+                  SizedBox(
+                    height: 200,
+                    child: ListView.separated(
+                      scrollDirection: Axis.horizontal,
+                      itemCount: message.mediaResults.length,
+                      separatorBuilder: (_, __) => const SizedBox(width: 8),
+                      itemBuilder: (context, index) {
+                        return _MediaResultCard(
+                            item: message.mediaResults[index]);
+                      },
+                    ),
+                  ),
+                ],
               ],
             ),
           ),


### PR DESCRIPTION
Reverts the previous change that rendered media cards above text during
streaming. Instead, cards are placed back below text and hidden while
the message is still streaming, then revealed once the response finishes.

https://claude.ai/code/session_01LyS3CW9dK8QgsAES5mYJFX