### PR TITLE
Clarify legacy AI provider settings

### DIFF
--- a/app/lib/features/settings/data/credentials_service.dart
+++ b/app/lib/features/settings/data/credentials_service.dart
@@ -44,13 +44,11 @@ class AiCredentialConfig {
     final providers = providersJson
         .map((e) => AiProviderOption.fromJson(e as Map<String, dynamic>))
         .toList();
-    final providerOptions =
-        providers.isNotEmpty ? providers : fallbackProviders;
     final defaultProvider =
-        providerOptions.isNotEmpty ? providerOptions.first.id : 'anthropic';
+        providers.isNotEmpty ? providers.first.id : 'anthropic';
     final selectedProvider = config['provider'] as String? ?? defaultProvider;
     AiProviderOption? selected;
-    for (final provider in providerOptions) {
+    for (final provider in providers) {
       if (provider.id == selectedProvider) {
         selected = provider;
         break;
@@ -63,103 +61,9 @@ class AiCredentialConfig {
           (selected?.models.isNotEmpty == true
               ? selected!.models.first.id
               : 'claude-opus-4-8'),
-      providers: providerOptions,
+      providers: providers,
     );
   }
-
-  static const fallbackProviders = [
-    AiProviderOption(
-      id: 'anthropic',
-      label: 'Anthropic',
-      credentialKey: 'anthropic_key',
-      models: [
-        AiModelOption(
-          id: 'claude-opus-4-8',
-          label: 'Claude Opus 4.8',
-          description: 'Most capable Claude Opus-tier model',
-        ),
-        AiModelOption(
-          id: 'claude-fable-5',
-          label: 'Claude Fable 5',
-          description: 'Highest-capability Claude model',
-        ),
-        AiModelOption(
-          id: 'claude-sonnet-4-6',
-          label: 'Claude Sonnet 4.6',
-          description: 'Balanced speed and intelligence',
-        ),
-        AiModelOption(
-          id: 'claude-haiku-4-5',
-          label: 'Claude Haiku 4.5',
-          description: 'Fastest, lowest-cost Claude option',
-        ),
-      ],
-    ),
-    AiProviderOption(
-      id: 'openai',
-      label: 'OpenAI',
-      credentialKey: 'openai_key',
-      models: [
-        AiModelOption(
-          id: 'gpt-5.5',
-          label: 'GPT-5.5',
-          description: 'Flagship OpenAI model',
-        ),
-        AiModelOption(
-          id: 'gpt-5.4',
-          label: 'GPT-5.4',
-          description: 'Affordable frontier model',
-        ),
-        AiModelOption(
-          id: 'gpt-5.4-mini',
-          label: 'GPT-5.4 mini',
-          description: 'Lower latency and cost',
-        ),
-        AiModelOption(
-          id: 'gpt-5.4-nano',
-          label: 'GPT-5.4 nano',
-          description: 'Smallest current GPT-5.4 model',
-        ),
-        AiModelOption(
-          id: 'gpt-4.1',
-          label: 'GPT-4.1',
-          description: 'Stable previous-generation model',
-        ),
-        AiModelOption(
-          id: 'gpt-4.1-mini',
-          label: 'GPT-4.1 mini',
-          description: 'Fast previous-generation model',
-        ),
-      ],
-    ),
-    AiProviderOption(
-      id: 'gemini',
-      label: 'Google Gemini',
-      credentialKey: 'gemini_key',
-      models: [
-        AiModelOption(
-          id: 'gemini-3.5-flash',
-          label: 'Gemini 3.5 Flash',
-          description: 'Current stable Gemini Flash model',
-        ),
-        AiModelOption(
-          id: 'gemini-2.5-pro',
-          label: 'Gemini 2.5 Pro',
-          description: 'Advanced reasoning and coding',
-        ),
-        AiModelOption(
-          id: 'gemini-2.5-flash',
-          label: 'Gemini 2.5 Flash',
-          description: 'Low-latency reasoning',
-        ),
-        AiModelOption(
-          id: 'gemini-2.5-flash-lite',
-          label: 'Gemini 2.5 Flash-Lite',
-          description: 'Fastest budget Gemini option',
-        ),
-      ],
-    ),
-  ];
 }
 
 class AiProviderOption {

--- a/app/lib/features/settings/ui/credentials_screen.dart
+++ b/app/lib/features/settings/ui/credentials_screen.dart
@@ -285,27 +285,30 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
                       onDelete: () =>
                           _deleteCredential('anthropic_key', 'Anthropic'),
                     ),
-                    const SizedBox(height: 20),
-                    _CredentialSection(
-                      title: 'OpenAI (AI)',
-                      description: 'GPT model provider',
-                      isConfigured:
-                          _status?.isConfigured('openai_key') ?? false,
-                      controller: _openAIController,
-                      hint: 'OpenAI API key',
-                      onDelete: () => _deleteCredential('openai_key', 'OpenAI'),
-                    ),
-                    const SizedBox(height: 20),
-                    _CredentialSection(
-                      title: 'Google Gemini (AI)',
-                      description: 'Gemini model provider',
-                      isConfigured:
-                          _status?.isConfigured('gemini_key') ?? false,
-                      controller: _geminiController,
-                      hint: 'Gemini API key',
-                      onDelete: () =>
-                          _deleteCredential('gemini_key', 'Google Gemini'),
-                    ),
+                    if (_status?.ai.providers.isNotEmpty ?? false) ...[
+                      const SizedBox(height: 20),
+                      _CredentialSection(
+                        title: 'OpenAI (AI)',
+                        description: 'GPT model provider',
+                        isConfigured:
+                            _status?.isConfigured('openai_key') ?? false,
+                        controller: _openAIController,
+                        hint: 'OpenAI API key',
+                        onDelete: () =>
+                            _deleteCredential('openai_key', 'OpenAI'),
+                      ),
+                      const SizedBox(height: 20),
+                      _CredentialSection(
+                        title: 'Google Gemini (AI)',
+                        description: 'Gemini model provider',
+                        isConfigured:
+                            _status?.isConfigured('gemini_key') ?? false,
+                        controller: _geminiController,
+                        hint: 'Gemini API key',
+                        onDelete: () =>
+                            _deleteCredential('gemini_key', 'Google Gemini'),
+                      ),
+                    ],
                     const SizedBox(height: 20),
                     _CredentialSection(
                       title: 'Trakt',
@@ -363,9 +366,23 @@ class _AISelectionSection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (providers.isEmpty) {
-      return const Text(
-        'AI model options are unavailable from this server.',
-        style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+      return const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'AI Model',
+            style: TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          SizedBox(height: 4),
+          Text(
+            'Update the server container to configure OpenAI, Gemini, and AI model selection. This server only supports the legacy Anthropic AI key.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ],
       );
     }
 

--- a/app/test/settings/credentials_service_test.dart
+++ b/app/test/settings/credentials_service_test.dart
@@ -36,7 +36,7 @@ void main() {
       expect(status.ai.providers.single.credentialKey, 'openai_key');
     });
 
-    test('falls back to built-in providers when metadata is missing', () {
+    test('handles legacy AI status without provider metadata', () {
       final status = CredentialsStatus.fromJson({
         'anthropic_key': true,
         'ai': true,
@@ -44,11 +44,8 @@ void main() {
 
       expect(status.isConfigured('anthropic_key'), true);
       expect(status.ai.provider, 'anthropic');
-      expect(status.ai.providers, isNotEmpty);
-      expect(
-        status.ai.providers.map((provider) => provider.id),
-        containsAll(['anthropic', 'openai', 'gemini']),
-      );
+      expect(status.ai.model, 'claude-opus-4-8');
+      expect(status.ai.providers, isEmpty);
     });
   });
 }

--- a/server/internal/credentials/registry.go
+++ b/server/internal/credentials/registry.go
@@ -87,6 +87,7 @@ var AIProviders = []AIProviderOption{
 		CredentialKey: KeyGeminiKey,
 		Models: []AIModelOption{
 			{ID: "gemini-3.5-flash", Label: "Gemini 3.5 Flash", Description: "Current stable Gemini Flash model"},
+			{ID: "gemini-3.1-pro-preview", Label: "Gemini 3.1 Pro Preview", Description: "Preview model optimized for agentic and coding workflows"},
 			{ID: "gemini-2.5-pro", Label: "Gemini 2.5 Pro", Description: "Advanced reasoning and coding"},
 			{ID: "gemini-2.5-flash", Label: "Gemini 2.5 Flash", Description: "Low-latency reasoning"},
 			{ID: "gemini-2.5-flash-lite", Label: "Gemini 2.5 Flash-Lite", Description: "Fastest budget Gemini option"},


### PR DESCRIPTION
## Summary
- show a clear server-update message when the credentials endpoint lacks AI provider metadata
- keep old-server compatibility to legacy Anthropic credentials instead of showing synthetic OpenAI/Gemini choices
- add Gemini 3.1 Pro Preview to the server-provided Gemini model presets
- update parser coverage for metadata and legacy AI status responses

## Tests
- flutter test test/settings/credentials_service_test.dart
- flutter analyze (unchanged existing info-level lints)
- go test ./...