### PR TITLE
Secrets at rest, realtime queue updates, Tautulli/NZBGet/Transmission, wanted screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Cantinarr makes it dead simple for your family and friends to discover and reque
 - **Automatic ID bridging** -- TMDB-to-TVDB translation with Trakt fallback. The #1 source of failed Sonarr adds, solved.
 - **AI assistant** -- "What should I watch tonight?" Claude searches your library, checks availability, and can request for you. Admins can also manage the server conversationally: check the queue, kick off searches, grab a specific release from the indexers, or clean up failed downloads.
 - **MCP server** -- The same 19 AI tools are exposed as a [Model Context Protocol](https://modelcontextprotocol.io/) endpoint at `/mcp`, so Claude Desktop and other MCP clients can connect directly. Every tool can be toggled on/off per server from Settings > AI Tools.
-- **Download clients** -- SABnzbd and qBittorrent modules with live queue management (pause, resume, remove, speeds) alongside full Radarr/Sonarr control: queue actions, history, calendar, and interactive release search.
+- **Download clients** -- SABnzbd, qBittorrent, NZBGet, and Transmission modules with live queue management (pause, resume, remove, speeds, real-time push updates) alongside full Radarr/Sonarr control: queue actions, history, wanted/missing, calendar, and interactive release search.
+- **Tautulli** -- watch what's playing on Plex right now: active streams with quality/transcode badges, watch history, and top movies/shows/users stats.
+- **Secrets encrypted at rest** -- arr API keys, download-client passwords, and external credentials are AES-256-GCM encrypted in the database.
 - **Household-friendly** -- Connect links, role-based access. Admins manage arr services, users just browse and request.
 - **Single container** -- One Go binary, one port, serves API + web UI. Runs great on a Raspberry Pi or NAS.
 
@@ -89,12 +91,16 @@ cantinarr/
 │   │   ├── downloads/      # Unified SABnzbd/qBittorrent queue API
 │   │   ├── mcpserver/      # MCP Streamable HTTP endpoint
 │   │   ├── proxy/          # Arr admin reverse proxy
+│   │   ├── nzbget/         # NZBGet JSON-RPC client
 │   │   ├── qbittorrent/    # qBittorrent WebUI v2 client
 │   │   ├── radarr/         # Radarr API v3 client
 │   │   ├── request/        # Request orchestration + bridging
 │   │   ├── sabnzbd/        # SABnzbd JSON API client
+│   │   ├── secrets/        # AES-256-GCM secrets-at-rest
 │   │   ├── sonarr/         # Sonarr API v3 client
+│   │   ├── tautulli/       # Tautulli activity/history/stats
 │   │   ├── tmdb/           # TMDB client + ID bridge
+│   │   ├── transmission/   # Transmission RPC client
 │   │   ├── trakt/          # Trakt fallback ID resolver
 │   │   ├── web/            # Flutter web embed (go:embed)
 │   │   └── websocket/      # Real-time download progress
@@ -121,7 +127,8 @@ All service credentials are managed through the admin UI -- no environment varia
 |---|---|---|
 | TMDB access token | Admin UI | Required for media discovery and search ([get one here](https://www.themoviedb.org/settings/api)) |
 | Radarr/Sonarr instances | Admin UI | Add via Settings > Add Instance |
-| SABnzbd/qBittorrent instances | Admin UI | Download client modules (queue, history, speeds) |
+| SABnzbd/qBittorrent/NZBGet/Transmission instances | Admin UI | Download client modules (queue, history, speeds) |
+| Tautulli instance | Admin UI | Plex activity, watch history, stats |
 | Anthropic API key | Admin UI | Enables AI assistant |
 | Trakt client ID | Admin UI | Enhances discovery + fallback ID bridging |
 
@@ -133,6 +140,7 @@ Optional server env vars for deployment tuning:
 | `CANTINARR_SERVER_NAME` | `Cantinarr` | Display name shown in clients |
 | `CANTINARR_JWT_SECRET` | auto-generated | HMAC secret for JWT signing |
 | `CANTINARR_AI_MODEL` | `claude-opus-4-8` | Claude model used by the AI assistant |
+| `CANTINARR_ENCRYPTION_KEY` | auto-generated key file | Base64 32-byte key for secrets-at-rest (default: `/config/encryption.key`) |
 
 ## How It Works
 

--- a/app/lib/core/models/app_module.dart
+++ b/app/lib/core/models/app_module.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// Types of modules available in the app.
-enum ModuleType { dashboard, radarr, sonarr, downloads, assistant }
+enum ModuleType { dashboard, radarr, sonarr, downloads, tautulli, assistant }
 
 /// Represents a navigable module in the app (shown in drawer).
 class AppModule {

--- a/app/lib/core/models/backend_connection.dart
+++ b/app/lib/core/models/backend_connection.dart
@@ -71,11 +71,19 @@ class BackendConnection {
   List<ServiceInstance> get sonarrInstances =>
       instances.where((i) => i.serviceType == 'sonarr').toList();
 
-  /// Get all download client instances (SABnzbd or qBittorrent).
+  /// Get all download client instances
+  /// (SABnzbd, qBittorrent, NZBGet or Transmission).
   List<ServiceInstance> get downloadInstances => instances
-      .where(
-          (i) => i.serviceType == 'sabnzbd' || i.serviceType == 'qbittorrent')
+      .where((i) =>
+          i.serviceType == 'sabnzbd' ||
+          i.serviceType == 'qbittorrent' ||
+          i.serviceType == 'nzbget' ||
+          i.serviceType == 'transmission')
       .toList();
+
+  /// Get all Tautulli instances.
+  List<ServiceInstance> get tautulliInstances =>
+      instances.where((i) => i.serviceType == 'tautulli').toList();
 
   /// Get the default Radarr instance, if any.
   ServiceInstance? get defaultRadarrInstance {

--- a/app/lib/core/network/websocket_client.dart
+++ b/app/lib/core/network/websocket_client.dart
@@ -21,9 +21,15 @@ class WsEvent {
 
 /// Manages a persistent WebSocket connection to the backend with
 /// automatic reconnection using exponential backoff.
+///
+/// The connection is lazy: nothing happens until [ensureConnected] is
+/// called (typically by the realtime providers when first listened to).
+/// The server URL and access token are read through callbacks at every
+/// (re)connect so reconnects always use the freshest credentials, even
+/// after a token refresh.
 class WebSocketClient extends ChangeNotifier {
-  final String _serverUrl;
-  final String _accessToken;
+  final String? Function() _getServerUrl;
+  final String? Function() _getAccessToken;
 
   WebSocketChannel? _channel;
   StreamSubscription? _subscription;
@@ -31,41 +37,68 @@ class WebSocketClient extends ChangeNotifier {
   int _reconnectAttempts = 0;
   bool _disposed = false;
   bool _connected = false;
+  bool _started = false;
 
   final _eventController = StreamController<WsEvent>.broadcast();
   Stream<WsEvent> get events => _eventController.stream;
   bool get isConnected => _connected;
 
   WebSocketClient({
-    required String serverUrl,
-    required String accessToken,
-  })  : _serverUrl = serverUrl,
-        _accessToken = accessToken {
+    required String? Function() getServerUrl,
+    required String? Function() getAccessToken,
+  })  : _getServerUrl = getServerUrl,
+        _getAccessToken = getAccessToken;
+
+  /// Starts the connection on first call; subsequent calls are no-ops.
+  /// Reconnection after that is handled internally with backoff.
+  void ensureConnected() {
+    if (_started || _disposed) return;
+    _started = true;
     _connect();
   }
 
   void _connect() {
     if (_disposed) return;
 
+    final serverUrl = _getServerUrl();
+    final accessToken = _getAccessToken();
+    if (serverUrl == null ||
+        serverUrl.isEmpty ||
+        accessToken == null ||
+        accessToken.isEmpty) {
+      // Not authenticated (yet) — don't handshake with credentials we know
+      // are invalid; retry later (login also recreates this client).
+      _scheduleReconnect();
+      return;
+    }
+
     try {
-      final wsUrl = _serverUrl
+      final wsUrl = serverUrl
           .replaceFirst('https://', 'wss://')
           .replaceFirst('http://', 'ws://');
 
-      _channel = WebSocketChannel.connect(
+      final channel = WebSocketChannel.connect(
         Uri.parse('$wsUrl/api/ws'),
-        protocols: ['Bearer', _accessToken],
+        protocols: ['Bearer', accessToken],
       );
+      _channel = channel;
 
-      _subscription = _channel!.stream.listen(
+      _subscription = channel.stream.listen(
         _onMessage,
         onDone: _onDisconnected,
         onError: (_) => _onDisconnected(),
       );
 
-      _connected = true;
-      _reconnectAttempts = 0;
-      notifyListeners();
+      // Only mark connected once the upgrade handshake completes; failures
+      // surface through the stream's onError/onDone above.
+      channel.ready.then((_) {
+        if (_disposed || !identical(channel, _channel)) return;
+        _connected = true;
+        _reconnectAttempts = 0;
+        notifyListeners();
+      }).catchError((_) {
+        // Handled via the stream's onError -> _onDisconnected.
+      });
     } catch (e) {
       debugPrint('WebSocket connection failed: $e');
       _scheduleReconnect();
@@ -82,14 +115,19 @@ class WebSocketClient extends ChangeNotifier {
   }
 
   void _onDisconnected() {
-    _connected = false;
-    notifyListeners();
+    if (_disposed) return;
+    if (_connected) {
+      _connected = false;
+      notifyListeners();
+    }
     _scheduleReconnect();
   }
 
   void _scheduleReconnect() {
     if (_disposed) return;
-    _reconnectTimer?.cancel();
+    // A failed connect can report both onError and onDone; don't let that
+    // double-schedule or double-increment the backoff.
+    if (_reconnectTimer?.isActive ?? false) return;
 
     // Exponential backoff: 1s, 2s, 4s, 8s, ... up to 30s
     final delay = Duration(
@@ -111,17 +149,22 @@ class WebSocketClient extends ChangeNotifier {
   }
 }
 
-/// Provides a WebSocket client connected to the backend.
+/// Provides the app-wide WebSocket client.
+///
+/// The client is created dormant and only connects once something calls
+/// [WebSocketClient.ensureConnected] (see realtime_provider.dart). It is
+/// recreated on login/logout/server switch (server URL changes); token
+/// refreshes are picked up through the getter on the next reconnect without
+/// tearing down a live connection.
 final webSocketClientProvider = ChangeNotifierProvider<WebSocketClient>((ref) {
-  final authState = ref.watch(authProvider);
-  final connection = authState.valueOrNull?.connection;
-
-  if (connection == null) {
-    return WebSocketClient(serverUrl: '', accessToken: '');
-  }
+  // Rebuild only when the server URL changes — not on every auth update
+  // (token refreshes would otherwise churn the connection).
+  ref.watch(authProvider.select((s) => s.valueOrNull?.connection?.serverUrl));
 
   return WebSocketClient(
-    serverUrl: connection.serverUrl,
-    accessToken: connection.accessToken,
+    getServerUrl: () =>
+        ref.read(authProvider).valueOrNull?.connection?.serverUrl,
+    getAccessToken: () =>
+        ref.read(authProvider).valueOrNull?.connection?.accessToken,
   );
 });

--- a/app/lib/core/network/websocket_client.dart
+++ b/app/lib/core/network/websocket_client.dart
@@ -129,9 +129,12 @@ class WebSocketClient extends ChangeNotifier {
     // double-schedule or double-increment the backoff.
     if (_reconnectTimer?.isActive ?? false) return;
 
-    // Exponential backoff: 1s, 2s, 4s, 8s, ... up to 30s
+    // Exponential backoff: 1s, 2s, 4s, 8s, ... up to 30s. Clamp the
+    // exponent, not the result: pow() overflows to infinity after ~1024
+    // straight failures and infinity.toInt() throws, which would kill the
+    // reconnect chain permanently.
     final delay = Duration(
-      seconds: min(pow(2, _reconnectAttempts).toInt(), 30),
+      seconds: min(1 << min(_reconnectAttempts, 5), 30),
     );
     _reconnectAttempts++;
 

--- a/app/lib/core/providers/instance_provider.dart
+++ b/app/lib/core/providers/instance_provider.dart
@@ -7,46 +7,54 @@ class InstanceState {
   final List<ServiceInstance> radarrInstances;
   final List<ServiceInstance> sonarrInstances;
   final List<ServiceInstance> downloadInstances;
+  final List<ServiceInstance> tautulliInstances;
   final String? activeRadarrInstanceId;
   final String? activeSonarrInstanceId;
   final String? activeDownloadInstanceId;
+  final String? activeTautulliInstanceId;
 
   const InstanceState({
     this.radarrInstances = const [],
     this.sonarrInstances = const [],
     this.downloadInstances = const [],
+    this.tautulliInstances = const [],
     this.activeRadarrInstanceId,
     this.activeSonarrInstanceId,
     this.activeDownloadInstanceId,
+    this.activeTautulliInstanceId,
   });
 
   InstanceState copyWith({
     List<ServiceInstance>? radarrInstances,
     List<ServiceInstance>? sonarrInstances,
     List<ServiceInstance>? downloadInstances,
+    List<ServiceInstance>? tautulliInstances,
     String? activeRadarrInstanceId,
     String? activeSonarrInstanceId,
     String? activeDownloadInstanceId,
+    String? activeTautulliInstanceId,
   }) =>
       InstanceState(
         radarrInstances: radarrInstances ?? this.radarrInstances,
         sonarrInstances: sonarrInstances ?? this.sonarrInstances,
         downloadInstances: downloadInstances ?? this.downloadInstances,
+        tautulliInstances: tautulliInstances ?? this.tautulliInstances,
         activeRadarrInstanceId:
             activeRadarrInstanceId ?? this.activeRadarrInstanceId,
         activeSonarrInstanceId:
             activeSonarrInstanceId ?? this.activeSonarrInstanceId,
         activeDownloadInstanceId:
             activeDownloadInstanceId ?? this.activeDownloadInstanceId,
+        activeTautulliInstanceId:
+            activeTautulliInstanceId ?? this.activeTautulliInstanceId,
       );
 
   /// Get the active Radarr instance, falling back to default.
   ServiceInstance? get activeRadarrInstance {
     if (radarrInstances.isEmpty) return null;
     if (activeRadarrInstanceId != null) {
-      final found = radarrInstances
-          .where((i) => i.id == activeRadarrInstanceId)
-          .toList();
+      final found =
+          radarrInstances.where((i) => i.id == activeRadarrInstanceId).toList();
       if (found.isNotEmpty) return found.first;
     }
     return radarrInstances.firstWhere((i) => i.isDefault,
@@ -57,9 +65,8 @@ class InstanceState {
   ServiceInstance? get activeSonarrInstance {
     if (sonarrInstances.isEmpty) return null;
     if (activeSonarrInstanceId != null) {
-      final found = sonarrInstances
-          .where((i) => i.id == activeSonarrInstanceId)
-          .toList();
+      final found =
+          sonarrInstances.where((i) => i.id == activeSonarrInstanceId).toList();
       if (found.isNotEmpty) return found.first;
     }
     return sonarrInstances.firstWhere((i) => i.isDefault,
@@ -78,6 +85,19 @@ class InstanceState {
     return downloadInstances.firstWhere((i) => i.isDefault,
         orElse: () => downloadInstances.first);
   }
+
+  /// Get the active Tautulli instance, falling back to default.
+  ServiceInstance? get activeTautulliInstance {
+    if (tautulliInstances.isEmpty) return null;
+    if (activeTautulliInstanceId != null) {
+      final found = tautulliInstances
+          .where((i) => i.id == activeTautulliInstanceId)
+          .toList();
+      if (found.isNotEmpty) return found.first;
+    }
+    return tautulliInstances.firstWhere((i) => i.isDefault,
+        orElse: () => tautulliInstances.first);
+  }
 }
 
 class InstanceNotifier extends Notifier<InstanceState> {
@@ -90,18 +110,28 @@ class InstanceNotifier extends Notifier<InstanceState> {
     final radarr = connection.radarrInstances;
     final sonarr = connection.sonarrInstances;
     final downloads = connection.downloadInstances;
+    final tautulli = connection.tautulliInstances;
 
     return InstanceState(
       radarrInstances: radarr,
       sonarrInstances: sonarr,
       downloadInstances: downloads,
-      activeRadarrInstanceId:
-          radarr.isNotEmpty ? (radarr.firstWhere((i) => i.isDefault, orElse: () => radarr.first)).id : null,
-      activeSonarrInstanceId:
-          sonarr.isNotEmpty ? (sonarr.firstWhere((i) => i.isDefault, orElse: () => sonarr.first)).id : null,
+      tautulliInstances: tautulli,
+      activeRadarrInstanceId: radarr.isNotEmpty
+          ? (radarr.firstWhere((i) => i.isDefault, orElse: () => radarr.first))
+              .id
+          : null,
+      activeSonarrInstanceId: sonarr.isNotEmpty
+          ? (sonarr.firstWhere((i) => i.isDefault, orElse: () => sonarr.first))
+              .id
+          : null,
       activeDownloadInstanceId: downloads.isNotEmpty
           ? (downloads.firstWhere((i) => i.isDefault,
               orElse: () => downloads.first)).id
+          : null,
+      activeTautulliInstanceId: tautulli.isNotEmpty
+          ? (tautulli.firstWhere((i) => i.isDefault,
+              orElse: () => tautulli.first)).id
           : null,
     );
   }
@@ -116,6 +146,10 @@ class InstanceNotifier extends Notifier<InstanceState> {
 
   void setActiveDownloadInstance(String instanceId) {
     state = state.copyWith(activeDownloadInstanceId: instanceId);
+  }
+
+  void setActiveTautulliInstance(String instanceId) {
+    state = state.copyWith(activeTautulliInstanceId: instanceId);
   }
 }
 

--- a/app/lib/core/providers/module_provider.dart
+++ b/app/lib/core/providers/module_provider.dart
@@ -25,8 +25,9 @@ class ModuleState {
       ModuleState(
         modules: modules ?? this.modules,
         activeModuleType: activeModuleType ?? this.activeModuleType,
-        activeInstanceId:
-            clearInstanceId ? null : (activeInstanceId ?? this.activeInstanceId),
+        activeInstanceId: clearInstanceId
+            ? null
+            : (activeInstanceId ?? this.activeInstanceId),
       );
 
   int get activeIndex {
@@ -92,6 +93,19 @@ class ModuleNotifier extends Notifier<ModuleState> {
             type: ModuleType.downloads,
             label: inst.name,
             icon: Icons.download,
+            instanceId: inst.id,
+            instanceName: inst.name,
+          ));
+        }
+      }
+
+      // Tautulli instances (admin only)
+      if (isAdmin) {
+        for (final inst in connection.tautulliInstances) {
+          modules.add(AppModule(
+            type: ModuleType.tautulli,
+            label: inst.name,
+            icon: Icons.monitor_heart,
             instanceId: inst.id,
             instanceName: inst.name,
           ));

--- a/app/lib/core/providers/realtime_provider.dart
+++ b/app/lib/core/providers/realtime_provider.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../network/websocket_client.dart';
+
+/// Raw, typed event stream from the backend WebSocket.
+///
+/// Watching this provider (directly or through one of the filtered family
+/// providers below) lazily starts the socket: the underlying
+/// [WebSocketClient] connects on first listen and then stays alive for the
+/// lifetime of the app, reconnecting with exponential backoff. The stream
+/// is best-effort — consumers must keep a REST polling fallback for when
+/// the socket is down (server restart, older server versions).
+final realtimeEventsProvider = Provider<Stream<WsEvent>>((ref) {
+  final client = ref.watch(webSocketClientProvider);
+  client.ensureConnected();
+  return client.events;
+});
+
+/// Full queue snapshots for one download client instance
+/// (`downloads_queue` events). The event `data` carries the same shape as
+/// the REST queue payload (`paused`, `speed_bps`, `items`) plus
+/// `instance_id`, so it can be applied directly without a REST roundtrip.
+///
+/// Riverpod cancels the underlying stream subscription when the last
+/// listener goes away (autoDispose), so screens can't leak subscriptions.
+final downloadsQueueEventsProvider =
+    StreamProvider.autoDispose.family<WsEvent, String>((ref, instanceId) {
+  final events = ref.watch(realtimeEventsProvider);
+  return events.where((e) =>
+      e.type == 'downloads_queue' && e.data['instance_id'] == instanceId);
+});
+
+/// Family key for [arrQueueChangedProvider]: which *arr instance and
+/// service type ("radarr" | "sonarr") to listen for.
+typedef ArrQueueKey = ({String instanceId, String serviceType});
+
+/// Lightweight invalidation pings for one *arr instance
+/// (`arr_queue_changed` events). On a ping, the consumer should refetch
+/// that instance's queue via REST (debounced, in case of bursts).
+final arrQueueChangedProvider =
+    StreamProvider.autoDispose.family<WsEvent, ArrQueueKey>((ref, key) {
+  final events = ref.watch(realtimeEventsProvider);
+  return events.where((e) =>
+      e.type == 'arr_queue_changed' &&
+      e.data['instance_id'] == key.instanceId &&
+      e.data['service_type'] == key.serviceType);
+});

--- a/app/lib/features/downloads/ui/downloads_queue_screen.dart
+++ b/app/lib/features/downloads/ui/downloads_queue_screen.dart
@@ -3,7 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/network/backend_client.dart';
+import '../../../core/network/websocket_client.dart';
 import '../../../core/providers/instance_provider.dart';
+import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/downloads_api_service.dart';
 import '../data/downloads_models.dart';
@@ -28,8 +30,10 @@ class _DownloadsQueueScreenState extends ConsumerState<DownloadsQueueScreen> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadQueue();
+      // Fallback poll only — live updates arrive over the WebSocket
+      // (downloads_queue events); this covers gaps when the socket is down.
       _refreshTimer =
-          Timer.periodic(const Duration(seconds: 7), (_) => _autoRefresh());
+          Timer.periodic(const Duration(seconds: 30), (_) => _autoRefresh());
     });
   }
 
@@ -83,6 +87,23 @@ class _DownloadsQueueScreenState extends ConsumerState<DownloadsQueueScreen> {
         _isLoading = false;
         _error = 'Failed to load queue: $e';
       });
+    }
+  }
+
+  /// Applies a full queue snapshot pushed over the WebSocket — no REST
+  /// roundtrip needed; the event data matches the REST queue payload.
+  void _applyQueueEvent(WsEvent event) {
+    if (!mounted) return;
+    try {
+      final queue = DownloadsQueue.fromJson(event.data);
+      setState(() {
+        _queue = queue;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (_) {
+      // Malformed payload (e.g. server/app version skew); the polling
+      // fallback will correct any drift.
     }
   }
 
@@ -148,6 +169,17 @@ class _DownloadsQueueScreenState extends ConsumerState<DownloadsQueueScreen> {
     // Rebuild when instance changes
     ref.listen(instanceProvider.select((s) => s.activeDownloadInstanceId),
         (_, __) => _loadQueue());
+
+    // Live queue snapshots over the WebSocket for the active instance;
+    // the periodic poll remains as a fallback when the socket is down.
+    final wsInstanceId =
+        ref.watch(instanceProvider.select((s) => s.activeDownloadInstance?.id));
+    if (wsInstanceId != null) {
+      ref.listen(downloadsQueueEventsProvider(wsInstanceId), (_, next) {
+        final event = next.valueOrNull;
+        if (event != null) _applyQueueEvent(event);
+      });
+    }
 
     if (_isLoading) {
       return const Center(

--- a/app/lib/features/radarr/data/radarr_api_service.dart
+++ b/app/lib/features/radarr/data/radarr_api_service.dart
@@ -139,6 +139,38 @@ class RadarrApiService {
     return RadarrHistoryPage.fromJson(resp.data as Map<String, dynamic>);
   }
 
+  /// Fetches a page of monitored movies that have no file, newest in
+  /// cinemas first.
+  Future<RadarrWantedPage> getWantedMissing({
+    int page = 1,
+    int pageSize = 50,
+  }) async {
+    final resp = await _dio.get('$_basePath/wanted/missing', queryParameters: {
+      'page': page,
+      'pageSize': pageSize,
+      'sortKey': 'movieMetadata.inCinemas',
+      'sortDirection': 'descending',
+      'monitored': true,
+    });
+    return RadarrWantedPage.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Fetches a page of monitored movies whose file is below the quality
+  /// profile cutoff, newest in cinemas first.
+  Future<RadarrWantedPage> getWantedCutoff({
+    int page = 1,
+    int pageSize = 50,
+  }) async {
+    final resp = await _dio.get('$_basePath/wanted/cutoff', queryParameters: {
+      'page': page,
+      'pageSize': pageSize,
+      'sortKey': 'movieMetadata.inCinemas',
+      'sortDirection': 'descending',
+      'monitored': true,
+    });
+    return RadarrWantedPage.fromJson(resp.data as Map<String, dynamic>);
+  }
+
   /// Interactive release search. Slow (10-60s): indexers are queried live.
   Future<List<RadarrRelease>> getReleases(int movieId) async {
     final resp = await _dio.get(

--- a/app/lib/features/radarr/data/radarr_models.dart
+++ b/app/lib/features/radarr/data/radarr_models.dart
@@ -17,6 +17,9 @@ class RadarrMovie {
   final String? status;
   final double? ratings;
   final int qualityProfileId;
+  final DateTime? inCinemas;
+  final DateTime? physicalRelease;
+  final DateTime? digitalRelease;
 
   const RadarrMovie({
     required this.id,
@@ -36,6 +39,9 @@ class RadarrMovie {
     this.status,
     this.ratings,
     this.qualityProfileId = 0,
+    this.inCinemas,
+    this.physicalRelease,
+    this.digitalRelease,
   });
 
   factory RadarrMovie.fromJson(Map<String, dynamic> json) => RadarrMovie(
@@ -66,6 +72,11 @@ class RadarrMovie {
         ratings:
             (json['ratings'] as Map<String, dynamic>?)?['value'] as double?,
         qualityProfileId: json['qualityProfileId'] as int? ?? 0,
+        inCinemas: DateTime.tryParse(json['inCinemas'] as String? ?? ''),
+        physicalRelease:
+            DateTime.tryParse(json['physicalRelease'] as String? ?? ''),
+        digitalRelease:
+            DateTime.tryParse(json['digitalRelease'] as String? ?? ''),
       );
 
   Map<String, dynamic> toJson() => {
@@ -344,6 +355,23 @@ class RadarrHistoryPage {
         records: (json['records'] as List<dynamic>?)
                 ?.map((r) =>
                     RadarrHistoryRecord.fromJson(r as Map<String, dynamic>))
+                .toList() ??
+            [],
+        totalRecords: json['totalRecords'] as int? ?? 0,
+      );
+}
+
+/// Paged envelope for Radarr wanted movies (missing / cutoff unmet).
+class RadarrWantedPage {
+  final List<RadarrMovie> records;
+  final int totalRecords;
+
+  const RadarrWantedPage({this.records = const [], this.totalRecords = 0});
+
+  factory RadarrWantedPage.fromJson(Map<String, dynamic> json) =>
+      RadarrWantedPage(
+        records: (json['records'] as List<dynamic>?)
+                ?.map((r) => RadarrMovie.fromJson(r as Map<String, dynamic>))
                 .toList() ??
             [],
         totalRecords: json['totalRecords'] as int? ?? 0,

--- a/app/lib/features/radarr/ui/radarr_module_shell.dart
+++ b/app/lib/features/radarr/ui/radarr_module_shell.dart
@@ -4,7 +4,8 @@ import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/instance_dropdown.dart';
 
-/// Radarr module shell with bottom nav: Library | Queue | History | Calendar.
+/// Radarr module shell with bottom nav:
+/// Library | Queue | History | Wanted | Calendar.
 /// Shows instance dropdown in the header when 2+ instances exist.
 class RadarrModuleShell extends ConsumerWidget {
   final int currentIndex;
@@ -59,6 +60,11 @@ class RadarrModuleShell extends ConsumerWidget {
               icon: Icon(Icons.history_outlined),
               activeIcon: Icon(Icons.history),
               label: 'History',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.report_gmailerrorred_outlined),
+              activeIcon: Icon(Icons.report_gmailerrorred),
+              label: 'Wanted',
             ),
             BottomNavigationBarItem(
               icon: Icon(Icons.calendar_month_outlined),

--- a/app/lib/features/radarr/ui/radarr_queue_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_queue_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
+import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/radarr_api_service.dart';
 import '../data/radarr_models.dart';
@@ -21,20 +22,24 @@ class _RadarrQueueScreenState extends ConsumerState<RadarrQueueScreen> {
   bool _isLoading = true;
   String? _error;
   Timer? _refreshTimer;
+  Timer? _wsRefetchDebounce;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadQueue();
+      // Fallback poll only — queue changes arrive as arr_queue_changed
+      // pings over the WebSocket; this covers gaps when the socket is down.
       _refreshTimer =
-          Timer.periodic(const Duration(seconds: 15), (_) => _autoRefresh());
+          Timer.periodic(const Duration(seconds: 45), (_) => _autoRefresh());
     });
   }
 
   @override
   void dispose() {
     _refreshTimer?.cancel();
+    _wsRefetchDebounce?.cancel();
     super.dispose();
   }
 
@@ -44,6 +49,13 @@ class _RadarrQueueScreenState extends ConsumerState<RadarrQueueScreen> {
     final route = ModalRoute.of(context);
     if (route != null && !route.isCurrent) return;
     _loadQueue(silent: true);
+  }
+
+  /// Debounced refetch triggered by WebSocket invalidation pings, so a
+  /// burst of changes only causes one REST roundtrip.
+  void _scheduleWsRefetch() {
+    _wsRefetchDebounce?.cancel();
+    _wsRefetchDebounce = Timer(const Duration(milliseconds: 500), _autoRefresh);
   }
 
   RadarrApiService? _buildService() {
@@ -116,6 +128,18 @@ class _RadarrQueueScreenState extends ConsumerState<RadarrQueueScreen> {
     // Rebuild when instance changes
     ref.listen(instanceProvider.select((s) => s.activeRadarrInstanceId),
         (_, __) => _loadQueue());
+
+    // Refetch on server-pushed queue-change pings for the active instance;
+    // the periodic poll remains as a fallback when the socket is down.
+    final wsInstanceId =
+        ref.watch(instanceProvider.select((s) => s.activeRadarrInstance?.id));
+    if (wsInstanceId != null) {
+      ref.listen(
+          arrQueueChangedProvider(
+              (instanceId: wsInstanceId, serviceType: 'radarr')), (_, next) {
+        if (next.valueOrNull != null) _scheduleWsRefetch();
+      });
+    }
 
     if (_isLoading) {
       return const Center(

--- a/app/lib/features/radarr/ui/radarr_wanted_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_wanted_screen.dart
@@ -29,6 +29,11 @@ class _RadarrWantedScreenState extends ConsumerState<RadarrWantedScreen> {
   int _page = 1;
   bool _isLoading = true;
   bool _isLoadingMore = false;
+
+  /// Bumped by every fresh load (view switch, instance switch, refresh) so
+  /// in-flight responses from a superseded fetch are dropped instead of
+  /// merged into the new list.
+  int _loadGeneration = 0;
   String? _error;
 
   @override
@@ -74,19 +79,23 @@ class _RadarrWantedScreenState extends ConsumerState<RadarrWantedScreen> {
     }
 
     final view = _view;
+    final gen = ++_loadGeneration;
     setState(() => _isLoading = true);
     try {
       final page = await _fetch(service, 1);
-      if (!mounted || view != _view) return;
+      if (!mounted || gen != _loadGeneration || view != _view) return;
       setState(() {
         _records = page.records;
         _totalRecords = page.totalRecords;
         _page = 1;
         _isLoading = false;
+        // A superseded _loadMore bails without clearing this flag; reset it
+        // here so pagination isn't blocked after a refresh/switch.
+        _isLoadingMore = false;
         _error = null;
       });
     } catch (e) {
-      if (!mounted || view != _view) return;
+      if (!mounted || gen != _loadGeneration || view != _view) return;
       setState(() {
         _isLoading = false;
         _error = 'Failed to load wanted movies: $e';
@@ -100,10 +109,11 @@ class _RadarrWantedScreenState extends ConsumerState<RadarrWantedScreen> {
     if (service == null) return;
 
     final view = _view;
+    final gen = _loadGeneration;
     setState(() => _isLoadingMore = true);
     try {
       final next = await _fetch(service, _page + 1);
-      if (!mounted || view != _view) return;
+      if (!mounted || gen != _loadGeneration || view != _view) return;
       setState(() {
         _page += 1;
         _records = [..._records, ...next.records];
@@ -111,7 +121,7 @@ class _RadarrWantedScreenState extends ConsumerState<RadarrWantedScreen> {
         _isLoadingMore = false;
       });
     } catch (_) {
-      if (!mounted || view != _view) return;
+      if (!mounted || gen != _loadGeneration || view != _view) return;
       setState(() => _isLoadingMore = false);
     }
   }

--- a/app/lib/features/radarr/ui/radarr_wanted_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_wanted_screen.dart
@@ -1,0 +1,327 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/radarr_api_service.dart';
+import '../data/radarr_models.dart';
+import 'radarr_releases_screen.dart';
+
+enum _WantedView { missing, cutoff }
+
+/// Paginated Radarr wanted movies: missing files and cutoff-unmet quality.
+class RadarrWantedScreen extends ConsumerStatefulWidget {
+  const RadarrWantedScreen({super.key});
+
+  @override
+  ConsumerState<RadarrWantedScreen> createState() => _RadarrWantedScreenState();
+}
+
+class _RadarrWantedScreenState extends ConsumerState<RadarrWantedScreen> {
+  static const _pageSize = 50;
+
+  final _scrollController = ScrollController();
+  _WantedView _view = _WantedView.missing;
+  List<RadarrMovie> _records = [];
+  int _totalRecords = 0;
+  int _page = 1;
+  bool _isLoading = true;
+  bool _isLoadingMore = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.extentAfter < 400) _loadMore();
+  }
+
+  RadarrApiService? _buildService() {
+    final instanceId = ref.read(instanceProvider).activeRadarrInstance?.id;
+    if (instanceId == null) return null;
+    return RadarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: instanceId,
+    );
+  }
+
+  Future<RadarrWantedPage> _fetch(RadarrApiService service, int page) {
+    return _view == _WantedView.missing
+        ? service.getWantedMissing(page: page, pageSize: _pageSize)
+        : service.getWantedCutoff(page: page, pageSize: _pageSize);
+  }
+
+  Future<void> _load() async {
+    final service = _buildService();
+    if (service == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Radarr instance configured';
+      });
+      return;
+    }
+
+    final view = _view;
+    setState(() => _isLoading = true);
+    try {
+      final page = await _fetch(service, 1);
+      if (!mounted || view != _view) return;
+      setState(() {
+        _records = page.records;
+        _totalRecords = page.totalRecords;
+        _page = 1;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted || view != _view) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load wanted movies: $e';
+      });
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_isLoading || _isLoadingMore || !_hasMore) return;
+    final service = _buildService();
+    if (service == null) return;
+
+    final view = _view;
+    setState(() => _isLoadingMore = true);
+    try {
+      final next = await _fetch(service, _page + 1);
+      if (!mounted || view != _view) return;
+      setState(() {
+        _page += 1;
+        _records = [..._records, ...next.records];
+        _totalRecords = next.totalRecords;
+        _isLoadingMore = false;
+      });
+    } catch (_) {
+      if (!mounted || view != _view) return;
+      setState(() => _isLoadingMore = false);
+    }
+  }
+
+  bool get _hasMore => _records.length < _totalRecords;
+
+  void _onViewChanged(_WantedView view) {
+    if (view == _view) return;
+    setState(() {
+      _view = view;
+      _records = [];
+      _totalRecords = 0;
+      _page = 1;
+      _error = null;
+    });
+    _load();
+  }
+
+  Future<void> _automaticSearch(RadarrMovie movie) async {
+    final service = _buildService();
+    if (service == null) return;
+    try {
+      await service.searchMovie(movie.id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Search started for "${movie.title}"')));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Failed to start search: $e')));
+    }
+  }
+
+  void _openInteractiveSearch(RadarrMovie movie) {
+    final instanceId = ref.read(instanceProvider).activeRadarrInstance?.id;
+    if (instanceId == null) return;
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute(
+        builder: (_) => RadarrReleasesScreen(
+          instanceId: instanceId,
+          movieId: movie.id,
+          movieTitle: movie.title,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Reload when the active instance changes.
+    ref.listen(instanceProvider.select((s) => s.activeRadarrInstanceId),
+        (_, __) => _load());
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          child: SegmentedButton<_WantedView>(
+            showSelectedIcon: false,
+            segments: const [
+              ButtonSegment(value: _WantedView.missing, label: Text('Missing')),
+              ButtonSegment(
+                  value: _WantedView.cutoff, label: Text('Cutoff Unmet')),
+            ],
+            selected: {_view},
+            onSelectionChanged: (value) => _onViewChanged(value.first),
+          ),
+        ),
+        Expanded(child: _buildBody()),
+      ],
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading && _records.isEmpty) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null && _records.isEmpty) {
+      return FullScreenError(message: _error!, onRetry: _load);
+    }
+    if (_records.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _load,
+        color: AppTheme.accent,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            const SizedBox(height: 160),
+            const Icon(Icons.check_circle_outline,
+                size: 48, color: AppTheme.available),
+            const SizedBox(height: 12),
+            Center(
+              child: Text(
+                _view == _WantedView.missing
+                    ? 'Nothing missing — library is healthy'
+                    : 'No cutoff unmet movies — quality goals met',
+                style: const TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 16),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _load,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _records.length + (_hasMore ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index >= _records.length) {
+            return const Padding(
+              padding: EdgeInsets.all(16),
+              child: Center(
+                child: SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(
+                      color: AppTheme.accent, strokeWidth: 2.5),
+                ),
+              ),
+            );
+          }
+
+          final movie = _records[index];
+          return _WantedTile(
+            movie: movie,
+            showQuality: _view == _WantedView.cutoff,
+            onAutomaticSearch: () => _automaticSearch(movie),
+            onInteractiveSearch: () => _openInteractiveSearch(movie),
+          );
+        },
+      ),
+    );
+  }
+}
+
+String _releaseLabel(RadarrMovie movie) {
+  final format = DateFormat('MMM d, yyyy');
+  if (movie.digitalRelease != null) {
+    return 'Digital ${format.format(movie.digitalRelease!.toLocal())}';
+  }
+  if (movie.physicalRelease != null) {
+    return 'Physical ${format.format(movie.physicalRelease!.toLocal())}';
+  }
+  if (movie.inCinemas != null) {
+    return 'In cinemas ${format.format(movie.inCinemas!.toLocal())}';
+  }
+  return movie.status ?? 'Unreleased';
+}
+
+class _WantedTile extends StatelessWidget {
+  final RadarrMovie movie;
+  final bool showQuality;
+  final VoidCallback onAutomaticSearch;
+  final VoidCallback onInteractiveSearch;
+
+  const _WantedTile({
+    required this.movie,
+    required this.showQuality,
+    required this.onAutomaticSearch,
+    required this.onInteractiveSearch,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final subtitleParts = [
+      if (showQuality && movie.movieFile?.quality != null)
+        'Current: ${movie.movieFile!.quality}',
+      _releaseLabel(movie),
+    ];
+
+    return ListTile(
+      contentPadding: const EdgeInsets.only(left: 16, right: 4),
+      title: Text(
+        movie.year > 0 ? '${movie.title} (${movie.year})' : movie.title,
+        style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 13.5,
+            fontWeight: FontWeight.w500),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        subtitleParts.join(' • '),
+        style: const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.search, color: AppTheme.accent, size: 22),
+            tooltip: 'Automatic search',
+            onPressed: onAutomaticSearch,
+          ),
+          IconButton(
+            icon: const Icon(Icons.manage_search,
+                color: AppTheme.textSecondary, size: 22),
+            tooltip: 'Interactive search',
+            onPressed: onInteractiveSearch,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -45,9 +45,35 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
   bool _isTesting = false;
   String? _testResult;
 
-  bool get _isQbittorrent => _serviceType == 'qbittorrent';
+  static const _serviceTypes = <(String, String)>[
+    ('radarr', 'Radarr'),
+    ('sonarr', 'Sonarr'),
+    ('sabnzbd', 'SABnzbd'),
+    ('qbittorrent', 'qBittorrent'),
+    ('nzbget', 'NZBGet'),
+    ('transmission', 'Transmission'),
+    ('tautulli', 'Tautulli'),
+  ];
+
+  /// Types that authenticate with username/password instead of an API key.
+  bool get _usesUserPass =>
+      _serviceType == 'qbittorrent' ||
+      _serviceType == 'nzbget' ||
+      _serviceType == 'transmission';
+
+  /// Transmission auth is optional (only when the daemon requires it).
+  bool get _credentialsOptional => _serviceType == 'transmission';
+
   bool get _isDownloadClient =>
-      _serviceType == 'sabnzbd' || _serviceType == 'qbittorrent';
+      _serviceType == 'sabnzbd' ||
+      _serviceType == 'qbittorrent' ||
+      _serviceType == 'nzbget' ||
+      _serviceType == 'transmission';
+
+  /// Only the arr services support a device-direct connection test; the
+  /// rest are validated by the backend when saving.
+  bool get _supportsDirectTest =>
+      _serviceType == 'radarr' || _serviceType == 'sonarr';
 
   @override
   void initState() {
@@ -125,7 +151,8 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
     }
     // When editing, blank credentials keep the existing ones.
     if (widget.isEditing) return null;
-    if (_isQbittorrent) {
+    if (_usesUserPass) {
+      if (_credentialsOptional) return null;
       if (_usernameController.text.trim().isEmpty ||
           _passwordController.text.isEmpty) {
         return 'Username and password are required';
@@ -254,6 +281,12 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
         return 'http://192.168.1.100:8080';
       case 'qbittorrent':
         return 'http://192.168.1.100:8081';
+      case 'nzbget':
+        return 'http://192.168.1.100:6789';
+      case 'transmission':
+        return 'http://192.168.1.100:9091';
+      case 'tautulli':
+        return 'http://192.168.1.100:8181';
       default:
         return 'http://192.168.1.100:7878';
     }
@@ -283,23 +316,24 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
                     fontSize: 13,
                     fontWeight: FontWeight.w600)),
             const SizedBox(height: 8),
-            SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: SegmentedButton<String>(
-                showSelectedIcon: false,
-                segments: const [
-                  ButtonSegment(value: 'radarr', label: Text('Radarr')),
-                  ButtonSegment(value: 'sonarr', label: Text('Sonarr')),
-                  ButtonSegment(value: 'sabnzbd', label: Text('SABnzbd')),
-                  ButtonSegment(
-                      value: 'qbittorrent', label: Text('qBittorrent')),
-                ],
-                selected: {_serviceType},
-                onSelectionChanged: (value) => setState(() {
-                  _serviceType = value.first;
+            // With 7 service types a segmented control no longer fits on a
+            // phone, so use a dropdown instead.
+            DropdownButtonFormField<String>(
+              initialValue: _serviceType,
+              dropdownColor: AppTheme.surfaceVariant,
+              items: _serviceTypes
+                  .map((t) => DropdownMenuItem(
+                        value: t.$1,
+                        child: Text(t.$2),
+                      ))
+                  .toList(),
+              onChanged: (value) {
+                if (value == null) return;
+                setState(() {
+                  _serviceType = value;
                   _testResult = null;
-                }),
-              ),
+                });
+              },
             ),
             const SizedBox(height: 24),
           ],
@@ -310,7 +344,9 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
               labelText: 'Name',
               hintText: _isDownloadClient
                   ? 'e.g. SABnzbd, qBittorrent'
-                  : 'e.g. Movies, 4K Movies',
+                  : (_serviceType == 'tautulli'
+                      ? 'e.g. Tautulli'
+                      : 'e.g. Movies, 4K Movies'),
             ),
           ),
           const SizedBox(height: 16),
@@ -325,15 +361,18 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
           ),
           const SizedBox(height: 16),
 
-          // qBittorrent authenticates with username/password; everything
-          // else uses an API key. Credentials are write-only: when editing,
-          // blank keeps the existing value.
-          if (_isQbittorrent) ...[
+          // qBittorrent, NZBGet and Transmission authenticate with
+          // username/password; everything else uses an API key. Credentials
+          // are write-only: when editing, blank keeps the existing value.
+          if (_usesUserPass) ...[
             TextField(
               controller: _usernameController,
-              decoration: const InputDecoration(
-                labelText: 'Username',
-                hintText: 'qBittorrent Web UI username',
+              decoration: InputDecoration(
+                labelText:
+                    _credentialsOptional ? 'Username (optional)' : 'Username',
+                hintText: _credentialsOptional
+                    ? 'Only if authentication is enabled'
+                    : 'Web UI username',
               ),
               autocorrect: false,
             ),
@@ -341,10 +380,13 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
             TextField(
               controller: _passwordController,
               decoration: InputDecoration(
-                labelText: 'Password',
+                labelText:
+                    _credentialsOptional ? 'Password (optional)' : 'Password',
                 hintText: widget.isEditing
                     ? 'Leave blank to keep existing'
-                    : 'qBittorrent Web UI password',
+                    : (_credentialsOptional
+                        ? 'Only if authentication is enabled'
+                        : 'Web UI password'),
               ),
               obscureText: true,
             ),
@@ -357,7 +399,9 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
                     ? 'Leave blank to keep existing'
                     : (_serviceType == 'sabnzbd'
                         ? 'Your SABnzbd API key'
-                        : 'Your Radarr/Sonarr API key'),
+                        : (_serviceType == 'tautulli'
+                            ? 'Your Tautulli API key'
+                            : 'Your Radarr/Sonarr API key')),
               ),
               obscureText: true,
             ),
@@ -369,7 +413,9 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
             subtitle: Text(
                 _isDownloadClient
                     ? 'Use this as the default download client'
-                    : 'Use this as the default for media requests',
+                    : (_serviceType == 'tautulli'
+                        ? 'Use this as the default Tautulli instance'
+                        : 'Use this as the default for media requests'),
                 style: const TextStyle(
                     color: AppTheme.textSecondary, fontSize: 13)),
             value: _isDefault,
@@ -380,9 +426,9 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
           const SizedBox(height: 24),
 
           // Test connection button (Radarr/Sonarr only — the device calls
-          // the arr server directly). Download clients are validated by the
-          // backend when saving.
-          if (!_isDownloadClient) ...[
+          // the arr server directly). Download clients and Tautulli are
+          // validated by the backend when saving.
+          if (_supportsDirectTest) ...[
             OutlinedButton.icon(
               onPressed: _isTesting ? null : _testConnection,
               icon: _isTesting

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -51,9 +51,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           _SettingsTile(
             icon: Icons.check_circle_outline,
             title: 'Status',
-            subtitle: auth?.isAuthenticated == true
-                ? 'Connected'
-                : 'Disconnected',
+            subtitle:
+                auth?.isAuthenticated == true ? 'Connected' : 'Disconnected',
             trailing: Icon(
               Icons.circle,
               size: 12,
@@ -277,8 +276,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                           if (dialogContext.mounted) {
                             ScaffoldMessenger.of(dialogContext).showSnackBar(
                               SnackBar(
-                                  content:
-                                      Text('Failed to generate link: $e')),
+                                  content: Text('Failed to generate link: $e')),
                             );
                           }
                         }
@@ -317,7 +315,11 @@ IconData _serviceIcon(String serviceType) {
       return Icons.tv_outlined;
     case 'sabnzbd':
     case 'qbittorrent':
+    case 'nzbget':
+    case 'transmission':
       return Icons.download_outlined;
+    case 'tautulli':
+      return Icons.monitor_heart_outlined;
     default:
       return Icons.dns_outlined;
   }
@@ -333,6 +335,12 @@ String _serviceLabel(String serviceType) {
       return 'SABnzbd';
     case 'qbittorrent':
       return 'qBittorrent';
+    case 'nzbget':
+      return 'NZBGet';
+    case 'transmission':
+      return 'Transmission';
+    case 'tautulli':
+      return 'Tautulli';
     default:
       return serviceType;
   }
@@ -382,12 +390,10 @@ class _SettingsTile extends StatelessWidget {
           style: const TextStyle(
               color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
       subtitle: Text(subtitle,
-          style:
-              const TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+          style: const TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
       trailing: trailing ??
           (onTap != null
-              ? const Icon(Icons.chevron_right,
-                  color: AppTheme.textSecondary)
+              ? const Icon(Icons.chevron_right, color: AppTheme.textSecondary)
               : null),
       onTap: onTap,
     );

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -748,6 +748,8 @@ class _AppShellState extends ConsumerState<AppShell>
           instances.setActiveSonarrInstance(instanceId);
         case ModuleType.downloads:
           instances.setActiveDownloadInstance(instanceId);
+        case ModuleType.tautulli:
+          instances.setActiveTautulliInstance(instanceId);
         default:
           break;
       }
@@ -761,6 +763,8 @@ class _AppShellState extends ConsumerState<AppShell>
         context.go('/sonarr/library');
       case ModuleType.downloads:
         context.go('/downloads/queue');
+      case ModuleType.tautulli:
+        context.go('/tautulli/activity');
       case ModuleType.assistant:
         context.go('/assistant');
     }

--- a/app/lib/features/sonarr/data/sonarr_api_service.dart
+++ b/app/lib/features/sonarr/data/sonarr_api_service.dart
@@ -90,6 +90,14 @@ class SonarrApiService {
     });
   }
 
+  /// Triggers an automatic indexer search for the given episodes.
+  Future<void> searchEpisodes(List<int> episodeIds) async {
+    await _dio.post('$_basePath/command', data: {
+      'name': 'EpisodeSearch',
+      'episodeIds': episodeIds,
+    });
+  }
+
   Future<List<Map<String, dynamic>>> getQueue() async {
     final resp = await _dio.get('$_basePath/queue',
         queryParameters: {'includeSeries': true, 'pageSize': 50});
@@ -146,6 +154,42 @@ class SonarrApiService {
       'sortDirection': 'descending',
     });
     return SonarrHistoryPage.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Fetches a page of monitored episodes that are missing a file, newest
+  /// air date first. Records include series context.
+  Future<SonarrWantedPage> getWantedMissing({
+    int page = 1,
+    int pageSize = 50,
+  }) async {
+    final resp = await _dio.get('$_basePath/wanted/missing', queryParameters: {
+      'page': page,
+      'pageSize': pageSize,
+      'sortKey': 'episodes.airDateUtc',
+      'sortDirection': 'descending',
+      'monitored': true,
+      'includeSeries': true,
+    });
+    return SonarrWantedPage.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Fetches a page of monitored episodes whose file is below the quality
+  /// profile cutoff, newest air date first. Records include series context
+  /// and the current episode file (for its quality).
+  Future<SonarrWantedPage> getWantedCutoff({
+    int page = 1,
+    int pageSize = 50,
+  }) async {
+    final resp = await _dio.get('$_basePath/wanted/cutoff', queryParameters: {
+      'page': page,
+      'pageSize': pageSize,
+      'sortKey': 'episodes.airDateUtc',
+      'sortDirection': 'descending',
+      'monitored': true,
+      'includeSeries': true,
+      'includeEpisodeFile': true,
+    });
+    return SonarrWantedPage.fromJson(resp.data as Map<String, dynamic>);
   }
 
   /// Interactive release search for one season.

--- a/app/lib/features/sonarr/data/sonarr_models.dart
+++ b/app/lib/features/sonarr/data/sonarr_models.dart
@@ -416,6 +416,71 @@ class SonarrHistoryPage {
       );
 }
 
+/// One wanted episode (missing or cutoff unmet) with series context.
+class SonarrWantedRecord {
+  final int id;
+  final int seriesId;
+  final int seasonNumber;
+  final int episodeNumber;
+  final String? title;
+  final DateTime? airDateUtc;
+  final bool monitored;
+  final String? seriesTitle;
+
+  /// Current file quality; only present on cutoff-unmet records fetched
+  /// with includeEpisodeFile.
+  final String? quality;
+
+  const SonarrWantedRecord({
+    required this.id,
+    this.seriesId = 0,
+    this.seasonNumber = 0,
+    this.episodeNumber = 0,
+    this.title,
+    this.airDateUtc,
+    this.monitored = true,
+    this.seriesTitle,
+    this.quality,
+  });
+
+  factory SonarrWantedRecord.fromJson(Map<String, dynamic> json) =>
+      SonarrWantedRecord(
+        id: json['id'] as int? ?? 0,
+        seriesId: json['seriesId'] as int? ?? 0,
+        seasonNumber: json['seasonNumber'] as int? ?? 0,
+        episodeNumber: json['episodeNumber'] as int? ?? 0,
+        title: json['title'] as String?,
+        airDateUtc: DateTime.tryParse(json['airDateUtc'] as String? ?? ''),
+        monitored: json['monitored'] as bool? ?? true,
+        seriesTitle:
+            (json['series'] as Map<String, dynamic>?)?['title'] as String?,
+        quality: (json['episodeFile'] as Map<String, dynamic>?)?['quality']
+            ?['quality']?['name'] as String?,
+      );
+
+  /// e.g. "S01E05".
+  String get seasonEpisodeLabel => 'S${seasonNumber.toString().padLeft(2, '0')}'
+      'E${episodeNumber.toString().padLeft(2, '0')}';
+}
+
+/// Paged envelope for Sonarr wanted episodes (missing / cutoff unmet).
+class SonarrWantedPage {
+  final List<SonarrWantedRecord> records;
+  final int totalRecords;
+
+  const SonarrWantedPage({this.records = const [], this.totalRecords = 0});
+
+  factory SonarrWantedPage.fromJson(Map<String, dynamic> json) =>
+      SonarrWantedPage(
+        records: (json['records'] as List<dynamic>?)
+                ?.map((r) =>
+                    SonarrWantedRecord.fromJson(r as Map<String, dynamic>))
+                .toList() ??
+            [],
+        totalRecords: json['totalRecords'] as int? ?? 0,
+      );
+}
+
 /// A release returned by Sonarr's interactive search.
 class SonarrRelease {
   final String guid;

--- a/app/lib/features/sonarr/ui/sonarr_queue_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_queue_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
+import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
@@ -21,20 +22,24 @@ class _SonarrQueueScreenState extends ConsumerState<SonarrQueueScreen> {
   bool _isLoading = true;
   String? _error;
   Timer? _refreshTimer;
+  Timer? _wsRefetchDebounce;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadQueue();
+      // Fallback poll only — queue changes arrive as arr_queue_changed
+      // pings over the WebSocket; this covers gaps when the socket is down.
       _refreshTimer =
-          Timer.periodic(const Duration(seconds: 15), (_) => _autoRefresh());
+          Timer.periodic(const Duration(seconds: 45), (_) => _autoRefresh());
     });
   }
 
   @override
   void dispose() {
     _refreshTimer?.cancel();
+    _wsRefetchDebounce?.cancel();
     super.dispose();
   }
 
@@ -44,6 +49,13 @@ class _SonarrQueueScreenState extends ConsumerState<SonarrQueueScreen> {
     final route = ModalRoute.of(context);
     if (route != null && !route.isCurrent) return;
     _loadQueue(silent: true);
+  }
+
+  /// Debounced refetch triggered by WebSocket invalidation pings, so a
+  /// burst of changes only causes one REST roundtrip.
+  void _scheduleWsRefetch() {
+    _wsRefetchDebounce?.cancel();
+    _wsRefetchDebounce = Timer(const Duration(milliseconds: 500), _autoRefresh);
   }
 
   SonarrApiService? _buildService() {
@@ -116,6 +128,18 @@ class _SonarrQueueScreenState extends ConsumerState<SonarrQueueScreen> {
     // Rebuild when instance changes
     ref.listen(instanceProvider.select((s) => s.activeSonarrInstanceId),
         (_, __) => _loadQueue());
+
+    // Refetch on server-pushed queue-change pings for the active instance;
+    // the periodic poll remains as a fallback when the socket is down.
+    final wsInstanceId =
+        ref.watch(instanceProvider.select((s) => s.activeSonarrInstance?.id));
+    if (wsInstanceId != null) {
+      ref.listen(
+          arrQueueChangedProvider(
+              (instanceId: wsInstanceId, serviceType: 'sonarr')), (_, next) {
+        if (next.valueOrNull != null) _scheduleWsRefetch();
+      });
+    }
 
     if (_isLoading) {
       return const Center(

--- a/app/lib/features/sonarr/ui/sonarr_wanted_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_wanted_screen.dart
@@ -1,0 +1,330 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/sonarr_api_service.dart';
+import '../data/sonarr_models.dart';
+import 'sonarr_releases_screen.dart';
+
+enum _WantedView { missing, cutoff }
+
+/// Paginated Sonarr wanted episodes: missing files and cutoff-unmet quality.
+class SonarrWantedScreen extends ConsumerStatefulWidget {
+  const SonarrWantedScreen({super.key});
+
+  @override
+  ConsumerState<SonarrWantedScreen> createState() => _SonarrWantedScreenState();
+}
+
+class _SonarrWantedScreenState extends ConsumerState<SonarrWantedScreen> {
+  static const _pageSize = 50;
+
+  final _scrollController = ScrollController();
+  _WantedView _view = _WantedView.missing;
+  List<SonarrWantedRecord> _records = [];
+  int _totalRecords = 0;
+  int _page = 1;
+  bool _isLoading = true;
+  bool _isLoadingMore = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.extentAfter < 400) _loadMore();
+  }
+
+  SonarrApiService? _buildService() {
+    final instanceId = ref.read(instanceProvider).activeSonarrInstance?.id;
+    if (instanceId == null) return null;
+    return SonarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: instanceId,
+    );
+  }
+
+  Future<SonarrWantedPage> _fetch(SonarrApiService service, int page) {
+    return _view == _WantedView.missing
+        ? service.getWantedMissing(page: page, pageSize: _pageSize)
+        : service.getWantedCutoff(page: page, pageSize: _pageSize);
+  }
+
+  Future<void> _load() async {
+    final service = _buildService();
+    if (service == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Sonarr instance configured';
+      });
+      return;
+    }
+
+    final view = _view;
+    setState(() => _isLoading = true);
+    try {
+      final page = await _fetch(service, 1);
+      if (!mounted || view != _view) return;
+      setState(() {
+        _records = page.records;
+        _totalRecords = page.totalRecords;
+        _page = 1;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted || view != _view) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load wanted episodes: $e';
+      });
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_isLoading || _isLoadingMore || !_hasMore) return;
+    final service = _buildService();
+    if (service == null) return;
+
+    final view = _view;
+    setState(() => _isLoadingMore = true);
+    try {
+      final next = await _fetch(service, _page + 1);
+      if (!mounted || view != _view) return;
+      setState(() {
+        _page += 1;
+        _records = [..._records, ...next.records];
+        _totalRecords = next.totalRecords;
+        _isLoadingMore = false;
+      });
+    } catch (_) {
+      if (!mounted || view != _view) return;
+      setState(() => _isLoadingMore = false);
+    }
+  }
+
+  bool get _hasMore => _records.length < _totalRecords;
+
+  void _onViewChanged(_WantedView view) {
+    if (view == _view) return;
+    setState(() {
+      _view = view;
+      _records = [];
+      _totalRecords = 0;
+      _page = 1;
+      _error = null;
+    });
+    _load();
+  }
+
+  Future<void> _automaticSearch(SonarrWantedRecord record) async {
+    final service = _buildService();
+    if (service == null) return;
+    try {
+      await service.searchEpisodes([record.id]);
+      if (!mounted) return;
+      final label = [
+        if (record.seriesTitle != null) record.seriesTitle,
+        record.seasonEpisodeLabel,
+      ].join(' ');
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Search started for $label')));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Failed to start search: $e')));
+    }
+  }
+
+  void _openInteractiveSearch(SonarrWantedRecord record) {
+    final instanceId = ref.read(instanceProvider).activeSonarrInstance?.id;
+    if (instanceId == null) return;
+    // The interactive search is season-scoped; pass the episode's season.
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute(
+        builder: (_) => SonarrReleasesScreen(
+          instanceId: instanceId,
+          seriesId: record.seriesId,
+          seasonNumber: record.seasonNumber,
+          seriesTitle: record.seriesTitle ?? 'Series',
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Reload when the active instance changes.
+    ref.listen(instanceProvider.select((s) => s.activeSonarrInstanceId),
+        (_, __) => _load());
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          child: SegmentedButton<_WantedView>(
+            showSelectedIcon: false,
+            segments: const [
+              ButtonSegment(value: _WantedView.missing, label: Text('Missing')),
+              ButtonSegment(
+                  value: _WantedView.cutoff, label: Text('Cutoff Unmet')),
+            ],
+            selected: {_view},
+            onSelectionChanged: (value) => _onViewChanged(value.first),
+          ),
+        ),
+        Expanded(child: _buildBody()),
+      ],
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading && _records.isEmpty) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null && _records.isEmpty) {
+      return FullScreenError(message: _error!, onRetry: _load);
+    }
+    if (_records.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _load,
+        color: AppTheme.accent,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            const SizedBox(height: 160),
+            const Icon(Icons.check_circle_outline,
+                size: 48, color: AppTheme.available),
+            const SizedBox(height: 12),
+            Center(
+              child: Text(
+                _view == _WantedView.missing
+                    ? 'Nothing missing — library is healthy'
+                    : 'No cutoff unmet episodes — quality goals met',
+                style: const TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 16),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _load,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _records.length + (_hasMore ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index >= _records.length) {
+            return const Padding(
+              padding: EdgeInsets.all(16),
+              child: Center(
+                child: SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(
+                      color: AppTheme.accent, strokeWidth: 2.5),
+                ),
+              ),
+            );
+          }
+
+          final record = _records[index];
+          return _WantedTile(
+            record: record,
+            showQuality: _view == _WantedView.cutoff,
+            onAutomaticSearch: () => _automaticSearch(record),
+            onInteractiveSearch: () => _openInteractiveSearch(record),
+          );
+        },
+      ),
+    );
+  }
+}
+
+String _airDateLabel(DateTime? airDateUtc) {
+  if (airDateUtc == null) return 'Unaired';
+  final local = airDateUtc.toLocal();
+  final now = DateTime.now();
+  if (local.year == now.year) return DateFormat('MMM d').format(local);
+  return DateFormat('MMM d, yyyy').format(local);
+}
+
+class _WantedTile extends StatelessWidget {
+  final SonarrWantedRecord record;
+  final bool showQuality;
+  final VoidCallback onAutomaticSearch;
+  final VoidCallback onInteractiveSearch;
+
+  const _WantedTile({
+    required this.record,
+    required this.showQuality,
+    required this.onAutomaticSearch,
+    required this.onInteractiveSearch,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final subtitleParts = [
+      [
+        record.seasonEpisodeLabel,
+        if (record.title != null && record.title!.isNotEmpty) record.title!,
+      ].join(' • '),
+      if (showQuality && record.quality != null) 'Current: ${record.quality}',
+      _airDateLabel(record.airDateUtc),
+    ];
+
+    return ListTile(
+      contentPadding: const EdgeInsets.only(left: 16, right: 4),
+      title: Text(
+        record.seriesTitle ?? 'Unknown series',
+        style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 13.5,
+            fontWeight: FontWeight.w500),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        subtitleParts.join(' • '),
+        style: const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.search, color: AppTheme.accent, size: 22),
+            tooltip: 'Automatic search',
+            onPressed: onAutomaticSearch,
+          ),
+          IconButton(
+            icon: const Icon(Icons.manage_search,
+                color: AppTheme.textSecondary, size: 22),
+            tooltip: 'Interactive search',
+            onPressed: onInteractiveSearch,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/sonarr/ui/sonarr_wanted_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_wanted_screen.dart
@@ -29,6 +29,11 @@ class _SonarrWantedScreenState extends ConsumerState<SonarrWantedScreen> {
   int _page = 1;
   bool _isLoading = true;
   bool _isLoadingMore = false;
+
+  /// Bumped by every fresh load (view switch, instance switch, refresh) so
+  /// in-flight responses from a superseded fetch are dropped instead of
+  /// merged into the new list.
+  int _loadGeneration = 0;
   String? _error;
 
   @override
@@ -74,19 +79,23 @@ class _SonarrWantedScreenState extends ConsumerState<SonarrWantedScreen> {
     }
 
     final view = _view;
+    final gen = ++_loadGeneration;
     setState(() => _isLoading = true);
     try {
       final page = await _fetch(service, 1);
-      if (!mounted || view != _view) return;
+      if (!mounted || gen != _loadGeneration || view != _view) return;
       setState(() {
         _records = page.records;
         _totalRecords = page.totalRecords;
         _page = 1;
         _isLoading = false;
+        // A superseded _loadMore bails without clearing this flag; reset it
+        // here so pagination isn't blocked after a refresh/switch.
+        _isLoadingMore = false;
         _error = null;
       });
     } catch (e) {
-      if (!mounted || view != _view) return;
+      if (!mounted || gen != _loadGeneration || view != _view) return;
       setState(() {
         _isLoading = false;
         _error = 'Failed to load wanted episodes: $e';
@@ -100,10 +109,11 @@ class _SonarrWantedScreenState extends ConsumerState<SonarrWantedScreen> {
     if (service == null) return;
 
     final view = _view;
+    final gen = _loadGeneration;
     setState(() => _isLoadingMore = true);
     try {
       final next = await _fetch(service, _page + 1);
-      if (!mounted || view != _view) return;
+      if (!mounted || gen != _loadGeneration || view != _view) return;
       setState(() {
         _page += 1;
         _records = [..._records, ...next.records];
@@ -111,7 +121,7 @@ class _SonarrWantedScreenState extends ConsumerState<SonarrWantedScreen> {
         _isLoadingMore = false;
       });
     } catch (_) {
-      if (!mounted || view != _view) return;
+      if (!mounted || gen != _loadGeneration || view != _view) return;
       setState(() => _isLoadingMore = false);
     }
   }

--- a/app/lib/features/tautulli/data/tautulli_api_service.dart
+++ b/app/lib/features/tautulli/data/tautulli_api_service.dart
@@ -1,0 +1,36 @@
+import 'package:dio/dio.dart';
+import 'tautulli_models.dart';
+
+/// Networking layer for Tautulli, proxied through the Cantinarr backend's
+/// normalized /api/tautulli API.
+class TautulliApiService {
+  final Dio _dio;
+  final String _instanceId;
+
+  TautulliApiService({required Dio backendDio, required String instanceId})
+      : _dio = backendDio,
+        _instanceId = instanceId;
+
+  String get _basePath => '/api/tautulli/$_instanceId';
+
+  Future<TautulliActivity> getActivity() async {
+    final resp = await _dio.get('$_basePath/activity');
+    return TautulliActivity.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<List<TautulliHistoryItem>> getHistory({int limit = 50}) async {
+    final resp =
+        await _dio.get('$_basePath/history', queryParameters: {'limit': limit});
+    final items =
+        (resp.data as Map<String, dynamic>)['items'] as List<dynamic>? ?? [];
+    return items
+        .map((i) => TautulliHistoryItem.fromJson(i as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<TautulliStats> getStats({int days = 30}) async {
+    final resp =
+        await _dio.get('$_basePath/stats', queryParameters: {'days': days});
+    return TautulliStats.fromJson(resp.data as Map<String, dynamic>);
+  }
+}

--- a/app/lib/features/tautulli/data/tautulli_models.dart
+++ b/app/lib/features/tautulli/data/tautulli_models.dart
@@ -1,0 +1,172 @@
+/// Models and formatters for the Tautulli module, matching the backend's
+/// normalized /api/tautulli payloads.
+library;
+
+/// Human-readable bandwidth from a kbps figure.
+String formatBandwidthKbps(num kbps) {
+  if (kbps <= 0) return '0 kbps';
+  if (kbps >= 1000) {
+    final mbps = kbps / 1000;
+    final decimals = mbps >= 100 ? 0 : 1;
+    return '${mbps.toStringAsFixed(decimals)} Mbps';
+  }
+  return '${kbps.round()} kbps';
+}
+
+/// Current Plex activity: stream count, total bandwidth and per-stream info.
+class TautulliActivity {
+  final int streamCount;
+  final int totalBandwidthKbps;
+  final List<TautulliStream> streams;
+
+  const TautulliActivity({
+    this.streamCount = 0,
+    this.totalBandwidthKbps = 0,
+    this.streams = const [],
+  });
+
+  factory TautulliActivity.fromJson(Map<String, dynamic> json) =>
+      TautulliActivity(
+        streamCount: (json['stream_count'] as num?)?.toInt() ?? 0,
+        totalBandwidthKbps:
+            (json['total_bandwidth_kbps'] as num?)?.toInt() ?? 0,
+        streams: (json['streams'] as List<dynamic>? ?? [])
+            .map((s) => TautulliStream.fromJson(s as Map<String, dynamic>))
+            .toList(),
+      );
+
+  String get totalBandwidthFormatted => formatBandwidthKbps(totalBandwidthKbps);
+}
+
+/// One active stream.
+class TautulliStream {
+  final String user;
+  final String title;
+  final String fullTitle;
+  final String player;
+  final String product;
+  final String state;
+  final int progressPercent;
+  final String quality;
+  final String streamType;
+  final int bandwidthKbps;
+
+  const TautulliStream({
+    this.user = '',
+    this.title = '',
+    this.fullTitle = '',
+    this.player = '',
+    this.product = '',
+    this.state = '',
+    this.progressPercent = 0,
+    this.quality = '',
+    this.streamType = '',
+    this.bandwidthKbps = 0,
+  });
+
+  factory TautulliStream.fromJson(Map<String, dynamic> json) => TautulliStream(
+        user: json['user'] as String? ?? '',
+        title: json['title'] as String? ?? '',
+        fullTitle: json['full_title'] as String? ?? '',
+        player: json['player'] as String? ?? '',
+        product: json['product'] as String? ?? '',
+        state: json['state'] as String? ?? '',
+        progressPercent: (json['progress_percent'] as num?)?.toInt() ?? 0,
+        quality: json['quality'] as String? ?? '',
+        streamType: json['stream_type'] as String? ?? '',
+        bandwidthKbps: (json['bandwidth_kbps'] as num?)?.toInt() ?? 0,
+      );
+
+  /// Title for display: prefer the full title (includes show/episode).
+  String get displayTitle => fullTitle.isNotEmpty ? fullTitle : title;
+
+  double get progressFraction => (progressPercent / 100).clamp(0.0, 1.0);
+
+  String get bandwidthFormatted => formatBandwidthKbps(bandwidthKbps);
+
+  bool get isPaused => state.toLowerCase() == 'paused';
+  bool get isBuffering => state.toLowerCase() == 'buffering';
+
+  bool get isTranscode => streamType.toLowerCase().contains('transcode');
+
+  /// Badge label for the stream decision.
+  String get streamTypeLabel {
+    final s = streamType.toLowerCase();
+    if (s.contains('transcode')) return 'Transcode';
+    if (s.contains('copy')) return 'Direct Stream';
+    return 'Direct Play';
+  }
+}
+
+/// One watch-history entry.
+class TautulliHistoryItem {
+  final String user;
+  final String fullTitle;
+  final DateTime? date;
+  final int durationSeconds;
+  final int percentComplete;
+  final String player;
+  final String platform;
+
+  const TautulliHistoryItem({
+    this.user = '',
+    this.fullTitle = '',
+    this.date,
+    this.durationSeconds = 0,
+    this.percentComplete = 0,
+    this.player = '',
+    this.platform = '',
+  });
+
+  factory TautulliHistoryItem.fromJson(Map<String, dynamic> json) {
+    final dateRaw = json['date'] as String? ?? '';
+    return TautulliHistoryItem(
+      user: json['user'] as String? ?? '',
+      fullTitle: json['full_title'] as String? ?? '',
+      date: dateRaw.isEmpty ? null : DateTime.tryParse(dateRaw),
+      durationSeconds: (json['duration_seconds'] as num?)?.toInt() ?? 0,
+      percentComplete: (json['percent_complete'] as num?)?.toInt() ?? 0,
+      player: json['player'] as String? ?? '',
+      platform: json['platform'] as String? ?? '',
+    );
+  }
+}
+
+/// A ranked play-count entry (movie, show or user).
+class TautulliStatEntry {
+  final String label;
+  final int plays;
+
+  const TautulliStatEntry({required this.label, this.plays = 0});
+
+  factory TautulliStatEntry.fromJson(Map<String, dynamic> json) =>
+      TautulliStatEntry(
+        label: json['title'] as String? ?? json['user'] as String? ?? '',
+        plays: (json['plays'] as num?)?.toInt() ?? 0,
+      );
+}
+
+/// Watch statistics over a period: top movies, shows and users.
+class TautulliStats {
+  final List<TautulliStatEntry> topMovies;
+  final List<TautulliStatEntry> topShows;
+  final List<TautulliStatEntry> topUsers;
+
+  const TautulliStats({
+    this.topMovies = const [],
+    this.topShows = const [],
+    this.topUsers = const [],
+  });
+
+  factory TautulliStats.fromJson(Map<String, dynamic> json) => TautulliStats(
+        topMovies: (json['top_movies'] as List<dynamic>? ?? [])
+            .map((e) => TautulliStatEntry.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        topShows: (json['top_shows'] as List<dynamic>? ?? [])
+            .map((e) => TautulliStatEntry.fromJson(e as Map<String, dynamic>))
+            .toList(),
+        topUsers: (json['top_users'] as List<dynamic>? ?? [])
+            .map((e) => TautulliStatEntry.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+}

--- a/app/lib/features/tautulli/ui/tautulli_activity_screen.dart
+++ b/app/lib/features/tautulli/ui/tautulli_activity_screen.dart
@@ -1,0 +1,359 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/tautulli_api_service.dart';
+import '../data/tautulli_models.dart';
+
+/// Now-playing view: one card per active Plex stream, with a header showing
+/// total stream count and bandwidth. Auto-refreshes every 10 seconds.
+class TautulliActivityScreen extends ConsumerStatefulWidget {
+  const TautulliActivityScreen({super.key});
+
+  @override
+  ConsumerState<TautulliActivityScreen> createState() =>
+      _TautulliActivityScreenState();
+}
+
+class _TautulliActivityScreenState
+    extends ConsumerState<TautulliActivityScreen> {
+  TautulliActivity? _activity;
+  bool _isLoading = true;
+  String? _error;
+  Timer? _refreshTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _load();
+      _refreshTimer =
+          Timer.periodic(const Duration(seconds: 10), (_) => _autoRefresh());
+    });
+  }
+
+  @override
+  void dispose() {
+    _refreshTimer?.cancel();
+    super.dispose();
+  }
+
+  void _autoRefresh() {
+    if (!mounted) return;
+    // Skip silent refreshes when another route is on top of this screen.
+    final route = ModalRoute.of(context);
+    if (route != null && !route.isCurrent) return;
+    _load(silent: true);
+  }
+
+  TautulliApiService? _buildService() {
+    final instanceId = ref.read(instanceProvider).activeTautulliInstance?.id;
+    if (instanceId == null) return null;
+    return TautulliApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: instanceId,
+    );
+  }
+
+  Future<void> _load({bool silent = false}) async {
+    final service = _buildService();
+    if (service == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Tautulli instance configured';
+      });
+      return;
+    }
+
+    if (!silent) setState(() => _isLoading = true);
+    try {
+      final activity = await service.getActivity();
+      if (!mounted) return;
+      setState(() {
+        _activity = activity;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      // Keep showing the last known data on silent refresh failures.
+      if (silent) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load activity: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Reload when the active instance changes.
+    ref.listen(instanceProvider.select((s) => s.activeTautulliInstanceId),
+        (_, __) => _load());
+
+    if (_isLoading) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Text(_error!,
+                  style: const TextStyle(color: AppTheme.textSecondary),
+                  textAlign: TextAlign.center),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(onPressed: _load, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+
+    final activity = _activity ?? const TautulliActivity();
+
+    return Column(
+      children: [
+        _ActivityHeader(
+          streamCount: activity.streamCount,
+          bandwidthFormatted: activity.totalBandwidthFormatted,
+        ),
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: _load,
+            color: AppTheme.accent,
+            child: activity.streams.isEmpty
+                ? ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    children: const [
+                      SizedBox(height: 160),
+                      Icon(Icons.tv_off_outlined,
+                          size: 48, color: AppTheme.textSecondary),
+                      SizedBox(height: 12),
+                      Center(
+                        child: Text('Nothing is playing',
+                            style: TextStyle(
+                                color: AppTheme.textSecondary, fontSize: 16)),
+                      ),
+                    ],
+                  )
+                : ListView.builder(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    itemCount: activity.streams.length,
+                    itemBuilder: (context, index) =>
+                        _StreamCard(stream: activity.streams[index]),
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Header row with active stream count and total bandwidth.
+class _ActivityHeader extends StatelessWidget {
+  final int streamCount;
+  final String bandwidthFormatted;
+
+  const _ActivityHeader({
+    required this.streamCount,
+    required this.bandwidthFormatted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      decoration: const BoxDecoration(
+        color: AppTheme.surface,
+        border: Border(
+          bottom: BorderSide(color: AppTheme.border, width: 0.5),
+        ),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            streamCount > 0 ? Icons.play_circle_outline : Icons.tv_outlined,
+            size: 18,
+            color:
+                streamCount > 0 ? AppTheme.downloading : AppTheme.unavailable,
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              streamCount > 0
+                  ? '$streamCount stream${streamCount == 1 ? '' : 's'} • $bandwidthFormatted'
+                  : 'No active streams',
+              style: const TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w500),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+({IconData icon, Color color, String label}) _stateStyle(
+    TautulliStream stream) {
+  if (stream.isPaused) {
+    return (
+      icon: Icons.pause_circle_outline,
+      color: AppTheme.unavailable,
+      label: 'Paused'
+    );
+  }
+  if (stream.isBuffering) {
+    return (
+      icon: Icons.downloading_outlined,
+      color: AppTheme.requested,
+      label: 'Buffering'
+    );
+  }
+  return (
+    icon: Icons.play_circle_outline,
+    color: AppTheme.downloading,
+    label: 'Playing'
+  );
+}
+
+/// One active stream: user, title, player/product, state, progress bar,
+/// quality, stream-decision badge and bandwidth.
+class _StreamCard extends StatelessWidget {
+  final TautulliStream stream;
+
+  const _StreamCard({required this.stream});
+
+  @override
+  Widget build(BuildContext context) {
+    final state = _stateStyle(stream);
+    final playerLine = [
+      if (stream.player.isNotEmpty) stream.player,
+      if (stream.product.isNotEmpty && stream.product != stream.player)
+        stream.product,
+    ].join(' • ');
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      padding: const EdgeInsets.fromLTRB(12, 10, 12, 12),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppTheme.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(state.icon, size: 22, color: state.color),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      stream.displayTitle,
+                      style: const TextStyle(
+                          color: AppTheme.textPrimary,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 14),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      [
+                        if (stream.user.isNotEmpty) stream.user,
+                        if (playerLine.isNotEmpty) playerLine,
+                      ].join(' • '),
+                      style: const TextStyle(
+                          color: AppTheme.textSecondary, fontSize: 12),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(3),
+            child: LinearProgressIndicator(
+              value: stream.progressFraction,
+              minHeight: 5,
+              backgroundColor: AppTheme.surfaceVariant,
+              valueColor: AlwaysStoppedAnimation(state.color),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: Wrap(
+                  spacing: 6,
+                  runSpacing: 4,
+                  children: [
+                    _StreamBadge(text: state.label, color: state.color),
+                    _StreamBadge(
+                      text: stream.streamTypeLabel,
+                      color: stream.isTranscode
+                          ? AppTheme.requested
+                          : AppTheme.available,
+                    ),
+                    if (stream.quality.isNotEmpty)
+                      _StreamBadge(
+                          text: stream.quality, color: AppTheme.accent),
+                  ],
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.only(left: 8),
+                child: Text(
+                  '${stream.progressPercent}% • ${stream.bandwidthFormatted}',
+                  style: const TextStyle(
+                      color: AppTheme.textSecondary, fontSize: 11),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StreamBadge extends StatelessWidget {
+  final String text;
+  final Color color;
+
+  const _StreamBadge({required this.text, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+            color: color, fontSize: 10.5, fontWeight: FontWeight.w500),
+      ),
+    );
+  }
+}

--- a/app/lib/features/tautulli/ui/tautulli_history_screen.dart
+++ b/app/lib/features/tautulli/ui/tautulli_history_screen.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/tautulli_api_service.dart';
+import '../data/tautulli_models.dart';
+
+/// Recent Plex watch history: who watched what, when and how much of it.
+class TautulliHistoryScreen extends ConsumerStatefulWidget {
+  const TautulliHistoryScreen({super.key});
+
+  @override
+  ConsumerState<TautulliHistoryScreen> createState() =>
+      _TautulliHistoryScreenState();
+}
+
+class _TautulliHistoryScreenState extends ConsumerState<TautulliHistoryScreen> {
+  List<TautulliHistoryItem> _items = [];
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  TautulliApiService? _buildService() {
+    final instanceId = ref.read(instanceProvider).activeTautulliInstance?.id;
+    if (instanceId == null) return null;
+    return TautulliApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: instanceId,
+    );
+  }
+
+  Future<void> _load() async {
+    final service = _buildService();
+    if (service == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Tautulli instance configured';
+      });
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      final items = await service.getHistory(limit: 50);
+      if (!mounted) return;
+      setState(() {
+        _items = items;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load history: $e';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Reload when the active instance changes.
+    ref.listen(instanceProvider.select((s) => s.activeTautulliInstanceId),
+        (_, __) => _load());
+
+    if (_isLoading && _items.isEmpty) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null && _items.isEmpty) {
+      return FullScreenError(message: _error!, onRetry: _load);
+    }
+    if (_items.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _load,
+        color: AppTheme.accent,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [
+            SizedBox(height: 160),
+            Icon(Icons.history, size: 48, color: AppTheme.textSecondary),
+            SizedBox(height: 12),
+            Center(
+              child: Text('No history yet',
+                  style:
+                      TextStyle(color: AppTheme.textSecondary, fontSize: 16)),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _load,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _items.length,
+        itemBuilder: (context, index) => _HistoryTile(item: _items[index]),
+      ),
+    );
+  }
+}
+
+String _relativeTime(DateTime? date) {
+  if (date == null) return '';
+  final local = date.toLocal();
+  final diff = DateTime.now().difference(local);
+  if (diff.inMinutes < 1) return 'just now';
+  if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+  if (diff.inHours < 24) return '${diff.inHours}h ago';
+  if (diff.inDays < 7) return '${diff.inDays}d ago';
+  if (local.year == DateTime.now().year) {
+    return DateFormat('MMM d').format(local);
+  }
+  return DateFormat('MMM d, yyyy').format(local);
+}
+
+class _HistoryTile extends StatelessWidget {
+  final TautulliHistoryItem item;
+
+  const _HistoryTile({required this.item});
+
+  @override
+  Widget build(BuildContext context) {
+    final watched = item.percentComplete >= 85;
+    final color = watched ? AppTheme.available : AppTheme.textSecondary;
+    final subtitleParts = [
+      if (item.user.isNotEmpty) item.user,
+      '${item.percentComplete}%',
+      if (item.platform.isNotEmpty) item.platform,
+    ];
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      leading: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.15),
+          shape: BoxShape.circle,
+        ),
+        child: Icon(
+          watched ? Icons.check_circle_outline : Icons.play_arrow_outlined,
+          color: color,
+          size: 20,
+        ),
+      ),
+      title: Text(
+        item.fullTitle,
+        style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 13.5,
+            fontWeight: FontWeight.w500),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        subtitleParts.join(' • '),
+        style: TextStyle(color: color, fontSize: 12),
+      ),
+      trailing: Text(
+        _relativeTime(item.date),
+        style: const TextStyle(color: AppTheme.textSecondary, fontSize: 11),
+      ),
+    );
+  }
+}

--- a/app/lib/features/tautulli/ui/tautulli_module_shell.dart
+++ b/app/lib/features/tautulli/ui/tautulli_module_shell.dart
@@ -4,15 +4,14 @@ import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/instance_dropdown.dart';
 
-/// Sonarr module shell with bottom nav:
-/// Library | Queue | History | Wanted | Calendar.
-/// Shows instance dropdown in the header when 2+ instances exist.
-class SonarrModuleShell extends ConsumerWidget {
+/// Tautulli module shell with bottom nav: Activity | History | Stats.
+/// Shows instance dropdown in the header when 2+ Tautulli instances exist.
+class TautulliModuleShell extends ConsumerWidget {
   final int currentIndex;
   final ValueChanged<int> onTabChanged;
   final Widget child;
 
-  const SonarrModuleShell({
+  const TautulliModuleShell({
     super.key,
     required this.currentIndex,
     required this.onTabChanged,
@@ -24,14 +23,14 @@ class SonarrModuleShell extends ConsumerWidget {
     final instanceState = ref.watch(instanceProvider);
 
     return Scaffold(
-      appBar: instanceState.sonarrInstances.length > 1
+      appBar: instanceState.tautulliInstances.length > 1
           ? AppBar(
               title: InstanceDropdown(
-                instances: instanceState.sonarrInstances,
-                activeInstanceId: instanceState.activeSonarrInstanceId,
+                instances: instanceState.tautulliInstances,
+                activeInstanceId: instanceState.activeTautulliInstanceId,
                 onChanged: (id) => ref
                     .read(instanceProvider.notifier)
-                    .setActiveSonarrInstance(id),
+                    .setActiveTautulliInstance(id),
               ),
               backgroundColor: AppTheme.background,
               elevation: 0,
@@ -47,14 +46,9 @@ class SonarrModuleShell extends ConsumerWidget {
           onTap: onTabChanged,
           items: const [
             BottomNavigationBarItem(
-              icon: Icon(Icons.video_library_outlined),
-              activeIcon: Icon(Icons.video_library),
-              label: 'Library',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.downloading_outlined),
-              activeIcon: Icon(Icons.downloading),
-              label: 'Queue',
+              icon: Icon(Icons.play_circle_outline),
+              activeIcon: Icon(Icons.play_circle),
+              label: 'Activity',
             ),
             BottomNavigationBarItem(
               icon: Icon(Icons.history_outlined),
@@ -62,14 +56,9 @@ class SonarrModuleShell extends ConsumerWidget {
               label: 'History',
             ),
             BottomNavigationBarItem(
-              icon: Icon(Icons.report_gmailerrorred_outlined),
-              activeIcon: Icon(Icons.report_gmailerrorred),
-              label: 'Wanted',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.calendar_month_outlined),
-              activeIcon: Icon(Icons.calendar_month),
-              label: 'Calendar',
+              icon: Icon(Icons.insights_outlined),
+              activeIcon: Icon(Icons.insights),
+              label: 'Stats',
             ),
           ],
         ),

--- a/app/lib/features/tautulli/ui/tautulli_stats_screen.dart
+++ b/app/lib/features/tautulli/ui/tautulli_stats_screen.dart
@@ -47,17 +47,29 @@ class _TautulliStatsScreenState extends ConsumerState<TautulliStatsScreen> {
       return;
     }
 
+    // Capture the request parameters so a slow response for a previously
+    // selected period (or instance) can't overwrite the current selection.
+    final days = _days;
+    final instanceId =
+        ref.read(instanceProvider.select((s) => s.activeTautulliInstanceId));
+    bool stale() =>
+        !mounted ||
+        days != _days ||
+        instanceId !=
+            ref.read(
+                instanceProvider.select((s) => s.activeTautulliInstanceId));
+
     setState(() => _isLoading = true);
     try {
-      final stats = await service.getStats(days: _days);
-      if (!mounted) return;
+      final stats = await service.getStats(days: days);
+      if (stale()) return;
       setState(() {
         _stats = stats;
         _isLoading = false;
         _error = null;
       });
     } catch (e) {
-      if (!mounted) return;
+      if (stale()) return;
       setState(() {
         _isLoading = false;
         _error = 'Failed to load stats: $e';

--- a/app/lib/features/tautulli/ui/tautulli_stats_screen.dart
+++ b/app/lib/features/tautulli/ui/tautulli_stats_screen.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/tautulli_api_service.dart';
+import '../data/tautulli_models.dart';
+
+/// Watch statistics: top movies, shows and users over a selectable period.
+class TautulliStatsScreen extends ConsumerStatefulWidget {
+  const TautulliStatsScreen({super.key});
+
+  @override
+  ConsumerState<TautulliStatsScreen> createState() =>
+      _TautulliStatsScreenState();
+}
+
+class _TautulliStatsScreenState extends ConsumerState<TautulliStatsScreen> {
+  TautulliStats? _stats;
+  bool _isLoading = true;
+  String? _error;
+  int _days = 30;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  TautulliApiService? _buildService() {
+    final instanceId = ref.read(instanceProvider).activeTautulliInstance?.id;
+    if (instanceId == null) return null;
+    return TautulliApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: instanceId,
+    );
+  }
+
+  Future<void> _load() async {
+    final service = _buildService();
+    if (service == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Tautulli instance configured';
+      });
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      final stats = await service.getStats(days: _days);
+      if (!mounted) return;
+      setState(() {
+        _stats = stats;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load stats: $e';
+      });
+    }
+  }
+
+  void _setDays(int days) {
+    if (days == _days) return;
+    setState(() => _days = days);
+    _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Reload when the active instance changes.
+    ref.listen(instanceProvider.select((s) => s.activeTautulliInstanceId),
+        (_, __) => _load());
+
+    final daysSelector = Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: SegmentedButton<int>(
+        showSelectedIcon: false,
+        segments: const [
+          ButtonSegment(value: 7, label: Text('7 days')),
+          ButtonSegment(value: 30, label: Text('30 days')),
+          ButtonSegment(value: 90, label: Text('90 days')),
+        ],
+        selected: {_days},
+        onSelectionChanged: (value) => _setDays(value.first),
+      ),
+    );
+
+    if (_isLoading && _stats == null) {
+      return Column(
+        children: [
+          daysSelector,
+          const Expanded(
+            child: Center(
+                child: CircularProgressIndicator(color: AppTheme.accent)),
+          ),
+        ],
+      );
+    }
+    if (_error != null && _stats == null) {
+      return Column(
+        children: [
+          daysSelector,
+          Expanded(child: FullScreenError(message: _error!, onRetry: _load)),
+        ],
+      );
+    }
+
+    final stats = _stats ?? const TautulliStats();
+    final isEmpty = stats.topMovies.isEmpty &&
+        stats.topShows.isEmpty &&
+        stats.topUsers.isEmpty;
+
+    return Column(
+      children: [
+        daysSelector,
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: _load,
+            color: AppTheme.accent,
+            child: isEmpty
+                ? ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    children: const [
+                      SizedBox(height: 140),
+                      Icon(Icons.insights_outlined,
+                          size: 48, color: AppTheme.textSecondary),
+                      SizedBox(height: 12),
+                      Center(
+                        child: Text('No stats for this period',
+                            style: TextStyle(
+                                color: AppTheme.textSecondary, fontSize: 16)),
+                      ),
+                    ],
+                  )
+                : ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.only(bottom: 24),
+                    children: [
+                      if (_isLoading)
+                        const LinearProgressIndicator(
+                          minHeight: 2,
+                          color: AppTheme.accent,
+                          backgroundColor: Colors.transparent,
+                        ),
+                      _StatSection(
+                        title: 'Top Movies',
+                        icon: Icons.movie_outlined,
+                        entries: stats.topMovies,
+                      ),
+                      _StatSection(
+                        title: 'Top Shows',
+                        icon: Icons.tv_outlined,
+                        entries: stats.topShows,
+                      ),
+                      _StatSection(
+                        title: 'Top Users',
+                        icon: Icons.person_outline,
+                        entries: stats.topUsers,
+                      ),
+                    ],
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A titled, ranked list of play-count entries.
+class _StatSection extends StatelessWidget {
+  final String title;
+  final IconData icon;
+  final List<TautulliStatEntry> entries;
+
+  const _StatSection({
+    required this.title,
+    required this.icon,
+    required this.entries,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+          child: Row(
+            children: [
+              Icon(icon, size: 18, color: AppTheme.accent),
+              const SizedBox(width: 8),
+              Text(
+                title,
+                style: const TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (entries.isEmpty)
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Text('No plays in this period',
+                style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+          )
+        else
+          ...entries.asMap().entries.map((entry) => _StatTile(
+                rank: entry.key + 1,
+                entry: entry.value,
+              )),
+      ],
+    );
+  }
+}
+
+class _StatTile extends StatelessWidget {
+  final int rank;
+  final TautulliStatEntry entry;
+
+  const _StatTile({required this.rank, required this.entry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 5),
+      child: Row(
+        children: [
+          Container(
+            width: 26,
+            height: 26,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: rank <= 3
+                  ? AppTheme.accent.withValues(alpha: 0.15)
+                  : AppTheme.surfaceVariant,
+              shape: BoxShape.circle,
+            ),
+            child: Text(
+              '$rank',
+              style: TextStyle(
+                color: rank <= 3 ? AppTheme.accent : AppTheme.textSecondary,
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              entry.label,
+              style: const TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 13.5,
+                  fontWeight: FontWeight.w500),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            '${entry.plays} play${entry.plays == 1 ? '' : 's'}',
+            style: const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -18,6 +18,7 @@ import '../features/radarr/ui/radarr_history_screen.dart';
 import '../features/radarr/ui/radarr_home_screen.dart';
 import '../features/radarr/ui/radarr_module_shell.dart';
 import '../features/radarr/ui/radarr_queue_screen.dart';
+import '../features/radarr/ui/radarr_wanted_screen.dart';
 import '../features/settings/ui/ai_tools_screen.dart';
 import '../features/settings/ui/credentials_screen.dart';
 import '../features/settings/ui/devices_screen.dart';
@@ -31,6 +32,11 @@ import '../features/sonarr/ui/sonarr_history_screen.dart';
 import '../features/sonarr/ui/sonarr_home_screen.dart';
 import '../features/sonarr/ui/sonarr_module_shell.dart';
 import '../features/sonarr/ui/sonarr_queue_screen.dart';
+import '../features/sonarr/ui/sonarr_wanted_screen.dart';
+import '../features/tautulli/ui/tautulli_activity_screen.dart';
+import '../features/tautulli/ui/tautulli_history_screen.dart';
+import '../features/tautulli/ui/tautulli_module_shell.dart';
+import '../features/tautulli/ui/tautulli_stats_screen.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
 
@@ -100,7 +106,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             ],
           ),
 
-          // Radarr module (Library/Queue/History/Calendar tabs)
+          // Radarr module (Library/Queue/History/Wanted/Calendar tabs)
           StatefulShellRoute.indexedStack(
             builder: (context, state, navigationShell) {
               return RadarrModuleShell(
@@ -137,6 +143,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               StatefulShellBranch(
                 routes: [
                   GoRoute(
+                    path: '/radarr/wanted',
+                    builder: (_, __) => const RadarrWantedScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
                     path: '/radarr/calendar',
                     builder: (_, __) => const RadarrCalendarScreen(),
                   ),
@@ -145,7 +159,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             ],
           ),
 
-          // Sonarr module (Library/Queue/History/Calendar tabs)
+          // Sonarr module (Library/Queue/History/Wanted/Calendar tabs)
           StatefulShellRoute.indexedStack(
             builder: (context, state, navigationShell) {
               return SonarrModuleShell(
@@ -176,6 +190,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   GoRoute(
                     path: '/sonarr/history',
                     builder: (_, __) => const SonarrHistoryScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/sonarr/wanted',
+                    builder: (_, __) => const SonarrWantedScreen(),
                   ),
                 ],
               ),
@@ -213,6 +235,43 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   GoRoute(
                     path: '/downloads/history',
                     builder: (_, __) => const DownloadsHistoryScreen(),
+                  ),
+                ],
+              ),
+            ],
+          ),
+
+          // Tautulli module (Activity/History/Stats tabs, admin only)
+          StatefulShellRoute.indexedStack(
+            builder: (context, state, navigationShell) {
+              return TautulliModuleShell(
+                currentIndex: navigationShell.currentIndex,
+                onTabChanged: (index) => navigationShell.goBranch(index),
+                child: navigationShell,
+              );
+            },
+            branches: [
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/tautulli/activity',
+                    builder: (_, __) => const TautulliActivityScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/tautulli/history',
+                    builder: (_, __) => const TautulliHistoryScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/tautulli/stats',
+                    builder: (_, __) => const TautulliStatsScreen(),
                   ),
                 ],
               ),

--- a/server/README.md
+++ b/server/README.md
@@ -122,11 +122,18 @@ PUT    /api/admin/ai-tools/:name # { enabled: bool } -- applies to chat and /mcp
 
 ### Downloads (admin only)
 ```
-GET    /api/downloads/:id/queue                 # unified SABnzbd/qBittorrent queue
+GET    /api/downloads/:id/queue                 # unified SABnzbd/qBittorrent/NZBGet/Transmission queue
 POST   /api/downloads/:id/pause|resume          # whole queue
 POST   /api/downloads/:id/queue/:item/pause|resume
 DELETE /api/downloads/:id/queue/:item?deleteData=bool
 GET    /api/downloads/:id/history?limit=50
+```
+
+### Tautulli (admin only)
+```
+GET    /api/tautulli/:id/activity   # current Plex streams + bandwidth
+GET    /api/tautulli/:id/history?limit=50
+GET    /api/tautulli/:id/stats?days=30
 ```
 
 ### MCP (external tool access)
@@ -150,6 +157,14 @@ WS     /api/ws                  # WebSocket (JWT via subprotocol header)
 WebSocket events:
 - `download_progress` -- `{ tmdb_id, media_type, progress, status }`
 - `request_status_changed` -- `{ tmdb_id, media_type, status }`
+- `downloads_queue` -- full download-client queue snapshot `{ instance_id, paused, speed_bps, items }`, sent on change
+- `arr_queue_changed` -- `{ instance_id, service_type }` invalidation ping; refetch the queue via REST
+
+Secrets at rest: instance API keys/passwords, external credentials, and the JWT
+secret are AES-256-GCM encrypted. Key: `CANTINARR_ENCRYPTION_KEY` env var
+(base64, 32 bytes) or the auto-generated `/config/encryption.key` (0600). Keep
+that file with your database backups -- without it encrypted secrets are
+unrecoverable.
 
 ## Architecture
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/mcp"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/request"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
 	"github.com/windoze95/cantinarr-server/internal/tmdb"
 	ws "github.com/windoze95/cantinarr-server/internal/websocket"
 )
@@ -46,16 +47,32 @@ func main() {
 	}
 	defer database.Close()
 
+	// Secrets-at-rest cipher: env key > key file next to the DB
+	encKey, err := secrets.LoadKey(cfg.EncryptionKeyFile)
+	if err != nil {
+		log.Fatalf("Failed to resolve encryption key: %v", err)
+	}
+	cipher, err := secrets.NewCipher(encKey)
+	if err != nil {
+		log.Fatalf("Failed to initialize secrets cipher: %v", err)
+	}
+	secretSettings := append([]string{"jwt_secret"}, credentials.AllKeys...)
+	if n, err := secrets.EncryptExisting(database, cipher, secretSettings); err != nil {
+		log.Fatalf("Failed to encrypt existing secrets: %v", err)
+	} else if n > 0 {
+		log.Printf("Encrypted %d existing secret value(s) at rest", n)
+	}
+
 	// Resolve JWT secret: env var > DB > generate and persist
 	if cfg.JWTSecret == "" {
-		cfg.JWTSecret, err = ensureJWTSecret(database)
+		cfg.JWTSecret, err = ensureJWTSecret(database, cipher)
 		if err != nil {
 			log.Fatalf("Failed to resolve JWT secret: %v", err)
 		}
 	}
 
 	// Credentials registry (lazy-creates TMDB/Trakt clients from DB)
-	creds := credentials.NewRegistry(database)
+	creds := credentials.NewRegistry(database, cipher)
 	credHandler := credentials.NewHandler(creds)
 
 	// Auth
@@ -69,7 +86,7 @@ func main() {
 	bridge := tmdb.NewBridge(creds, database)
 
 	// Instance store and registry
-	instanceStore := instance.NewStore(database)
+	instanceStore := instance.NewStore(database, cipher)
 	registry := instance.NewRegistry(instanceStore)
 	instanceHandler := instance.NewHandler(instanceStore, registry)
 
@@ -108,11 +125,11 @@ func main() {
 
 // ensureJWTSecret loads the JWT secret from the settings table, or generates
 // and persists a new one. This ensures tokens survive server restarts.
-func ensureJWTSecret(database *sql.DB) (string, error) {
-	var secret string
-	err := database.QueryRow("SELECT value FROM settings WHERE key = 'jwt_secret'").Scan(&secret)
+func ensureJWTSecret(database *sql.DB, cipher *secrets.Cipher) (string, error) {
+	var stored string
+	err := database.QueryRow("SELECT value FROM settings WHERE key = 'jwt_secret'").Scan(&stored)
 	if err == nil {
-		return secret, nil
+		return cipher.Decrypt(stored)
 	}
 
 	// Generate a new secret
@@ -120,9 +137,13 @@ func ensureJWTSecret(database *sql.DB) (string, error) {
 	if _, err := rand.Read(b); err != nil {
 		return "", fmt.Errorf("generate secret: %w", err)
 	}
-	secret = hex.EncodeToString(b)
+	secret := hex.EncodeToString(b)
 
-	_, err = database.Exec("INSERT INTO settings (key, value) VALUES ('jwt_secret', ?)", secret)
+	enc, err := cipher.Encrypt(secret)
+	if err != nil {
+		return "", fmt.Errorf("encrypt secret: %w", err)
+	}
+	_, err = database.Exec("INSERT INTO settings (key, value) VALUES ('jwt_secret', ?)", enc)
 	if err != nil {
 		return "", fmt.Errorf("persist secret: %w", err)
 	}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -57,6 +57,9 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to initialize secrets cipher: %v", err)
 	}
+	if err := secrets.VerifyKeyIdentity(database, cipher); err != nil {
+		log.Fatalf("Encryption key check failed: %v", err)
+	}
 	secretSettings := append([]string{"jwt_secret"}, credentials.AllKeys...)
 	if n, err := secrets.EncryptExisting(database, cipher, secretSettings); err != nil {
 		log.Fatalf("Failed to encrypt existing secrets: %v", err)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/request"
 	"github.com/windoze95/cantinarr-server/internal/secrets"
+	"github.com/windoze95/cantinarr-server/internal/tautulli"
 	"github.com/windoze95/cantinarr-server/internal/tmdb"
 	ws "github.com/windoze95/cantinarr-server/internal/websocket"
 )
@@ -90,8 +91,11 @@ func main() {
 	registry := instance.NewRegistry(instanceStore)
 	instanceHandler := instance.NewHandler(instanceStore, registry)
 
-	// Downloads handler (SABnzbd / qBittorrent queue management)
+	// Downloads handler (SABnzbd / qBittorrent / NZBGet / Transmission queue management)
 	downloadsHandler := downloads.NewHandler(instanceStore, registry)
+
+	// Tautulli handler (Plex monitoring)
+	tautulliHandler := tautulli.NewHandler(instanceStore, registry)
 
 	// Request service
 	requestService := request.NewService(database, registry, bridge)
@@ -114,7 +118,7 @@ func main() {
 	go wsHub.Run(context.Background())
 
 	// Router
-	router := api.NewRouter(cfg, authHandler, authService, requestHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, creds, credHandler, toolServer)
+	router := api.NewRouter(cfg, authHandler, authService, requestHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer)
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	log.Printf("Cantinarr server starting on %s", addr)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -19,6 +19,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/mcpserver"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/request"
+	"github.com/windoze95/cantinarr-server/internal/tautulli"
 	"github.com/windoze95/cantinarr-server/internal/web"
 	ws "github.com/windoze95/cantinarr-server/internal/websocket"
 )
@@ -35,6 +36,7 @@ func NewRouter(
 	instanceHandler *instance.Handler,
 	instanceStore *instance.Store,
 	downloadsHandler *downloads.Handler,
+	tautulliHandler *tautulli.Handler,
 	creds *credentials.Registry,
 	credHandler *credentials.Handler,
 	toolServer *mcp.ToolServer,
@@ -204,6 +206,16 @@ func NewRouter(
 			r.Post("/downloads/{instanceID}/pause", downloadsHandler.PauseAll)
 			r.Post("/downloads/{instanceID}/resume", downloadsHandler.ResumeAll)
 			r.Get("/downloads/{instanceID}/history", downloadsHandler.GetHistory)
+		})
+
+		// Tautulli (Plex monitoring) routes (admin only)
+		r.Group(func(r chi.Router) {
+			r.Use(authService.AuthMiddleware)
+			r.Use(auth.AdminMiddleware)
+
+			r.Get("/tautulli/{instanceID}/activity", tautulliHandler.GetActivity)
+			r.Get("/tautulli/{instanceID}/history", tautulliHandler.GetHistory)
+			r.Get("/tautulli/{instanceID}/stats", tautulliHandler.GetStats)
 		})
 
 	})

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -14,6 +14,9 @@ type Config struct {
 	DBPath     string
 	Port       int
 	ServerName string
+	// EncryptionKeyFile backs secrets-at-rest when CANTINARR_ENCRYPTION_KEY
+	// is not set; it lives next to the database.
+	EncryptionKeyFile string
 }
 
 func Load() (*Config, error) {
@@ -23,9 +26,10 @@ func Load() (*Config, error) {
 	}
 
 	cfg := &Config{
-		JWTSecret:  os.Getenv("CANTINARR_JWT_SECRET"),
-		DBPath:     "/config/cantinarr.db",
-		ServerName: os.Getenv("CANTINARR_SERVER_NAME"),
+		JWTSecret:         os.Getenv("CANTINARR_JWT_SECRET"),
+		DBPath:            "/config/cantinarr.db",
+		ServerName:        os.Getenv("CANTINARR_SERVER_NAME"),
+		EncryptionKeyFile: "/config/encryption.key",
 	}
 
 	if cfg.ServerName == "" {

--- a/server/internal/credentials/registry.go
+++ b/server/internal/credentials/registry.go
@@ -2,25 +2,38 @@ package credentials
 
 import (
 	"database/sql"
+	"log"
 	"sync"
 
+	"github.com/windoze95/cantinarr-server/internal/secrets"
 	"github.com/windoze95/cantinarr-server/internal/tmdb"
 	"github.com/windoze95/cantinarr-server/internal/trakt"
 )
 
 // Credential keys stored in the settings table.
 const (
-	KeyTMDBAccessToken   = "tmdb_access_token"
-	KeyAnthropicKey      = "anthropic_key"
-	KeyTraktClientID = "trakt_client_id"
+	KeyTMDBAccessToken = "tmdb_access_token"
+	KeyAnthropicKey    = "anthropic_key"
+	KeyTraktClientID   = "trakt_client_id"
 )
 
-// AllKeys lists every credential key the system manages.
+// AllKeys lists every credential key the system manages. Values for these
+// keys are encrypted at rest; other settings (e.g. tool toggles) stay plain.
 var AllKeys = []string{KeyTMDBAccessToken, KeyAnthropicKey, KeyTraktClientID}
+
+func isSecretKey(key string) bool {
+	for _, k := range AllKeys {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
 
 // Registry lazily creates and caches TMDB/Trakt clients from DB-stored credentials.
 type Registry struct {
-	db *sql.DB
+	db     *sql.DB
+	cipher *secrets.Cipher
 
 	mu          sync.RWMutex
 	cachedTMDB  *tmdb.Client
@@ -29,8 +42,8 @@ type Registry struct {
 }
 
 // NewRegistry creates a new credentials registry.
-func NewRegistry(db *sql.DB) *Registry {
-	return &Registry{db: db}
+func NewRegistry(db *sql.DB, cipher *secrets.Cipher) *Registry {
+	return &Registry{db: db, cipher: cipher}
 }
 
 // TMDB returns the cached TMDB client, creating it lazily from the DB credential.
@@ -73,19 +86,33 @@ func (r *Registry) Trakt() *trakt.Client {
 	return r.cachedTrakt
 }
 
-// GetCredential reads a raw credential value from the DB.
-// Returns empty string if not set.
+// GetCredential reads a credential value from the DB, decrypting stored
+// ciphertext (legacy plaintext passes through). Returns empty string if not
+// set or undecryptable.
 func (r *Registry) GetCredential(key string) string {
 	var value string
 	err := r.db.QueryRow("SELECT value FROM settings WHERE key = ?", key).Scan(&value)
 	if err != nil {
 		return ""
 	}
-	return value
+	plain, err := r.cipher.Decrypt(value)
+	if err != nil {
+		log.Printf("credentials: failed to decrypt %s (wrong encryption key?): %v", key, err)
+		return ""
+	}
+	return plain
 }
 
-// SetCredential writes a credential to the DB (upsert).
+// SetCredential writes a credential to the DB (upsert). Secret keys are
+// encrypted at rest; non-secret settings are stored as-is.
 func (r *Registry) SetCredential(key, value string) error {
+	if isSecretKey(key) && value != "" {
+		enc, err := r.cipher.Encrypt(value)
+		if err != nil {
+			return err
+		}
+		value = enc
+	}
 	_, err := r.db.Exec(
 		"INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
 		key, value,
@@ -130,5 +157,10 @@ func (r *Registry) load() {
 func (r *Registry) getSettingLocked(key string) string {
 	var value string
 	r.db.QueryRow("SELECT value FROM settings WHERE key = ?", key).Scan(&value)
-	return value
+	plain, err := r.cipher.Decrypt(value)
+	if err != nil {
+		log.Printf("credentials: failed to decrypt %s (wrong encryption key?): %v", key, err)
+		return ""
+	}
+	return plain
 }

--- a/server/internal/downloads/handler.go
+++ b/server/internal/downloads/handler.go
@@ -299,7 +299,7 @@ func (h *Handler) PauseAll(w http.ResponseWriter, r *http.Request) {
 		func(c *sabnzbd.Client) error { return c.PauseQueue() },
 		func(c *qbittorrent.Client) error { return c.PauseTorrents("all") },
 		func(c *nzbget.Client) error { return c.PauseDownload() },
-		func(c *transmission.Client) error { return c.StopTorrents(nil) },
+		func(c *transmission.Client) error { return transmissionQueueAction(c, c.StopTorrents) },
 	)
 }
 
@@ -309,8 +309,30 @@ func (h *Handler) ResumeAll(w http.ResponseWriter, r *http.Request) {
 		func(c *sabnzbd.Client) error { return c.ResumeQueue() },
 		func(c *qbittorrent.Client) error { return c.ResumeTorrents("all") },
 		func(c *nzbget.Client) error { return c.ResumeDownload() },
-		func(c *transmission.Client) error { return c.StartTorrents(nil) },
+		func(c *transmission.Client) error { return transmissionQueueAction(c, c.StartTorrents) },
 	)
+}
+
+// transmissionQueueAction applies a start/stop action only to the torrents
+// visible in the unified queue view (incomplete ones). A nil ids list would
+// hit every torrent Transmission knows — silently stopping seeding on
+// completed torrents, or resuming torrents the user deliberately stopped,
+// none of which appear in the queue the user thinks they are acting on.
+func transmissionQueueAction(c *transmission.Client, action func([]string) error) error {
+	torrents, err := c.GetTorrents()
+	if err != nil {
+		return err
+	}
+	var hashes []string
+	for _, t := range torrents {
+		if t.PercentDone < 1 {
+			hashes = append(hashes, t.HashString)
+		}
+	}
+	if len(hashes) == 0 {
+		return nil
+	}
+	return action(hashes)
 }
 
 // GetHistory returns recently completed downloads. ?limit=N (default 50).

--- a/server/internal/downloads/handler.go
+++ b/server/internal/downloads/handler.go
@@ -1,5 +1,6 @@
-// Package downloads exposes a unified REST API over SABnzbd and qBittorrent
-// download-client instances, normalizing both backends into a common shape.
+// Package downloads exposes a unified REST API over SABnzbd, qBittorrent,
+// NZBGet, and Transmission download-client instances, normalizing all
+// backends into a common shape.
 package downloads
 
 import (
@@ -8,12 +9,15 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/windoze95/cantinarr-server/internal/instance"
+	"github.com/windoze95/cantinarr-server/internal/nzbget"
 	"github.com/windoze95/cantinarr-server/internal/qbittorrent"
 	"github.com/windoze95/cantinarr-server/internal/sabnzbd"
+	"github.com/windoze95/cantinarr-server/internal/transmission"
 )
 
 // qBittorrent reports this ETA when it is unknown/infinite; normalize to 0.
@@ -30,9 +34,10 @@ func NewHandler(store *instance.Store, registry *instance.Registry) *Handler {
 	return &Handler{store: store, registry: registry}
 }
 
-// queueItem is the normalized shape of a single download across backends.
-// id is the SABnzbd nzo_id or the qBittorrent torrent hash.
-type queueItem struct {
+// QueueItem is the normalized shape of a single download across backends.
+// id is the SABnzbd nzo_id, the qBittorrent/Transmission torrent hash, or the
+// NZBGet NZBID.
+type QueueItem struct {
 	ID            string  `json:"id"`
 	Name          string  `json:"name"`
 	SizeBytes     int64   `json:"size_bytes"`
@@ -44,10 +49,13 @@ type queueItem struct {
 	Category      string  `json:"category"`
 }
 
-type queueResponse struct {
+// QueueView is the normalized download queue for one instance. It is the
+// response body of the queue endpoint and the payload of the websocket
+// downloads_queue event.
+type QueueView struct {
 	Paused   bool        `json:"paused"`
 	SpeedBPS int64       `json:"speed_bps"`
-	Items    []queueItem `json:"items"`
+	Items    []QueueItem `json:"items"`
 }
 
 type historyItem struct {
@@ -63,36 +71,31 @@ type historyResponse struct {
 	Items []historyItem `json:"items"`
 }
 
-// GetQueue returns the normalized download queue for an instance.
-func (h *Handler) GetQueue(w http.ResponseWriter, r *http.Request) {
-	inst := h.resolveInstance(w, r)
-	if inst == nil {
-		return
-	}
-
+// Snapshot builds the normalized queue view for a download-client instance.
+// It is the single implementation behind both the HTTP queue endpoint and the
+// websocket hub's downloads poller.
+func Snapshot(reg *instance.Registry, inst instance.Instance) (*QueueView, error) {
 	switch inst.ServiceType {
 	case "sabnzbd":
-		client, err := h.registry.GetSabnzbdClient(inst.ID)
+		client, err := reg.GetSabnzbdClient(inst.ID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
+			return nil, err
 		}
 		queue, err := client.GetQueue()
 		if err != nil {
-			writeError(w, http.StatusBadGateway, err.Error())
-			return
+			return nil, err
 		}
-		resp := queueResponse{
+		view := &QueueView{
 			Paused:   queue.Paused,
 			SpeedBPS: queue.SpeedBPS(),
-			Items:    make([]queueItem, 0, len(queue.Slots)),
+			Items:    make([]QueueItem, 0, len(queue.Slots)),
 		}
 		for _, slot := range queue.Slots {
 			category := slot.Category
 			if category == "*" {
 				category = ""
 			}
-			resp.Items = append(resp.Items, queueItem{
+			view.Items = append(view.Items, QueueItem{
 				ID:            slot.NzoID,
 				Name:          slot.Filename,
 				SizeBytes:     slot.SizeBytes(),
@@ -104,28 +107,24 @@ func (h *Handler) GetQueue(w http.ResponseWriter, r *http.Request) {
 				Category:      category,
 			})
 		}
-		writeJSON(w, resp)
+		return view, nil
 
 	case "qbittorrent":
-		client, err := h.registry.GetQbittorrentClient(inst.ID)
+		client, err := reg.GetQbittorrentClient(inst.ID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, err.Error())
-			return
+			return nil, err
 		}
 		torrents, err := client.GetTorrents()
 		if err != nil {
-			writeError(w, http.StatusBadGateway, err.Error())
-			return
+			return nil, err
 		}
 		info, err := client.GetTransferInfo()
 		if err != nil {
-			writeError(w, http.StatusBadGateway, err.Error())
-			return
+			return nil, err
 		}
-
-		resp := queueResponse{
+		view := &QueueView{
 			SpeedBPS: info.DLInfoSpeed,
-			Items:    make([]queueItem, 0),
+			Items:    make([]QueueItem, 0),
 		}
 		anyActive := false
 		for _, t := range torrents {
@@ -143,7 +142,7 @@ func (h *Handler) GetQueue(w http.ResponseWriter, r *http.Request) {
 			if sizeLeft < 0 {
 				sizeLeft = 0
 			}
-			resp.Items = append(resp.Items, queueItem{
+			view.Items = append(view.Items, QueueItem{
 				ID:            t.Hash,
 				Name:          t.Name,
 				SizeBytes:     t.Size,
@@ -155,9 +154,112 @@ func (h *Handler) GetQueue(w http.ResponseWriter, r *http.Request) {
 				Category:      t.Category,
 			})
 		}
-		resp.Paused = len(resp.Items) > 0 && !anyActive
-		writeJSON(w, resp)
+		view.Paused = len(view.Items) > 0 && !anyActive
+		return view, nil
+
+	case "nzbget":
+		client, err := reg.GetNzbgetClient(inst.ID)
+		if err != nil {
+			return nil, err
+		}
+		groups, err := client.ListGroups()
+		if err != nil {
+			return nil, err
+		}
+		status, err := client.GetStatus()
+		if err != nil {
+			return nil, err
+		}
+		view := &QueueView{
+			Paused:   status.DownloadPaused,
+			SpeedBPS: status.DownloadRate,
+			Items:    make([]QueueItem, 0, len(groups)),
+		}
+		for _, g := range groups {
+			size := g.SizeBytes()
+			left := g.RemainingBytes()
+			progress := 0.0
+			if size > 0 {
+				progress = float64(size-left) / float64(size) * 100
+			}
+			var eta int64
+			if status.DownloadRate > 0 {
+				eta = left / status.DownloadRate
+			}
+			view.Items = append(view.Items, QueueItem{
+				ID:            strconv.Itoa(g.NZBID),
+				Name:          g.NZBName,
+				SizeBytes:     size,
+				SizeLeftBytes: left,
+				Progress:      progress,
+				SpeedBPS:      0, // NZBGet does not report per-item speed
+				ETASeconds:    eta,
+				Status:        g.Status,
+				Category:      g.Category,
+			})
+		}
+		return view, nil
+
+	case "transmission":
+		client, err := reg.GetTransmissionClient(inst.ID)
+		if err != nil {
+			return nil, err
+		}
+		torrents, err := client.GetTorrents()
+		if err != nil {
+			return nil, err
+		}
+		stats, err := client.GetSessionStats()
+		if err != nil {
+			return nil, err
+		}
+		view := &QueueView{
+			SpeedBPS: stats.DownloadSpeed,
+			Items:    make([]QueueItem, 0),
+		}
+		anyActive := false
+		for _, t := range torrents {
+			if t.PercentDone >= 1 {
+				continue // completed torrents are reported via /history
+			}
+			if t.Status != transmission.StatusStopped {
+				anyActive = true
+			}
+			eta := t.ETA
+			if eta < 0 {
+				eta = 0 // negative = unknown/unavailable
+			}
+			view.Items = append(view.Items, QueueItem{
+				ID:            t.HashString,
+				Name:          t.Name,
+				SizeBytes:     t.TotalSize,
+				SizeLeftBytes: t.LeftUntilDone,
+				Progress:      t.PercentDone * 100,
+				SpeedBPS:      t.RateDownload,
+				ETASeconds:    eta,
+				Status:        transmission.StatusString(t.Status),
+				Category:      transmissionCategory(t),
+			})
+		}
+		view.Paused = len(view.Items) > 0 && !anyActive
+		return view, nil
 	}
+	return nil, fmt.Errorf("instance %s is not a download client", inst.ID)
+}
+
+// GetQueue returns the normalized download queue for an instance.
+func (h *Handler) GetQueue(w http.ResponseWriter, r *http.Request) {
+	inst := h.resolveInstance(w, r)
+	if inst == nil {
+		return
+	}
+
+	view, err := Snapshot(h.registry, *inst)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, view)
 }
 
 // PauseItem pauses a single queue item.
@@ -165,6 +267,8 @@ func (h *Handler) PauseItem(w http.ResponseWriter, r *http.Request) {
 	h.itemAction(w, r,
 		func(c *sabnzbd.Client, itemID string) error { return c.PauseItem(itemID) },
 		func(c *qbittorrent.Client, itemID string) error { return c.PauseTorrents(itemID) },
+		func(c *nzbget.Client, nzbID int) error { return c.PauseGroups([]int{nzbID}) },
+		func(c *transmission.Client, hash string) error { return c.StopTorrents([]string{hash}) },
 	)
 }
 
@@ -173,6 +277,8 @@ func (h *Handler) ResumeItem(w http.ResponseWriter, r *http.Request) {
 	h.itemAction(w, r,
 		func(c *sabnzbd.Client, itemID string) error { return c.ResumeItem(itemID) },
 		func(c *qbittorrent.Client, itemID string) error { return c.ResumeTorrents(itemID) },
+		func(c *nzbget.Client, nzbID int) error { return c.ResumeGroups([]int{nzbID}) },
+		func(c *transmission.Client, hash string) error { return c.StartTorrents([]string{hash}) },
 	)
 }
 
@@ -182,6 +288,8 @@ func (h *Handler) DeleteItem(w http.ResponseWriter, r *http.Request) {
 	h.itemAction(w, r,
 		func(c *sabnzbd.Client, itemID string) error { return c.DeleteItem(itemID, deleteData) },
 		func(c *qbittorrent.Client, itemID string) error { return c.Delete(itemID, deleteData) },
+		func(c *nzbget.Client, nzbID int) error { return c.DeleteGroups([]int{nzbID}) },
+		func(c *transmission.Client, hash string) error { return c.RemoveTorrents([]string{hash}, deleteData) },
 	)
 }
 
@@ -190,6 +298,8 @@ func (h *Handler) PauseAll(w http.ResponseWriter, r *http.Request) {
 	h.queueAction(w, r,
 		func(c *sabnzbd.Client) error { return c.PauseQueue() },
 		func(c *qbittorrent.Client) error { return c.PauseTorrents("all") },
+		func(c *nzbget.Client) error { return c.PauseDownload() },
+		func(c *transmission.Client) error { return c.StopTorrents(nil) },
 	)
 }
 
@@ -198,6 +308,8 @@ func (h *Handler) ResumeAll(w http.ResponseWriter, r *http.Request) {
 	h.queueAction(w, r,
 		func(c *sabnzbd.Client) error { return c.ResumeQueue() },
 		func(c *qbittorrent.Client) error { return c.ResumeTorrents("all") },
+		func(c *nzbget.Client) error { return c.ResumeDownload() },
+		func(c *transmission.Client) error { return c.StartTorrents(nil) },
 	)
 }
 
@@ -287,6 +399,93 @@ func (h *Handler) GetHistory(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 		writeJSON(w, resp)
+
+	case "nzbget":
+		client, err := h.registry.GetNzbgetClient(inst.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		entries, err := client.GetHistory()
+		if err != nil {
+			writeError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].HistoryTime > entries[j].HistoryTime
+		})
+		if len(entries) > limit {
+			entries = entries[:limit]
+		}
+		resp := historyResponse{Items: make([]historyItem, 0, len(entries))}
+		for _, e := range entries {
+			completedAt := ""
+			if e.HistoryTime > 0 {
+				completedAt = time.Unix(e.HistoryTime, 0).UTC().Format(time.RFC3339)
+			}
+			status := e.Status
+			errMsg := ""
+			switch {
+			case strings.HasPrefix(e.Status, "SUCCESS"):
+				status = "Completed"
+			case strings.HasPrefix(e.Status, "FAILURE"):
+				status = "Failed"
+				errMsg = e.Status
+			}
+			resp.Items = append(resp.Items, historyItem{
+				Name:        e.Name,
+				Status:      status,
+				SizeBytes:   e.SizeBytes(),
+				CompletedAt: completedAt,
+				Category:    e.Category,
+				Error:       errMsg,
+			})
+		}
+		writeJSON(w, resp)
+
+	case "transmission":
+		client, err := h.registry.GetTransmissionClient(inst.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		torrents, err := client.GetTorrents()
+		if err != nil {
+			writeError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+		completed := torrents[:0:0]
+		for _, t := range torrents {
+			if t.PercentDone >= 1 {
+				completed = append(completed, t)
+			}
+		}
+		sort.Slice(completed, func(i, j int) bool {
+			return completed[i].DoneDate > completed[j].DoneDate
+		})
+		if len(completed) > limit {
+			completed = completed[:limit]
+		}
+		resp := historyResponse{Items: make([]historyItem, 0, len(completed))}
+		for _, t := range completed {
+			completedAt := ""
+			if t.DoneDate > 0 {
+				completedAt = time.Unix(t.DoneDate, 0).UTC().Format(time.RFC3339)
+			}
+			errMsg := ""
+			if t.Error != 0 {
+				errMsg = t.ErrorString
+			}
+			resp.Items = append(resp.Items, historyItem{
+				Name:        t.Name,
+				Status:      transmission.StatusString(t.Status),
+				SizeBytes:   t.TotalSize,
+				CompletedAt: completedAt,
+				Category:    transmissionCategory(t),
+				Error:       errMsg,
+			})
+		}
+		writeJSON(w, resp)
 	}
 }
 
@@ -294,7 +493,12 @@ func (h *Handler) GetHistory(w http.ResponseWriter, r *http.Request) {
 
 // itemAction resolves the instance and itemID, dispatches the per-item action
 // for the backend, and replies 204 on success.
-func (h *Handler) itemAction(w http.ResponseWriter, r *http.Request, sabFn func(*sabnzbd.Client, string) error, qbitFn func(*qbittorrent.Client, string) error) {
+func (h *Handler) itemAction(w http.ResponseWriter, r *http.Request,
+	sabFn func(*sabnzbd.Client, string) error,
+	qbitFn func(*qbittorrent.Client, string) error,
+	nzbFn func(*nzbget.Client, int) error,
+	transFn func(*transmission.Client, string) error,
+) {
 	inst := h.resolveInstance(w, r)
 	if inst == nil {
 		return
@@ -326,13 +530,43 @@ func (h *Handler) itemAction(w http.ResponseWriter, r *http.Request, sabFn func(
 			writeError(w, http.StatusBadGateway, err.Error())
 			return
 		}
+	case "nzbget":
+		nzbID, err := strconv.Atoi(itemID)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "item id must be a numeric NZBGet id")
+			return
+		}
+		client, err := h.registry.GetNzbgetClient(inst.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if err := nzbFn(client, nzbID); err != nil {
+			writeError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+	case "transmission":
+		client, err := h.registry.GetTransmissionClient(inst.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if err := transFn(client, itemID); err != nil {
+			writeError(w, http.StatusBadGateway, err.Error())
+			return
+		}
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
 // queueAction resolves the instance, dispatches the whole-queue action for
 // the backend, and replies 204 on success.
-func (h *Handler) queueAction(w http.ResponseWriter, r *http.Request, sabFn func(*sabnzbd.Client) error, qbitFn func(*qbittorrent.Client) error) {
+func (h *Handler) queueAction(w http.ResponseWriter, r *http.Request,
+	sabFn func(*sabnzbd.Client) error,
+	qbitFn func(*qbittorrent.Client) error,
+	nzbFn func(*nzbget.Client) error,
+	transFn func(*transmission.Client) error,
+) {
 	inst := h.resolveInstance(w, r)
 	if inst == nil {
 		return
@@ -359,6 +593,26 @@ func (h *Handler) queueAction(w http.ResponseWriter, r *http.Request, sabFn func
 			writeError(w, http.StatusBadGateway, err.Error())
 			return
 		}
+	case "nzbget":
+		client, err := h.registry.GetNzbgetClient(inst.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if err := nzbFn(client); err != nil {
+			writeError(w, http.StatusBadGateway, err.Error())
+			return
+		}
+	case "transmission":
+		client, err := h.registry.GetTransmissionClient(inst.ID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, err.Error())
+			return
+		}
+		if err := transFn(client); err != nil {
+			writeError(w, http.StatusBadGateway, err.Error())
+			return
+		}
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -376,11 +630,22 @@ func (h *Handler) resolveInstance(w http.ResponseWriter, r *http.Request) *insta
 		writeError(w, http.StatusNotFound, "instance not found")
 		return nil
 	}
-	if inst.ServiceType != "sabnzbd" && inst.ServiceType != "qbittorrent" {
+	switch inst.ServiceType {
+	case "sabnzbd", "qbittorrent", "nzbget", "transmission":
+	default:
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("instance %s is not a download client", instanceID))
 		return nil
 	}
 	return inst
+}
+
+// transmissionCategory maps a torrent's labels to the unified category field:
+// the first label, or "" when unlabeled.
+func transmissionCategory(t transmission.Torrent) string {
+	if len(t.Labels) > 0 {
+		return t.Labels[0]
+	}
+	return ""
 }
 
 func isQbitPausedState(state string) bool {

--- a/server/internal/instance/handler.go
+++ b/server/internal/instance/handler.go
@@ -8,16 +8,22 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/nzbget"
 	"github.com/windoze95/cantinarr-server/internal/qbittorrent"
 	"github.com/windoze95/cantinarr-server/internal/sabnzbd"
+	"github.com/windoze95/cantinarr-server/internal/tautulli"
+	"github.com/windoze95/cantinarr-server/internal/transmission"
 )
 
 // allowedServiceTypes is the set of supported service types.
 var allowedServiceTypes = map[string]bool{
-	"radarr":      true,
-	"sonarr":      true,
-	"sabnzbd":     true,
-	"qbittorrent": true,
+	"radarr":       true,
+	"sonarr":       true,
+	"sabnzbd":      true,
+	"qbittorrent":  true,
+	"nzbget":       true,
+	"transmission": true,
+	"tautulli":     true,
 }
 
 // instanceResponse is the JSON shape returned to clients — API keys and
@@ -79,7 +85,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !allowedServiceTypes[inst.ServiceType] {
-		http.Error(w, `{"error":"service_type must be one of 'radarr', 'sonarr', 'sabnzbd', 'qbittorrent'"}`, http.StatusBadRequest)
+		http.Error(w, `{"error":"service_type must be one of 'radarr', 'sonarr', 'sabnzbd', 'qbittorrent', 'nzbget', 'transmission', 'tautulli'"}`, http.StatusBadRequest)
 		return
 	}
 	if err := validateRequiredFields(&inst); err != nil {
@@ -183,11 +189,13 @@ func validateRequiredFields(inst *Instance) error {
 		return fmt.Errorf("name and url are required")
 	}
 	switch inst.ServiceType {
-	case "qbittorrent":
+	case "qbittorrent", "nzbget":
 		if inst.Username == "" || inst.Password == "" {
-			return fmt.Errorf("username and password are required for qbittorrent")
+			return fmt.Errorf("username and password are required for %s", inst.ServiceType)
 		}
-	default: // radarr, sonarr, sabnzbd
+	case "transmission":
+		// Username/password are optional: Transmission RPC may run without auth.
+	default: // radarr, sonarr, sabnzbd, tautulli
 		if inst.APIKey == "" {
 			return fmt.Errorf("name, url, and api_key are required")
 		}
@@ -209,6 +217,15 @@ func validateConnection(inst *Instance) error {
 			return err
 		}
 		_, err := client.Version()
+		return err
+	case "nzbget":
+		_, err := nzbget.NewClient(inst.URL, inst.Username, inst.Password).Version()
+		return err
+	case "transmission":
+		_, err := transmission.NewClient(inst.URL, inst.Username, inst.Password).SessionGet()
+		return err
+	case "tautulli":
+		_, err := tautulli.NewClient(inst.URL, inst.APIKey).GetServerInfo()
 		return err
 	default:
 		return fmt.Errorf("unknown service type: %s", inst.ServiceType)

--- a/server/internal/instance/registry.go
+++ b/server/internal/instance/registry.go
@@ -4,30 +4,39 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/windoze95/cantinarr-server/internal/nzbget"
 	"github.com/windoze95/cantinarr-server/internal/qbittorrent"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
 	"github.com/windoze95/cantinarr-server/internal/sabnzbd"
 	"github.com/windoze95/cantinarr-server/internal/sonarr"
+	"github.com/windoze95/cantinarr-server/internal/tautulli"
+	"github.com/windoze95/cantinarr-server/internal/transmission"
 )
 
 // Registry lazily creates and caches service clients keyed by instance ID.
 type Registry struct {
-	store              *Store
-	mu                 sync.RWMutex
-	radarrClients      map[string]*radarr.Client
-	sonarrClients      map[string]*sonarr.Client
-	sabnzbdClients     map[string]*sabnzbd.Client
-	qbittorrentClients map[string]*qbittorrent.Client
+	store               *Store
+	mu                  sync.RWMutex
+	radarrClients       map[string]*radarr.Client
+	sonarrClients       map[string]*sonarr.Client
+	sabnzbdClients      map[string]*sabnzbd.Client
+	qbittorrentClients  map[string]*qbittorrent.Client
+	nzbgetClients       map[string]*nzbget.Client
+	transmissionClients map[string]*transmission.Client
+	tautulliClients     map[string]*tautulli.Client
 }
 
 // NewRegistry creates a new client registry.
 func NewRegistry(store *Store) *Registry {
 	return &Registry{
-		store:              store,
-		radarrClients:      make(map[string]*radarr.Client),
-		sonarrClients:      make(map[string]*sonarr.Client),
-		sabnzbdClients:     make(map[string]*sabnzbd.Client),
-		qbittorrentClients: make(map[string]*qbittorrent.Client),
+		store:               store,
+		radarrClients:       make(map[string]*radarr.Client),
+		sonarrClients:       make(map[string]*sonarr.Client),
+		sabnzbdClients:      make(map[string]*sabnzbd.Client),
+		qbittorrentClients:  make(map[string]*qbittorrent.Client),
+		nzbgetClients:       make(map[string]*nzbget.Client),
+		transmissionClients: make(map[string]*transmission.Client),
+		tautulliClients:     make(map[string]*tautulli.Client),
 	}
 }
 
@@ -123,6 +132,75 @@ func (r *Registry) GetQbittorrentClient(instanceID string) (*qbittorrent.Client,
 	return client, nil
 }
 
+// GetNzbgetClient returns a cached or new NZBGet client for the given instance ID.
+func (r *Registry) GetNzbgetClient(instanceID string) (*nzbget.Client, error) {
+	r.mu.RLock()
+	if client, ok := r.nzbgetClients[instanceID]; ok {
+		r.mu.RUnlock()
+		return client, nil
+	}
+	r.mu.RUnlock()
+
+	inst, err := r.getInstanceOfType(instanceID, "nzbget")
+	if err != nil {
+		return nil, err
+	}
+
+	client := nzbget.NewClient(inst.URL, inst.Username, inst.Password)
+
+	r.mu.Lock()
+	r.nzbgetClients[instanceID] = client
+	r.mu.Unlock()
+
+	return client, nil
+}
+
+// GetTransmissionClient returns a cached or new Transmission client for the given instance ID.
+func (r *Registry) GetTransmissionClient(instanceID string) (*transmission.Client, error) {
+	r.mu.RLock()
+	if client, ok := r.transmissionClients[instanceID]; ok {
+		r.mu.RUnlock()
+		return client, nil
+	}
+	r.mu.RUnlock()
+
+	inst, err := r.getInstanceOfType(instanceID, "transmission")
+	if err != nil {
+		return nil, err
+	}
+
+	client := transmission.NewClient(inst.URL, inst.Username, inst.Password)
+
+	r.mu.Lock()
+	r.transmissionClients[instanceID] = client
+	r.mu.Unlock()
+
+	return client, nil
+}
+
+// GetTautulliClient returns a cached or new Tautulli client for the given instance ID.
+func (r *Registry) GetTautulliClient(instanceID string) (*tautulli.Client, error) {
+	r.mu.RLock()
+	if client, ok := r.tautulliClients[instanceID]; ok {
+		r.mu.RUnlock()
+		return client, nil
+	}
+	r.mu.RUnlock()
+
+	inst, err := r.getInstanceOfType(instanceID, "tautulli")
+	if err != nil {
+		return nil, err
+	}
+
+	client := tautulli.NewClient(inst.URL, inst.APIKey)
+
+	r.mu.Lock()
+	r.tautulliClients[instanceID] = client
+	r.mu.Unlock()
+
+	return client, nil
+}
+
 // GetDefaultRadarrClient returns the client for the default Radarr instance.
 func (r *Registry) GetDefaultRadarrClient() (*radarr.Client, string, error) {
 	inst, err := r.store.GetDefault("radarr")
@@ -175,6 +253,45 @@ func (r *Registry) GetDefaultQbittorrentClient() (*qbittorrent.Client, string, e
 	return client, inst.ID, err
 }
 
+// GetDefaultNzbgetClient returns the client for the default NZBGet instance.
+func (r *Registry) GetDefaultNzbgetClient() (*nzbget.Client, string, error) {
+	inst, err := r.store.GetDefault("nzbget")
+	if err != nil {
+		return nil, "", fmt.Errorf("get default nzbget: %w", err)
+	}
+	if inst == nil {
+		return nil, "", nil
+	}
+	client, err := r.GetNzbgetClient(inst.ID)
+	return client, inst.ID, err
+}
+
+// GetDefaultTransmissionClient returns the client for the default Transmission instance.
+func (r *Registry) GetDefaultTransmissionClient() (*transmission.Client, string, error) {
+	inst, err := r.store.GetDefault("transmission")
+	if err != nil {
+		return nil, "", fmt.Errorf("get default transmission: %w", err)
+	}
+	if inst == nil {
+		return nil, "", nil
+	}
+	client, err := r.GetTransmissionClient(inst.ID)
+	return client, inst.ID, err
+}
+
+// GetDefaultTautulliClient returns the client for the default Tautulli instance.
+func (r *Registry) GetDefaultTautulliClient() (*tautulli.Client, string, error) {
+	inst, err := r.store.GetDefault("tautulli")
+	if err != nil {
+		return nil, "", fmt.Errorf("get default tautulli: %w", err)
+	}
+	if inst == nil {
+		return nil, "", nil
+	}
+	client, err := r.GetTautulliClient(inst.ID)
+	return client, inst.ID, err
+}
+
 // InvalidateClient removes a cached client, forcing recreation on next access.
 func (r *Registry) InvalidateClient(instanceID string) {
 	r.mu.Lock()
@@ -182,7 +299,24 @@ func (r *Registry) InvalidateClient(instanceID string) {
 	delete(r.sonarrClients, instanceID)
 	delete(r.sabnzbdClients, instanceID)
 	delete(r.qbittorrentClients, instanceID)
+	delete(r.nzbgetClients, instanceID)
+	delete(r.transmissionClients, instanceID)
+	delete(r.tautulliClients, instanceID)
 	r.mu.Unlock()
+}
+
+// LookupServiceType returns an instance's service type and whether the
+// instance exists. It lets leaf service packages (e.g. tautulli, whose client
+// type this package caches) resolve instances without importing this package.
+func (s *Store) LookupServiceType(instanceID string) (string, bool, error) {
+	inst, err := s.Get(instanceID)
+	if err != nil {
+		return "", false, err
+	}
+	if inst == nil {
+		return "", false, nil
+	}
+	return inst.ServiceType, true, nil
 }
 
 // getInstanceOfType loads an instance and verifies its service type.

--- a/server/internal/instance/store.go
+++ b/server/internal/instance/store.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/windoze95/cantinarr-server/internal/secrets"
 )
 
 // Instance represents a configured service instance (Radarr, Sonarr, SABnzbd,
@@ -26,14 +28,41 @@ type Instance struct {
 
 const instanceColumns = "id, service_type, name, url, api_key, username, password, is_default, sort_order, created_at"
 
-// Store provides CRUD operations for service instances.
+// Store provides CRUD operations for service instances. API keys and
+// passwords are encrypted at rest; legacy plaintext rows decrypt as-is.
 type Store struct {
-	db *sql.DB
+	db     *sql.DB
+	cipher *secrets.Cipher
 }
 
 // NewStore creates a new instance store.
-func NewStore(db *sql.DB) *Store {
-	return &Store{db: db}
+func NewStore(db *sql.DB, cipher *secrets.Cipher) *Store {
+	return &Store{db: db, cipher: cipher}
+}
+
+// decryptSecrets resolves stored secret fields to plaintext for callers.
+func (s *Store) decryptSecrets(inst *Instance) error {
+	apiKey, err := s.cipher.Decrypt(inst.APIKey)
+	if err != nil {
+		return fmt.Errorf("decrypt api key for %s (wrong encryption key?): %w", inst.ID, err)
+	}
+	password, err := s.cipher.Decrypt(inst.Password)
+	if err != nil {
+		return fmt.Errorf("decrypt password for %s (wrong encryption key?): %w", inst.ID, err)
+	}
+	inst.APIKey, inst.Password = apiKey, password
+	return nil
+}
+
+// encryptSecrets returns the at-rest representations of the secret fields.
+func (s *Store) encryptSecrets(inst *Instance) (apiKey, password string, err error) {
+	if apiKey, err = s.cipher.Encrypt(inst.APIKey); err != nil {
+		return "", "", fmt.Errorf("encrypt api key: %w", err)
+	}
+	if password, err = s.cipher.Encrypt(inst.Password); err != nil {
+		return "", "", fmt.Errorf("encrypt password: %w", err)
+	}
+	return apiKey, password, nil
 }
 
 // List returns all instances of the given service type, ordered by sort_order.
@@ -46,7 +75,7 @@ func (s *Store) List(serviceType string) ([]Instance, error) {
 		return nil, fmt.Errorf("list instances: %w", err)
 	}
 	defer rows.Close()
-	return scanInstances(rows)
+	return s.scanInstances(rows)
 }
 
 // ListAll returns all instances across all service types.
@@ -58,7 +87,7 @@ func (s *Store) ListAll() ([]Instance, error) {
 		return nil, fmt.Errorf("list all instances: %w", err)
 	}
 	defer rows.Close()
-	return scanInstances(rows)
+	return s.scanInstances(rows)
 }
 
 // Get returns a single instance by ID.
@@ -74,6 +103,9 @@ func (s *Store) Get(id string) (*Instance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get instance: %w", err)
 	}
+	if err := s.decryptSecrets(&inst); err != nil {
+		return nil, err
+	}
 	return &inst, nil
 }
 
@@ -84,9 +116,13 @@ func (s *Store) Create(inst *Instance) error {
 	}
 	inst.CreatedAt = time.Now()
 
-	_, err := s.db.Exec(
+	apiKey, password, err := s.encryptSecrets(inst)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(
 		"INSERT INTO service_instances (id, service_type, name, url, api_key, username, password, is_default, sort_order, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-		inst.ID, inst.ServiceType, inst.Name, inst.URL, inst.APIKey, inst.Username, inst.Password, inst.IsDefault, inst.SortOrder, inst.CreatedAt,
+		inst.ID, inst.ServiceType, inst.Name, inst.URL, apiKey, inst.Username, password, inst.IsDefault, inst.SortOrder, inst.CreatedAt,
 	)
 	if err != nil {
 		return fmt.Errorf("create instance: %w", err)
@@ -96,9 +132,13 @@ func (s *Store) Create(inst *Instance) error {
 
 // Update modifies an existing instance.
 func (s *Store) Update(inst *Instance) error {
+	apiKey, password, err := s.encryptSecrets(inst)
+	if err != nil {
+		return err
+	}
 	result, err := s.db.Exec(
 		"UPDATE service_instances SET name = ?, url = ?, api_key = ?, username = ?, password = ?, is_default = ?, sort_order = ? WHERE id = ?",
-		inst.Name, inst.URL, inst.APIKey, inst.Username, inst.Password, inst.IsDefault, inst.SortOrder, inst.ID,
+		inst.Name, inst.URL, apiKey, inst.Username, password, inst.IsDefault, inst.SortOrder, inst.ID,
 	)
 	if err != nil {
 		return fmt.Errorf("update instance: %w", err)
@@ -143,6 +183,9 @@ func (s *Store) GetDefault(serviceType string) (*Instance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get default instance: %w", err)
 	}
+	if err := s.decryptSecrets(&inst); err != nil {
+		return nil, err
+	}
 	return &inst, nil
 }
 
@@ -153,12 +196,15 @@ func (s *Store) Count(serviceType string) (int, error) {
 	return count, err
 }
 
-func scanInstances(rows *sql.Rows) ([]Instance, error) {
+func (s *Store) scanInstances(rows *sql.Rows) ([]Instance, error) {
 	var instances []Instance
 	for rows.Next() {
 		var inst Instance
 		if err := rows.Scan(&inst.ID, &inst.ServiceType, &inst.Name, &inst.URL, &inst.APIKey, &inst.Username, &inst.Password, &inst.IsDefault, &inst.SortOrder, &inst.CreatedAt); err != nil {
 			return nil, fmt.Errorf("scan instance: %w", err)
+		}
+		if err := s.decryptSecrets(&inst); err != nil {
+			return nil, err
 		}
 		instances = append(instances, inst)
 	}

--- a/server/internal/instance/store.go
+++ b/server/internal/instance/store.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/google/uuid"
@@ -204,7 +205,13 @@ func (s *Store) scanInstances(rows *sql.Rows) ([]Instance, error) {
 			return nil, fmt.Errorf("scan instance: %w", err)
 		}
 		if err := s.decryptSecrets(&inst); err != nil {
-			return nil, err
+			// Degrade rather than fail the whole listing: an undecryptable
+			// row would otherwise brick the instances admin UI, leaving no
+			// way to view, fix, or delete the broken entry. Secrets are
+			// blanked; paths that need the plaintext (client construction
+			// via Get/GetDefault) still fail loudly.
+			log.Printf("instance: %v — listing %s with blanked credentials", err, inst.ID)
+			inst.APIKey, inst.Password = "", ""
 		}
 		instances = append(instances, inst)
 	}

--- a/server/internal/mcp/arr_tools.go
+++ b/server/internal/mcp/arr_tools.go
@@ -248,6 +248,19 @@ func (s *ToolServer) findSeriesByTMDB(client *sonarr.Client, tmdbID int) (*sonar
 
 // --- get_queue ---
 
+// maxQueueItems caps how many queue items are rendered per service.
+const maxQueueItems = 30
+
+// renderQueueSection renders up to maxQueueItems lines with a truncation
+// notice when the queue is longer.
+func renderQueueSection(label string, total int, lines []string) string {
+	section := fmt.Sprintf("%s (%d items):\n%s", label, total, strings.Join(lines, "\n"))
+	if total > len(lines) {
+		section += fmt.Sprintf("\n…and %d more (%d total)", total-len(lines), total)
+	}
+	return section
+}
+
 func formatRadarrQueueItem(item radarr.DetailedQueueItem) string {
 	title := item.Title
 	if item.Movie != nil {
@@ -346,11 +359,15 @@ func (s *ToolServer) getQueue(input json.RawMessage) (*ToolResult, error) {
 			if len(items) == 0 {
 				sections = append(sections, "Movie queue: empty.")
 			} else {
-				lines := make([]string, 0, len(items))
-				for _, item := range items {
+				shown := items
+				if len(shown) > maxQueueItems {
+					shown = shown[:maxQueueItems]
+				}
+				lines := make([]string, 0, len(shown))
+				for _, item := range shown {
 					lines = append(lines, formatRadarrQueueItem(item))
 				}
-				sections = append(sections, fmt.Sprintf("Movie queue (%d items):\n%s", len(items), strings.Join(lines, "\n")))
+				sections = append(sections, renderQueueSection("Movie queue", len(items), lines))
 			}
 		}
 	}
@@ -370,11 +387,15 @@ func (s *ToolServer) getQueue(input json.RawMessage) (*ToolResult, error) {
 			if len(items) == 0 {
 				sections = append(sections, "TV queue: empty.")
 			} else {
-				lines := make([]string, 0, len(items))
-				for _, item := range items {
+				shown := items
+				if len(shown) > maxQueueItems {
+					shown = shown[:maxQueueItems]
+				}
+				lines := make([]string, 0, len(shown))
+				for _, item := range shown {
 					lines = append(lines, formatSonarrQueueItem(item))
 				}
-				sections = append(sections, fmt.Sprintf("TV queue (%d items):\n%s", len(items), strings.Join(lines, "\n")))
+				sections = append(sections, renderQueueSection("TV queue", len(items), lines))
 			}
 		}
 	}
@@ -561,7 +582,7 @@ func (s *ToolServer) getLibrary(input json.RawMessage) (*ToolResult, error) {
 		shown := matched
 		if len(shown) > maxLibraryItems {
 			shown = shown[:maxLibraryItems]
-			fmt.Fprintf(&sb, ", showing first %d", maxLibraryItems)
+			fmt.Fprintf(&sb, ", showing first %d of %d matches for filter %q", maxLibraryItems, len(matched), filter)
 		}
 		for _, m := range shown {
 			status := "missing"
@@ -613,7 +634,7 @@ func (s *ToolServer) getLibrary(input json.RawMessage) (*ToolResult, error) {
 		shown := matched
 		if len(shown) > maxLibraryItems {
 			shown = shown[:maxLibraryItems]
-			fmt.Fprintf(&sb, ", showing first %d", maxLibraryItems)
+			fmt.Fprintf(&sb, ", showing first %d of %d matches for filter %q", maxLibraryItems, len(matched), filter)
 		}
 		for _, sr := range shown {
 			fmt.Fprintf(&sb, "\n- %s (%d) [ID %d, TVDB %d", sr.Title, sr.Year, sr.ID, sr.TvdbID)

--- a/server/internal/nzbget/client.go
+++ b/server/internal/nzbget/client.go
@@ -1,0 +1,275 @@
+// Package nzbget provides a client for the NZBGet JSON-RPC API.
+package nzbget
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client talks to the NZBGet JSON-RPC API:
+// POST {base}/jsonrpc with HTTP Basic auth.
+type Client struct {
+	baseURL    string
+	username   string
+	password   string
+	httpClient *http.Client
+}
+
+// NewClient creates a new NZBGet client.
+func NewClient(baseURL, username, password string) *Client {
+	return &Client{
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		username: username,
+		password: password,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// call performs a JSON-RPC request, checks both the HTTP status and the
+// JSON-RPC error envelope, and decodes the result into out when out is non-nil.
+func (c *Client) call(method string, params []interface{}, out interface{}) error {
+	if params == nil {
+		params = []interface{}{}
+	}
+	reqBody, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"method":  method,
+		"params":  params,
+		"id":      1,
+	})
+	if err != nil {
+		return fmt.Errorf("nzbget encode request: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", c.baseURL+"/jsonrpc", bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("nzbget request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("nzbget request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return fmt.Errorf("nzbget read response: %w", err)
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("nzbget: invalid credentials")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("nzbget returned status %d", resp.StatusCode)
+	}
+
+	var envelope struct {
+		Result json.RawMessage `json:"result"`
+		Error  *struct {
+			Name    string `json:"name"`
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("nzbget decode response: %w", err)
+	}
+	if envelope.Error != nil {
+		msg := envelope.Error.Message
+		if msg == "" {
+			msg = envelope.Error.Name
+		}
+		if msg == "" {
+			msg = "unknown error"
+		}
+		return fmt.Errorf("nzbget %s: %s", method, msg)
+	}
+
+	if out != nil && len(envelope.Result) > 0 {
+		if err := json.Unmarshal(envelope.Result, out); err != nil {
+			return fmt.Errorf("nzbget decode result: %w", err)
+		}
+	}
+	return nil
+}
+
+// Version returns the NZBGet version; used as the connection test.
+func (c *Client) Version() (string, error) {
+	var version string
+	if err := c.call("version", nil, &version); err != nil {
+		return "", err
+	}
+	if version == "" {
+		return "", fmt.Errorf("nzbget returned no version (wrong URL or credentials?)")
+	}
+	return version, nil
+}
+
+// combineLoHi reassembles NZBGet's 32-bit Lo/Hi pair into a byte count.
+func combineLoHi(lo, hi uint32) int64 {
+	return int64(uint64(hi)<<32 | uint64(lo))
+}
+
+// Group is a single entry in the NZBGet download queue (one NZB).
+type Group struct {
+	NZBID           int    `json:"NZBID"`
+	NZBName         string `json:"NZBName"`
+	FileSizeLo      uint32 `json:"FileSizeLo"`
+	FileSizeHi      uint32 `json:"FileSizeHi"`
+	FileSizeMB      int64  `json:"FileSizeMB"`
+	RemainingSizeLo uint32 `json:"RemainingSizeLo"`
+	RemainingSizeHi uint32 `json:"RemainingSizeHi"`
+	RemainingSizeMB int64  `json:"RemainingSizeMB"`
+	Status          string `json:"Status"`
+	Category        string `json:"Category"`
+}
+
+// SizeBytes returns the total size of the item in bytes, preferring the exact
+// Lo/Hi pair over the rounded MB value.
+func (g Group) SizeBytes() int64 {
+	if b := combineLoHi(g.FileSizeLo, g.FileSizeHi); b > 0 {
+		return b
+	}
+	return g.FileSizeMB * 1024 * 1024
+}
+
+// RemainingBytes returns the remaining size of the item in bytes.
+func (g Group) RemainingBytes() int64 {
+	if b := combineLoHi(g.RemainingSizeLo, g.RemainingSizeHi); b > 0 {
+		return b
+	}
+	return g.RemainingSizeMB * 1024 * 1024
+}
+
+// ListGroups returns the current download queue.
+func (c *Client) ListGroups() ([]Group, error) {
+	var groups []Group
+	if err := c.call("listgroups", []interface{}{0}, &groups); err != nil {
+		return nil, err
+	}
+	return groups, nil
+}
+
+// Status is NZBGet's global download state.
+type Status struct {
+	DownloadRate    int64  `json:"DownloadRate"` // bytes/s
+	DownloadPaused  bool   `json:"DownloadPaused"`
+	RemainingSizeLo uint32 `json:"RemainingSizeLo"`
+	RemainingSizeHi uint32 `json:"RemainingSizeHi"`
+	RemainingSizeMB int64  `json:"RemainingSizeMB"`
+}
+
+// RemainingBytes returns the total remaining queue size in bytes.
+func (s Status) RemainingBytes() int64 {
+	if b := combineLoHi(s.RemainingSizeLo, s.RemainingSizeHi); b > 0 {
+		return b
+	}
+	return s.RemainingSizeMB * 1024 * 1024
+}
+
+// GetStatus returns the global download state.
+func (c *Client) GetStatus() (*Status, error) {
+	var status Status
+	if err := c.call("status", nil, &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
+// HistoryEntry is a single entry in NZBGet's download history. Status is
+// "SUCCESS/...", "WARNING/...", "FAILURE/..." or "DELETED/...".
+type HistoryEntry struct {
+	NZBID       int    `json:"NZBID"`
+	Name        string `json:"Name"`
+	Status      string `json:"Status"`
+	FileSizeLo  uint32 `json:"FileSizeLo"`
+	FileSizeHi  uint32 `json:"FileSizeHi"`
+	FileSizeMB  int64  `json:"FileSizeMB"`
+	HistoryTime int64  `json:"HistoryTime"` // unix seconds
+	Category    string `json:"Category"`
+}
+
+// SizeBytes returns the total size of the item in bytes.
+func (e HistoryEntry) SizeBytes() int64 {
+	if b := combineLoHi(e.FileSizeLo, e.FileSizeHi); b > 0 {
+		return b
+	}
+	return e.FileSizeMB * 1024 * 1024
+}
+
+// GetHistory returns the download history (excluding hidden entries).
+func (c *Client) GetHistory() ([]HistoryEntry, error) {
+	var entries []HistoryEntry
+	if err := c.call("history", []interface{}{false}, &entries); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+// PauseDownload pauses the entire download queue.
+func (c *Client) PauseDownload() error {
+	var ok bool
+	if err := c.call("pausedownload", nil, &ok); err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("nzbget pausedownload failed")
+	}
+	return nil
+}
+
+// ResumeDownload resumes the entire download queue.
+func (c *Client) ResumeDownload() error {
+	var ok bool
+	if err := c.call("resumedownload", nil, &ok); err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("nzbget resumedownload failed")
+	}
+	return nil
+}
+
+// editQueue invokes the editqueue RPC using the modern 3-parameter signature
+// (NZBGet v16+: Command, Param, IDs), falling back to the older 4-parameter
+// signature (Command, Offset, Param, IDs) when the server rejects it.
+func (c *Client) editQueue(command string, ids []int) error {
+	var ok bool
+	err := c.call("editqueue", []interface{}{command, "", ids}, &ok)
+	if err != nil {
+		// Pre-v16 NZBGet requires the legacy signature with an Offset param.
+		if legacyErr := c.call("editqueue", []interface{}{command, 0, "", ids}, &ok); legacyErr != nil {
+			return err
+		}
+	}
+	if !ok {
+		return fmt.Errorf("nzbget editqueue %s failed", command)
+	}
+	return nil
+}
+
+// PauseGroups pauses the given queue items by NZBID.
+func (c *Client) PauseGroups(ids []int) error {
+	return c.editQueue("GroupPause", ids)
+}
+
+// ResumeGroups resumes the given queue items by NZBID.
+func (c *Client) ResumeGroups(ids []int) error {
+	return c.editQueue("GroupResume", ids)
+}
+
+// DeleteGroups removes the given queue items by NZBID.
+func (c *Client) DeleteGroups(ids []int) error {
+	return c.editQueue("GroupDelete", ids)
+}

--- a/server/internal/radarr/client.go
+++ b/server/internal/radarr/client.go
@@ -275,15 +275,35 @@ type DetailedQueueItem struct {
 	Movie *MovieContext `json:"movie,omitempty"`
 }
 
-// GetQueueDetailed returns the full download queue with movie context.
+// queuePageSize is the per-request page size for queue pagination, and
+// queueMaxRecords is a safety cap on the total records accumulated.
+const (
+	queuePageSize   = 100
+	queueMaxRecords = 1000
+)
+
+// GetQueueDetailed returns the full download queue with movie context,
+// paginating until all records are fetched (capped at queueMaxRecords).
 func (c *Client) GetQueueDetailed() ([]DetailedQueueItem, error) {
-	var resp struct {
-		Records []DetailedQueueItem `json:"records"`
+	var all []DetailedQueueItem
+	for page := 1; ; page++ {
+		var resp struct {
+			TotalRecords int                 `json:"totalRecords"`
+			Records      []DetailedQueueItem `json:"records"`
+		}
+		path := fmt.Sprintf("/api/v3/queue?page=%d&pageSize=%d&includeMovie=true", page, queuePageSize)
+		if err := c.do("GET", path, nil, &resp); err != nil {
+			return nil, fmt.Errorf("radarr queue: %w", err)
+		}
+		all = append(all, resp.Records...)
+		if len(resp.Records) == 0 || len(all) >= resp.TotalRecords || len(all) >= queueMaxRecords {
+			break
+		}
 	}
-	if err := c.do("GET", "/api/v3/queue?page=1&pageSize=100&includeMovie=true", nil, &resp); err != nil {
-		return nil, fmt.Errorf("radarr queue: %w", err)
+	if len(all) > queueMaxRecords {
+		all = all[:queueMaxRecords]
 	}
-	return resp.Records, nil
+	return all, nil
 }
 
 // RemoveQueueItem removes an item from the download queue.

--- a/server/internal/sabnzbd/client.go
+++ b/server/internal/sabnzbd/client.go
@@ -45,7 +45,9 @@ func (c *Client) call(params url.Values, out interface{}) error {
 
 	resp, err := c.httpClient.Get(c.baseURL + "/api?" + q.Encode())
 	if err != nil {
-		return fmt.Errorf("sabnzbd request: %w", err)
+		// Transport errors embed the full URL including the apikey query
+		// parameter; redact it before the error can reach logs or clients.
+		return fmt.Errorf("sabnzbd request: %s", redactSecret(err.Error(), c.apiKey))
 	}
 	defer resp.Body.Close()
 
@@ -231,4 +233,13 @@ func (c *Client) SetSpeedLimit(value string) error {
 func parseFloat(s string) float64 {
 	f, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
 	return f
+}
+
+// redactSecret removes a secret value from an error string before it can
+// escape into logs or HTTP responses.
+func redactSecret(msg, secret string) string {
+	if secret == "" {
+		return msg
+	}
+	return strings.ReplaceAll(msg, secret, "[redacted]")
 }

--- a/server/internal/secrets/migrate.go
+++ b/server/internal/secrets/migrate.go
@@ -1,0 +1,77 @@
+package secrets
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// EncryptExisting encrypts legacy plaintext secrets in place: the given
+// settings keys plus the api_key and password columns of service_instances.
+// It is idempotent — already-encrypted values are skipped — and returns the
+// number of values rewritten.
+func EncryptExisting(db *sql.DB, c *Cipher, settingsKeys []string) (int, error) {
+	migrated := 0
+
+	for _, key := range settingsKeys {
+		var value string
+		err := db.QueryRow("SELECT value FROM settings WHERE key = ?", key).Scan(&value)
+		if err == sql.ErrNoRows {
+			continue
+		}
+		if err != nil {
+			return migrated, fmt.Errorf("read setting %s: %w", key, err)
+		}
+		if value == "" || IsEncrypted(value) {
+			continue
+		}
+		enc, err := c.Encrypt(value)
+		if err != nil {
+			return migrated, fmt.Errorf("encrypt setting %s: %w", key, err)
+		}
+		if _, err := db.Exec("UPDATE settings SET value = ? WHERE key = ?", enc, key); err != nil {
+			return migrated, fmt.Errorf("rewrite setting %s: %w", key, err)
+		}
+		migrated++
+	}
+
+	rows, err := db.Query("SELECT id, api_key, password FROM service_instances")
+	if err != nil {
+		return migrated, fmt.Errorf("scan instances: %w", err)
+	}
+	type instRow struct{ id, apiKey, password string }
+	var pending []instRow
+	for rows.Next() {
+		var r instRow
+		if err := rows.Scan(&r.id, &r.apiKey, &r.password); err != nil {
+			rows.Close()
+			return migrated, fmt.Errorf("scan instance row: %w", err)
+		}
+		if (r.apiKey != "" && !IsEncrypted(r.apiKey)) || (r.password != "" && !IsEncrypted(r.password)) {
+			pending = append(pending, r)
+		}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return migrated, fmt.Errorf("iterate instances: %w", err)
+	}
+
+	for _, r := range pending {
+		apiKey, password := r.apiKey, r.password
+		if apiKey != "" && !IsEncrypted(apiKey) {
+			if apiKey, err = c.Encrypt(apiKey); err != nil {
+				return migrated, fmt.Errorf("encrypt instance %s api key: %w", r.id, err)
+			}
+		}
+		if password != "" && !IsEncrypted(password) {
+			if password, err = c.Encrypt(password); err != nil {
+				return migrated, fmt.Errorf("encrypt instance %s password: %w", r.id, err)
+			}
+		}
+		if _, err := db.Exec("UPDATE service_instances SET api_key = ?, password = ? WHERE id = ?", apiKey, password, r.id); err != nil {
+			return migrated, fmt.Errorf("rewrite instance %s: %w", r.id, err)
+		}
+		migrated++
+	}
+
+	return migrated, nil
+}

--- a/server/internal/secrets/migrate.go
+++ b/server/internal/secrets/migrate.go
@@ -5,6 +5,40 @@ import (
 	"fmt"
 )
 
+const (
+	canaryKey   = "encryption_canary"
+	canaryValue = "cantinarr-canary"
+)
+
+// VerifyKeyIdentity guards against starting with a key that doesn't match
+// already-encrypted data (deleted key file, switched/rotated env key): a
+// canary value encrypted with the first-used key is stored in settings, and
+// every startup must decrypt it. Returns a fatal-worthy error on mismatch —
+// proceeding would brick every stored secret and write new ones with an
+// irreconcilable second key.
+func VerifyKeyIdentity(db *sql.DB, c *Cipher) error {
+	var stored string
+	err := db.QueryRow("SELECT value FROM settings WHERE key = ?", canaryKey).Scan(&stored)
+	if err == sql.ErrNoRows {
+		enc, err := c.Encrypt(canaryValue)
+		if err != nil {
+			return fmt.Errorf("encrypt canary: %w", err)
+		}
+		if _, err := db.Exec("INSERT INTO settings (key, value) VALUES (?, ?)", canaryKey, enc); err != nil {
+			return fmt.Errorf("persist canary: %w", err)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read canary: %w", err)
+	}
+	plain, err := c.Decrypt(stored)
+	if err != nil || plain != canaryValue {
+		return fmt.Errorf("encryption key does not match existing encrypted data — restore /config/encryption.key (or the original CANTINARR_ENCRYPTION_KEY); generating a new key would orphan all stored secrets")
+	}
+	return nil
+}
+
 // EncryptExisting encrypts legacy plaintext secrets in place: the given
 // settings keys plus the api_key and password columns of service_instances.
 // It is idempotent — already-encrypted values are skipped — and returns the

--- a/server/internal/secrets/secrets.go
+++ b/server/internal/secrets/secrets.go
@@ -1,0 +1,122 @@
+// Package secrets provides AES-256-GCM encryption-at-rest for credential
+// values stored in SQLite. Encrypted values carry an "enc:v1:" prefix;
+// values without it are treated as legacy plaintext and pass through reads
+// unchanged, so existing databases keep working and migrate in place.
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	prefix = "enc:v1:"
+	// EnvKey holds a base64-encoded 32-byte key; when unset a key file is
+	// generated next to the database instead.
+	EnvKey  = "CANTINARR_ENCRYPTION_KEY"
+	keySize = 32
+)
+
+// Cipher encrypts and decrypts stored secret values.
+type Cipher struct {
+	aead cipher.AEAD
+}
+
+// NewCipher creates a Cipher from a 32-byte key.
+func NewCipher(key []byte) (*Cipher, error) {
+	if len(key) != keySize {
+		return nil, fmt.Errorf("encryption key must be %d bytes, got %d", keySize, len(key))
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("create cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create GCM: %w", err)
+	}
+	return &Cipher{aead: aead}, nil
+}
+
+// LoadKey resolves the encryption key: the CANTINARR_ENCRYPTION_KEY env var
+// (base64, 32 bytes) wins; otherwise a key is generated once and persisted to
+// keyFile with 0600 permissions.
+func LoadKey(keyFile string) ([]byte, error) {
+	if env := os.Getenv(EnvKey); env != "" {
+		key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(env))
+		if err != nil {
+			return nil, fmt.Errorf("%s is not valid base64: %w", EnvKey, err)
+		}
+		if len(key) != keySize {
+			return nil, fmt.Errorf("%s must decode to %d bytes, got %d", EnvKey, keySize, len(key))
+		}
+		return key, nil
+	}
+
+	if data, err := os.ReadFile(keyFile); err == nil {
+		key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(data)))
+		if err != nil {
+			return nil, fmt.Errorf("key file %s is corrupt: %w", keyFile, err)
+		}
+		if len(key) != keySize {
+			return nil, fmt.Errorf("key file %s must hold %d bytes, got %d", keyFile, keySize, len(key))
+		}
+		return key, nil
+	}
+
+	key := make([]byte, keySize)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generate key: %w", err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(key) + "\n"
+	if err := os.WriteFile(keyFile, []byte(encoded), 0o600); err != nil {
+		return nil, fmt.Errorf("persist key file: %w", err)
+	}
+	return key, nil
+}
+
+// Encrypt seals plain and returns the prefixed, base64-encoded ciphertext.
+// Empty strings stay empty so optional secrets round-trip cleanly.
+func (c *Cipher) Encrypt(plain string) (string, error) {
+	if plain == "" {
+		return "", nil
+	}
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := rand.Read(nonce); err != nil {
+		return "", fmt.Errorf("generate nonce: %w", err)
+	}
+	sealed := c.aead.Seal(nonce, nonce, []byte(plain), nil)
+	return prefix + base64.StdEncoding.EncodeToString(sealed), nil
+}
+
+// Decrypt opens a stored value. Values without the encryption prefix are
+// legacy plaintext and are returned unchanged; prefixed values that fail
+// authentication return an error rather than leaking ciphertext to callers.
+func (c *Cipher) Decrypt(stored string) (string, error) {
+	if !IsEncrypted(stored) {
+		return stored, nil
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(stored, prefix))
+	if err != nil {
+		return "", fmt.Errorf("decode secret: %w", err)
+	}
+	if len(raw) < c.aead.NonceSize() {
+		return "", fmt.Errorf("secret too short")
+	}
+	nonce, ct := raw[:c.aead.NonceSize()], raw[c.aead.NonceSize():]
+	plain, err := c.aead.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return "", fmt.Errorf("decrypt secret: %w", err)
+	}
+	return string(plain), nil
+}
+
+// IsEncrypted reports whether a stored value carries the encryption prefix.
+func IsEncrypted(s string) bool {
+	return strings.HasPrefix(s, prefix)
+}

--- a/server/internal/secrets/secrets.go
+++ b/server/internal/secrets/secrets.go
@@ -9,7 +9,9 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 )
@@ -58,7 +60,8 @@ func LoadKey(keyFile string) ([]byte, error) {
 		return key, nil
 	}
 
-	if data, err := os.ReadFile(keyFile); err == nil {
+	data, err := os.ReadFile(keyFile)
+	if err == nil {
 		key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(data)))
 		if err != nil {
 			return nil, fmt.Errorf("key file %s is corrupt: %w", keyFile, err)
@@ -68,14 +71,36 @@ func LoadKey(keyFile string) ([]byte, error) {
 		}
 		return key, nil
 	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		// A key file that exists but can't be read must never be silently
+		// replaced — regenerating here would permanently orphan every
+		// secret encrypted with the old key.
+		return nil, fmt.Errorf("read key file %s: %w", keyFile, err)
+	}
 
 	key := make([]byte, keySize)
 	if _, err := rand.Read(key); err != nil {
 		return nil, fmt.Errorf("generate key: %w", err)
 	}
 	encoded := base64.StdEncoding.EncodeToString(key) + "\n"
-	if err := os.WriteFile(keyFile, []byte(encoded), 0o600); err != nil {
+	// O_EXCL: if a concurrent process won the race, defer to its key.
+	f, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if errors.Is(err, fs.ErrExist) {
+		return LoadKey(keyFile)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("create key file: %w", err)
+	}
+	if _, err := f.WriteString(encoded); err != nil {
+		f.Close()
 		return nil, fmt.Errorf("persist key file: %w", err)
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("sync key file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return nil, fmt.Errorf("close key file: %w", err)
 	}
 	return key, nil
 }
@@ -97,6 +122,12 @@ func (c *Cipher) Encrypt(plain string) (string, error) {
 // Decrypt opens a stored value. Values without the encryption prefix are
 // legacy plaintext and are returned unchanged; prefixed values that fail
 // authentication return an error rather than leaking ciphertext to callers.
+//
+// Known edge: a legacy plaintext secret whose literal value happens to start
+// with "enc:v1:" would be misclassified as ciphertext and fail to decrypt.
+// Real API keys never look like that; secrets saved after this feature
+// shipped are encrypted (and decryption restores the literal), so the
+// ambiguity only exists for pre-migration rows.
 func (c *Cipher) Decrypt(stored string) (string, error) {
 	if !IsEncrypted(stored) {
 		return stored, nil

--- a/server/internal/secrets/secrets_test.go
+++ b/server/internal/secrets/secrets_test.go
@@ -1,0 +1,94 @@
+package secrets
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func testCipher(t *testing.T) *Cipher {
+	t.Helper()
+	c, err := NewCipher(bytes.Repeat([]byte{0x42}, 32))
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	return c
+}
+
+func TestRoundTrip(t *testing.T) {
+	c := testCipher(t)
+	for _, plain := range []string{"hunter2", "a much longer secret value with spaces", "ключ"} {
+		enc, err := c.Encrypt(plain)
+		if err != nil {
+			t.Fatalf("Encrypt(%q): %v", plain, err)
+		}
+		if !IsEncrypted(enc) {
+			t.Fatalf("Encrypt(%q) missing prefix: %q", plain, enc)
+		}
+		got, err := c.Decrypt(enc)
+		if err != nil {
+			t.Fatalf("Decrypt: %v", err)
+		}
+		if got != plain {
+			t.Fatalf("round trip: got %q want %q", got, plain)
+		}
+	}
+}
+
+func TestEmptyStaysEmpty(t *testing.T) {
+	c := testCipher(t)
+	enc, err := c.Encrypt("")
+	if err != nil || enc != "" {
+		t.Fatalf("Encrypt(\"\") = %q, %v; want empty, nil", enc, err)
+	}
+}
+
+func TestPlaintextPassthrough(t *testing.T) {
+	c := testCipher(t)
+	got, err := c.Decrypt("legacy-plaintext-api-key")
+	if err != nil {
+		t.Fatalf("Decrypt plaintext: %v", err)
+	}
+	if got != "legacy-plaintext-api-key" {
+		t.Fatalf("plaintext passthrough mangled: %q", got)
+	}
+}
+
+func TestTamperDetection(t *testing.T) {
+	c := testCipher(t)
+	enc, _ := c.Encrypt("secret")
+	tampered := enc[:len(enc)-2] + "AA"
+	if tampered == enc {
+		tampered = enc[:len(enc)-2] + "BB"
+	}
+	if _, err := c.Decrypt(tampered); err == nil {
+		t.Fatal("tampered ciphertext decrypted without error")
+	}
+}
+
+func TestWrongKeyFails(t *testing.T) {
+	c := testCipher(t)
+	other, _ := NewCipher(bytes.Repeat([]byte{0x07}, 32))
+	enc, _ := c.Encrypt("secret")
+	if _, err := other.Decrypt(enc); err == nil {
+		t.Fatal("decrypt with wrong key succeeded")
+	}
+}
+
+func TestIsEncrypted(t *testing.T) {
+	if IsEncrypted("plain") || !IsEncrypted("enc:v1:abc") {
+		t.Fatal("IsEncrypted misclassifies")
+	}
+}
+
+func TestNonceUniqueness(t *testing.T) {
+	c := testCipher(t)
+	a, _ := c.Encrypt("same")
+	b, _ := c.Encrypt("same")
+	if a == b {
+		t.Fatal("two encryptions of the same value produced identical ciphertext")
+	}
+	if !strings.HasPrefix(a, "enc:v1:") {
+		t.Fatalf("unexpected format: %q", a)
+	}
+}

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -307,15 +307,35 @@ type DetailedQueueItem struct {
 	Episode *EpisodeContext `json:"episode,omitempty"`
 }
 
-// GetQueueDetailed returns the full download queue with series and episode context.
+// queuePageSize is the per-request page size for queue pagination, and
+// queueMaxRecords is a safety cap on the total records accumulated.
+const (
+	queuePageSize   = 100
+	queueMaxRecords = 1000
+)
+
+// GetQueueDetailed returns the full download queue with series and episode
+// context, paginating until all records are fetched (capped at queueMaxRecords).
 func (c *Client) GetQueueDetailed() ([]DetailedQueueItem, error) {
-	var resp struct {
-		Records []DetailedQueueItem `json:"records"`
+	var all []DetailedQueueItem
+	for page := 1; ; page++ {
+		var resp struct {
+			TotalRecords int                 `json:"totalRecords"`
+			Records      []DetailedQueueItem `json:"records"`
+		}
+		path := fmt.Sprintf("/api/v3/queue?page=%d&pageSize=%d&includeSeries=true&includeEpisode=true", page, queuePageSize)
+		if err := c.do("GET", path, nil, &resp); err != nil {
+			return nil, fmt.Errorf("sonarr queue: %w", err)
+		}
+		all = append(all, resp.Records...)
+		if len(resp.Records) == 0 || len(all) >= resp.TotalRecords || len(all) >= queueMaxRecords {
+			break
+		}
 	}
-	if err := c.do("GET", "/api/v3/queue?page=1&pageSize=100&includeSeries=true&includeEpisode=true", nil, &resp); err != nil {
-		return nil, fmt.Errorf("sonarr queue: %w", err)
+	if len(all) > queueMaxRecords {
+		all = all[:queueMaxRecords]
 	}
-	return resp.Records, nil
+	return all, nil
 }
 
 // RemoveQueueItem removes an item from the download queue.

--- a/server/internal/tautulli/client.go
+++ b/server/internal/tautulli/client.go
@@ -1,0 +1,205 @@
+// Package tautulli provides a client and REST handler for Tautulli (Plex
+// monitoring) instances.
+package tautulli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Client talks to the Tautulli API v2:
+// GET {base}/api/v2?apikey={key}&cmd=...
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewClient creates a new Tautulli client.
+func NewClient(baseURL, apiKey string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// call performs a GET against the Tautulli API, checks both the HTTP status
+// and Tautulli's response envelope ({"response":{"result":"success",...}}),
+// and decodes the data field into out when out is non-nil.
+func (c *Client) call(cmd string, params url.Values, out interface{}) error {
+	q := url.Values{}
+	q.Set("apikey", c.apiKey)
+	q.Set("cmd", cmd)
+	for key, values := range params {
+		for _, v := range values {
+			q.Add(key, v)
+		}
+	}
+
+	resp, err := c.httpClient.Get(c.baseURL + "/api/v2?" + q.Encode())
+	if err != nil {
+		return fmt.Errorf("tautulli request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		return fmt.Errorf("tautulli read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("tautulli returned status %d", resp.StatusCode)
+	}
+
+	var envelope struct {
+		Response struct {
+			Result  string          `json:"result"`
+			Message string          `json:"message"`
+			Data    json.RawMessage `json:"data"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return fmt.Errorf("tautulli decode response: %w", err)
+	}
+	if envelope.Response.Result != "success" {
+		msg := envelope.Response.Message
+		if msg == "" {
+			msg = "unknown error"
+		}
+		return fmt.Errorf("tautulli %s: %s", cmd, msg)
+	}
+
+	if out != nil && len(envelope.Response.Data) > 0 {
+		if err := json.Unmarshal(envelope.Response.Data, out); err != nil {
+			return fmt.Errorf("tautulli decode data: %w", err)
+		}
+	}
+	return nil
+}
+
+// flexInt is an int64 that tolerates Tautulli's habit of encoding numbers as
+// strings (and occasionally empty strings) in JSON.
+type flexInt int64
+
+func (f *flexInt) UnmarshalJSON(b []byte) error {
+	s := strings.Trim(strings.TrimSpace(string(b)), `"`)
+	if s == "" || s == "null" {
+		*f = 0
+		return nil
+	}
+	n, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		*f = 0
+		return nil
+	}
+	*f = flexInt(n)
+	return nil
+}
+
+// ServerInfo is the subset of get_server_info used here.
+type ServerInfo struct {
+	PMSName    string `json:"pms_name"`
+	PMSVersion string `json:"pms_version"`
+}
+
+// GetServerInfo returns the connected Plex server info; used as the
+// connection test.
+func (c *Client) GetServerInfo() (*ServerInfo, error) {
+	var info ServerInfo
+	if err := c.call("get_server_info", nil, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Session is a single active stream from get_activity.
+type Session struct {
+	User              string  `json:"user"`
+	Title             string  `json:"title"`
+	FullTitle         string  `json:"full_title"`
+	Player            string  `json:"player"`
+	Product           string  `json:"product"`
+	State             string  `json:"state"` // playing/paused/buffering
+	ProgressPercent   flexInt `json:"progress_percent"`
+	QualityProfile    string  `json:"quality_profile"`
+	TranscodeDecision string  `json:"transcode_decision"` // direct play/copy/transcode
+	Bandwidth         flexInt `json:"bandwidth"`          // kbps
+}
+
+// Activity is the current streaming activity from get_activity.
+type Activity struct {
+	StreamCount    flexInt   `json:"stream_count"`
+	TotalBandwidth flexInt   `json:"total_bandwidth"` // kbps
+	Sessions       []Session `json:"sessions"`
+}
+
+// GetActivity returns the current streaming activity.
+func (c *Client) GetActivity() (*Activity, error) {
+	var activity Activity
+	if err := c.call("get_activity", nil, &activity); err != nil {
+		return nil, err
+	}
+	return &activity, nil
+}
+
+// HistoryRow is a single watch-history entry from get_history.
+type HistoryRow struct {
+	User            string  `json:"user"`
+	FullTitle       string  `json:"full_title"`
+	Date            flexInt `json:"date"`     // unix seconds
+	Duration        flexInt `json:"duration"` // seconds played
+	PercentComplete flexInt `json:"percent_complete"`
+	Player          string  `json:"player"`
+	Platform        string  `json:"platform"`
+}
+
+// GetHistory returns the most recent watch-history entries, up to length
+// (0 = server default).
+func (c *Client) GetHistory(length int) ([]HistoryRow, error) {
+	params := url.Values{}
+	if length > 0 {
+		params.Set("length", strconv.Itoa(length))
+	}
+	var out struct {
+		Data []HistoryRow `json:"data"`
+	}
+	if err := c.call("get_history", params, &out); err != nil {
+		return nil, err
+	}
+	return out.Data, nil
+}
+
+// HomeStatRow is a single row within a get_home_stats stat block.
+type HomeStatRow struct {
+	Title        string  `json:"title"`
+	User         string  `json:"user"`
+	FriendlyName string  `json:"friendly_name"`
+	TotalPlays   flexInt `json:"total_plays"`
+}
+
+// HomeStat is one stat block (e.g. top_movies) from get_home_stats.
+type HomeStat struct {
+	StatID string        `json:"stat_id"`
+	Rows   []HomeStatRow `json:"rows"`
+}
+
+// GetHomeStats returns the home statistics over the given number of days.
+func (c *Client) GetHomeStats(days int) ([]HomeStat, error) {
+	params := url.Values{}
+	if days > 0 {
+		params.Set("time_range", strconv.Itoa(days))
+	}
+	var stats []HomeStat
+	if err := c.call("get_home_stats", params, &stats); err != nil {
+		return nil, err
+	}
+	return stats, nil
+}

--- a/server/internal/tautulli/client.go
+++ b/server/internal/tautulli/client.go
@@ -47,7 +47,10 @@ func (c *Client) call(cmd string, params url.Values, out interface{}) error {
 
 	resp, err := c.httpClient.Get(c.baseURL + "/api/v2?" + q.Encode())
 	if err != nil {
-		return fmt.Errorf("tautulli request: %w", err)
+		// Transport errors (*url.Error) embed the full request URL including
+		// the apikey query parameter; redact it so the secret can never leak
+		// into logs or API error responses.
+		return fmt.Errorf("tautulli request: %s", redactSecret(err.Error(), c.apiKey))
 	}
 	defer resp.Body.Close()
 
@@ -202,4 +205,13 @@ func (c *Client) GetHomeStats(days int) ([]HomeStat, error) {
 		return nil, err
 	}
 	return stats, nil
+}
+
+// redactSecret removes a secret value from an error string before it can
+// escape into logs or HTTP responses.
+func redactSecret(msg, secret string) string {
+	if secret == "" {
+		return msg
+	}
+	return strings.ReplaceAll(msg, secret, "[redacted]")
 }

--- a/server/internal/tautulli/handler.go
+++ b/server/internal/tautulli/handler.go
@@ -1,0 +1,248 @@
+package tautulli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// InstanceSource is the subset of the instance store used by the handler. It
+// is defined here rather than importing the instance package because that
+// package's registry imports this one for its client cache; implemented by
+// *instance.Store.
+type InstanceSource interface {
+	LookupServiceType(instanceID string) (serviceType string, found bool, err error)
+}
+
+// ClientSource provides cached Tautulli clients; implemented by
+// *instance.Registry.
+type ClientSource interface {
+	GetTautulliClient(instanceID string) (*Client, error)
+}
+
+// Handler provides REST endpoints for Tautulli instances.
+type Handler struct {
+	store    InstanceSource
+	registry ClientSource
+}
+
+// NewHandler creates a new Tautulli handler.
+func NewHandler(store InstanceSource, registry ClientSource) *Handler {
+	return &Handler{store: store, registry: registry}
+}
+
+// activityStream is the normalized shape of a single active stream.
+type activityStream struct {
+	User            string `json:"user"`
+	Title           string `json:"title"`
+	FullTitle       string `json:"full_title"`
+	Player          string `json:"player"`
+	Product         string `json:"product"`
+	State           string `json:"state"` // playing/paused/buffering
+	ProgressPercent int    `json:"progress_percent"`
+	Quality         string `json:"quality"`
+	StreamType      string `json:"stream_type"` // direct play/copy/transcode
+	BandwidthKbps   int    `json:"bandwidth_kbps"`
+}
+
+type activityResponse struct {
+	StreamCount        int              `json:"stream_count"`
+	TotalBandwidthKbps int              `json:"total_bandwidth_kbps"`
+	Streams            []activityStream `json:"streams"`
+}
+
+// GetActivity returns the current streaming activity for an instance.
+func (h *Handler) GetActivity(w http.ResponseWriter, r *http.Request) {
+	client := h.resolveClient(w, r)
+	if client == nil {
+		return
+	}
+
+	activity, err := client.GetActivity()
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+
+	resp := activityResponse{
+		StreamCount:        int(activity.StreamCount),
+		TotalBandwidthKbps: int(activity.TotalBandwidth),
+		Streams:            make([]activityStream, 0, len(activity.Sessions)),
+	}
+	for _, s := range activity.Sessions {
+		resp.Streams = append(resp.Streams, activityStream{
+			User:            s.User,
+			Title:           s.Title,
+			FullTitle:       s.FullTitle,
+			Player:          s.Player,
+			Product:         s.Product,
+			State:           s.State,
+			ProgressPercent: int(s.ProgressPercent),
+			Quality:         s.QualityProfile,
+			StreamType:      s.TranscodeDecision,
+			BandwidthKbps:   int(s.Bandwidth),
+		})
+	}
+	writeJSON(w, resp)
+}
+
+// historyEntry is the normalized shape of a single watch-history entry.
+type historyEntry struct {
+	User            string `json:"user"`
+	FullTitle       string `json:"full_title"`
+	Date            string `json:"date"` // RFC3339 UTC, "" if unknown
+	DurationSeconds int    `json:"duration_seconds"`
+	PercentComplete int    `json:"percent_complete"`
+	Player          string `json:"player"`
+	Platform        string `json:"platform"`
+}
+
+type historyResponse struct {
+	Items []historyEntry `json:"items"`
+}
+
+// GetHistory returns recent watch history. ?limit=N (default 50).
+func (h *Handler) GetHistory(w http.ResponseWriter, r *http.Request) {
+	client := h.resolveClient(w, r)
+	if client == nil {
+		return
+	}
+
+	limit := 50
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	rows, err := client.GetHistory(limit)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+
+	resp := historyResponse{Items: make([]historyEntry, 0, len(rows))}
+	for _, row := range rows {
+		date := ""
+		if row.Date > 0 {
+			date = time.Unix(int64(row.Date), 0).UTC().Format(time.RFC3339)
+		}
+		resp.Items = append(resp.Items, historyEntry{
+			User:            row.User,
+			FullTitle:       row.FullTitle,
+			Date:            date,
+			DurationSeconds: int(row.Duration),
+			PercentComplete: int(row.PercentComplete),
+			Player:          row.Player,
+			Platform:        row.Platform,
+		})
+	}
+	writeJSON(w, resp)
+}
+
+// titleStat is a play count keyed by title (top movies/shows).
+type titleStat struct {
+	Title string `json:"title"`
+	Plays int    `json:"plays"`
+}
+
+// userStat is a play count keyed by user (top users).
+type userStat struct {
+	User  string `json:"user"`
+	Plays int    `json:"plays"`
+}
+
+type statsResponse struct {
+	TopMovies []titleStat `json:"top_movies"`
+	TopShows  []titleStat `json:"top_shows"`
+	TopUsers  []userStat  `json:"top_users"`
+}
+
+// GetStats returns the top movies/shows/users. ?days=N (default 30).
+func (h *Handler) GetStats(w http.ResponseWriter, r *http.Request) {
+	client := h.resolveClient(w, r)
+	if client == nil {
+		return
+	}
+
+	days := 30
+	if v := r.URL.Query().Get("days"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			days = n
+		}
+	}
+
+	stats, err := client.GetHomeStats(days)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+
+	resp := statsResponse{
+		TopMovies: make([]titleStat, 0),
+		TopShows:  make([]titleStat, 0),
+		TopUsers:  make([]userStat, 0),
+	}
+	for _, stat := range stats {
+		switch stat.StatID {
+		case "top_movies":
+			for _, row := range stat.Rows {
+				resp.TopMovies = append(resp.TopMovies, titleStat{Title: row.Title, Plays: int(row.TotalPlays)})
+			}
+		case "top_tv":
+			for _, row := range stat.Rows {
+				resp.TopShows = append(resp.TopShows, titleStat{Title: row.Title, Plays: int(row.TotalPlays)})
+			}
+		case "top_users":
+			for _, row := range stat.Rows {
+				user := row.FriendlyName
+				if user == "" {
+					user = row.User
+				}
+				resp.TopUsers = append(resp.TopUsers, userStat{User: user, Plays: int(row.TotalPlays)})
+			}
+		}
+	}
+	writeJSON(w, resp)
+}
+
+// resolveClient loads the instance from the path, verifies it is a Tautulli
+// instance, and returns its client. On failure it writes the error response
+// and returns nil.
+func (h *Handler) resolveClient(w http.ResponseWriter, r *http.Request) *Client {
+	instanceID := chi.URLParam(r, "instanceID")
+	serviceType, found, err := h.store.LookupServiceType(instanceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return nil
+	}
+	if !found {
+		writeError(w, http.StatusNotFound, "instance not found")
+		return nil
+	}
+	if serviceType != "tautulli" {
+		writeError(w, http.StatusBadRequest, fmt.Sprintf("instance %s is not a tautulli instance", instanceID))
+		return nil
+	}
+	client, err := h.registry.GetTautulliClient(instanceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return nil
+	}
+	return client
+}
+
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/server/internal/transmission/client.go
+++ b/server/internal/transmission/client.go
@@ -1,0 +1,259 @@
+// Package transmission provides a client for the Transmission RPC API.
+package transmission
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// sessionHeader carries the CSRF token Transmission requires on every request.
+const sessionHeader = "X-Transmission-Session-Id"
+
+// Transmission torrent status codes (the "status" field of torrent-get).
+const (
+	StatusStopped       = 0
+	StatusCheckWaiting  = 1
+	StatusChecking      = 2
+	StatusDownloadQueue = 3
+	StatusDownloading   = 4
+	StatusSeedQueue     = 5
+	StatusSeeding       = 6
+)
+
+// StatusString maps a Transmission numeric torrent status to a readable string.
+func StatusString(status int) string {
+	switch status {
+	case StatusStopped:
+		return "stopped"
+	case StatusCheckWaiting:
+		return "checkWaiting"
+	case StatusChecking:
+		return "checking"
+	case StatusDownloadQueue:
+		return "downloadWaiting"
+	case StatusDownloading:
+		return "downloading"
+	case StatusSeedQueue:
+		return "seedWaiting"
+	case StatusSeeding:
+		return "seeding"
+	}
+	return fmt.Sprintf("unknown (%d)", status)
+}
+
+// Client talks to the Transmission RPC API:
+// POST {base}/transmission/rpc with optional HTTP Basic auth and the
+// X-Transmission-Session-Id handshake (on a 409 the new session id is read
+// from the response and the request retried once).
+type Client struct {
+	baseURL    string
+	username   string
+	password   string
+	httpClient *http.Client
+
+	mu        sync.Mutex
+	sessionID string
+}
+
+// NewClient creates a new Transmission client. Username/password may be blank
+// when the RPC endpoint has no authentication enabled.
+func NewClient(baseURL, username, password string) *Client {
+	return &Client{
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		username: username,
+		password: password,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// call performs an RPC request, handling the 409 session-id handshake, and
+// decodes the response arguments into out when out is non-nil.
+func (c *Client) call(method string, args interface{}, out interface{}) error {
+	payload := map[string]interface{}{"method": method}
+	if args != nil {
+		payload["arguments"] = args
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("transmission encode request: %w", err)
+	}
+
+	resp, err := c.doOnce(body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == http.StatusConflict {
+		sid := resp.Header.Get(sessionHeader)
+		io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+		resp.Body.Close()
+		if sid == "" {
+			return fmt.Errorf("transmission: 409 response without %s header", sessionHeader)
+		}
+		c.mu.Lock()
+		c.sessionID = sid
+		c.mu.Unlock()
+		resp, err = c.doOnce(body)
+		if err != nil {
+			return err
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("transmission: invalid credentials")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("transmission returned status %d", resp.StatusCode)
+	}
+
+	var envelope struct {
+		Result    string          `json:"result"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 10<<20)).Decode(&envelope); err != nil {
+		return fmt.Errorf("transmission decode response: %w", err)
+	}
+	if envelope.Result != "success" {
+		return fmt.Errorf("transmission %s: %s", method, envelope.Result)
+	}
+	if out != nil && len(envelope.Arguments) > 0 {
+		if err := json.Unmarshal(envelope.Arguments, out); err != nil {
+			return fmt.Errorf("transmission decode arguments: %w", err)
+		}
+	}
+	return nil
+}
+
+// doOnce executes a single RPC POST with the current session id.
+func (c *Client) doOnce(body []byte) (*http.Response, error) {
+	req, err := http.NewRequest("POST", c.baseURL+"/transmission/rpc", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("transmission request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	c.mu.Lock()
+	sid := c.sessionID
+	c.mu.Unlock()
+	if sid != "" {
+		req.Header.Set(sessionHeader, sid)
+	}
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("transmission request: %w", err)
+	}
+	return resp, nil
+}
+
+// Session is the subset of session-get used here.
+type Session struct {
+	Version    string `json:"version"`
+	RPCVersion int    `json:"rpc-version"`
+}
+
+// SessionGet returns the Transmission session info; used (together with the
+// 409 handshake inside call) as the connection test.
+func (c *Client) SessionGet() (*Session, error) {
+	var session Session
+	if err := c.call("session-get", nil, &session); err != nil {
+		return nil, err
+	}
+	if session.Version == "" {
+		return nil, fmt.Errorf("transmission returned no version (wrong URL?)")
+	}
+	return &session, nil
+}
+
+// Torrent is a single torrent as returned by torrent-get.
+type Torrent struct {
+	ID            int64    `json:"id"`
+	HashString    string   `json:"hashString"`
+	Name          string   `json:"name"`
+	TotalSize     int64    `json:"totalSize"`
+	LeftUntilDone int64    `json:"leftUntilDone"`
+	PercentDone   float64  `json:"percentDone"`  // 0-1
+	RateDownload  int64    `json:"rateDownload"` // bytes/s
+	RateUpload    int64    `json:"rateUpload"`   // bytes/s
+	ETA           int64    `json:"eta"`          // seconds; negative = unknown/unavailable
+	Status        int      `json:"status"`
+	Error         int      `json:"error"` // 0 = none
+	ErrorString   string   `json:"errorString"`
+	DownloadDir   string   `json:"downloadDir"`
+	Labels        []string `json:"labels"`
+	DoneDate      int64    `json:"doneDate"` // unix seconds, 0 if not finished
+}
+
+var torrentFields = []string{
+	"id", "hashString", "name", "totalSize", "leftUntilDone", "percentDone",
+	"rateDownload", "rateUpload", "eta", "status", "error", "errorString",
+	"downloadDir", "labels", "doneDate",
+}
+
+// GetTorrents returns all torrents known to Transmission.
+func (c *Client) GetTorrents() ([]Torrent, error) {
+	var out struct {
+		Torrents []Torrent `json:"torrents"`
+	}
+	if err := c.call("torrent-get", map[string]interface{}{"fields": torrentFields}, &out); err != nil {
+		return nil, err
+	}
+	return out.Torrents, nil
+}
+
+// idsArgs builds the arguments map for an ids-based action. A nil/empty hash
+// list omits "ids", which Transmission treats as "all torrents".
+func idsArgs(hashes []string) map[string]interface{} {
+	args := map[string]interface{}{}
+	if len(hashes) > 0 {
+		args["ids"] = hashes
+	}
+	return args
+}
+
+// StopTorrents stops the given torrents by hash; nil/empty stops all.
+func (c *Client) StopTorrents(hashes []string) error {
+	return c.call("torrent-stop", idsArgs(hashes), nil)
+}
+
+// StartTorrents starts the given torrents by hash; nil/empty starts all.
+func (c *Client) StartTorrents(hashes []string) error {
+	return c.call("torrent-start", idsArgs(hashes), nil)
+}
+
+// RemoveTorrents removes the given torrents by hash, optionally deleting
+// downloaded data. An empty hash list is rejected to avoid removing everything.
+func (c *Client) RemoveTorrents(hashes []string, deleteData bool) error {
+	if len(hashes) == 0 {
+		return fmt.Errorf("transmission torrent-remove: no torrents specified")
+	}
+	args := idsArgs(hashes)
+	args["delete-local-data"] = deleteData
+	return c.call("torrent-remove", args, nil)
+}
+
+// SessionStats is the subset of session-stats used here.
+type SessionStats struct {
+	DownloadSpeed int64 `json:"downloadSpeed"` // bytes/s
+	UploadSpeed   int64 `json:"uploadSpeed"`   // bytes/s
+}
+
+// GetSessionStats returns the global transfer statistics.
+func (c *Client) GetSessionStats() (*SessionStats, error) {
+	var stats SessionStats
+	if err := c.call("session-stats", nil, &stats); err != nil {
+		return nil, err
+	}
+	return &stats, nil
+}

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -2,25 +2,35 @@ package websocket
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/downloads"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
 	"github.com/windoze95/cantinarr-server/internal/sonarr"
 )
 
 const (
-	writeWait  = 60 * time.Second
-	pongWait   = 60 * time.Second
-	pingPeriod = (pongWait * 9) / 10
-	pollPeriod = 30 * time.Second
+	writeWait           = 60 * time.Second
+	pongWait            = 60 * time.Second
+	pingPeriod          = (pongWait * 9) / 10
+	pollPeriod          = 30 * time.Second
+	downloadsPollPeriod = 15 * time.Second
 )
+
+// downloadClientTypes are the service types polled for downloads_queue events.
+var downloadClientTypes = []string{"sabnzbd", "qbittorrent", "nzbget", "transmission"}
 
 // Event represents a WebSocket event sent to clients.
 type Event struct {
@@ -52,20 +62,35 @@ type Hub struct {
 	// Previous polling state for detecting transitions
 	prevRadarrQueue map[string]map[int]float64 // instanceID -> movieId -> progress
 	prevSonarrQueue map[string]map[int]float64 // instanceID -> seriesId -> progress
+
+	// prevArrQueueHash tracks the queue composition (id/status/sizeleft
+	// tuples) per arr instance so any change can emit an invalidation ping.
+	prevArrQueueHash map[string]string // instanceID -> composition hash
+
+	// prevDownloadsHash tracks the marshaled downloads snapshot per download
+	// client instance so downloads_queue is only broadcast on change.
+	prevDownloadsHash map[string]string // instanceID -> snapshot hash
+
+	// downloadsErrLogged suppresses repeat error logs for an instance until
+	// it succeeds again (one log per failure streak).
+	downloadsErrLogged map[string]bool
 }
 
 // NewHub creates a new WebSocket hub.
 func NewHub(authService *auth.Service, registry *instance.Registry, store *instance.Store) *Hub {
 	return &Hub{
-		clients:         make(map[*Client]bool),
-		broadcast:       make(chan []byte, 256),
-		register:        make(chan *Client),
-		unregister:      make(chan *Client),
-		authService:     authService,
-		registry:        registry,
-		store:           store,
-		prevRadarrQueue: make(map[string]map[int]float64),
-		prevSonarrQueue: make(map[string]map[int]float64),
+		clients:            make(map[*Client]bool),
+		broadcast:          make(chan []byte, 256),
+		register:           make(chan *Client),
+		unregister:         make(chan *Client),
+		authService:        authService,
+		registry:           registry,
+		store:              store,
+		prevRadarrQueue:    make(map[string]map[int]float64),
+		prevSonarrQueue:    make(map[string]map[int]float64),
+		prevArrQueueHash:   make(map[string]string),
+		prevDownloadsHash:  make(map[string]string),
+		downloadsErrLogged: make(map[string]bool),
 	}
 }
 
@@ -195,18 +220,105 @@ func (c *Client) writePump() {
 }
 
 func (h *Hub) pollLoop(ctx context.Context) {
-	ticker := time.NewTicker(pollPeriod)
-	defer ticker.Stop()
+	arrTicker := time.NewTicker(pollPeriod)
+	defer arrTicker.Stop()
+	downloadsTicker := time.NewTicker(downloadsPollPeriod)
+	defer downloadsTicker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-arrTicker.C:
 			h.pollAllRadarr()
 			h.pollAllSonarr()
+		case <-downloadsTicker.C:
+			h.pollAllDownloadClients()
 		}
 	}
+}
+
+func (h *Hub) pollAllDownloadClients() {
+	if h.store == nil || h.registry == nil {
+		return
+	}
+	for _, serviceType := range downloadClientTypes {
+		instances, err := h.store.List(serviceType)
+		if err != nil {
+			continue
+		}
+		for _, inst := range instances {
+			h.pollDownloadClientInstance(inst)
+		}
+	}
+}
+
+func (h *Hub) pollDownloadClientInstance(inst instance.Instance) {
+	view, err := downloads.Snapshot(h.registry, inst)
+	if err != nil {
+		if !h.downloadsErrLogged[inst.ID] {
+			log.Printf("websocket: poll downloads queue (%s/%s): %v", inst.ServiceType, inst.ID, err)
+			h.downloadsErrLogged[inst.ID] = true
+		}
+		return
+	}
+	delete(h.downloadsErrLogged, inst.ID)
+
+	payload, err := json.Marshal(view)
+	if err != nil {
+		log.Printf("websocket: marshal downloads snapshot (%s): %v", inst.ID, err)
+		return
+	}
+	sum := sha256.Sum256(payload)
+	hash := hex.EncodeToString(sum[:])
+	if h.prevDownloadsHash[inst.ID] == hash {
+		return
+	}
+	h.prevDownloadsHash[inst.ID] = hash
+
+	// Decode the snapshot back into a map so the event carries exactly the
+	// QueueView JSON shape (paused, speed_bps, items) plus instance_id.
+	data := make(map[string]interface{})
+	if err := json.Unmarshal(payload, &data); err != nil {
+		log.Printf("websocket: decode downloads snapshot (%s): %v", inst.ID, err)
+		return
+	}
+	if data["items"] == nil {
+		data["items"] = []interface{}{}
+	}
+	data["instance_id"] = inst.ID
+
+	h.Broadcast(Event{
+		Type: "downloads_queue",
+		Data: data,
+	})
+}
+
+// queueCompositionHash builds an order-independent hash over per-item tuples
+// so any queue change (add/remove/status/progress) is detected cheaply.
+func queueCompositionHash(tuples []string) string {
+	sort.Strings(tuples)
+	sum := sha256.Sum256([]byte(strings.Join(tuples, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+// noteArrQueueComposition compares the instance's queue composition hash to
+// the previous poll and broadcasts an arr_queue_changed invalidation ping on
+// any change. The first poll only seeds the hash.
+func (h *Hub) noteArrQueueComposition(instanceID, serviceType string, tuples []string) {
+	newHash := queueCompositionHash(tuples)
+	prevHash, seen := h.prevArrQueueHash[instanceID]
+	h.prevArrQueueHash[instanceID] = newHash
+	if !seen || prevHash == newHash {
+		return
+	}
+	h.Broadcast(Event{
+		Type: "arr_queue_changed",
+		Data: map[string]interface{}{
+			"instance_id":  instanceID,
+			"service_type": serviceType,
+		},
+	})
 }
 
 func (h *Hub) pollAllRadarr() {
@@ -251,12 +363,14 @@ func (h *Hub) pollRadarrInstance(instanceID string, client *radarr.Client) {
 	}
 
 	currentQueue := make(map[int]float64)
+	tuples := make([]string, 0, len(queue))
 	for _, item := range queue {
 		var progress float64
 		if item.Size > 0 {
 			progress = (item.Size - item.Sizeleft) / item.Size
 		}
 		currentQueue[item.MovieID] = progress
+		tuples = append(tuples, fmt.Sprintf("%d|%s|%.0f", item.MovieID, item.Status, item.Sizeleft))
 
 		// Look up TMDB ID for this movie
 		movie, err := client.GetMovie(item.MovieID)
@@ -303,6 +417,7 @@ func (h *Hub) pollRadarrInstance(instanceID string, client *radarr.Client) {
 	}
 
 	h.prevRadarrQueue[instanceID] = currentQueue
+	h.noteArrQueueComposition(instanceID, "radarr", tuples)
 }
 
 func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
@@ -313,12 +428,14 @@ func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
 	}
 
 	currentQueue := make(map[int]float64)
+	tuples := make([]string, 0, len(queue))
 	for _, item := range queue {
 		var progress float64
 		if item.Size > 0 {
 			progress = (item.Size - item.Sizeleft) / item.Size
 		}
 		currentQueue[item.SeriesID] = progress
+		tuples = append(tuples, fmt.Sprintf("%d|%s|%.0f", item.SeriesID, item.Status, item.Sizeleft))
 
 		series, err := client.GetSeries(item.SeriesID)
 		if err != nil {
@@ -366,4 +483,5 @@ func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
 	}
 
 	h.prevSonarrQueue[instanceID] = currentQueue
+	h.noteArrQueueComposition(instanceID, "sonarr", tuples)
 }

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -40,17 +40,18 @@ type Event struct {
 
 // Client represents a connected WebSocket client.
 type Client struct {
-	hub    *Hub
-	conn   *websocket.Conn
-	userID int64
-	send   chan []byte
+	hub     *Hub
+	conn    *websocket.Conn
+	userID  int64
+	isAdmin bool
+	send    chan []byte
 }
 
 // Hub manages WebSocket clients and broadcasts events.
 type Hub struct {
 	upgrader   websocket.Upgrader
 	clients    map[*Client]bool
-	broadcast  chan []byte
+	broadcast  chan outboundMessage
 	register   chan *Client
 	unregister chan *Client
 	mu         sync.RWMutex
@@ -74,13 +75,17 @@ type Hub struct {
 	// downloadsErrLogged suppresses repeat error logs for an instance until
 	// it succeeds again (one log per failure streak).
 	downloadsErrLogged map[string]bool
+
+	// pollMu guards prevDownloadsHash and downloadsErrLogged, which are
+	// written from concurrent per-instance poll goroutines.
+	pollMu sync.Mutex
 }
 
 // NewHub creates a new WebSocket hub.
 func NewHub(authService *auth.Service, registry *instance.Registry, store *instance.Store) *Hub {
 	return &Hub{
 		clients:            make(map[*Client]bool),
-		broadcast:          make(chan []byte, 256),
+		broadcast:          make(chan outboundMessage, 256),
 		register:           make(chan *Client),
 		unregister:         make(chan *Client),
 		authService:        authService,
@@ -116,8 +121,11 @@ func (h *Hub) Run(ctx context.Context) {
 		case msg := <-h.broadcast:
 			h.mu.RLock()
 			for client := range h.clients {
+				if msg.adminOnly && !client.isAdmin {
+					continue
+				}
 				select {
-				case client.send <- msg:
+				case client.send <- msg.data:
 				default:
 					close(client.send)
 					delete(h.clients, client)
@@ -128,14 +136,31 @@ func (h *Hub) Run(ctx context.Context) {
 	}
 }
 
+// outboundMessage pairs a marshaled event with its audience.
+type outboundMessage struct {
+	data      []byte
+	adminOnly bool
+}
+
 // Broadcast sends an event to all connected clients.
 func (h *Hub) Broadcast(event Event) {
+	h.enqueue(event, false)
+}
+
+// BroadcastAdmin sends an event only to clients authenticated as admins.
+// Used for payloads whose REST equivalents sit behind the admin middleware
+// (e.g. download-client queue contents).
+func (h *Hub) BroadcastAdmin(event Event) {
+	h.enqueue(event, true)
+}
+
+func (h *Hub) enqueue(event Event, adminOnly bool) {
 	data, err := json.Marshal(event)
 	if err != nil {
 		log.Printf("websocket: marshal event: %v", err)
 		return
 	}
-	h.broadcast <- data
+	h.broadcast <- outboundMessage{data: data, adminOnly: adminOnly}
 }
 
 // ServeWS handles WebSocket upgrade with JWT auth via subprotocol.
@@ -164,10 +189,11 @@ func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	client := &Client{
-		hub:    h,
-		conn:   conn,
-		userID: claims.UserID,
-		send:   make(chan []byte, 256),
+		hub:     h,
+		conn:    conn,
+		userID:  claims.UserID,
+		isAdmin: claims.Role == "admin",
+		send:    make(chan []byte, 256),
 	}
 	h.register <- client
 
@@ -242,27 +268,40 @@ func (h *Hub) pollAllDownloadClients() {
 	if h.store == nil || h.registry == nil {
 		return
 	}
+	// Poll instances concurrently: a hung backend (30s client timeout, two
+	// calls per snapshot) would otherwise stall the shared poll goroutine
+	// and starve every other instance's events for minutes.
+	var wg sync.WaitGroup
 	for _, serviceType := range downloadClientTypes {
 		instances, err := h.store.List(serviceType)
 		if err != nil {
 			continue
 		}
 		for _, inst := range instances {
-			h.pollDownloadClientInstance(inst)
+			wg.Add(1)
+			go func(inst instance.Instance) {
+				defer wg.Done()
+				h.pollDownloadClientInstance(inst)
+			}(inst)
 		}
 	}
+	wg.Wait()
 }
 
 func (h *Hub) pollDownloadClientInstance(inst instance.Instance) {
 	view, err := downloads.Snapshot(h.registry, inst)
 	if err != nil {
+		h.pollMu.Lock()
 		if !h.downloadsErrLogged[inst.ID] {
 			log.Printf("websocket: poll downloads queue (%s/%s): %v", inst.ServiceType, inst.ID, err)
 			h.downloadsErrLogged[inst.ID] = true
 		}
+		h.pollMu.Unlock()
 		return
 	}
+	h.pollMu.Lock()
 	delete(h.downloadsErrLogged, inst.ID)
+	h.pollMu.Unlock()
 
 	payload, err := json.Marshal(view)
 	if err != nil {
@@ -271,10 +310,15 @@ func (h *Hub) pollDownloadClientInstance(inst instance.Instance) {
 	}
 	sum := sha256.Sum256(payload)
 	hash := hex.EncodeToString(sum[:])
-	if h.prevDownloadsHash[inst.ID] == hash {
+	h.pollMu.Lock()
+	unchanged := h.prevDownloadsHash[inst.ID] == hash
+	if !unchanged {
+		h.prevDownloadsHash[inst.ID] = hash
+	}
+	h.pollMu.Unlock()
+	if unchanged {
 		return
 	}
-	h.prevDownloadsHash[inst.ID] = hash
 
 	// Decode the snapshot back into a map so the event carries exactly the
 	// QueueView JSON shape (paused, speed_bps, items) plus instance_id.
@@ -288,7 +332,7 @@ func (h *Hub) pollDownloadClientInstance(inst instance.Instance) {
 	}
 	data["instance_id"] = inst.ID
 
-	h.Broadcast(Event{
+	h.BroadcastAdmin(Event{
 		Type: "downloads_queue",
 		Data: data,
 	})


### PR DESCRIPTION
## Why

Addresses every caveat logged in #47: plaintext credentials, the unconsumed WebSocket client, tool-output caps, the missing Tautulli/NZBGet/Transmission modules, and wanted/missing screens.

## Secrets at rest

Instance API keys/passwords, external credentials (TMDB/Anthropic/Trakt), and the JWT secret are now AES-256-GCM encrypted in SQLite (`enc:v1:` prefix). Key resolution: `CANTINARR_ENCRYPTION_KEY` env (base64, 32 bytes) > auto-generated `/config/encryption.key` (0600, O_EXCL, fsynced). Legacy plaintext passes through reads and a startup migration encrypts existing rows in place. Hardening from review: a key that can't decrypt existing data **fails startup with a clear message** (encrypted canary) instead of booting "healthy" with dead credentials; an unreadable key file is fatal rather than silently regenerated; undecryptable instance rows degrade to blanked credentials in listings so the admin UI stays usable for recovery. **Back up `/config/encryption.key` with the database** — docs updated.

## Realtime (WebSocket finally consumed)

- Server: `downloads_queue` snapshots (15s poll, broadcast only on change, **admin-only** — role captured at socket upgrade to match the REST gate) and `arr_queue_changed` invalidation pings; per-instance polls run concurrently so one hung backend can't starve events.
- App: new realtime provider wires up the previously dead WebSocket client (fixing three latent bugs in it: eager connect, stale token on reconnect, optimistic connected state, plus a backoff overflow that permanently killed reconnection after ~8.5h). Downloads queue applies push snapshots with no REST roundtrip; arr queue screens refetch on pings (debounced). Polling stays as a 30/45s fallback so everything still works against an old server or a dropped socket.

## New integrations

- **NZBGet** (JSON-RPC) and **Transmission** (RPC w/ 409 session handshake) serve the same unified `/api/downloads` contract — the existing Downloads module picks them up with zero new screens. Pause/resume-all on Transmission is scoped to queue-visible torrents (won't stop seeding or resume deliberately-stopped completed torrents).
- **Tautulli module**: live Plex activity (streams, transcode badges, bandwidth), watch history, top movies/shows/users stats. Admin-only `/api/tautulli/{id}` API.
- Instance editor handles 7 service types (switched to a dropdown), per-type validation server-side.

## Arr parity

- **Wanted tab** (Missing | Cutoff Unmet) on Radarr and Sonarr: paginated, with automatic + interactive search per row (sortKeys verified against current arr sources, with safe fallbacks for older servers).
- Arr queue fetching paginates to a 1000-item cap; `get_queue` tool output renders top 30 with an overflow note.

## Verification

- `go build`/`vet`/`test` and `flutter analyze`/`build web --release` clean.
- Whole-branch adversarial review (5 dimensions, 68 agents, 3-skeptic panels): 18 confirmed findings, **all fixed** — including two genuine data-loss hazards in the encryption key handling, an authz leak broadcasting admin queue data to all users, and API keys leaking through Go transport-error strings into error responses.

## Notes

- Known WS gap (by design): after a reconnect, a snapshot that changed while disconnected arrives via the 30s fallback poll rather than instantly.
- Per-request quality-profile/root-folder selection and chat persistence/markdown/cancel remain on the backlog — happy to take those as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)