### PR TITLE
Fix search assistant back navigation

### DIFF
--- a/app/lib/features/shell/logic/shell_search_provider.dart
+++ b/app/lib/features/shell/logic/shell_search_provider.dart
@@ -219,6 +219,7 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
 
   /// Exit AI mode and return to normal search.
   void exitAiMode() {
+    _searchDebounce?.cancel();
     _searchGeneration++;
     state = state.copyWith(
       searchMode: SearchMode.search,

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -196,14 +196,17 @@ class _AppShellState extends ConsumerState<AppShell>
     _aiChatNotifier!.sendMessage(text);
   }
 
-  /// Submit top-bar input as an inline AI chat message.
+  /// Submit top-bar input through the full-screen assistant route.
   void _submitSearchBarToAi() {
     final text = _searchController.text.trim();
     if (text.isEmpty) return;
-    ref.read(shellSearchProvider.notifier).beginAiChat();
-    _searchController.clear();
-    _dismissKeyboard();
-    _getOrCreateAiChat().sendMessage(text);
+
+    _exitAiMode();
+    context.push('/assistant');
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref.read(aiChatProvider).sendMessage(text);
+    });
   }
 
   void _submitSearchBar() {

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -1,0 +1,109 @@
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/features/ai_assistant/data/ai_chat_service.dart';
+import 'package:cantinarr/features/ai_assistant/logic/ai_chat_provider.dart';
+import 'package:cantinarr/features/ai_assistant/ui/ai_chat_screen.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/shell/ui/app_shell.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  testWidgets(
+      'search-bar assistant submit opens route over previous shell content',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final chatNotifier = _FakeAiChatNotifier();
+    final router = GoRouter(
+      initialLocation: '/dashboard/movies',
+      routes: [
+        ShellRoute(
+          builder: (context, state, child) => AppShell(child: child),
+          routes: [
+            GoRoute(
+              path: '/dashboard/movies',
+              builder: (_, __) => const Scaffold(body: Text('Dashboard home')),
+            ),
+          ],
+        ),
+        GoRoute(
+          path: '/assistant',
+          builder: (_, __) => const AiChatScreen(aiAvailable: true),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith(
+            () => _FakeAuthNotifier(_authenticatedAiState),
+          ),
+          aiChatProvider.overrideWith((ref) => chatNotifier),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dashboard home'), findsOneWidget);
+
+    await tester.enterText(
+      find.byType(TextField).first,
+      'What should I watch tonight?',
+    );
+    await tester.pump();
+    await tester.tap(find.byIcon(Icons.send_rounded));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AiChatScreen), findsOneWidget);
+    expect(find.byTooltip('Exit assistant'), findsOneWidget);
+    expect(chatNotifier.sentMessage, 'What should I watch tonight?');
+
+    await tester.binding.handlePopRoute();
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dashboard home'), findsOneWidget);
+    expect(find.byType(AiChatScreen), findsNothing);
+    expect(find.text('What should I watch tonight?'), findsNothing);
+  });
+}
+
+const _authenticatedAiState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(ai: true),
+  ),
+  user: UserProfile(id: 1, username: 'tester', role: 'admin'),
+);
+
+class _FakeAuthNotifier extends AuthNotifier {
+  final AuthState authState;
+
+  _FakeAuthNotifier(this.authState);
+
+  @override
+  Future<AuthState> build() async => authState;
+}
+
+class _FakeAiChatNotifier extends AiChatNotifier {
+  String? sentMessage;
+
+  _FakeAiChatNotifier() : super(chatService: AiChatService(backendDio: Dio()));
+
+  @override
+  Future<void> sendMessage(String text) async {
+    sentMessage = text;
+  }
+}


### PR DESCRIPTION
## Summary
- open the full-screen assistant route when a prompt is submitted from shell search
- clear shell search state before routing so back returns to the screen that was up before search
- cancel pending search debounce when exiting AI/search mode
- add a shell regression test for search-bar assistant navigation and back behavior

## Tests
- flutter test
- flutter analyze (still reports existing unrelated info-level lints)