### PR TITLE
Add multi-provider AI model options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Cantinarr makes it dead simple for your family and friends to discover and reque
 │  Cantinarr Server (Go, single container, port 8585)     │
 │                                                         │
 │  ┌──────────┐  ┌──────────┐  ┌───────────────────────┐  │
-│  │ Auth/JWT │  │ Request  │  │ AI Chat (Claude)      │  │
+│  │ Auth/JWT │  │ Request  │  │ AI Chat               │  │
 │  │          │  │ Service  │  │ + 19 MCP Tools        │  │
 │  └──────────┘  └────┬─────┘  └───────────────────────┘  │
 │                     │                                    │
@@ -43,7 +43,7 @@ Cantinarr makes it dead simple for your family and friends to discover and reque
 - **Zero-config requesting** -- Your users never see API keys, TVDB IDs, or quality profiles. They browse, they tap, it works.
 - **TMDB + Trakt for discovery** -- The best metadata, images, and trending data. Sonarr's TVDB dependency is invisible.
 - **Automatic ID bridging** -- TMDB-to-TVDB translation with Trakt fallback. The #1 source of failed Sonarr adds, solved.
-- **AI assistant** -- "What should I watch tonight?" Claude searches your library, checks availability, and can request for you. Admins can also manage the server conversationally: check the queue, kick off searches, grab a specific release from the indexers, or clean up failed downloads.
+- **AI assistant** -- "What should I watch tonight?" Bring Anthropic, OpenAI, or Gemini; the assistant searches your library, checks availability, and can request for you. Admins can also manage the server conversationally: check the queue, kick off searches, grab a specific release from the indexers, or clean up failed downloads.
 - **MCP server** -- The same 19 AI tools are exposed as a [Model Context Protocol](https://modelcontextprotocol.io/) endpoint at `/mcp`, so Claude Desktop and other MCP clients can connect directly. Every tool can be toggled on/off per server from Settings > AI Tools.
 - **Download clients** -- SABnzbd, qBittorrent, NZBGet, and Transmission modules with live queue management (pause, resume, remove, speeds, real-time push updates) alongside full Radarr/Sonarr control: queue actions, history, wanted/missing, calendar, and interactive release search.
 - **Tautulli** -- watch what's playing on Plex right now: active streams with quality/transcode badges, watch history, and top movies/shows/users stats.
@@ -81,7 +81,7 @@ cantinarr/
 ├── server/                 # Go backend
 │   ├── cmd/server/         # Entry point
 │   ├── internal/
-│   │   ├── ai/             # Claude AI chat with SSE streaming
+│   │   ├── ai/             # Multi-provider AI chat with SSE streaming
 │   │   ├── api/            # Chi router, middleware, routes
 │   │   ├── auth/           # JWT, bcrypt, connect tokens
 │   │   ├── config/         # Server configuration (port, name)
@@ -129,7 +129,7 @@ All service credentials are managed through the admin UI -- no environment varia
 | Radarr/Sonarr instances | Admin UI | Add via Settings > Add Instance |
 | SABnzbd/qBittorrent/NZBGet/Transmission instances | Admin UI | Download client modules (queue, history, speeds) |
 | Tautulli instance | Admin UI | Plex activity, watch history, stats |
-| Anthropic API key | Admin UI | Enables AI assistant |
+| Anthropic/OpenAI/Gemini API key | Admin UI | Enables AI assistant for the selected provider |
 | Trakt client ID | Admin UI | Enhances discovery + fallback ID bridging |
 
 Optional server env vars for deployment tuning:
@@ -139,7 +139,8 @@ Optional server env vars for deployment tuning:
 | `CANTINARR_PORT` | `8585` | HTTP listen port |
 | `CANTINARR_SERVER_NAME` | `Cantinarr` | Display name shown in clients |
 | `CANTINARR_JWT_SECRET` | auto-generated | HMAC secret for JWT signing |
-| `CANTINARR_AI_MODEL` | `claude-opus-4-8` | Claude model used by the AI assistant |
+| `CANTINARR_AI_PROVIDER` | `anthropic` | AI provider used by the assistant (`anthropic`, `openai`, or `gemini`) |
+| `CANTINARR_AI_MODEL` | provider default | Model used by the AI assistant when no admin UI model is saved |
 | `CANTINARR_ENCRYPTION_KEY` | auto-generated key file | Base64 32-byte key for secrets-at-rest (default: `/config/encryption.key`) |
 
 ## How It Works
@@ -184,7 +185,7 @@ Movies don't need bridging -- Radarr natively supports TMDB IDs.
 | Server | Go, Chi router, SQLite (pure Go) |
 | Client | Flutter (Dart), Riverpod, GoRouter |
 | Auth | JWT (HS256), bcrypt, connect tokens |
-| AI | Anthropic Claude API, SSE streaming |
+| AI | Anthropic, OpenAI, or Gemini APIs with SSE app streaming |
 | MCP | [mcp-go](https://github.com/mark3labs/mcp-go), Streamable HTTP |
 | Real-time | gorilla/websocket |
 | Discovery | TMDB API v3, Trakt API v2 |

--- a/app/lib/features/settings/data/credentials_service.dart
+++ b/app/lib/features/settings/data/credentials_service.dart
@@ -1,5 +1,112 @@
 import 'package:dio/dio.dart';
 
+class CredentialsStatus {
+  final Map<String, bool> credentials;
+  final AiCredentialConfig ai;
+
+  const CredentialsStatus({
+    required this.credentials,
+    required this.ai,
+  });
+
+  factory CredentialsStatus.fromJson(Map<String, dynamic> json) {
+    final rawCredentials = json['credentials'] as Map<String, dynamic>?;
+    final credentials = rawCredentials != null
+        ? rawCredentials.map((k, v) => MapEntry(k, v as bool? ?? false))
+        : json.map((k, v) => MapEntry(k, v is bool ? v : false));
+
+    return CredentialsStatus(
+      credentials: credentials,
+      ai: AiCredentialConfig.fromJson(
+        json['ai'] as Map<String, dynamic>? ?? const {},
+      ),
+    );
+  }
+
+  bool isConfigured(String key) => credentials[key] ?? false;
+}
+
+class AiCredentialConfig {
+  final String provider;
+  final String model;
+  final List<AiProviderOption> providers;
+
+  const AiCredentialConfig({
+    required this.provider,
+    required this.model,
+    required this.providers,
+  });
+
+  factory AiCredentialConfig.fromJson(Map<String, dynamic> json) {
+    final config = json['config'] as Map<String, dynamic>? ?? const {};
+    final providersJson = json['providers'] as List? ?? const [];
+    final providers = providersJson
+        .map((e) => AiProviderOption.fromJson(e as Map<String, dynamic>))
+        .toList();
+    final defaultProvider =
+        providers.isNotEmpty ? providers.first.id : 'anthropic';
+    final selectedProvider = config['provider'] as String? ?? defaultProvider;
+    AiProviderOption? selected;
+    for (final provider in providers) {
+      if (provider.id == selectedProvider) {
+        selected = provider;
+        break;
+      }
+    }
+
+    return AiCredentialConfig(
+      provider: selectedProvider,
+      model: config['model'] as String? ??
+          (selected?.models.isNotEmpty == true
+              ? selected!.models.first.id
+              : 'claude-opus-4-8'),
+      providers: providers,
+    );
+  }
+}
+
+class AiProviderOption {
+  final String id;
+  final String label;
+  final String credentialKey;
+  final List<AiModelOption> models;
+
+  const AiProviderOption({
+    required this.id,
+    required this.label,
+    required this.credentialKey,
+    required this.models,
+  });
+
+  factory AiProviderOption.fromJson(Map<String, dynamic> json) =>
+      AiProviderOption(
+        id: json['id'] as String,
+        label: json['label'] as String? ?? json['id'] as String,
+        credentialKey: json['credential_key'] as String,
+        models: ((json['models'] as List?) ?? const [])
+            .map((e) => AiModelOption.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+}
+
+class AiModelOption {
+  final String id;
+  final String label;
+  final String description;
+
+  const AiModelOption({
+    required this.id,
+    required this.label,
+    required this.description,
+  });
+
+  factory AiModelOption.fromJson(Map<String, dynamic> json) => AiModelOption(
+        id: json['id'] as String,
+        label: json['label'] as String? ?? json['id'] as String,
+        description: json['description'] as String? ?? '',
+      );
+}
+
 /// API service for admin credential management (write-only).
 class CredentialsService {
   final Dio _dio;
@@ -7,11 +114,9 @@ class CredentialsService {
   CredentialsService({required Dio backendDio}) : _dio = backendDio;
 
   /// Returns which credentials are configured (booleans, never values).
-  Future<Map<String, bool>> getStatus() async {
+  Future<CredentialsStatus> getStatus() async {
     final resp = await _dio.get('/api/admin/credentials');
-    return (resp.data as Map<String, dynamic>).map(
-      (k, v) => MapEntry(k, v as bool),
-    );
+    return CredentialsStatus.fromJson(resp.data as Map<String, dynamic>);
   }
 
   /// Updates one or more credentials. Only non-empty values are written.

--- a/app/lib/features/settings/ui/credentials_screen.dart
+++ b/app/lib/features/settings/ui/credentials_screen.dart
@@ -15,13 +15,20 @@ class CredentialsScreen extends ConsumerStatefulWidget {
 
 class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
   late final CredentialsService _service;
-  Map<String, bool>? _status;
+  CredentialsStatus? _status;
   bool _isLoading = true;
   String? _error;
 
+  static const _customModelValue = '__custom__';
+
   final _tmdbController = TextEditingController();
   final _anthropicController = TextEditingController();
+  final _openAIController = TextEditingController();
+  final _geminiController = TextEditingController();
   final _traktIdController = TextEditingController();
+  final _customModelController = TextEditingController();
+  String _selectedProvider = 'anthropic';
+  String _selectedModel = 'claude-opus-4-8';
   bool _isSaving = false;
 
   @override
@@ -44,6 +51,7 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
       final status = await _service.getStatus();
       setState(() {
         _status = status;
+        _syncAISelection(status);
         _isLoading = false;
       });
     } catch (e) {
@@ -62,8 +70,30 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
     if (_anthropicController.text.isNotEmpty) {
       creds['anthropic_key'] = _anthropicController.text.trim();
     }
+    if (_openAIController.text.isNotEmpty) {
+      creds['openai_key'] = _openAIController.text.trim();
+    }
+    if (_geminiController.text.isNotEmpty) {
+      creds['gemini_key'] = _geminiController.text.trim();
+    }
     if (_traktIdController.text.isNotEmpty) {
       creds['trakt_client_id'] = _traktIdController.text.trim();
+    }
+
+    final selectedModel = _selectedModel == _customModelValue
+        ? _customModelController.text.trim()
+        : _selectedModel;
+    if (_selectedModel == _customModelValue && selectedModel.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Enter a custom model ID')),
+      );
+      return;
+    }
+    if (_status == null ||
+        _selectedProvider != _status!.ai.provider ||
+        selectedModel != _status!.ai.model) {
+      creds['ai_provider'] = _selectedProvider;
+      creds['ai_model'] = selectedModel;
     }
 
     if (creds.isEmpty) {
@@ -78,6 +108,8 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
       await _service.update(creds);
       _tmdbController.clear();
       _anthropicController.clear();
+      _openAIController.clear();
+      _geminiController.clear();
       _traktIdController.clear();
       await _loadStatus();
       // Refresh config so service availability updates app-wide
@@ -111,8 +143,8 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
           ),
           TextButton(
             onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Remove',
-                style: TextStyle(color: AppTheme.error)),
+            child:
+                const Text('Remove', style: TextStyle(color: AppTheme.error)),
           ),
         ],
       ),
@@ -141,8 +173,47 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
   void dispose() {
     _tmdbController.dispose();
     _anthropicController.dispose();
+    _openAIController.dispose();
+    _geminiController.dispose();
     _traktIdController.dispose();
+    _customModelController.dispose();
     super.dispose();
+  }
+
+  void _syncAISelection(CredentialsStatus status) {
+    _selectedProvider = status.ai.provider;
+    final provider = _providerFor(_selectedProvider, status.ai.providers);
+    final hasModel =
+        provider?.models.any((model) => model.id == status.ai.model) ?? false;
+    if (hasModel) {
+      _selectedModel = status.ai.model;
+      _customModelController.clear();
+    } else {
+      _selectedModel = _customModelValue;
+      _customModelController.text = status.ai.model;
+    }
+  }
+
+  AiProviderOption? _providerFor(
+    String id,
+    List<AiProviderOption> providers,
+  ) {
+    for (final provider in providers) {
+      if (provider.id == id) return provider;
+    }
+    return providers.isNotEmpty ? providers.first : null;
+  }
+
+  void _selectProvider(String providerId) {
+    final provider =
+        _providerFor(providerId, _status?.ai.providers ?? const []);
+    setState(() {
+      _selectedProvider = provider?.id ?? providerId;
+      _selectedModel = provider?.models.isNotEmpty == true
+          ? provider!.models.first.id
+          : _customModelValue;
+      _customModelController.clear();
+    });
   }
 
   @override
@@ -174,37 +245,78 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
                           color: AppTheme.textSecondary, fontSize: 13),
                     ),
                     const SizedBox(height: 24),
+                    _AISelectionSection(
+                      providers: _status?.ai.providers ?? const [],
+                      selectedProvider: _selectedProvider,
+                      selectedModel: _selectedModel,
+                      customModelValue: _customModelValue,
+                      customModelController: _customModelController,
+                      isSelectedProviderConfigured: _status?.isConfigured(
+                            _providerFor(
+                                  _selectedProvider,
+                                  _status?.ai.providers ?? const [],
+                                )?.credentialKey ??
+                                'anthropic_key',
+                          ) ??
+                          false,
+                      onProviderChanged: _selectProvider,
+                      onModelChanged: (value) =>
+                          setState(() => _selectedModel = value),
+                    ),
+                    const SizedBox(height: 24),
                     _CredentialSection(
                       title: 'TMDB',
                       description: 'Required for media discovery and search',
                       isConfigured:
-                          _status?['tmdb_access_token'] ?? false,
+                          _status?.isConfigured('tmdb_access_token') ?? false,
                       controller: _tmdbController,
                       hint: 'TMDB access token',
-                      onDelete: () => _deleteCredential(
-                          'tmdb_access_token', 'TMDB'),
+                      onDelete: () =>
+                          _deleteCredential('tmdb_access_token', 'TMDB'),
                     ),
                     const SizedBox(height: 20),
                     _CredentialSection(
                       title: 'Anthropic (AI)',
-                      description: 'Enables the AI assistant',
+                      description: 'Claude model provider',
                       isConfigured:
-                          _status?['anthropic_key'] ?? false,
+                          _status?.isConfigured('anthropic_key') ?? false,
                       controller: _anthropicController,
                       hint: 'Anthropic API key',
-                      onDelete: () => _deleteCredential(
-                          'anthropic_key', 'Anthropic'),
+                      onDelete: () =>
+                          _deleteCredential('anthropic_key', 'Anthropic'),
+                    ),
+                    const SizedBox(height: 20),
+                    _CredentialSection(
+                      title: 'OpenAI (AI)',
+                      description: 'GPT model provider',
+                      isConfigured:
+                          _status?.isConfigured('openai_key') ?? false,
+                      controller: _openAIController,
+                      hint: 'OpenAI API key',
+                      onDelete: () => _deleteCredential('openai_key', 'OpenAI'),
+                    ),
+                    const SizedBox(height: 20),
+                    _CredentialSection(
+                      title: 'Google Gemini (AI)',
+                      description: 'Gemini model provider',
+                      isConfigured:
+                          _status?.isConfigured('gemini_key') ?? false,
+                      controller: _geminiController,
+                      hint: 'Gemini API key',
+                      onDelete: () =>
+                          _deleteCredential('gemini_key', 'Google Gemini'),
                     ),
                     const SizedBox(height: 20),
                     _CredentialSection(
                       title: 'Trakt',
-                      description: 'Enhances discovery with trending and popular lists',
+                      description:
+                          'Enhances discovery with trending and popular lists',
                       isConfigured:
-                          _status?['trakt_client_id'] ?? false,
+                          _status?.isConfigured('trakt_client_id') ?? false,
                       controller: _traktIdController,
                       hint: 'Trakt client ID',
-                      onDelete: () => _deleteCredential(
-                          'trakt_client_id', 'Trakt'),
+                      onDelete: () =>
+                          _deleteCredential('trakt_client_id', 'Trakt'),
                     ),
                     const SizedBox(height: 32),
                     SizedBox(
@@ -215,8 +327,8 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
                             ? const SizedBox(
                                 width: 20,
                                 height: 20,
-                                child: CircularProgressIndicator(
-                                    strokeWidth: 2),
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
                               )
                             : const Text('Save'),
                       ),
@@ -224,6 +336,148 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
                   ],
                 ),
     );
