### PR TITLE
Persist assistant chat across closes

### DIFF
--- a/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
+++ b/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
@@ -1,7 +1,101 @@
-import 'package:flutter/foundation.dart';
+import 'dart:async';
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
+import '../../../core/network/backend_client.dart';
 import '../data/ai_models.dart';
 import '../data/ai_chat_service.dart';
+
+/// How long an assistant session can sit unused before it is refreshed.
+const aiChatSessionIdleTimeout = Duration(minutes: 30);
+
+/// Shared assistant conversation for both the full-screen assistant and the
+/// shell's inline AI mode.
+///
+/// The keep-alive link lets users leave and reopen the assistant without
+/// losing the active conversation. Auto-dispose still gives us a natural
+/// refresh after the app is backgrounded or the assistant has no listeners for
+/// a while.
+final aiChatProvider =
+    ChangeNotifierProvider.autoDispose<AiChatNotifier>((ref) {
+  final backendDio = ref.watch(backendClientProvider);
+  final notifier = AiChatNotifier(
+    chatService: AiChatService(backendDio: backendDio),
+  );
+  final keepAliveLink = ref.keepAlive();
+
+  Timer? idleTimer;
+  Timer? backgroundTimer;
+
+  void expireSession() {
+    idleTimer?.cancel();
+    backgroundTimer?.cancel();
+    ref.invalidateSelf();
+  }
+
+  void startIdleTimer() {
+    idleTimer?.cancel();
+    idleTimer = Timer(aiChatSessionIdleTimeout, expireSession);
+  }
+
+  void cancelIdleTimer() {
+    idleTimer?.cancel();
+    idleTimer = null;
+  }
+
+  void startBackgroundTimer() {
+    backgroundTimer?.cancel();
+    backgroundTimer = Timer(aiChatSessionIdleTimeout, expireSession);
+  }
+
+  void cancelBackgroundTimer() {
+    backgroundTimer?.cancel();
+    backgroundTimer = null;
+  }
+
+  final lifecycleObserver = _AiChatLifecycleObserver(
+    onBackgrounded: startBackgroundTimer,
+    onResumed: cancelBackgroundTimer,
+  );
+
+  WidgetsBinding.instance.addObserver(lifecycleObserver);
+
+  ref.onCancel(startIdleTimer);
+  ref.onResume(cancelIdleTimer);
+  ref.onDispose(() {
+    cancelIdleTimer();
+    cancelBackgroundTimer();
+    WidgetsBinding.instance.removeObserver(lifecycleObserver);
+    keepAliveLink.close();
+  });
+
+  return notifier;
+});
+
+class _AiChatLifecycleObserver extends WidgetsBindingObserver {
+  final VoidCallback onBackgrounded;
+  final VoidCallback onResumed;
+
+  _AiChatLifecycleObserver({
+    required this.onBackgrounded,
+    required this.onResumed,
+  });
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      onResumed();
+      return;
+    }
+
+    if (state == AppLifecycleState.hidden ||
+        state == AppLifecycleState.paused ||
+        state == AppLifecycleState.detached) {
+      onBackgrounded();
+    }
+  }
+}
 
 /// State for the AI chat conversation.
 class AiChatState {
@@ -34,6 +128,7 @@ class AiChatState {
 class AiChatNotifier extends ChangeNotifier {
   final AiChatService _chatService;
   final _uuid = const Uuid();
+  bool _disposed = false;
 
   /// Server-assigned conversation ID; sent on every turn so the server can
   /// keep full tool context. Reset when the chat is cleared.
@@ -47,6 +142,7 @@ class AiChatNotifier extends ChangeNotifier {
   AiChatState _state = const AiChatState();
   AiChatState get state => _state;
   set state(AiChatState value) {
+    if (_disposed) return;
     _state = value;
     notifyListeners();
   }
@@ -65,6 +161,7 @@ class AiChatNotifier extends ChangeNotifier {
 
   /// Send a user message and stream the AI response.
   Future<void> sendMessage(String text) async {
+    if (_disposed) return;
     if (text.trim().isEmpty) return;
     // One turn at a time: a second concurrent stream would corrupt chat
     // state and race the server-side conversation store.
@@ -213,6 +310,7 @@ class AiChatNotifier extends ChangeNotifier {
   void clearError() => state = state.copyWith(error: null);
 
   void clearChat() {
+    if (_disposed) return;
     _conversationId = null;
     _generation++; // orphan any in-flight stream
     state = const AiChatState();
@@ -223,5 +321,12 @@ class AiChatNotifier extends ChangeNotifier {
       timestamp: DateTime.now(),
       excludeFromHistory: true,
     ));
+  }
+
+  @override
+  void dispose() {
+    _generation++;
+    _disposed = true;
+    super.dispose();
   }
 }

--- a/app/lib/features/ai_assistant/ui/ai_chat_screen.dart
+++ b/app/lib/features/ai_assistant/ui/ai_chat_screen.dart
@@ -2,10 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/models/app_module.dart';
-import '../../../core/network/backend_client.dart';
 import '../../../core/providers/module_provider.dart';
 import '../../../core/theme/app_theme.dart';
-import '../data/ai_chat_service.dart';
 import '../data/ai_models.dart';
 import '../logic/ai_chat_provider.dart';
 import 'chat_bubble.dart';
@@ -29,20 +27,11 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
   final _scrollController = ScrollController();
   final _focusNode = FocusNode();
 
-  @override
-  void initState() {
-    super.initState();
-    if (widget.aiAvailable) {
-      _initNotifier();
-    }
-  }
-
-  void _initNotifier() {
-    final backendDio = ref.read(backendClientProvider);
-    _notifier = AiChatNotifier(
-      chatService: AiChatService(backendDio: backendDio),
-    );
-    _notifier!.addListener(_scrollToBottom);
+  void _setNotifier(AiChatNotifier? notifier) {
+    if (identical(_notifier, notifier)) return;
+    _notifier?.removeListener(_scrollToBottom);
+    _notifier = notifier;
+    _notifier?.addListener(_scrollToBottom);
   }
 
   void _scrollToBottom() {
@@ -60,7 +49,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
 
   @override
   void dispose() {
-    _notifier?.removeListener(_scrollToBottom);
+    _setNotifier(null);
     _inputController.dispose();
     _scrollController.dispose();
     _focusNode.dispose();
@@ -92,7 +81,8 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
 
   @override
   Widget build(BuildContext context) {
-    if (!widget.aiAvailable || _notifier == null) {
+    if (!widget.aiAvailable) {
+      _setNotifier(null);
       return Scaffold(
         appBar: AppBar(
           leading: IconButton(
@@ -132,7 +122,14 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
       );
     }
 
-    final state = _notifier!.state;
+    final notifier = ref.watch(aiChatProvider);
+    _setNotifier(notifier);
+
+    return _buildChat(context, notifier);
+  }
+
+  Widget _buildChat(BuildContext context, AiChatNotifier notifier) {
+    final state = notifier.state;
 
     return Scaffold(
       appBar: AppBar(
@@ -145,7 +142,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
         actions: [
           IconButton(
             icon: const Icon(Icons.add_comment_outlined),
-            onPressed: _notifier!.clearChat,
+            onPressed: notifier.clearChat,
             tooltip: 'New chat',
           ),
         ],
@@ -178,7 +175,7 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
                     return ChatBubble(
                       message: msg,
                       onRetry: isLast && msg.errorText != null
-                          ? _notifier!.retryLast
+                          ? notifier.retryLast
                           : null,
                     );
                   },

--- a/app/lib/features/shell/logic/shell_ai_chat_provider.dart
+++ b/app/lib/features/shell/logic/shell_ai_chat_provider.dart
@@ -1,17 +1,4 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../../core/network/backend_client.dart';
-import '../../ai_assistant/data/ai_chat_service.dart';
 import '../../ai_assistant/logic/ai_chat_provider.dart';
 
-/// Provides an [AiChatNotifier] scoped to the shell's inline AI mode.
-///
-/// Created lazily on first access, persists until the provider is disposed.
-/// Reuses the existing [AiChatService] and [AiChatNotifier] classes.
-final shellAiChatProvider = Provider<AiChatNotifier>((ref) {
-  final backendDio = ref.watch(backendClientProvider);
-  final notifier = AiChatNotifier(
-    chatService: AiChatService(backendDio: backendDio),
-  );
-  ref.onDispose(() => notifier.dispose());
-  return notifier;
-});
+/// Backwards-compatible alias for the shared assistant conversation.
+final shellAiChatProvider = aiChatProvider;

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -8,7 +8,6 @@ import '../../../core/providers/module_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/search_bar.dart';
 import '../../../core/widgets/shimmer_border.dart';
-import '../../ai_assistant/data/ai_chat_service.dart';
 import '../../ai_assistant/data/ai_models.dart';
 import '../../ai_assistant/logic/ai_chat_provider.dart';
 import '../../ai_assistant/ui/chat_bubble.dart';
@@ -119,16 +118,20 @@ class _AppShellState extends ConsumerState<AppShell>
     FocusManager.instance.primaryFocus?.unfocus();
   }
 
-  /// Lazily create the shell-scoped AI chat notifier.
+  /// Lazily attach to the shared AI chat notifier.
   AiChatNotifier _getOrCreateAiChat() {
-    if (_aiChatNotifier == null) {
-      final backendDio = ref.read(backendClientProvider);
-      _aiChatNotifier = AiChatNotifier(
-        chatService: AiChatService(backendDio: backendDio),
-      );
-      _aiChatNotifier!.addListener(_onAiChatChanged);
-    }
-    return _aiChatNotifier!;
+    final existing = _aiChatNotifier;
+    if (existing != null) return existing;
+    final notifier = ref.read(aiChatProvider);
+    _setAiChatNotifier(notifier);
+    return notifier;
+  }
+
+  void _setAiChatNotifier(AiChatNotifier? notifier) {
+    if (identical(_aiChatNotifier, notifier)) return;
+    _aiChatNotifier?.removeListener(_onAiChatChanged);
+    _aiChatNotifier = notifier;
+    _aiChatNotifier?.addListener(_onAiChatChanged);
   }
 
   void _onAiChatChanged() {
@@ -156,7 +159,6 @@ class _AppShellState extends ConsumerState<AppShell>
       case SearchMode.noResults:
       case SearchMode.aiReady:
         _shimmerRotationAnim.repeat();
-        _getOrCreateAiChat();
 
       case SearchMode.aiChat:
         _shimmerRotationAnim.stop();
@@ -315,8 +317,7 @@ class _AppShellState extends ConsumerState<AppShell>
     _aiModeAnim.dispose();
     _shimmerRotationAnim.dispose();
     _chatScrollController.dispose();
-    _aiChatNotifier?.removeListener(_onAiChatChanged);
-    _aiChatNotifier?.dispose();
+    _setAiChatNotifier(null);
     _radarrNotifier?.removeListener(_onLibraryChanged);
     _sonarrNotifier?.removeListener(_onLibraryChanged);
     _searchController.dispose();
@@ -344,6 +345,11 @@ class _AppShellState extends ConsumerState<AppShell>
 
     final isAiMode = searchState.searchMode == SearchMode.aiChat;
     final isAiReady = searchState.searchMode == SearchMode.aiReady;
+    if (isAiMode) {
+      _setAiChatNotifier(ref.watch(aiChatProvider));
+    } else {
+      _setAiChatNotifier(null);
+    }
 
     final searchBar = Padding(
       padding: EdgeInsets.fromLTRB(desktop ? 16 : 4, 8, 16, 8),
@@ -769,10 +775,12 @@ class _AppShellState extends ConsumerState<AppShell>
                   onTap: () {
                     if (isOverlay) Navigator.pop(context);
                     _navigateToModule(context, module);
-                    ref.read(moduleProvider.notifier).setActiveModule(
-                          module.type,
-                          instanceId: module.instanceId,
-                        );
+                    if (module.type != ModuleType.assistant) {
+                      ref.read(moduleProvider.notifier).setActiveModule(
+                            module.type,
+                            instanceId: module.instanceId,
+                          );
+                    }
                   },
                 );
               }).toList(),
@@ -835,7 +843,7 @@ class _AppShellState extends ConsumerState<AppShell>
       case ModuleType.tautulli:
         context.go('/tautulli/activity');
       case ModuleType.assistant:
-        context.go('/assistant');
+        context.push('/assistant');
     }
   }
 }

--- a/app/test/ai_assistant/ai_chat_screen_test.dart
+++ b/app/test/ai_assistant/ai_chat_screen_test.dart
@@ -37,4 +37,53 @@ void main() {
 
     expect(find.text('Dashboard'), findsOneWidget);
   });
+
+  testWidgets('assistant conversation persists after route close and reopen',
+      (tester) async {
+    final router = GoRouter(
+      initialLocation: '/dashboard/movies',
+      routes: [
+        GoRoute(
+          path: '/dashboard/movies',
+          builder: (context, __) => Scaffold(
+            body: Center(
+              child: ElevatedButton(
+                onPressed: () => context.push('/assistant'),
+                child: const Text('Open assistant'),
+              ),
+            ),
+          ),
+        ),
+        GoRoute(
+          path: '/assistant',
+          builder: (_, __) => const AiChatScreen(aiAvailable: true),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Open assistant'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('New chat'));
+    await tester.pumpAndSettle();
+    expect(
+        find.text('Chat cleared! What can I help you find?'), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Exit assistant'));
+    await tester.pumpAndSettle();
+    expect(find.text('Open assistant'), findsOneWidget);
+
+    await tester.tap(find.text('Open assistant'));
+    await tester.pumpAndSettle();
+
+    expect(
+        find.text('Chat cleared! What can I help you find?'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
Summary:
- open the full assistant as a pushed route so swipe/back can close it
- share assistant chat state across full-screen and inline entry points
- expire the retained chat after 30 minutes idle or backgrounded/hidden
- add a widget test for close/reopen persistence

Validation:
- flutter test test/ai_assistant/ai_chat_screen_test.dart
- flutter analyze lib/features/ai_assistant lib/features/shell test/ai_assistant/ai_chat_screen_test.dart

Note: full flutter analyze still reports existing unrelated info-level lints outside this change.