### PR TITLE
Update TestFlight workflow to Xcode 26

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: macos-15
+    runs-on: macos-26
 
     defaults:
       run:
@@ -35,10 +35,10 @@ jobs:
           gem install fastlane
           APP_VERSION=$VERSION fastlane next_build_number
 
-      - name: Setup Xcode 16
+      - name: Setup Xcode 26
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16"
+          xcode-version: latest-stable
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2


### PR DESCRIPTION
## Summary
- move TestFlight CI from macOS 15 to macOS 26
- select latest stable Xcode 26 instead of Xcode 16
- satisfy Apple’s iOS/iPadOS 26 SDK upload requirement effective April 28, 2026

## Validation
- parsed .github/workflows/testflight.yml with Ruby YAML loader