+  }
+}
+
+class _AISelectionSection extends StatelessWidget {
+  final List<AiProviderOption> providers;
+  final String selectedProvider;
+  final String selectedModel;
+  final String customModelValue;
+  final TextEditingController customModelController;
+  final bool isSelectedProviderConfigured;
+  final ValueChanged<String> onProviderChanged;
+  final ValueChanged<String> onModelChanged;
+
+  const _AISelectionSection({
+    required this.providers,
+    required this.selectedProvider,
+    required this.selectedModel,
+    required this.customModelValue,
+    required this.customModelController,
+    required this.isSelectedProviderConfigured,
+    required this.onProviderChanged,
+    required this.onModelChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (providers.isEmpty) {
+      return const Text(
+        'AI model options are unavailable from this server.',
+        style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+      );
+    }
+
+    final provider = _currentProvider;
+    final models = provider?.models ?? const <AiModelOption>[];
+    final providerValue = provider?.id ?? selectedProvider;
+    final modelIds = models.map((model) => model.id).toSet();
+    final modelValue =
+        modelIds.contains(selectedModel) ? selectedModel : customModelValue;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Expanded(
+              child: Text(
+                'AI Model',
+                style: TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+              decoration: BoxDecoration(
+                color: isSelectedProviderConfigured
+                    ? AppTheme.available.withValues(alpha: 0.15)
+                    : AppTheme.unavailable.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Text(
+                isSelectedProviderConfigured ? 'Key set' : 'Key missing',
+                style: TextStyle(
+                  color: isSelectedProviderConfigured
+                      ? AppTheme.available
+                      : AppTheme.unavailable,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 4),
+        const Text(
+          'Select which provider and model the assistant should use.',
+          style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        ),
+        const SizedBox(height: 12),
+        DropdownButtonFormField<String>(
+          key: ValueKey('ai-provider-$providerValue'),
+          initialValue: providerValue,
+          isExpanded: true,
+          decoration: const InputDecoration(
+            labelText: 'Provider',
+            isDense: true,
+          ),
+          items: providers
+              .map((provider) => DropdownMenuItem(
+                    value: provider.id,
+                    child: Text(provider.label),
+                  ))
+              .toList(),
+          onChanged: (value) {
+            if (value != null) onProviderChanged(value);
+          },
+        ),
+        const SizedBox(height: 12),
+        DropdownButtonFormField<String>(
+          key: ValueKey('ai-model-$providerValue-$modelValue'),
+          initialValue: modelValue,
+          isExpanded: true,
+          decoration: const InputDecoration(
+            labelText: 'Model',
+            isDense: true,
+          ),
+          items: [
+            ...models.map((model) => DropdownMenuItem(
+                  value: model.id,
+                  child: Text(model.label),
+                )),
+            DropdownMenuItem(
+              value: customModelValue,
+              child: const Text('Custom model ID'),
+            ),
+          ],
+          onChanged: (value) {
+            if (value != null) onModelChanged(value);
+          },
+        ),
+        if (modelValue == customModelValue) ...[
+          const SizedBox(height: 12),
+          TextField(
+            controller: customModelController,
+            decoration: const InputDecoration(
+              hintText: 'Provider model ID',
+              isDense: true,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  AiProviderOption? get _currentProvider {
+    for (final provider in providers) {
+      if (provider.id == selectedProvider) return provider;
+    }
+    return providers.isNotEmpty ? providers.first : null;
   }
 }
 
@@ -262,8 +516,7 @@ class _CredentialSection extends StatelessWidget {
               ),
             ),
             Container(
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
               decoration: BoxDecoration(
                 color: isConfigured
                     ? AppTheme.available.withValues(alpha: 0.15)
@@ -273,9 +526,8 @@ class _CredentialSection extends StatelessWidget {
               child: Text(
                 isConfigured ? 'Configured' : 'Not set',
                 style: TextStyle(
-                  color: isConfigured
-                      ? AppTheme.available
-                      : AppTheme.unavailable,
+                  color:
+                      isConfigured ? AppTheme.available : AppTheme.unavailable,
                   fontSize: 12,
                   fontWeight: FontWeight.w500,
                 ),
@@ -293,8 +545,8 @@ class _CredentialSection extends StatelessWidget {
         ),
         const SizedBox(height: 4),
         Text(description,
-            style: const TextStyle(
-                color: AppTheme.textSecondary, fontSize: 13)),
+            style:
+                const TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
         const SizedBox(height: 8),
         TextField(
           controller: controller,

--- a/app/lib/features/setup_wizard/ui/setup_wizard_screen.dart
+++ b/app/lib/features/setup_wizard/ui/setup_wizard_screen.dart
@@ -45,9 +45,9 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
       title: 'AI Assistant (Optional)',
       icon: Icons.smart_toy_outlined,
       description:
-          'Add an Anthropic API key to unlock the AI assistant. It can help you discover content, get personalized recommendations, and guide you through setup.',
+          'Add an Anthropic, OpenAI, or Gemini API key to unlock the AI assistant. It can help you discover content, get personalized recommendations, and guide you through setup.',
       hasTextField: true,
-      textFieldHint: 'Anthropic API Key (optional)',
+      textFieldHint: 'AI provider API key (optional)',
     ),
     _SetupStep(
       title: 'You\'re All Set!',
@@ -134,7 +134,9 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
                     Text(
                       step.description,
                       style: const TextStyle(
-                          color: AppTheme.textSecondary, fontSize: 16, height: 1.5),
+                          color: AppTheme.textSecondary,
+                          fontSize: 16,
+                          height: 1.5),
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 32),
@@ -187,8 +189,7 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
                   if (!isFirst)
                     Expanded(
                       child: OutlinedButton(
-                        onPressed: () =>
-                            setState(() => _currentStep--),
+                        onPressed: () => setState(() => _currentStep--),
                         style: OutlinedButton.styleFrom(
                           foregroundColor: AppTheme.textPrimary,
                           side: const BorderSide(color: AppTheme.border),

--- a/server/README.md
+++ b/server/README.md
@@ -8,7 +8,7 @@ A single Go binary that bridges your arr stack, serves the web UI, and keeps API
                         Cantinarr Server (:8585)
     ┌──────────────────────────────────────────────────┐
     │                                                  │
-    │   Auth (JWT)    Requests    AI Chat (Claude)     │
+    │   Auth (JWT)    Requests    AI Chat              │
     │       │             │             │              │
     │       │      ┌──────┴──────┐      │              │
     │       │      │    ID       │      │              │
@@ -16,7 +16,7 @@ A single Go binary that bridges your arr stack, serves the web UI, and keeps API
     │       │      │             │      │              │
     │       │      └──┬─────┬───┘      │              │
     │       │         │     │          │              │
-    │       │    Radarr   Sonarr    Anthropic         │
+    │       │    Radarr   Sonarr    AI Providers      │
     │       │         │     │       API               │
     │   Flutter Web (embedded)     WebSocket Hub      │
     └──────────────────────────────────────────────────┘
@@ -27,7 +27,7 @@ A single Go binary that bridges your arr stack, serves the web UI, and keeps API
 - **One-tap requests** -- Users browse TMDB/Trakt on the app, tap request, and the server handles everything: ID bridging, arr lookups, quality profiles, root folders.
 - **Automatic ID bridging** -- Transparently translates TMDB IDs to TVDB IDs for Sonarr. Falls back to Trakt cross-references, then title+year search. Results cached in SQLite for 30 days.
 - **Connect link auth** -- Admin generates one-time connect links for household members. JWT-based sessions with 15-minute access / 30-day refresh tokens.
-- **AI assistant** -- Claude-powered chat with server-side tool execution (search, recommendations, request status, make requests). Streams responses via SSE.
+- **AI assistant** -- Anthropic, OpenAI, or Gemini-powered chat with server-side tool execution (search, recommendations, request status, make requests). Streams responses via SSE.
 - **Real-time updates** -- WebSocket hub polls arr queues every 30 seconds and pushes download progress to connected clients.
 - **Arr proxy** -- Admins get full passthrough to Radarr/Sonarr APIs for management without exposing keys.
 - **Flutter web embed** -- The Flutter web build is embedded in the binary via `go:embed`. One container, one port, serves both API and UI.
@@ -65,7 +65,7 @@ go build -o cantinarr ./cmd/server
 
 ## Configuration
 
-Service credentials (TMDB, Anthropic, Trakt) and Radarr/Sonarr instances are managed through the admin UI at **Settings > API Credentials** and **Settings > Add Instance**. No environment variables needed for API keys.
+Service credentials (TMDB, Anthropic/OpenAI/Gemini, Trakt) and Radarr/Sonarr instances are managed through the admin UI at **Settings > API Credentials** and **Settings > Add Instance**. No environment variables needed for API keys.
 
 Optional env vars for deployment tuning:
 
@@ -106,7 +106,7 @@ GET    /api/requests            # request history for current user
 
 ### AI Chat
 ```
-POST   /api/ai/chat             # SSE-streamed Claude conversation with tool use
+POST   /api/ai/chat             # SSE-streamed AI conversation with tool use
 GET    /api/ai/available        # { available: true/false }
 ```
 The chat request accepts an optional `conversation_id`; when supplied, the server
@@ -260,7 +260,8 @@ server/
 ├── internal/
 │   ├── ai/
 │   │   ├── handler.go              # SSE streaming chat endpoint
-│   │   └── service.go              # Anthropic API client + tool loop
+│   │   ├── service.go              # Anthropic API client + tool loop
+│   │   └── http_providers.go       # OpenAI/Gemini API clients + tool loops
 │   ├── api/router.go               # Chi router, CORS, middleware, routes
 │   ├── auth/
 │   │   ├── handler.go              # Login, refresh, connect token
@@ -305,7 +306,7 @@ server/
 - **SQLite** via [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite) (pure Go, no CGO)
 - **JWT** via [golang-jwt](https://github.com/golang-jwt/jwt)
 - **WebSocket** via [gorilla/websocket](https://github.com/gorilla/websocket)
-- **Anthropic Messages API** (raw HTTP, no SDK)
+- **Anthropic Messages API** (SDK), **OpenAI Chat Completions API**, and **Gemini generateContent API**
 
 ## License
 

--- a/server/internal/ai/handler.go
+++ b/server/internal/ai/handler.go
@@ -36,12 +36,12 @@ type chatRequest struct {
 
 // Chat handles POST /api/ai/chat with SSE streaming.
 func (h *Handler) Chat(w http.ResponseWriter, r *http.Request) {
-	apiKey := h.creds.GetCredential(credentials.KeyAnthropicKey)
+	aiConfig := h.creds.GetAIConfig()
+	apiKey := h.creds.GetCredential(credentials.AIKeyCredentialKey(aiConfig.Provider))
 	if apiKey == "" {
 		http.Error(w, `{"error":"AI is not configured"}`, http.StatusServiceUnavailable)
 		return
 	}
-	service := NewService(apiKey, h.toolServer)
 
 	claims := auth.GetClaims(r.Context())
 	if claims == nil {
@@ -149,15 +149,32 @@ func (h *Handler) Chat(w http.ResponseWriter, r *http.Request) {
 
 	emit(map[string]string{"conversation_id": convID})
 
-	finalHistory, err := service.SendMessage(r.Context(), history, chatCtx, callbacks)
+	var err error
+	switch aiConfig.Provider {
+	case credentials.AIProviderAnthropic:
+		service := NewService(apiKey, aiConfig.Model, h.toolServer)
+		var finalHistory []anthropic.MessageParam
+		finalHistory, err = service.SendMessage(r.Context(), history, chatCtx, callbacks)
+		if err == nil {
+			h.conversations.Put(convID, claims.UserID, sanitizeTranscript(finalHistory))
+		}
+	case credentials.AIProviderOpenAI:
+		service := NewOpenAIService(apiKey, aiConfig.Model, h.toolServer)
+		err = service.SendMessage(r.Context(), req.Messages, chatCtx, callbacks)
+	case credentials.AIProviderGemini:
+		service := NewGeminiService(apiKey, aiConfig.Model, h.toolServer)
+		err = service.SendMessage(r.Context(), req.Messages, chatCtx, callbacks)
+	default:
+		err = fmt.Errorf("unsupported AI provider: %s", aiConfig.Provider)
+	}
 	if err != nil {
-		// Drop the stored state rather than persist a possibly poisoned
+		// Drop Anthropic stored state rather than persist a possibly poisoned
 		// transcript; the client's retry falls back to its own transcript.
-		h.conversations.Delete(convID)
+		if aiConfig.Provider == credentials.AIProviderAnthropic {
+			h.conversations.Delete(convID)
+		}
 		log.Printf("ai chat error: %v", err)
 		emit(map[string]string{"error": err.Error()})
-	} else {
-		h.conversations.Put(convID, claims.UserID, sanitizeTranscript(finalHistory))
 	}
 
 	writeMu.Lock()
@@ -187,7 +204,10 @@ func (h *Handler) configuredServices() []string {
 // Available handles GET /api/ai/available.
 func (h *Handler) Available(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]bool{
-		"available": h.creds.IsConfigured(credentials.KeyAnthropicKey),
+	cfg := h.creds.GetAIConfig()
+	json.NewEncoder(w).Encode(map[string]any{
+		"available": h.creds.IsConfigured(credentials.AIKeyCredentialKey(cfg.Provider)),
+		"provider":  cfg.Provider,
+		"model":     cfg.Model,
 	})
 }

--- a/server/internal/ai/http_providers.go
+++ b/server/internal/ai/http_providers.go
@@ -1,0 +1,502 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/mcp"
+)
+
+const httpProviderMaxOutputTokens = 16000
+
+type openAIService struct {
+	apiKey     string
+	model      string
+	httpClient *http.Client
+	toolServer *mcp.ToolServer
+}
+
+func NewOpenAIService(apiKey, model string, toolServer *mcp.ToolServer) *openAIService {
+	if model == "" {
+		model = "gpt-5.5"
+	}
+	return &openAIService{
+		apiKey:     apiKey,
+		model:      model,
+		httpClient: &http.Client{Timeout: 5 * time.Minute},
+		toolServer: toolServer,
+	}
+}
+
+func (s *openAIService) SendMessage(ctx context.Context, history []Message, chatCtx ChatContext, cb StreamCallbacks) error {
+	messages := []openAIMessage{{
+		Role:    "system",
+		Content: systemPrompt + "\n\n" + dynamicContext(chatCtx),
+	}}
+	messages = append(messages, toOpenAIMessages(history)...)
+	tools := toOpenAITools(s.toolServer.GetTools())
+
+	for iteration := 0; iteration < maxToolIterations; iteration++ {
+		req := openAIChatRequest{
+			Model:               s.model,
+			Messages:            messages,
+			MaxCompletionTokens: httpProviderMaxOutputTokens,
+			Tools:               tools,
+		}
+		if iteration == maxToolIterations-1 {
+			req.ToolChoice = "none"
+		}
+
+		message, finishReason, err := s.chat(ctx, req)
+		if err != nil {
+			return err
+		}
+		if len(message.ToolCalls) == 0 {
+			if message.Content != "" && cb.OnText != nil {
+				cb.OnText(message.Content)
+			}
+			if finishReason == "length" && cb.OnText != nil {
+				cb.OnText("\n\n_(Reply truncated at the length limit - ask me to continue.)_")
+			}
+			return nil
+		}
+
+		messages = append(messages, message)
+		for _, toolCall := range message.ToolCalls {
+			messages = append(messages, s.runOpenAITool(ctx, toolCall, chatCtx, cb))
+		}
+	}
+
+	return fmt.Errorf("agent loop exceeded %d iterations", maxToolIterations)
+}
+
+func (s *openAIService) chat(ctx context.Context, payload openAIChatRequest) (openAIMessage, string, error) {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return openAIMessage{}, "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.openai.com/v1/chat/completions", &body)
+	if err != nil {
+		return openAIMessage{}, "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return openAIMessage{}, "", fmt.Errorf("openai chat: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return openAIMessage{}, "", err
+	}
+	if resp.StatusCode >= 300 {
+		return openAIMessage{}, "", fmt.Errorf("openai chat: %s", providerErrorMessage(data))
+	}
+
+	var parsed openAIChatResponse
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return openAIMessage{}, "", fmt.Errorf("decode openai chat: %w", err)
+	}
+	if parsed.Error != nil {
+		return openAIMessage{}, "", fmt.Errorf("openai chat: %s", parsed.Error.Message)
+	}
+	if len(parsed.Choices) == 0 {
+		return openAIMessage{}, "", fmt.Errorf("openai chat: response had no choices")
+	}
+	return parsed.Choices[0].Message, parsed.Choices[0].FinishReason, nil
+}
+
+func (s *openAIService) runOpenAITool(ctx context.Context, toolCall openAIToolCall, chatCtx ChatContext, cb StreamCallbacks) openAIMessage {
+	name := toolCall.Function.Name
+	if cb.OnToolStart != nil {
+		cb.OnToolStart(name, toolLabel(name))
+	}
+
+	input := json.RawMessage(toolCall.Function.Arguments)
+	if len(input) == 0 || string(input) == "null" {
+		input = json.RawMessage("{}")
+	}
+
+	result, err := s.toolServer.ExecuteTool(ctx, name, input, mcp.CallContext{UserID: chatCtx.UserID, Role: chatCtx.Role})
+	if err != nil {
+		if cb.OnToolEnd != nil {
+			cb.OnToolEnd(name, false)
+		}
+		return openAIMessage{Role: "tool", ToolCallID: toolCall.ID, Content: "Error: " + err.Error()}
+	}
+	if result.StructuredData != nil && mcp.ToolsWithUI[name] && cb.OnToolResult != nil {
+		cb.OnToolResult(name, result.StructuredData)
+	}
+	if cb.OnToolEnd != nil {
+		cb.OnToolEnd(name, true)
+	}
+	return openAIMessage{Role: "tool", ToolCallID: toolCall.ID, Content: result.Text}
+}
+
+type openAIChatRequest struct {
+	Model               string          `json:"model"`
+	Messages            []openAIMessage `json:"messages"`
+	Tools               []openAITool    `json:"tools,omitempty"`
+	ToolChoice          any             `json:"tool_choice,omitempty"`
+	MaxCompletionTokens int             `json:"max_completion_tokens,omitempty"`
+}
+
+type openAIChatResponse struct {
+	Choices []struct {
+		Message      openAIMessage `json:"message"`
+		FinishReason string        `json:"finish_reason"`
+	} `json:"choices"`
+	Error *providerError `json:"error,omitempty"`
+}
+
+type openAIMessage struct {
+	Role       string           `json:"role"`
+	Content    string           `json:"content,omitempty"`
+	ToolCalls  []openAIToolCall `json:"tool_calls,omitempty"`
+	ToolCallID string           `json:"tool_call_id,omitempty"`
+}
+
+type openAIToolCall struct {
+	ID       string             `json:"id"`
+	Type     string             `json:"type"`
+	Function openAIFunctionCall `json:"function"`
+}
+
+type openAIFunctionCall struct {
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type openAITool struct {
+	Type     string             `json:"type"`
+	Function openAIFunctionTool `json:"function"`
+}
+
+type openAIFunctionTool struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	Parameters  map[string]interface{} `json:"parameters"`
+}
+
+func toOpenAIMessages(messages []Message) []openAIMessage {
+	out := make([]openAIMessage, 0, len(messages))
+	for _, m := range messages {
+		text := messageText(m.Content)
+		if text == "" {
+			continue
+		}
+		switch m.Role {
+		case "assistant":
+			if len(out) == 0 {
+				continue
+			}
+			out = append(out, openAIMessage{Role: "assistant", Content: text})
+		default:
+			out = append(out, openAIMessage{Role: "user", Content: text})
+		}
+	}
+	return out
+}
+
+func toOpenAITools(tools []mcp.Tool) []openAITool {
+	out := make([]openAITool, 0, len(tools))
+	for _, t := range tools {
+		out = append(out, openAITool{
+			Type: "function",
+			Function: openAIFunctionTool{
+				Name:        t.Name,
+				Description: t.Description,
+				Parameters:  t.InputSchema,
+			},
+		})
+	}
+	return out
+}
+
+type geminiService struct {
+	apiKey     string
+	model      string
+	httpClient *http.Client
+	toolServer *mcp.ToolServer
+}
+
+func NewGeminiService(apiKey, model string, toolServer *mcp.ToolServer) *geminiService {
+	if model == "" {
+		model = "gemini-3.5-flash"
+	}
+	return &geminiService{
+		apiKey:     apiKey,
+		model:      strings.TrimPrefix(model, "models/"),
+		httpClient: &http.Client{Timeout: 5 * time.Minute},
+		toolServer: toolServer,
+	}
+}
+
+func (s *geminiService) SendMessage(ctx context.Context, history []Message, chatCtx ChatContext, cb StreamCallbacks) error {
+	contents := toGeminiContents(history)
+	tools := toGeminiTools(s.toolServer.GetTools())
+	system := geminiContent{Parts: []geminiPart{{Text: systemPrompt + "\n\n" + dynamicContext(chatCtx)}}}
+
+	for iteration := 0; iteration < maxToolIterations; iteration++ {
+		useTools := iteration != maxToolIterations-1
+		resp, err := s.generate(ctx, geminiGenerateRequest{
+			SystemInstruction: &system,
+			Contents:          contents,
+			Tools:             enabledGeminiTools(tools, useTools),
+			GenerationConfig:  &geminiGenerationConfig{MaxOutputTokens: httpProviderMaxOutputTokens},
+		})
+		if err != nil {
+			return err
+		}
+		if len(resp.Candidates) == 0 {
+			return fmt.Errorf("gemini: response had no candidates")
+		}
+
+		content := resp.Candidates[0].Content
+		if content.Role == "" {
+			content.Role = "model"
+		}
+		functionCalls := geminiFunctionCalls(content)
+		if len(functionCalls) == 0 {
+			text := geminiText(content)
+			if text != "" && cb.OnText != nil {
+				cb.OnText(text)
+			}
+			if resp.Candidates[0].FinishReason == "MAX_TOKENS" && cb.OnText != nil {
+				cb.OnText("\n\n_(Reply truncated at the length limit - ask me to continue.)_")
+			}
+			return nil
+		}
+
+		contents = append(contents, content)
+		resultParts := make([]geminiPart, 0, len(functionCalls))
+		for _, call := range functionCalls {
+			resultParts = append(resultParts, s.runGeminiTool(ctx, call, chatCtx, cb))
+		}
+		contents = append(contents, geminiContent{Role: "user", Parts: resultParts})
+	}
+
+	return fmt.Errorf("agent loop exceeded %d iterations", maxToolIterations)
+}
+
+func (s *geminiService) generate(ctx context.Context, payload geminiGenerateRequest) (geminiGenerateResponse, error) {
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return geminiGenerateResponse{}, err
+	}
+	endpoint := fmt.Sprintf(
+		"https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent",
+		url.PathEscape(s.model),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
+	if err != nil {
+		return geminiGenerateResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", s.apiKey)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return geminiGenerateResponse{}, fmt.Errorf("gemini generate: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return geminiGenerateResponse{}, err
+	}
+	if resp.StatusCode >= 300 {
+		return geminiGenerateResponse{}, fmt.Errorf("gemini generate: %s", providerErrorMessage(data))
+	}
+
+	var parsed geminiGenerateResponse
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return geminiGenerateResponse{}, fmt.Errorf("decode gemini response: %w", err)
+	}
+	if parsed.Error != nil {
+		return geminiGenerateResponse{}, fmt.Errorf("gemini generate: %s", parsed.Error.Message)
+	}
+	return parsed, nil
+}
+
+func (s *geminiService) runGeminiTool(ctx context.Context, call geminiFunctionCall, chatCtx ChatContext, cb StreamCallbacks) geminiPart {
+	if cb.OnToolStart != nil {
+		cb.OnToolStart(call.Name, toolLabel(call.Name))
+	}
+
+	input, err := json.Marshal(call.Args)
+	if err != nil || len(input) == 0 || string(input) == "null" {
+		input = []byte("{}")
+	}
+
+	result, err := s.toolServer.ExecuteTool(ctx, call.Name, json.RawMessage(input), mcp.CallContext{UserID: chatCtx.UserID, Role: chatCtx.Role})
+	if err != nil {
+		if cb.OnToolEnd != nil {
+			cb.OnToolEnd(call.Name, false)
+		}
+		return geminiPart{FunctionResponse: &geminiFunctionResponse{
+			Name:     call.Name,
+			ID:       call.ID,
+			Response: map[string]any{"error": err.Error()},
+		}}
+	}
+	if result.StructuredData != nil && mcp.ToolsWithUI[call.Name] && cb.OnToolResult != nil {
+		cb.OnToolResult(call.Name, result.StructuredData)
+	}
+	if cb.OnToolEnd != nil {
+		cb.OnToolEnd(call.Name, true)
+	}
+	return geminiPart{FunctionResponse: &geminiFunctionResponse{
+		Name:     call.Name,
+		ID:       call.ID,
+		Response: map[string]any{"response": result.Text},
+	}}
+}
+
+type geminiGenerateRequest struct {
+	SystemInstruction *geminiContent          `json:"systemInstruction,omitempty"`
+	Contents          []geminiContent         `json:"contents"`
+	Tools             []geminiTool            `json:"tools,omitempty"`
+	GenerationConfig  *geminiGenerationConfig `json:"generationConfig,omitempty"`
+}
+
+type geminiGenerationConfig struct {
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty"`
+}
+
+type geminiGenerateResponse struct {
+	Candidates []struct {
+		Content      geminiContent `json:"content"`
+		FinishReason string        `json:"finishReason"`
+	} `json:"candidates"`
+	Error *providerError `json:"error,omitempty"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role,omitempty"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text             string                  `json:"text,omitempty"`
+	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
+	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+	Thought          bool                    `json:"thought,omitempty"`
+	ThoughtSignature string                  `json:"thoughtSignature,omitempty"`
+}
+
+type geminiFunctionCall struct {
+	Name string         `json:"name"`
+	Args map[string]any `json:"args,omitempty"`
+	ID   string         `json:"id,omitempty"`
+}
+
+type geminiFunctionResponse struct {
+	Name     string         `json:"name"`
+	Response map[string]any `json:"response"`
+	ID       string         `json:"id,omitempty"`
+}
+
+type geminiTool struct {
+	FunctionDeclarations []geminiFunctionDeclaration `json:"functionDeclarations,omitempty"`
+}
+
+type geminiFunctionDeclaration struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description,omitempty"`
+	Parameters  map[string]interface{} `json:"parameters"`
+}
+
+func toGeminiContents(messages []Message) []geminiContent {
+	out := make([]geminiContent, 0, len(messages))
+	for _, m := range messages {
+		text := messageText(m.Content)
+		if text == "" {
+			continue
+		}
+		switch m.Role {
+		case "assistant":
+			if len(out) == 0 {
+				continue
+			}
+			out = append(out, geminiContent{Role: "model", Parts: []geminiPart{{Text: text}}})
+		default:
+			out = append(out, geminiContent{Role: "user", Parts: []geminiPart{{Text: text}}})
+		}
+	}
+	return out
+}
+
+func toGeminiTools(tools []mcp.Tool) []geminiTool {
+	declarations := make([]geminiFunctionDeclaration, 0, len(tools))
+	for _, t := range tools {
+		declarations = append(declarations, geminiFunctionDeclaration{
+			Name:        t.Name,
+			Description: t.Description,
+			Parameters:  t.InputSchema,
+		})
+	}
+	if len(declarations) == 0 {
+		return nil
+	}
+	return []geminiTool{{FunctionDeclarations: declarations}}
+}
+
+func enabledGeminiTools(tools []geminiTool, enabled bool) []geminiTool {
+	if !enabled {
+		return nil
+	}
+	return tools
+}
+
+func geminiFunctionCalls(content geminiContent) []geminiFunctionCall {
+	var calls []geminiFunctionCall
+	for _, part := range content.Parts {
+		if part.FunctionCall != nil {
+			calls = append(calls, *part.FunctionCall)
+		}
+	}
+	return calls
+}
+
+func geminiText(content geminiContent) string {
+	var sb strings.Builder
+	for _, part := range content.Parts {
+		sb.WriteString(part.Text)
+	}
+	return sb.String()
+}
+
+type providerError struct {
+	Message string `json:"message"`
+	Status  string `json:"status,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Code    any    `json:"code,omitempty"`
+}
+
+func providerErrorMessage(data []byte) string {
+	var wrapped struct {
+		Error *providerError `json:"error"`
+	}
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Error != nil && wrapped.Error.Message != "" {
+		return wrapped.Error.Message
+	}
+	text := strings.TrimSpace(string(data))
+	if text == "" {
+		return "request failed"
+	}
+	if len(text) > 1000 {
+		return text[:1000] + "..."
+	}
+	return text
+}

--- a/server/internal/ai/service.go
+++ b/server/internal/ai/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -15,8 +14,8 @@ import (
 )
 
 const (
-	defaultModel = "claude-opus-4-8"
-	maxTokens    = 64000
+	defaultAnthropicModel = "claude-opus-4-8"
+	maxTokens             = 64000
 	// maxToolIterations bounds the agent loop. On the final iteration the
 	// model is forced to answer in text (tool_choice: none) so the user
 	// always gets a reply instead of a hard error.
@@ -78,10 +77,9 @@ type Service struct {
 }
 
 // NewService creates a new AI service.
-func NewService(apiKey string, toolServer *mcp.ToolServer) *Service {
-	model := os.Getenv("CANTINARR_AI_MODEL")
+func NewService(apiKey, model string, toolServer *mcp.ToolServer) *Service {
 	if model == "" {
-		model = defaultModel
+		model = defaultAnthropicModel
 	}
 	return &Service{
 		client:     anthropic.NewClient(option.WithAPIKey(apiKey)),
@@ -97,7 +95,6 @@ func (s *Service) SendMessage(ctx context.Context, history []anthropic.MessagePa
 	params := anthropic.MessageNewParams{
 		Model:     s.model,
 		MaxTokens: maxTokens,
-		Thinking:  anthropic.ThinkingConfigParamUnion{OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{}},
 		// Top-level cache_control auto-places a breakpoint on the last
 		// cacheable block each request, so the growing transcript reuses the
 		// cache across loop iterations and follow-up turns.
@@ -110,6 +107,9 @@ func (s *Service) SendMessage(ctx context.Context, history []anthropic.MessagePa
 		},
 		Messages: history,
 		Tools:    toSDKTools(s.toolServer.GetTools()),
+	}
+	if supportsAnthropicAdaptiveThinking(s.model) {
+		params.Thinking = anthropic.ThinkingConfigParamUnion{OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{}}
 	}
 
 	for iteration := 0; iteration < maxToolIterations; iteration++ {
@@ -148,6 +148,14 @@ func (s *Service) SendMessage(ctx context.Context, history []anthropic.MessagePa
 	}
 
 	return params.Messages, fmt.Errorf("agent loop exceeded %d iterations", maxToolIterations)
+}
+
+func supportsAnthropicAdaptiveThinking(model anthropic.Model) bool {
+	m := string(model)
+	return strings.Contains(m, "opus-4") ||
+		strings.Contains(m, "sonnet-4") ||
+		strings.Contains(m, "fable-5") ||
+		strings.Contains(m, "mythos-5")
 }
 
 // streamOne sends a single streaming request and returns the accumulated message.

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -285,7 +285,7 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 			"services": map[string]bool{
 				"radarr": hasRadarr,
 				"sonarr": hasSonarr,
-				"ai":     creds.IsConfigured(credentials.KeyAnthropicKey),
+				"ai":     creds.IsAIConfigured(),
 				"tmdb":   creds.IsConfigured(credentials.KeyTMDBAccessToken),
 				"trakt":  creds.IsConfigured(credentials.KeyTraktClientID),
 			},

--- a/server/internal/credentials/handler.go
+++ b/server/internal/credentials/handler.go
@@ -3,6 +3,7 @@ package credentials
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -19,15 +20,24 @@ func NewHandler(registry *Registry) *Handler {
 
 // Get returns which credentials are configured (booleans, never values).
 func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
-	status := make(map[string]bool, len(AllKeys))
+	status := make(map[string]any, len(AllKeys)+1)
+	credentials := make(map[string]bool, len(AllKeys))
 	for _, key := range AllKeys {
-		status[key] = h.registry.IsConfigured(key)
+		configured := h.registry.IsConfigured(key)
+		status[key] = configured
+		credentials[key] = configured
+	}
+	status["credentials"] = credentials
+	status["ai"] = map[string]any{
+		"config":    h.registry.GetAIConfig(),
+		"providers": AIProviders,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(status)
 }
 
-// Update sets one or more credentials. Only non-empty fields are written.
+// Update sets one or more credentials and non-secret AI settings. Only
+// non-empty fields are written.
 func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 	var body map[string]string
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -39,17 +49,48 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 	for _, k := range AllKeys {
 		valid[k] = true
 	}
+	valid[KeyAIProvider] = true
+	valid[KeyAIModel] = true
 
 	for key, value := range body {
 		if !valid[key] {
 			http.Error(w, `{"error":"unknown credential key: `+key+`"}`, http.StatusBadRequest)
 			return
 		}
+		if key == KeyAIProvider || key == KeyAIModel {
+			continue
+		}
 		if value == "" {
 			continue
 		}
 		if err := h.registry.SetCredential(key, value); err != nil {
 			http.Error(w, `{"error":"failed to save credential"}`, http.StatusInternalServerError)
+			return
+		}
+	}
+
+	provider, providerSet := body[KeyAIProvider]
+	model, modelSet := body[KeyAIModel]
+	if providerSet || modelSet {
+		current := h.registry.GetAIConfig()
+		provider = strings.TrimSpace(provider)
+		model = strings.TrimSpace(model)
+		if !providerSet || provider == "" {
+			provider = current.Provider
+		}
+		if !IsValidAIProvider(provider) {
+			http.Error(w, `{"error":"unknown AI provider"}`, http.StatusBadRequest)
+			return
+		}
+		if !modelSet || model == "" {
+			if provider != current.Provider {
+				model = DefaultAIModel(provider)
+			} else {
+				model = current.Model
+			}
+		}
+		if err := h.registry.SetAIConfig(provider, model); err != nil {
+			http.Error(w, `{"error":"failed to save AI settings"}`, http.StatusInternalServerError)
 			return
 		}
 	}

--- a/server/internal/credentials/registry.go
+++ b/server/internal/credentials/registry.go
@@ -3,6 +3,7 @@ package credentials
 import (
 	"database/sql"
 	"log"
+	"os"
 	"sync"
 
 	"github.com/windoze95/cantinarr-server/internal/secrets"
@@ -14,16 +15,142 @@ import (
 const (
 	KeyTMDBAccessToken = "tmdb_access_token"
 	KeyAnthropicKey    = "anthropic_key"
+	KeyOpenAIKey       = "openai_key"
+	KeyGeminiKey       = "gemini_key"
 	KeyTraktClientID   = "trakt_client_id"
+
+	KeyAIProvider = "ai_provider"
+	KeyAIModel    = "ai_model"
 )
 
 // AllKeys lists every credential key the system manages. Values for these
 // keys are encrypted at rest; other settings (e.g. tool toggles) stay plain.
-var AllKeys = []string{KeyTMDBAccessToken, KeyAnthropicKey, KeyTraktClientID}
+var AllKeys = []string{KeyTMDBAccessToken, KeyAnthropicKey, KeyOpenAIKey, KeyGeminiKey, KeyTraktClientID}
+
+const (
+	AIProviderAnthropic = "anthropic"
+	AIProviderOpenAI    = "openai"
+	AIProviderGemini    = "gemini"
+
+	DefaultAIProvider = AIProviderAnthropic
+)
+
+// AIModelOption describes one selectable chat model for the admin UI.
+type AIModelOption struct {
+	ID          string `json:"id"`
+	Label       string `json:"label"`
+	Description string `json:"description,omitempty"`
+}
+
+// AIProviderOption describes a supported AI provider and its default models.
+type AIProviderOption struct {
+	ID            string          `json:"id"`
+	Label         string          `json:"label"`
+	CredentialKey string          `json:"credential_key"`
+	Models        []AIModelOption `json:"models"`
+}
+
+// AIConfig is the active provider/model pair used by the AI assistant.
+type AIConfig struct {
+	Provider string `json:"provider"`
+	Model    string `json:"model"`
+}
+
+var AIProviders = []AIProviderOption{
+	{
+		ID:            AIProviderAnthropic,
+		Label:         "Anthropic",
+		CredentialKey: KeyAnthropicKey,
+		Models: []AIModelOption{
+			{ID: "claude-opus-4-8", Label: "Claude Opus 4.8", Description: "Most capable Claude Opus-tier model"},
+			{ID: "claude-fable-5", Label: "Claude Fable 5", Description: "Highest-capability Claude model"},
+			{ID: "claude-sonnet-4-6", Label: "Claude Sonnet 4.6", Description: "Balanced speed and intelligence"},
+			{ID: "claude-haiku-4-5", Label: "Claude Haiku 4.5", Description: "Fastest, lowest-cost Claude option"},
+		},
+	},
+	{
+		ID:            AIProviderOpenAI,
+		Label:         "OpenAI",
+		CredentialKey: KeyOpenAIKey,
+		Models: []AIModelOption{
+			{ID: "gpt-5.5", Label: "GPT-5.5", Description: "Flagship OpenAI model"},
+			{ID: "gpt-5.4", Label: "GPT-5.4", Description: "Affordable frontier model"},
+			{ID: "gpt-5.4-mini", Label: "GPT-5.4 mini", Description: "Lower latency and cost"},
+			{ID: "gpt-5.4-nano", Label: "GPT-5.4 nano", Description: "Smallest current GPT-5.4 model"},
+			{ID: "gpt-4.1", Label: "GPT-4.1", Description: "Stable previous-generation model"},
+			{ID: "gpt-4.1-mini", Label: "GPT-4.1 mini", Description: "Fast previous-generation model"},
+		},
+	},
+	{
+		ID:            AIProviderGemini,
+		Label:         "Google Gemini",
+		CredentialKey: KeyGeminiKey,
+		Models: []AIModelOption{
+			{ID: "gemini-3.5-flash", Label: "Gemini 3.5 Flash", Description: "Current stable Gemini Flash model"},
+			{ID: "gemini-2.5-pro", Label: "Gemini 2.5 Pro", Description: "Advanced reasoning and coding"},
+			{ID: "gemini-2.5-flash", Label: "Gemini 2.5 Flash", Description: "Low-latency reasoning"},
+			{ID: "gemini-2.5-flash-lite", Label: "Gemini 2.5 Flash-Lite", Description: "Fastest budget Gemini option"},
+		},
+	},
+}
 
 func isSecretKey(key string) bool {
 	for _, k := range AllKeys {
 		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// DefaultAIModel returns the default model for a provider.
+func DefaultAIModel(provider string) string {
+	for _, p := range AIProviders {
+		if p.ID == provider && len(p.Models) > 0 {
+			return p.Models[0].ID
+		}
+	}
+	return AIProviders[0].Models[0].ID
+}
+
+// AIKeyCredentialKey returns the secret setting key for a provider API key.
+func AIKeyCredentialKey(provider string) string {
+	for _, p := range AIProviders {
+		if p.ID == provider {
+			return p.CredentialKey
+		}
+	}
+	return KeyAnthropicKey
+}
+
+// IsValidAIProvider reports whether provider is supported.
+func IsValidAIProvider(provider string) bool {
+	for _, p := range AIProviders {
+		if p.ID == provider {
+			return true
+		}
+	}
+	return false
+}
+
+func inferAIProvider(model string) string {
+	switch {
+	case model == "":
+		return ""
+	case hasAnyPrefix(model, "claude-"):
+		return AIProviderAnthropic
+	case hasAnyPrefix(model, "gpt-", "o1", "o3", "o4"):
+		return AIProviderOpenAI
+	case hasAnyPrefix(model, "gemini-"):
+		return AIProviderGemini
+	default:
+		return ""
+	}
+}
+
+func hasAnyPrefix(value string, prefixes ...string) bool {
+	for _, prefix := range prefixes {
+		if len(value) >= len(prefix) && value[:len(prefix)] == prefix {
 			return true
 		}
 	}
@@ -103,6 +230,24 @@ func (r *Registry) GetCredential(key string) string {
 	return plain
 }
 
+// GetSetting reads a non-secret setting value from the DB.
+func (r *Registry) GetSetting(key string) string {
+	var value string
+	if err := r.db.QueryRow("SELECT value FROM settings WHERE key = ?", key).Scan(&value); err != nil {
+		return ""
+	}
+	return value
+}
+
+// SetSetting writes a non-secret setting value to the DB.
+func (r *Registry) SetSetting(key, value string) error {
+	_, err := r.db.Exec(
+		"INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)",
+		key, value,
+	)
+	return err
+}
+
 // SetCredential writes a credential to the DB (upsert). Secret keys are
 // encrypted at rest; non-secret settings are stored as-is.
 func (r *Registry) SetCredential(key, value string) error {
@@ -118,6 +263,51 @@ func (r *Registry) SetCredential(key, value string) error {
 		key, value,
 	)
 	return err
+}
+
+// GetAIConfig resolves the active AI provider/model. Stored settings win over
+// environment defaults, and custom model IDs are allowed.
+func (r *Registry) GetAIConfig() AIConfig {
+	provider := r.GetSetting(KeyAIProvider)
+	model := r.GetSetting(KeyAIModel)
+
+	if model == "" {
+		model = os.Getenv("CANTINARR_AI_MODEL")
+	}
+	if provider == "" {
+		provider = os.Getenv("CANTINARR_AI_PROVIDER")
+	}
+	if provider == "" {
+		provider = inferAIProvider(model)
+	}
+	if !IsValidAIProvider(provider) {
+		provider = DefaultAIProvider
+	}
+	if model == "" {
+		model = DefaultAIModel(provider)
+	}
+	return AIConfig{Provider: provider, Model: model}
+}
+
+// SetAIConfig persists the active AI provider/model. Unknown providers are
+// rejected; model is intentionally free-form so admins can use new provider IDs.
+func (r *Registry) SetAIConfig(provider, model string) error {
+	if !IsValidAIProvider(provider) {
+		provider = DefaultAIProvider
+	}
+	if model == "" {
+		model = DefaultAIModel(provider)
+	}
+	if err := r.SetSetting(KeyAIProvider, provider); err != nil {
+		return err
+	}
+	return r.SetSetting(KeyAIModel, model)
+}
+
+// IsAIConfigured reports whether the selected provider has an API key.
+func (r *Registry) IsAIConfigured() bool {
+	cfg := r.GetAIConfig()
+	return r.IsConfigured(AIKeyCredentialKey(cfg.Provider))
 }
 
 // DeleteCredential removes a credential from the DB.

--- a/server/internal/mcp/toolsettings.go
+++ b/server/internal/mcp/toolsettings.go
@@ -26,7 +26,7 @@ func (s *ToolServer) loadTogglesLocked() {
 	if s.creds == nil {
 		return
 	}
-	raw := s.creds.GetCredential(disabledToolsKey)
+	raw := s.creds.GetSetting(disabledToolsKey)
 	if raw == "" {
 		return
 	}
@@ -102,7 +102,7 @@ func (s *ToolServer) SetToolEnabled(name string, enabled bool) error {
 	if err != nil {
 		return fmt.Errorf("marshal disabled tools: %w", err)
 	}
-	if err := s.creds.SetCredential(disabledToolsKey, string(data)); err != nil {
+	if err := s.creds.SetSetting(disabledToolsKey, string(data)); err != nil {
 		return fmt.Errorf("persist disabled tools: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- add selectable Anthropic, OpenAI, and Gemini AI providers with model presets and custom model IDs
- add encrypted OpenAI/Gemini credential support and route AI availability through the selected provider
- add OpenAI/Gemini tool-calling adapters and update settings/docs copy

## Tests
- go test ./...
- flutter test
- flutter analyze (remaining 20 info-level lints are pre-existing)