### PR TITLE
Fix search keyboard and AI intent flow

### DIFF
--- a/app/lib/core/widgets/search_bar.dart
+++ b/app/lib/core/widgets/search_bar.dart
@@ -8,6 +8,7 @@ class CantinarrSearchBar extends StatelessWidget {
   final FocusNode focusNode;
   final String hintText;
   final ValueChanged<String>? onChanged;
+  final VoidCallback? onSubmitted;
   final VoidCallback? onClear;
 
   /// When true, shows a sparkle icon hinting at AI capability.
@@ -32,6 +33,7 @@ class CantinarrSearchBar extends StatelessWidget {
     required this.focusNode,
     this.hintText = 'Search movies & TV shows...',
     this.onChanged,
+    this.onSubmitted,
     this.onClear,
     this.aiEnabled = false,
     this.multiline = false,
@@ -67,7 +69,8 @@ class CantinarrSearchBar extends StatelessWidget {
         focusNode: focusNode,
         keyboardType: TextInputType.text,
         onChanged: onChanged,
-        onSubmitted: multiline ? null : null,
+        onSubmitted: multiline ? null : (_) => onSubmitted?.call(),
+        onTapOutside: (_) => focusNode.unfocus(),
         textInputAction:
             multiline ? TextInputAction.newline : TextInputAction.search,
         maxLines: maxLines ?? (multiline ? 3 : 1),
@@ -106,7 +109,8 @@ class CantinarrSearchBar extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           IconButton(
-            icon: const Icon(Icons.close, size: 20, color: AppTheme.textSecondary),
+            icon: const Icon(Icons.close,
+                size: 20, color: AppTheme.textSecondary),
             onPressed: () {
               controller.clear();
               onClear?.call();

--- a/app/lib/features/ai_assistant/ui/ai_chat_screen.dart
+++ b/app/lib/features/ai_assistant/ui/ai_chat_screen.dart
@@ -71,7 +71,13 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
     final text = _inputController.text.trim();
     if (text.isEmpty || _notifier == null) return;
     _inputController.clear();
+    _dismissKeyboard();
     _notifier!.sendMessage(text);
+  }
+
+  void _dismissKeyboard() {
+    _focusNode.unfocus();
+    FocusManager.instance.primaryFocus?.unfocus();
   }
 
   void _exitAssistant() {
@@ -148,31 +154,37 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
         children: [
           // Messages
           Expanded(
-            child: Builder(builder: (context) {
-              // Only show the typing indicator before the assistant bubble
-              // materializes (text, tool activity, or media arriving).
-              final showTyping = state.isLoading &&
-                  (state.messages.isEmpty ||
-                      state.messages.last.role != ChatRole.assistant);
-              return ListView.builder(
-                controller: _scrollController,
-                padding: const EdgeInsets.all(16),
-                itemCount: state.messages.length + (showTyping ? 1 : 0),
-                itemBuilder: (context, index) {
-                  if (index >= state.messages.length) {
-                    return const _TypingIndicator();
-                  }
-                  final msg = state.messages[index];
-                  final isLast = index == state.messages.length - 1;
-                  return ChatBubble(
-                    message: msg,
-                    onRetry: isLast && msg.errorText != null
-                        ? _notifier!.retryLast
-                        : null,
-                  );
-                },
-              );
-            }),
+            child: GestureDetector(
+              behavior: HitTestBehavior.translucent,
+              onTap: _dismissKeyboard,
+              child: Builder(builder: (context) {
+                // Only show the typing indicator before the assistant bubble
+                // materializes (text, tool activity, or media arriving).
+                final showTyping = state.isLoading &&
+                    (state.messages.isEmpty ||
+                        state.messages.last.role != ChatRole.assistant);
+                return ListView.builder(
+                  controller: _scrollController,
+                  keyboardDismissBehavior:
+                      ScrollViewKeyboardDismissBehavior.onDrag,
+                  padding: const EdgeInsets.all(16),
+                  itemCount: state.messages.length + (showTyping ? 1 : 0),
+                  itemBuilder: (context, index) {
+                    if (index >= state.messages.length) {
+                      return const _TypingIndicator();
+                    }
+                    final msg = state.messages[index];
+                    final isLast = index == state.messages.length - 1;
+                    return ChatBubble(
+                      message: msg,
+                      onRetry: isLast && msg.errorText != null
+                          ? _notifier!.retryLast
+                          : null,
+                    );
+                  },
+                );
+              }),
+            ),
           ),
 
           // Error
@@ -211,6 +223,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                           keyboardType: TextInputType.multiline,
                           textInputAction: TextInputAction.send,
                           onSubmitted: (_) => _send(),
+                          onTapOutside: (_) => _dismissKeyboard(),
                           decoration: const InputDecoration(
                             hintText: 'Ask me anything...',
                             border: InputBorder.none,

--- a/app/lib/features/discover/ui/search_results_view.dart
+++ b/app/lib/features/discover/ui/search_results_view.dart
@@ -20,6 +20,7 @@ class SearchResultsView extends StatelessWidget {
   final bool isLoading;
   final String query;
   final void Function(MediaItem)? onLoadMore;
+  final VoidCallback? onResultTap;
   final Map<int, LibraryStatus> libraryStatus;
 
   const SearchResultsView({
@@ -28,6 +29,7 @@ class SearchResultsView extends StatelessWidget {
     required this.isLoading,
     required this.query,
     this.onLoadMore,
+    this.onResultTap,
     this.libraryStatus = const {},
   });
 
@@ -47,14 +49,13 @@ class SearchResultsView extends StatelessWidget {
             const SizedBox(height: 12),
             Text(
               'No results for "$query"',
-              style: const TextStyle(
-                  color: AppTheme.textSecondary, fontSize: 16),
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 16),
             ),
             const SizedBox(height: 4),
             const Text(
               'Try a different search term',
-              style:
-                  TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
             ),
           ],
         ),
@@ -62,6 +63,7 @@ class SearchResultsView extends StatelessWidget {
     }
 
     return ListView.separated(
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       itemCount: results.length + (isLoading ? 3 : 0),
       separatorBuilder: (_, __) => const SizedBox.shrink(),
@@ -76,6 +78,7 @@ class SearchResultsView extends StatelessWidget {
         return _SearchResultTile(
           item: item,
           status: libraryStatus[item.id],
+          onTap: onResultTap,
         );
       },
     );
@@ -83,6 +86,7 @@ class SearchResultsView extends StatelessWidget {
 
   Widget _buildLoadingList() {
     return ListView.separated(
+      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       itemCount: 8,
       separatorBuilder: (_, __) => const SizedBox(height: 12),
@@ -160,6 +164,7 @@ class SearchResultsView extends StatelessWidget {
 class _SearchResultTile extends StatelessWidget {
   final MediaItem item;
   final LibraryStatus? status;
+  final VoidCallback? onTap;
 
   static const _titleStyle = TextStyle(
     color: AppTheme.textPrimary,
@@ -167,7 +172,7 @@ class _SearchResultTile extends StatelessWidget {
     fontWeight: FontWeight.w600,
   );
 
-  const _SearchResultTile({required this.item, this.status});
+  const _SearchResultTile({required this.item, this.status, this.onTap});
 
   @override
   Widget build(BuildContext context) {
@@ -178,98 +183,102 @@ class _SearchResultTile extends StatelessWidget {
   }
 
   Widget _buildPersonTile(BuildContext context) {
-    final imageUrl = item.posterPath != null &&
-            item.posterPath!.startsWith('http')
-        ? item.posterPath!
-        : AppConfig.tmdbPoster(item.posterPath, width: 154);
+    final imageUrl =
+        item.posterPath != null && item.posterPath!.startsWith('http')
+            ? item.posterPath!
+            : AppConfig.tmdbPoster(item.posterPath, width: 154);
 
     return GestureDetector(
-      onTap: () => showPersonDetailSheet(
-        context,
-        personId: item.id,
-        personName: item.title,
-        profilePath: item.posterPath,
-      ),
+      onTap: () {
+        onTap?.call();
+        showPersonDetailSheet(
+          context,
+          personId: item.id,
+          personName: item.title,
+          profilePath: item.posterPath,
+        );
+      },
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 10),
         child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          // Circular profile thumbnail
-          ClipOval(
-            child: SizedBox(
-              width: 50,
-              height: 50,
-              child: item.posterPath != null
-                  ? CachedNetworkImage(
-                      imageUrl: imageUrl,
-                      fit: BoxFit.cover,
-                      placeholder: (_, __) => Container(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            // Circular profile thumbnail
+            ClipOval(
+              child: SizedBox(
+                width: 50,
+                height: 50,
+                child: item.posterPath != null
+                    ? CachedNetworkImage(
+                        imageUrl: imageUrl,
+                        fit: BoxFit.cover,
+                        placeholder: (_, __) => Container(
+                          color: AppTheme.surfaceVariant,
+                          child: const Center(
+                            child: Icon(Icons.person,
+                                color: AppTheme.textSecondary, size: 18),
+                          ),
+                        ),
+                        errorWidget: (_, __, ___) => Container(
+                          color: AppTheme.surfaceVariant,
+                          child: const Center(
+                            child: Icon(Icons.person,
+                                color: AppTheme.textSecondary, size: 18),
+                          ),
+                        ),
+                      )
+                    : Container(
                         color: AppTheme.surfaceVariant,
                         child: const Center(
                           child: Icon(Icons.person,
                               color: AppTheme.textSecondary, size: 18),
                         ),
                       ),
-                      errorWidget: (_, __, ___) => Container(
-                        color: AppTheme.surfaceVariant,
-                        child: const Center(
-                          child: Icon(Icons.person,
-                              color: AppTheme.textSecondary, size: 18),
-                        ),
-                      ),
-                    )
-                  : Container(
-                      color: AppTheme.surfaceVariant,
-                      child: const Center(
-                        child: Icon(Icons.person,
-                            color: AppTheme.textSecondary, size: 18),
-                      ),
-                    ),
+              ),
             ),
-          ),
-          const SizedBox(width: 10),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  item.title,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: _titleStyle,
-                ),
-                const SizedBox(height: 3),
-                const Text(
-                  'Person',
-                  style: TextStyle(
-                    color: AppTheme.textSecondary,
-                    fontSize: 12,
+            const SizedBox(width: 10),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    item.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: _titleStyle,
                   ),
-                ),
-              ],
+                  const SizedBox(height: 3),
+                  const Text(
+                    'Person',
+                    style: TextStyle(
+                      color: AppTheme.textSecondary,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ),
             ),
-          ),
-        ],
-      ),
+          ],
+        ),
       ),
     );
   }
 
   Widget _buildMediaTile(BuildContext context) {
-    final imageUrl = item.posterPath != null &&
-            item.posterPath!.startsWith('http')
-        ? item.posterPath!
-        : AppConfig.tmdbPoster(item.posterPath, width: 154);
+    final imageUrl =
+        item.posterPath != null && item.posterPath!.startsWith('http')
+            ? item.posterPath!
+            : AppConfig.tmdbPoster(item.posterPath, width: 154);
 
     final year = item.releaseDate != null && item.releaseDate!.length >= 4
         ? item.releaseDate!.substring(0, 4)
         : null;
 
     return GestureDetector(
-      onTap: () => context.push(
-        '/detail/${item.mediaType.name}/${item.id}',
-      ),
+      onTap: () {
+        onTap?.call();
+        context.push('/detail/${item.mediaType.name}/${item.id}');
+      },
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 10),
         child: Row(
@@ -320,10 +329,12 @@ class _SearchResultTile extends StatelessWidget {
                     maxLines: 3,
                     textDirection: TextDirection.ltr,
                   )..layout(maxWidth: constraints.maxWidth);
-                  final titleLines =
-                      titlePainter.computeLineMetrics().length;
-                  final descMaxLines =
-                      titleLines <= 1 ? 2 : titleLines <= 2 ? 1 : 0;
+                  final titleLines = titlePainter.computeLineMetrics().length;
+                  final descMaxLines = titleLines <= 1
+                      ? 2
+                      : titleLines <= 2
+                          ? 1
+                          : 0;
                   final hasOverview = descMaxLines > 0 &&
                       item.overview != null &&
                       item.overview!.isNotEmpty;

--- a/app/lib/features/shell/logic/shell_search_provider.dart
+++ b/app/lib/features/shell/logic/shell_search_provider.dart
@@ -21,6 +21,58 @@ enum SearchMode {
   aiChat,
 }
 
+/// Lightweight client-side intent hint for the unified search/AI bar.
+///
+/// Title-like input still goes to TMDB search. Question phrases and common
+/// assistant commands should move directly to AI so matching media titles do
+/// not steal an obvious AI prompt.
+bool isAiPromptQuery(String query) {
+  final normalized = query.trim().toLowerCase();
+  if (normalized.isEmpty) return false;
+  if (normalized.endsWith('?')) return true;
+
+  const commandPrefixes = [
+    'tell me ',
+    'recommend ',
+    'suggest ',
+    'show me ',
+    'find me ',
+    'help me ',
+    'give me ',
+    'i want ',
+    'i need ',
+    'im looking for ',
+    "i'm looking for ",
+    'movies like ',
+    'shows like ',
+  ];
+
+  if (commandPrefixes.any(normalized.startsWith)) return true;
+
+  final questionPatterns = [
+    RegExp(
+      r'^what\s+(is|are|was|were|should|can|could|do|does|did|would|will)\b',
+    ),
+    RegExp(r"^(whats|what's)\s+"),
+    RegExp(
+      r'^who\s+(is|are|was|were|plays|played|stars|starred|directed|wrote|made)\b',
+    ),
+    RegExp(r'^when\s+(is|are|was|were|did|does|do|will|can|should)\b'),
+    RegExp(r'^where\s+(is|are|was|were|can|could|do|does|did)\b'),
+    RegExp(r'^why\s+(is|are|was|were|did|does|do|would|should)\b'),
+    RegExp(
+      r'^how\s+(do|does|did|can|could|would|should|is|are|was|were|many|much|long|old|good)\b',
+    ),
+    RegExp(r'^which\s+'),
+    RegExp(r'^(can|could|would|should|do|does|did)\s+(you|i|we)\b'),
+    RegExp(
+      r'^(is|are|was|were)\s+.+\b(available|streaming|worth|good|downloaded|missing|requested|on)\b',
+    ),
+  ];
+
+  return questionPatterns.any((pattern) => pattern.hasMatch(normalized));
+}
+
 /// Shell-level search state visible across all tabs.
 class ShellSearchState {
   final String searchQuery;
@@ -61,14 +113,17 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
   final bool aiAvailable;
   final PagedLoader _searchLoader = PagedLoader();
   Timer? _searchDebounce;
+  int _searchGeneration = 0;
 
   ShellSearchNotifier(this._api, {this.aiAvailable = false})
       : super(const ShellSearchState());
 
   void updateSearch(String query) {
+    final trimmed = query.trim();
     _searchDebounce?.cancel();
+    final generation = ++_searchGeneration;
 
-    if (query.isEmpty) {
+    if (trimmed.isEmpty) {
       state = state.copyWith(
         searchQuery: '',
         searchResults: [],
@@ -79,9 +134,14 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
       return;
     }
 
-    // In aiReady mode, just update the query text — don't re-search TMDB.
-    if (state.searchMode == SearchMode.aiReady) {
-      state = state.copyWith(searchQuery: query);
+    if (aiAvailable && isAiPromptQuery(trimmed)) {
+      state = state.copyWith(
+        searchQuery: query,
+        searchResults: [],
+        isLoadingSearch: false,
+        searchMode: SearchMode.aiReady,
+      );
+      _searchLoader.reset();
       return;
     }
 
@@ -90,18 +150,30 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
       isLoadingSearch: true,
       searchMode: SearchMode.search,
     );
-    _searchDebounce = Timer(AppConfig.searchDebounce, () => _executeSearch());
+    _searchDebounce = Timer(
+      AppConfig.searchDebounce,
+      () => _executeSearch(query: query, generation: generation),
+    );
   }
 
-  Future<void> _executeSearch() async {
+  Future<void> _executeSearch({
+    required String query,
+    required int generation,
+  }) async {
     _searchLoader.reset();
     if (!_searchLoader.beginLoading()) return;
 
     try {
       final page = await _api.multiSearch(
-        query: state.searchQuery,
+        query: query,
         page: _searchLoader.page,
       );
+
+      if (generation != _searchGeneration ||
+          state.searchQuery != query ||
+          state.searchMode != SearchMode.search) {
+        return;
+      }
 
       if (page.results.isEmpty && aiAvailable) {
         state = state.copyWith(
@@ -117,6 +189,11 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
       }
       _searchLoader.endLoading(page.totalPages);
     } catch (e) {
+      if (generation != _searchGeneration ||
+          state.searchQuery != query ||
+          state.searchMode != SearchMode.search) {
+        return;
+      }
       _searchLoader.cancelLoading();
       state = state.copyWith(
         isLoadingSearch: false,
@@ -125,15 +202,22 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
     }
   }
 
-  /// Transition from aiReady to full AI chat mode (after user submits).
-  void submitAiReady() {
-    if (state.searchMode == SearchMode.aiReady) {
-      state = state.copyWith(searchMode: SearchMode.aiChat, searchQuery: '');
-    }
+  /// Transition from top-bar intent capture to full inline AI chat mode.
+  void beginAiChat() {
+    _searchDebounce?.cancel();
+    _searchGeneration++;
+    _searchLoader.reset();
+    state = state.copyWith(
+      searchMode: SearchMode.aiChat,
+      searchQuery: '',
+      searchResults: [],
+      isLoadingSearch: false,
+    );
   }
 
   /// Exit AI mode and return to normal search.
   void exitAiMode() {
+    _searchGeneration++;
     state = state.copyWith(
       searchMode: SearchMode.search,
       searchQuery: '',
@@ -152,18 +236,30 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
 
   Future<void> _loadMoreSearchResults() async {
     if (!_searchLoader.beginLoading()) return;
+    final generation = _searchGeneration;
+    final query = state.searchQuery;
     state = state.copyWith(isLoadingSearch: true);
     try {
       final page = await _api.multiSearch(
-        query: state.searchQuery,
+        query: query,
         page: _searchLoader.page,
       );
+      if (generation != _searchGeneration ||
+          state.searchQuery != query ||
+          state.searchMode != SearchMode.search) {
+        return;
+      }
       state = state.copyWith(
         searchResults: [...state.searchResults, ...page.results],
         isLoadingSearch: false,
       );
       _searchLoader.endLoading(page.totalPages);
     } catch (_) {
+      if (generation != _searchGeneration ||
+          state.searchQuery != query ||
+          state.searchMode != SearchMode.search) {
+        return;
+      }
       _searchLoader.cancelLoading();
       state = state.copyWith(isLoadingSearch: false);
     }

--- a/app/lib/features/shell/logic/shell_search_provider.dart
+++ b/app/lib/features/shell/logic/shell_search_provider.dart
@@ -122,6 +122,9 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
     final trimmed = query.trim();
     _searchDebounce?.cancel();
     final generation = ++_searchGeneration;
+    final mode = aiAvailable && isAiPromptQuery(trimmed)
+        ? SearchMode.aiReady
+        : SearchMode.search;
 
     if (trimmed.isEmpty) {
       state = state.copyWith(
@@ -134,31 +137,22 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
       return;
     }
 
-    if (aiAvailable && isAiPromptQuery(trimmed)) {
-      state = state.copyWith(
-        searchQuery: query,
-        searchResults: [],
-        isLoadingSearch: false,
-        searchMode: SearchMode.aiReady,
-      );
-      _searchLoader.reset();
-      return;
-    }
-
     state = state.copyWith(
       searchQuery: query,
+      searchResults: [],
       isLoadingSearch: true,
-      searchMode: SearchMode.search,
+      searchMode: mode,
     );
     _searchDebounce = Timer(
       AppConfig.searchDebounce,
-      () => _executeSearch(query: query, generation: generation),
+      () => _executeSearch(query: query, generation: generation, mode: mode),
     );
   }
 
   Future<void> _executeSearch({
     required String query,
     required int generation,
+    required SearchMode mode,
   }) async {
     _searchLoader.reset();
     if (!_searchLoader.beginLoading()) return;
@@ -171,7 +165,7 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
 
       if (generation != _searchGeneration ||
           state.searchQuery != query ||
-          state.searchMode != SearchMode.search) {
+          state.searchMode != mode) {
         return;
       }
 
@@ -191,7 +185,7 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
     } catch (e) {
       if (generation != _searchGeneration ||
           state.searchQuery != query ||
-          state.searchMode != SearchMode.search) {
+          state.searchMode != mode) {
         return;
       }
       _searchLoader.cancelLoading();
@@ -238,6 +232,7 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
     if (!_searchLoader.beginLoading()) return;
     final generation = _searchGeneration;
     final query = state.searchQuery;
+    final mode = state.searchMode;
     state = state.copyWith(isLoadingSearch: true);
     try {
       final page = await _api.multiSearch(
@@ -246,7 +241,7 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
       );
       if (generation != _searchGeneration ||
           state.searchQuery != query ||
-          state.searchMode != SearchMode.search) {
+          state.searchMode != mode) {
         return;
       }
       state = state.copyWith(
@@ -257,7 +252,7 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
     } catch (_) {
       if (generation != _searchGeneration ||
           state.searchQuery != query ||
-          state.searchMode != SearchMode.search) {
+          state.searchMode != mode) {
         return;
       }
       _searchLoader.cancelLoading();

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -114,6 +114,11 @@ class _AppShellState extends ConsumerState<AppShell>
     if (mounted) setState(() {});
   }
 
+  void _dismissKeyboard() {
+    _searchFocusNode.unfocus();
+    FocusManager.instance.primaryFocus?.unfocus();
+  }
+
   /// Lazily create the shell-scoped AI chat notifier.
   AiChatNotifier _getOrCreateAiChat() {
     if (_aiChatNotifier == null) {
@@ -157,7 +162,8 @@ class _AppShellState extends ConsumerState<AppShell>
         _shimmerRotationAnim.stop();
         _shimmerRotationAnim.value = 0;
         _aiModeAnim.forward();
-        // Transfer query text to the bottom input and re-request focus
+        // Transfer query text to the bottom input if AI chat is opened
+        // without immediately sending the existing prompt.
         final query = ref.read(shellSearchProvider).searchQuery;
         if (query.isNotEmpty && _searchController.text != query) {
           _searchController.text = query;
@@ -166,11 +172,6 @@ class _AppShellState extends ConsumerState<AppShell>
           );
         }
         _getOrCreateAiChat();
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted && !_searchFocusNode.hasFocus) {
-            _searchFocusNode.requestFocus();
-          }
-        });
 
       case SearchMode.search:
         _shimmerRotationAnim.stop();
@@ -182,27 +183,45 @@ class _AppShellState extends ConsumerState<AppShell>
   void _exitAiMode() {
     _searchController.clear();
     ref.read(shellSearchProvider.notifier).exitAiMode();
-    _searchFocusNode.unfocus();
+    _dismissKeyboard();
   }
 
   void _sendAiMessage() {
     final text = _searchController.text.trim();
     if (text.isEmpty || _aiChatNotifier == null) return;
     _searchController.clear();
+    _dismissKeyboard();
     _aiChatNotifier!.sendMessage(text);
   }
 
-  /// Submit from the aiReady state: transition to full chat and send message.
-  void _submitFromAiReady() {
+  /// Submit top-bar input as an inline AI chat message.
+  void _submitSearchBarToAi() {
     final text = _searchController.text.trim();
     if (text.isEmpty) return;
-    ref.read(shellSearchProvider.notifier).submitAiReady();
+    ref.read(shellSearchProvider.notifier).beginAiChat();
     _searchController.clear();
+    _dismissKeyboard();
     _getOrCreateAiChat().sendMessage(text);
   }
 
-  Map<int, LibraryStatus> _buildLibraryStatus(
-      List<MediaItem> searchResults) {
+  void _submitSearchBar() {
+    final text = _searchController.text.trim();
+    if (text.isEmpty) return;
+
+    final searchState = ref.read(shellSearchProvider);
+    final searchNotifier = ref.read(shellSearchProvider.notifier);
+    final shouldAskAi = searchState.searchMode == SearchMode.aiReady ||
+        (searchNotifier.aiAvailable && isAiPromptQuery(text));
+
+    if (shouldAskAi) {
+      _submitSearchBarToAi();
+      return;
+    }
+
+    _dismissKeyboard();
+  }
+
+  Map<int, LibraryStatus> _buildLibraryStatus(List<MediaItem> searchResults) {
     final map = <int, LibraryStatus>{};
 
     // Radarr: match by TMDB ID
@@ -269,6 +288,20 @@ class _AppShellState extends ConsumerState<AppShell>
       MediaQuery.sizeOf(context).width >= 900;
 
   bool _handleScrollNotification(ScrollNotification notification) {
+    final atTop =
+        notification.metrics.pixels <= notification.metrics.minScrollExtent + 4;
+
+    if (notification is ScrollStartNotification ||
+        notification is ScrollUpdateNotification ||
+        notification is OverscrollNotification) {
+      _dismissKeyboard();
+    }
+
+    if (atTop) {
+      _searchBarAnim.forward();
+      return false;
+    }
+
     if (notification is ScrollUpdateNotification) {
       final delta = notification.scrollDelta ?? 0;
       if (delta > 2) {
@@ -299,11 +332,12 @@ class _AppShellState extends ConsumerState<AppShell>
   Widget build(BuildContext context) {
     final searchState = ref.watch(shellSearchProvider);
     final searchNotifier = ref.read(shellSearchProvider.notifier);
-    final hasAi = ref.watch(authProvider).valueOrNull?.connection?.services.ai ?? false;
-    final libraryStatus = searchState.isSearching &&
-            searchState.searchMode == SearchMode.search
-        ? _buildLibraryStatus(searchState.searchResults)
-        : const <int, LibraryStatus>{};
+    final hasAi =
+        ref.watch(authProvider).valueOrNull?.connection?.services.ai ?? false;
+    final libraryStatus =
+        searchState.isSearching && searchState.searchMode == SearchMode.search
+            ? _buildLibraryStatus(searchState.searchResults)
+            : const <int, LibraryStatus>{};
 
     final mobile = _isMobile(context);
     final desktop = _isDesktop(context);
@@ -335,9 +369,12 @@ class _AppShellState extends ConsumerState<AppShell>
           focusNode: _searchFocusNode,
           hintText: isAiReady
               ? 'Edit your question or press send...'
-              : (hasAi ? 'Search or ask AI...' : 'Search by title or person...'),
+              : (hasAi
+                  ? 'Search or ask AI...'
+                  : 'Search by title or person...'),
           aiEnabled: hasAi,
-          onSend: isAiReady ? _submitFromAiReady : null,
+          onSubmitted: _submitSearchBar,
+          onSend: isAiReady ? _submitSearchBarToAi : null,
           onChanged: isAiMode ? null : (q) => searchNotifier.updateSearch(q),
           onClear: isAiReady || isAiMode
               ? _exitAiMode
@@ -357,7 +394,10 @@ class _AppShellState extends ConsumerState<AppShell>
             padding: const EdgeInsets.only(left: 4, top: 8, bottom: 8),
             child: IconButton(
               icon: const Icon(Icons.menu, color: AppTheme.textPrimary),
-              onPressed: () => _scaffoldKey.currentState?.openDrawer(),
+              onPressed: () {
+                _dismissKeyboard();
+                _scaffoldKey.currentState?.openDrawer();
+              },
             ),
           ),
           Expanded(child: searchBar),
@@ -390,10 +430,12 @@ class _AppShellState extends ConsumerState<AppShell>
                   child: Stack(
                     children: [
                       NotificationListener<ScrollNotification>(
-                        onNotification:
-                            mobile && !searchState.isSearching && !isAiMode && !isAiReady
-                                ? _handleScrollNotification
-                                : null,
+                        onNotification: mobile &&
+                                !searchState.isSearching &&
+                                !isAiMode &&
+                                !isAiReady
+                            ? _handleScrollNotification
+                            : null,
                         child: widget.child,
                       ),
                       if (isAiReady)
@@ -439,6 +481,7 @@ class _AppShellState extends ConsumerState<AppShell>
                     query: searchState.searchQuery,
                     onLoadMore: searchNotifier.loadMoreSearch,
                     libraryStatus: libraryStatus,
+                    onResultTap: _dismissKeyboard,
                   ),
                 ),
               ),
@@ -511,8 +554,8 @@ class _AppShellState extends ConsumerState<AppShell>
                 children: [
                   // Header
                   Container(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 12, vertical: 8),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                     decoration: const BoxDecoration(
                       border: Border(
                         bottom: BorderSide(color: AppTheme.border),
@@ -556,31 +599,39 @@ class _AppShellState extends ConsumerState<AppShell>
 
                   // Chat messages
                   Expanded(
-                    child: ListView.builder(
-                      controller: _chatScrollController,
-                      padding: const EdgeInsets.all(16),
-                      itemCount: messages.length +
-                          (isLoading && (messages.isEmpty ||
-                                  messages.last.role != ChatRole.assistant)
-                              ? 1
-                              : 0),
-                      itemBuilder: (context, index) {
-                        if (index >= messages.length) {
-                          return const _TypingIndicator();
-                        }
-                        // Skip the initial welcome message
-                        final msg = messages[index];
-                        if (index == 0 && msg.role == ChatRole.assistant) {
-                          return const SizedBox.shrink();
-                        }
-                        final isLast = index == messages.length - 1;
-                        return ChatBubble(
-                          message: msg,
-                          onRetry: isLast && msg.errorText != null
-                              ? _aiChatNotifier?.retryLast
-                              : null,
-                        );
-                      },
+                    child: GestureDetector(
+                      behavior: HitTestBehavior.translucent,
+                      onTap: _dismissKeyboard,
+                      child: ListView.builder(
+                        controller: _chatScrollController,
+                        keyboardDismissBehavior:
+                            ScrollViewKeyboardDismissBehavior.onDrag,
+                        padding: const EdgeInsets.all(16),
+                        itemCount: messages.length +
+                            (isLoading &&
+                                    (messages.isEmpty ||
+                                        messages.last.role !=
+                                            ChatRole.assistant)
+                                ? 1
+                                : 0),
+                        itemBuilder: (context, index) {
+                          if (index >= messages.length) {
+                            return const _TypingIndicator();
+                          }
+                          // Skip the initial welcome message
+                          final msg = messages[index];
+                          if (index == 0 && msg.role == ChatRole.assistant) {
+                            return const SizedBox.shrink();
+                          }
+                          final isLast = index == messages.length - 1;
+                          return ChatBubble(
+                            message: msg,
+                            onRetry: isLast && msg.errorText != null
+                                ? _aiChatNotifier?.retryLast
+                                : null,
+                          );
+                        },
+                      ),
                     ),
                   ),
 
@@ -677,8 +728,7 @@ class _AppShellState extends ConsumerState<AppShell>
                 ),
                 const Text(
                   'Your media companion',
-                  style:
-                      TextStyle(color: AppTheme.textSecondary, fontSize: 14),
+                  style: TextStyle(color: AppTheme.textSecondary, fontSize: 14),
                 ),
               ],
             ),
@@ -815,8 +865,7 @@ class _TypingIndicator extends StatelessWidget {
       child: Row(
         children: [
           Container(
-            padding:
-                const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
             decoration: BoxDecoration(
               color: AppTheme.surfaceVariant,
               borderRadius: BorderRadius.circular(16),

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -334,10 +334,11 @@ class _AppShellState extends ConsumerState<AppShell>
     final searchNotifier = ref.read(shellSearchProvider.notifier);
     final hasAi =
         ref.watch(authProvider).valueOrNull?.connection?.services.ai ?? false;
-    final libraryStatus =
-        searchState.isSearching && searchState.searchMode == SearchMode.search
-            ? _buildLibraryStatus(searchState.searchResults)
-            : const <int, LibraryStatus>{};
+    final showSearchResults = searchState.searchMode == SearchMode.search ||
+        searchState.searchMode == SearchMode.aiReady;
+    final libraryStatus = searchState.isSearching && showSearchResults
+        ? _buildLibraryStatus(searchState.searchResults)
+        : const <int, LibraryStatus>{};
 
     final mobile = _isMobile(context);
     final desktop = _isDesktop(context);
@@ -444,20 +445,42 @@ class _AppShellState extends ConsumerState<AppShell>
                             color: AppTheme.background,
                             child: Column(
                               children: [
-                                const SizedBox(height: 48),
-                                Icon(
-                                  Icons.auto_awesome,
-                                  size: 32,
-                                  color: AppTheme.accent.withValues(alpha: 0.5),
-                                ),
-                                const SizedBox(height: 8),
-                                const Text(
-                                  'Press send to ask AI',
-                                  style: TextStyle(
-                                    color: AppTheme.textSecondary,
-                                    fontSize: 14,
+                                Padding(
+                                  padding:
+                                      const EdgeInsets.fromLTRB(16, 20, 16, 12),
+                                  child: Column(
+                                    children: [
+                                      Icon(
+                                        Icons.auto_awesome,
+                                        size: 32,
+                                        color: AppTheme.accent
+                                            .withValues(alpha: 0.5),
+                                      ),
+                                      const SizedBox(height: 8),
+                                      const Text(
+                                        'Press send to ask AI',
+                                        style: TextStyle(
+                                          color: AppTheme.textSecondary,
+                                          fontSize: 14,
+                                        ),
+                                      ),
+                                    ],
                                   ),
                                 ),
+                                if (searchState.searchResults.isNotEmpty ||
+                                    searchState.isLoadingSearch)
+                                  Expanded(
+                                    child: SearchResultsView(
+                                      results: searchState.searchResults,
+                                      isLoading: searchState.isLoadingSearch,
+                                      query: searchState.searchQuery,
+                                      onLoadMore: searchNotifier.loadMoreSearch,
+                                      libraryStatus: libraryStatus,
+                                      onResultTap: _dismissKeyboard,
+                                    ),
+                                  )
+                                else
+                                  const Spacer(),
                               ],
                             ),
                           ),

--- a/app/test/shell/shell_search_provider_test.dart
+++ b/app/test/shell/shell_search_provider_test.dart
@@ -1,4 +1,6 @@
+import 'package:cantinarr/features/discover/data/discover_api_service.dart';
 import 'package:cantinarr/features/shell/logic/shell_search_provider.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -17,5 +19,22 @@ void main() {
       expect(isAiPromptQuery('How I Met Your Mother'), false);
       expect(isAiPromptQuery('Who Framed Roger Rabbit'), false);
     });
+  });
+
+  test('search mode re-evaluates when an AI prompt is edited into a title', () {
+    final notifier = ShellSearchNotifier(
+      DiscoverApiService(backendDio: Dio()),
+      aiAvailable: true,
+    );
+
+    addTearDown(notifier.dispose);
+
+    notifier.updateSearch('What should I watch tonight?');
+    expect(notifier.state.searchMode, SearchMode.aiReady);
+    expect(notifier.state.isLoadingSearch, true);
+
+    notifier.updateSearch('Severance');
+    expect(notifier.state.searchMode, SearchMode.search);
+    expect(notifier.state.isLoadingSearch, true);
   });
 }

--- a/app/test/shell/shell_search_provider_test.dart
+++ b/app/test/shell/shell_search_provider_test.dart
@@ -1,0 +1,21 @@
+import 'package:cantinarr/features/shell/logic/shell_search_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('isAiPromptQuery', () {
+    test('detects obvious AI prompts', () {
+      expect(isAiPromptQuery('What should I watch tonight?'), true);
+      expect(isAiPromptQuery('recommend sci-fi movies'), true);
+      expect(isAiPromptQuery('find me shows like Severance'), true);
+      expect(isAiPromptQuery('is The Matrix worth watching'), true);
+    });
+
+    test('keeps title-like searches in normal search', () {
+      expect(isAiPromptQuery('Severance'), false);
+      expect(isAiPromptQuery('Once Upon a Time in Hollywood'), false);
+      expect(isAiPromptQuery('What We Do in the Shadows'), false);
+      expect(isAiPromptQuery('How I Met Your Mother'), false);
+      expect(isAiPromptQuery('Who Framed Roger Rabbit'), false);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- dismiss the keyboard naturally when scrolling, tapping results, sending AI messages, or opening shell controls
- make the mobile search bar reappear reliably at the top of scrollable content
- route question-like search bar input directly into AI mode and guard against stale TMDB search responses
- add tests for AI prompt detection versus title-like searches

## Tests
- flutter test
- flutter analyze --no-fatal-infos

Note: plain `flutter analyze` still reports existing info-level lints in unrelated files.