### PR TITLE
Add display_media tool for agent-curated asset carousels

### DIFF
--- a/server/internal/ai/service.go
+++ b/server/internal/ai/service.go
@@ -27,7 +27,8 @@ Guidelines:
 - Always check request status before suggesting a request
 - When recommending content, include title, year, and a brief description
 - If a user asks to request something, use the request_media tool
-- Format lists neatly with bullets or numbers`
+- Format lists neatly with bullets or numbers
+- IMPORTANT: After selecting specific items to recommend, you MUST call the display_media tool with those items' TMDB IDs and media types. This controls which items appear in the visual carousel the user sees. Order items by relevance. Search results alone do NOT populate the carousel — only display_media does.`
 )
 
 // Message represents a chat message sent to/from the Anthropic API.

--- a/server/internal/mcp/server.go
+++ b/server/internal/mcp/server.go
@@ -82,6 +82,8 @@ func (s *ToolServer) ExecuteTool(ctx context.Context, name string, input json.Ra
 		return s.requestMedia(input, userID)
 	case "list_my_requests":
 		return s.listMyRequests(userID)
+	case "display_media":
+		return s.displayMedia(input)
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", name)
 	}

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -159,7 +159,8 @@ var toolDefinitions = []Tool{
 			"properties": map[string]interface{}{
 				"items": map[string]interface{}{
 					"type":        "array",
-					"description": "List of media items to display, ordered by relevance",
+					"description": "List of media items to display, ordered by relevance (max 10)",
+					"maxItems":    10,
 					"items": map[string]interface{}{
 						"type": "object",
 						"properties": map[string]interface{}{
@@ -436,6 +437,8 @@ func (s *ToolServer) requestMedia(input json.RawMessage, userID int64) (*ToolRes
 	return &ToolResult{Text: string(data)}, nil
 }
 
+const maxDisplayMediaItems = 10
+
 func (s *ToolServer) displayMedia(input json.RawMessage) (*ToolResult, error) {
 	tmdbClient := s.creds.TMDB()
 	if tmdbClient == nil {
@@ -450,13 +453,18 @@ func (s *ToolServer) displayMedia(input json.RawMessage) (*ToolResult, error) {
 	if err := json.Unmarshal(input, &params); err != nil {
 		return nil, fmt.Errorf("parse input: %w", err)
 	}
+	if len(params.Items) > maxDisplayMediaItems {
+		params.Items = params.Items[:maxDisplayMediaItems]
+	}
 
 	items := make([]MediaResultItem, 0, len(params.Items))
+	var failures []string
 	for _, p := range params.Items {
 		switch p.MediaType {
 		case "movie":
 			movie, err := tmdbClient.GetMovieDetails(p.TmdbID)
 			if err != nil {
+				failures = append(failures, fmt.Sprintf("movie %d: %s", p.TmdbID, err.Error()))
 				continue
 			}
 			year := ""
@@ -475,6 +483,7 @@ func (s *ToolServer) displayMedia(input json.RawMessage) (*ToolResult, error) {
 		case "tv":
 			tv, err := tmdbClient.GetTVDetails(p.TmdbID)
 			if err != nil {
+				failures = append(failures, fmt.Sprintf("tv %d: %s", p.TmdbID, err.Error()))
 				continue
 			}
 			year := ""
@@ -493,8 +502,14 @@ func (s *ToolServer) displayMedia(input json.RawMessage) (*ToolResult, error) {
 		}
 	}
 
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Displaying %d media item(s) in the carousel.", len(items))
+	if len(failures) > 0 {
+		fmt.Fprintf(&sb, " Failed to fetch %d item(s): %s", len(failures), strings.Join(failures, "; "))
+	}
+
 	return &ToolResult{
-		Text:           fmt.Sprintf("Displaying %d media item(s) in the carousel.", len(items)),
+		Text:           sb.String(),
 		StructuredData: items,
 	}, nil
 }

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -151,6 +151,35 @@ var toolDefinitions = []Tool{
 			"properties": map[string]interface{}{},
 		},
 	},
+	{
+		Name:        "display_media",
+		Description: "Display specific movies or TV shows in the UI carousel. Call this after searching to show only the items you want to recommend. The carousel will display items in the order provided.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"items": map[string]interface{}{
+					"type":        "array",
+					"description": "List of media items to display, ordered by relevance",
+					"items": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"tmdb_id": map[string]interface{}{
+								"type":        "integer",
+								"description": "The TMDB ID of the movie or TV show",
+							},
+							"media_type": map[string]interface{}{
+								"type":        "string",
+								"enum":        []string{"movie", "tv"},
+								"description": "Whether this is a movie or TV show",
+							},
+						},
+						"required": []string{"tmdb_id", "media_type"},
+					},
+				},
+			},
+			"required": []string{"items"},
+		},
+	},
 }
 
 // MediaResultItem is the structured data the MCP App UI renders.
@@ -173,10 +202,7 @@ type ToolResult struct {
 
 // ToolsWithUI is the set of tool names that have MCP App UI attached.
 var ToolsWithUI = map[string]bool{
-	"search_movies":       true,
-	"search_tv_shows":     true,
-	"get_trending":        true,
-	"get_recommendations": true,
+	"display_media": true,
 }
 
 func toMediaResultItems(results []tmdb.SearchResult, limit int) []MediaResultItem {
@@ -408,6 +434,69 @@ func (s *ToolServer) requestMedia(input json.RawMessage, userID int64) (*ToolRes
 	}
 	data, _ := json.Marshal(resp)
 	return &ToolResult{Text: string(data)}, nil
+}
+
+func (s *ToolServer) displayMedia(input json.RawMessage) (*ToolResult, error) {
+	tmdbClient := s.creds.TMDB()
+	if tmdbClient == nil {
+		return &ToolResult{Text: "TMDB is not configured on the server."}, nil
+	}
+	var params struct {
+		Items []struct {
+			TmdbID    int    `json:"tmdb_id"`
+			MediaType string `json:"media_type"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(input, &params); err != nil {
+		return nil, fmt.Errorf("parse input: %w", err)
+	}
+
+	items := make([]MediaResultItem, 0, len(params.Items))
+	for _, p := range params.Items {
+		switch p.MediaType {
+		case "movie":
+			movie, err := tmdbClient.GetMovieDetails(p.TmdbID)
+			if err != nil {
+				continue
+			}
+			year := ""
+			if len(movie.ReleaseDate) >= 4 {
+				year = movie.ReleaseDate[:4]
+			}
+			items = append(items, MediaResultItem{
+				ID:          movie.ID,
+				Title:       movie.Title,
+				Year:        year,
+				PosterPath:  movie.PosterPath,
+				VoteAverage: movie.VoteAverage,
+				Overview:    movie.Overview,
+				MediaType:   "movie",
+			})
+		case "tv":
+			tv, err := tmdbClient.GetTVDetails(p.TmdbID)
+			if err != nil {
+				continue
+			}
+			year := ""
+			if len(tv.FirstAir) >= 4 {
+				year = tv.FirstAir[:4]
+			}
+			items = append(items, MediaResultItem{
+				ID:          tv.ID,
+				Title:       tv.Name,
+				Year:        year,
+				PosterPath:  tv.PosterPath,
+				VoteAverage: tv.VoteAverage,
+				Overview:    tv.Overview,
+				MediaType:   "tv",
+			})
+		}
+	}
+
+	return &ToolResult{
+		Text:           fmt.Sprintf("Displaying %d media item(s) in the carousel.", len(items)),
+		StructuredData: items,
+	}, nil
 }
 
 func (s *ToolServer) listMyRequests(userID int64) (*ToolResult, error) {

--- a/server/internal/tmdb/client.go
+++ b/server/internal/tmdb/client.go
@@ -43,16 +43,22 @@ type ExternalIDs struct {
 }
 
 type MovieDetails struct {
-	ID          int    `json:"id"`
-	Title       string `json:"title"`
-	ReleaseDate string `json:"release_date"`
-	IMDBID      string `json:"imdb_id"`
+	ID          int     `json:"id"`
+	Title       string  `json:"title"`
+	ReleaseDate string  `json:"release_date"`
+	IMDBID      string  `json:"imdb_id"`
+	PosterPath  string  `json:"poster_path,omitempty"`
+	Overview    string  `json:"overview,omitempty"`
+	VoteAverage float64 `json:"vote_average,omitempty"`
 }
 
 type TVDetails struct {
-	ID       int    `json:"id"`
-	Name     string `json:"name"`
-	FirstAir string `json:"first_air_date"`
+	ID          int     `json:"id"`
+	Name        string  `json:"name"`
+	FirstAir    string  `json:"first_air_date"`
+	PosterPath  string  `json:"poster_path,omitempty"`
+	Overview    string  `json:"overview,omitempty"`
+	VoteAverage float64 `json:"vote_average,omitempty"`
 }
 
 // DoGetRaw fetches a TMDB API path and returns the raw JSON bytes.


### PR DESCRIPTION
Search tools (search_movies, search_tv_shows, etc.) previously dumped all
raw TMDB results into the carousel, causing mismatches between what the
agent recommended in text and what appeared in the UI. Now search tools
only return text for the LLM, and the agent explicitly calls display_media
with specific TMDB IDs to control exactly which items appear in the
carousel and in what order.

Changes:
- Add display_media tool accepting [{tmdb_id, media_type}] pairs
- Remove search/browse tools from ToolsWithUI, add only display_media
- Expand MovieDetails/TVDetails structs with poster, overview, rating
- Update system prompt to instruct agent to use display_media

https://claude.ai/code/session_015H5JLN2EzTeQh9moTc1bjN