### PR TITLE
Fix AI-ready typing and submit behavior

### DIFF
--- a/app/lib/core/widgets/search_bar.dart
+++ b/app/lib/core/widgets/search_bar.dart
@@ -48,6 +48,7 @@ class CantinarrSearchBar extends StatelessWidget {
     final borderColor = hasGlow
         ? Color.lerp(AppTheme.border, AppTheme.accent, glowIntensity)!
         : AppTheme.border;
+    final submitAction = multiline ? onSend : onSubmitted;
 
     return Container(
       decoration: BoxDecoration(
@@ -69,10 +70,11 @@ class CantinarrSearchBar extends StatelessWidget {
         focusNode: focusNode,
         keyboardType: TextInputType.text,
         onChanged: onChanged,
-        onSubmitted: multiline ? null : (_) => onSubmitted?.call(),
+        onSubmitted: submitAction == null ? null : (_) => submitAction(),
         onTapOutside: (_) => focusNode.unfocus(),
-        textInputAction:
-            multiline ? TextInputAction.newline : TextInputAction.search,
+        textInputAction: multiline
+            ? (onSend == null ? TextInputAction.newline : TextInputAction.send)
+            : TextInputAction.search,
         maxLines: maxLines ?? (multiline ? 3 : 1),
         minLines: multiline ? 2 : 1,
         style: const TextStyle(color: AppTheme.textPrimary, fontSize: 16),

--- a/app/lib/features/shell/logic/shell_search_provider.dart
+++ b/app/lib/features/shell/logic/shell_search_provider.dart
@@ -120,11 +120,19 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
 
   void updateSearch(String query) {
     final trimmed = query.trim();
+    final normalized = trimmed.toLowerCase();
+    final previousNormalized = state.searchQuery.trim().toLowerCase();
+    final continuingAiReadyInput = aiAvailable &&
+        state.searchMode == SearchMode.aiReady &&
+        previousNormalized.isNotEmpty &&
+        normalized.length >= previousNormalized.length &&
+        normalized.startsWith(previousNormalized);
     _searchDebounce?.cancel();
     final generation = ++_searchGeneration;
-    final mode = aiAvailable && isAiPromptQuery(trimmed)
-        ? SearchMode.aiReady
-        : SearchMode.search;
+    final mode =
+        continuingAiReadyInput || (aiAvailable && isAiPromptQuery(trimmed))
+            ? SearchMode.aiReady
+            : SearchMode.search;
 
     if (trimmed.isEmpty) {
       state = state.copyWith(

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -209,11 +209,7 @@ class _AppShellState extends ConsumerState<AppShell>
     if (text.isEmpty) return;
 
     final searchState = ref.read(shellSearchProvider);
-    final searchNotifier = ref.read(shellSearchProvider.notifier);
-    final shouldAskAi = searchState.searchMode == SearchMode.aiReady ||
-        (searchNotifier.aiAvailable && isAiPromptQuery(text));
-
-    if (shouldAskAi) {
+    if (searchState.searchMode == SearchMode.aiReady) {
       _submitSearchBarToAi();
       return;
     }

--- a/app/test/core/widgets/search_bar_test.dart
+++ b/app/test/core/widgets/search_bar_test.dart
@@ -1,0 +1,35 @@
+import 'package:cantinarr/core/widgets/search_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('multiline search bar submits on keyboard send action',
+      (tester) async {
+    final controller = TextEditingController(text: 'Find something good');
+    final focusNode = FocusNode();
+    var sendCount = 0;
+
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CantinarrSearchBar(
+            controller: controller,
+            focusNode: focusNode,
+            multiline: true,
+            onSend: () => sendCount++,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.byType(TextField));
+    await tester.pump();
+    await tester.testTextInput.receiveAction(TextInputAction.send);
+    await tester.pump();
+
+    expect(sendCount, 1);
+  });
+}

--- a/app/test/shell/shell_search_provider_test.dart
+++ b/app/test/shell/shell_search_provider_test.dart
@@ -37,4 +37,20 @@ void main() {
     expect(notifier.state.searchMode, SearchMode.search);
     expect(notifier.state.isLoadingSearch, true);
   });
+
+  test('ai-ready mode sticks while the user appends more text', () {
+    final notifier = ShellSearchNotifier(
+      DiscoverApiService(backendDio: Dio()),
+      aiAvailable: true,
+    );
+
+    addTearDown(notifier.dispose);
+
+    notifier.updateSearch('Dune?');
+    expect(notifier.state.searchMode, SearchMode.aiReady);
+
+    notifier.updateSearch('Dune? part two');
+    expect(notifier.state.searchMode, SearchMode.aiReady);
+    expect(notifier.state.isLoadingSearch, true);
+  });
 }


### PR DESCRIPTION
## Summary
- keep AI-ready mode active while the user appends more text to an AI-ready query, so only the fuzzy results refresh
- keep deletion/replacement edits re-evaluating the query so AI-ready can turn off when the user corrects a typo into a normal title search
- make Enter/keyboard send submit multiline AI input
- make top-bar Enter submit send only when already in AI-ready mode; otherwise it just dismisses the keyboard

## Tests
- flutter test
- flutter analyze --no-fatal-infos

Note: plain `flutter analyze` still reports existing info-level lints in unrelated files.