### PR TITLE
Unify AI provider streaming loops

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Agent Instructions
+
+## Workflow
+
+- Before starting any PR-sized change, fetch `origin/main`, make sure local `main` is even with `origin/main`, and create a feature branch from that fresh base.
+- Do not open PRs directly from `main`. If work accidentally happens on `main`, verify `main` is still even with `origin/main`, then move the work to a feature branch before committing.
+- Preserve user work. Do not revert or delete unrelated local changes or untracked files.
+- When the change is ready, commit on the feature branch, push it, and open a PR with `gh pr create` unless the user explicitly asks not to.
+
+## Verification
+
+- For server changes, run `go test ./...` from `server/`.
+- For Flutter app changes, run `flutter analyze` and the relevant `flutter test` targets from `app/` when feasible.
+- Mention any tests or checks that could not be run.

--- a/app/README.md
+++ b/app/README.md
@@ -52,7 +52,7 @@ Dark-first UI with warm gold accents, designed for couch browsing.
 - **Status indicators** -- available (green), requested (orange), downloading (blue), unavailable (grey)
 
 ### AI Assistant
-- **Claude-powered chat** -- ask for recommendations, check availability, make requests via conversation
+- **Multi-provider AI chat** -- ask for recommendations, check availability, make requests via conversation
 - **SSE streaming** -- responses appear incrementally, not all-at-once
 - **Server-side tools** -- the AI can search TMDB, check your server, and make requests on your behalf
 

--- a/server/README.md
+++ b/server/README.md
@@ -110,9 +110,10 @@ POST   /api/ai/chat             # SSE-streamed AI conversation with tool use
 GET    /api/ai/available        # { available: true/false }
 ```
 The chat request accepts an optional `conversation_id`; when supplied, the server
-replays its stored transcript (including tool results) so follow-up turns keep
-full grounding. SSE frames: `{conversation_id}`, `{text}`, `{tool_start: {name, label}}`,
-`{tool_end: {name, ok}}`, `{media_results}`, `{error}`, then `[DONE]`.
+replays its provider-neutral stored transcript (including tool results) so follow-up
+turns keep full grounding across Anthropic, OpenAI, and Gemini. SSE frames:
+`{conversation_id}`, `{text}`, `{tool_start: {name, label}}`, `{tool_end: {name, ok}}`,
+`{media_results}`, `{error}`, then `[DONE]`.
 
 ### AI Tool Toggles (admin only)
 ```
@@ -260,8 +261,8 @@ server/
 ├── internal/
 │   ├── ai/
 │   │   ├── handler.go              # SSE streaming chat endpoint
-│   │   ├── service.go              # Anthropic API client + tool loop
-│   │   └── http_providers.go       # OpenAI/Gemini API clients + tool loops
+│   │   ├── service.go              # Anthropic streaming API client + tool loop
+│   │   └── http_providers.go       # OpenAI/Gemini streaming API clients + tool loops
 │   ├── api/router.go               # Chi router, CORS, middleware, routes
 │   ├── auth/
 │   │   ├── handler.go              # Login, refresh, connect token
@@ -307,7 +308,7 @@ server/
 - **SQLite** via [modernc.org/sqlite](https://pkg.go.dev/modernc.org/sqlite) (pure Go, no CGO)
 - **JWT** via [golang-jwt](https://github.com/golang-jwt/jwt)
 - **WebSocket** via [gorilla/websocket](https://github.com/gorilla/websocket)
-- **Anthropic Messages API** (SDK), **OpenAI Chat Completions API**, and **Gemini generateContent API**
+- **Anthropic Messages API** (SDK streaming), **OpenAI Chat Completions API** (streaming), and **Gemini streamGenerateContent API**
 
 ## License
 

--- a/server/internal/ai/conversation.go
+++ b/server/internal/ai/conversation.go
@@ -3,21 +3,46 @@ package ai
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"sync"
 	"time"
-
-	"github.com/anthropics/anthropic-sdk-go"
 )
 
 const (
 	conversationTTL   = 4 * time.Hour
 	maxConversations  = 200
 	maxStoredMessages = 60
+
+	agentRoleUser      = "user"
+	agentRoleAssistant = "assistant"
+
+	blockTypeText       = "text"
+	blockTypeToolUse    = "tool_use"
+	blockTypeToolResult = "tool_result"
 )
 
-// conversationStore keeps full agent transcripts (including tool_use and
-// tool_result blocks) server-side so follow-up turns retain grounding that
-// the client's plain-text transcript cannot carry.
+// transcript is the provider-neutral history used by the agent loop. It keeps
+// tool calls/results server-side so follow-up turns remain grounded no matter
+// which AI provider is selected.
+type transcript []transcriptMessage
+
+type transcriptMessage struct {
+	Role    string
+	Content []transcriptBlock
+}
+
+type transcriptBlock struct {
+	Type      string
+	Text      string
+	ID        string
+	Name      string
+	Input     json.RawMessage
+	ToolUseID string
+	Content   string
+	IsError   bool
+}
+
+// conversationStore keeps full provider-neutral agent transcripts server-side.
 type conversationStore struct {
 	mu            sync.Mutex
 	conversations map[string]*conversation
@@ -25,7 +50,7 @@ type conversationStore struct {
 
 type conversation struct {
 	userID    int64
-	messages  []anthropic.MessageParam
+	messages  transcript
 	updatedAt time.Time
 }
 
@@ -37,20 +62,20 @@ func newConversationStore() *conversationStore {
 // The returned slice is a copy: callers append to it while the loop runs, and
 // sharing the backing array with the stored entry would race with concurrent
 // turns on the same conversation.
-func (s *conversationStore) Get(id string, userID int64) ([]anthropic.MessageParam, bool) {
+func (s *conversationStore) Get(id string, userID int64) (transcript, bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	conv, ok := s.conversations[id]
 	if !ok || conv.userID != userID || time.Since(conv.updatedAt) > conversationTTL {
 		return nil, false
 	}
-	return append([]anthropic.MessageParam(nil), conv.messages...), true
+	return cloneTranscript(conv.messages), true
 }
 
 // Put stores the full transcript for id, trimming old turns and evicting
 // stale conversations. The transcript is copied so the store never aliases a
 // caller's slice.
-func (s *conversationStore) Put(id string, userID int64, messages []anthropic.MessageParam) {
+func (s *conversationStore) Put(id string, userID int64, messages transcript) {
 	trimmed := trimHistory(messages, maxStoredMessages)
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -58,7 +83,7 @@ func (s *conversationStore) Put(id string, userID int64, messages []anthropic.Me
 	s.evictLocked()
 	s.conversations[id] = &conversation{
 		userID:    userID,
-		messages:  append([]anthropic.MessageParam(nil), trimmed...),
+		messages:  cloneTranscript(trimmed),
 		updatedAt: time.Now(),
 	}
 }
@@ -95,12 +120,12 @@ func (s *conversationStore) evictLocked() {
 // trimHistory bounds the transcript while keeping it valid for the API: the
 // first retained message must be a plain user message (not tool results),
 // so assistant tool_use blocks are never orphaned from their results.
-func trimHistory(messages []anthropic.MessageParam, maxLen int) []anthropic.MessageParam {
+func trimHistory(messages transcript, maxLen int) transcript {
 	if len(messages) <= maxLen {
 		return messages
 	}
 	for i := len(messages) - maxLen; i < len(messages); i++ {
-		if messages[i].Role != anthropic.MessageParamRoleUser {
+		if messages[i].Role != agentRoleUser {
 			continue
 		}
 		if containsToolResult(messages[i]) {
@@ -113,9 +138,9 @@ func trimHistory(messages []anthropic.MessageParam, maxLen int) []anthropic.Mess
 	return messages
 }
 
-func containsToolResult(m anthropic.MessageParam) bool {
+func containsToolResult(m transcriptMessage) bool {
 	for _, block := range m.Content {
-		if block.OfToolResult != nil {
+		if block.Type == blockTypeToolResult {
 			return true
 		}
 	}
@@ -127,10 +152,10 @@ func containsToolResult(m anthropic.MessageParam) bool {
 // stream errors) are stripped, and messages left with no content are dropped.
 // Without this, one bad turn would 400 every subsequent request on the
 // conversation until its TTL expired.
-func sanitizeTranscript(messages []anthropic.MessageParam) []anthropic.MessageParam {
-	out := make([]anthropic.MessageParam, 0, len(messages))
+func sanitizeTranscript(messages transcript) transcript {
+	out := make(transcript, 0, len(messages))
 	for i, m := range messages {
-		if m.Role == anthropic.MessageParamRoleAssistant {
+		if m.Role == agentRoleAssistant {
 			m = stripOrphanToolUse(m, followingToolResults(messages, i))
 		}
 		if len(m.Content) == 0 {
@@ -142,12 +167,12 @@ func sanitizeTranscript(messages []anthropic.MessageParam) []anthropic.MessagePa
 }
 
 // followingToolResults collects tool_use IDs answered by the next message.
-func followingToolResults(messages []anthropic.MessageParam, i int) map[string]bool {
+func followingToolResults(messages transcript, i int) map[string]bool {
 	answered := make(map[string]bool)
 	if i+1 < len(messages) {
 		for _, block := range messages[i+1].Content {
-			if tr := block.OfToolResult; tr != nil {
-				answered[tr.ToolUseID] = true
+			if block.Type == blockTypeToolResult {
+				answered[block.ToolUseID] = true
 			}
 		}
 	}
@@ -155,10 +180,10 @@ func followingToolResults(messages []anthropic.MessageParam, i int) map[string]b
 }
 
 // stripOrphanToolUse removes tool_use blocks that have no matching tool_result.
-func stripOrphanToolUse(m anthropic.MessageParam, answered map[string]bool) anthropic.MessageParam {
+func stripOrphanToolUse(m transcriptMessage, answered map[string]bool) transcriptMessage {
 	hasOrphan := false
 	for _, block := range m.Content {
-		if tu := block.OfToolUse; tu != nil && !answered[tu.ID] {
+		if block.Type == blockTypeToolUse && !answered[block.ID] {
 			hasOrphan = true
 			break
 		}
@@ -166,15 +191,62 @@ func stripOrphanToolUse(m anthropic.MessageParam, answered map[string]bool) anth
 	if !hasOrphan {
 		return m
 	}
-	kept := make([]anthropic.ContentBlockParamUnion, 0, len(m.Content))
+	kept := make([]transcriptBlock, 0, len(m.Content))
 	for _, block := range m.Content {
-		if tu := block.OfToolUse; tu != nil && !answered[tu.ID] {
+		if block.Type == blockTypeToolUse && !answered[block.ID] {
 			continue
 		}
 		kept = append(kept, block)
 	}
 	m.Content = kept
 	return m
+}
+
+func transcriptFromClient(messages []Message) transcript {
+	out := make(transcript, 0, len(messages))
+	for _, m := range messages {
+		text := messageText(m.Content)
+		if text == "" {
+			continue
+		}
+		switch m.Role {
+		case agentRoleAssistant:
+			// Every provider requires the first conversational message to be
+			// user-authored; drop display-only welcome assistant messages.
+			if len(out) == 0 {
+				continue
+			}
+			out = append(out, textTranscriptMessage(agentRoleAssistant, text))
+		default:
+			out = append(out, textTranscriptMessage(agentRoleUser, text))
+		}
+	}
+	return out
+}
+
+func textTranscriptMessage(role, text string) transcriptMessage {
+	return transcriptMessage{
+		Role:    role,
+		Content: []transcriptBlock{{Type: blockTypeText, Text: text}},
+	}
+}
+
+func cloneTranscript(messages transcript) transcript {
+	out := make(transcript, len(messages))
+	for i, message := range messages {
+		out[i].Role = message.Role
+		if len(message.Content) == 0 {
+			continue
+		}
+		out[i].Content = make([]transcriptBlock, len(message.Content))
+		copy(out[i].Content, message.Content)
+		for j := range out[i].Content {
+			if out[i].Content[j].Input != nil {
+				out[i].Content[j].Input = append(json.RawMessage(nil), out[i].Content[j].Input...)
+			}
+		}
+	}
+	return out
 }
 
 func newConversationID() string {

--- a/server/internal/ai/conversation_test.go
+++ b/server/internal/ai/conversation_test.go
@@ -1,0 +1,52 @@
+package ai
+
+import "testing"
+
+func TestSanitizeTranscriptStripsOrphanToolUse(t *testing.T) {
+	history := transcript{
+		textTranscriptMessage(agentRoleUser, "search"),
+		{
+			Role: agentRoleAssistant,
+			Content: []transcriptBlock{
+				{Type: blockTypeText, Text: "Checking."},
+				{Type: blockTypeToolUse, ID: "call_orphan", Name: "search_movies", Input: []byte(`{"query":"Alien"}`)},
+			},
+		},
+	}
+
+	sanitized := sanitizeTranscript(history)
+	if len(sanitized) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(sanitized))
+	}
+	if len(sanitized[1].Content) != 1 || sanitized[1].Content[0].Type != blockTypeText {
+		t.Fatalf("expected orphan tool_use to be stripped, got %#v", sanitized[1].Content)
+	}
+}
+
+func TestTrimHistoryStartsAtPlainUserMessage(t *testing.T) {
+	history := transcript{
+		textTranscriptMessage(agentRoleUser, "old"),
+		{
+			Role: agentRoleAssistant,
+			Content: []transcriptBlock{
+				{Type: blockTypeToolUse, ID: "call_1", Name: "search_movies", Input: []byte(`{"query":"Dune"}`)},
+			},
+		},
+		{
+			Role: agentRoleUser,
+			Content: []transcriptBlock{
+				{Type: blockTypeToolResult, ToolUseID: "call_1", Name: "search_movies", Content: "Dune"},
+			},
+		},
+		textTranscriptMessage(agentRoleUser, "new"),
+		textTranscriptMessage(agentRoleAssistant, "answer"),
+	}
+
+	trimmed := trimHistory(history, 3)
+	if len(trimmed) != 2 {
+		t.Fatalf("expected trim to start at plain user message and keep 2 messages, got %d", len(trimmed))
+	}
+	if got := trimmed[0].Content[0].Text; got != "new" {
+		t.Fatalf("expected first trimmed message to be new user text, got %q", got)
+	}
+}

--- a/server/internal/ai/handler.go
+++ b/server/internal/ai/handler.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/anthropics/anthropic-sdk-go"
-
 	"github.com/windoze95/cantinarr-server/internal/auth"
 	"github.com/windoze95/cantinarr-server/internal/credentials"
 	"github.com/windoze95/cantinarr-server/internal/mcp"
@@ -131,11 +129,11 @@ func (h *Handler) Chat(w http.ResponseWriter, r *http.Request) {
 	// context across turns) and append the new user message; fall back to
 	// the client's plain-text transcript for new or expired conversations.
 	convID := req.ConversationID
-	var history []anthropic.MessageParam
+	var history transcript
 	if convID != "" {
 		if stored, ok := h.conversations.Get(convID, claims.UserID); ok {
 			if text := latestUserText(req.Messages); text != "" {
-				history = append(stored, anthropic.NewUserMessage(anthropic.NewTextBlock(text)))
+				history = append(stored, textTranscriptMessage(agentRoleUser, text))
 			}
 		}
 	}
@@ -145,7 +143,7 @@ func (h *Handler) Chat(w http.ResponseWriter, r *http.Request) {
 		// id so an attacker-supplied id can never overwrite someone else's
 		// stored conversation.
 		convID = newConversationID()
-		history = toSDKMessages(req.Messages)
+		history = transcriptFromClient(req.Messages)
 	}
 	if len(history) == 0 {
 		http.Error(w, `{"error":"no usable messages in request"}`, http.StatusBadRequest)
@@ -155,32 +153,31 @@ func (h *Handler) Chat(w http.ResponseWriter, r *http.Request) {
 	emit(map[string]string{"conversation_id": convID})
 
 	var err error
+	var finalHistory transcript
 	switch aiConfig.Provider {
 	case credentials.AIProviderAnthropic:
 		service := NewService(apiKey, aiConfig.Model, h.toolServer)
-		var finalHistory []anthropic.MessageParam
 		finalHistory, err = service.SendMessage(r.Context(), history, chatCtx, callbacks)
-		if err == nil {
-			h.conversations.Put(convID, claims.UserID, sanitizeTranscript(finalHistory))
-		}
 	case credentials.AIProviderOpenAI:
 		service := NewOpenAIService(apiKey, aiConfig.Model, h.toolServer)
-		err = service.SendMessage(r.Context(), req.Messages, chatCtx, callbacks)
+		finalHistory, err = service.SendMessage(r.Context(), history, chatCtx, callbacks)
 	case credentials.AIProviderGemini:
 		service := NewGeminiService(apiKey, aiConfig.Model, h.toolServer)
-		err = service.SendMessage(r.Context(), req.Messages, chatCtx, callbacks)
+		finalHistory, err = service.SendMessage(r.Context(), history, chatCtx, callbacks)
 	default:
 		err = fmt.Errorf("unsupported AI provider: %s", aiConfig.Provider)
 	}
 	if err != nil {
-		// Drop Anthropic stored state rather than persist a possibly poisoned
-		// transcript; the client's retry falls back to its own transcript.
-		if aiConfig.Provider == credentials.AIProviderAnthropic {
-			h.conversations.Delete(convID)
-		}
+		// Drop stored state rather than persist a possibly poisoned transcript;
+		// the client's retry falls back to its own plain-text transcript.
+		h.conversations.Delete(convID)
 		log.Printf("ai chat error: %v", err)
 		emit(map[string]string{"error": err.Error()})
-	} else if h.toolServer.IsAIDebugEnabled() {
+	} else {
+		h.conversations.Put(convID, claims.UserID, sanitizeTranscript(finalHistory))
+	}
+
+	if err == nil && h.toolServer.IsAIDebugEnabled() {
 		log.Printf("ai debug: chat complete provider=%s model=%s user_id=%d conversation_id=%s", aiConfig.Provider, aiConfig.Model, claims.UserID, convID)
 	}
 

--- a/server/internal/ai/http_providers.go
+++ b/server/internal/ai/http_providers.go
@@ -1,13 +1,16 @@
 package ai
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -15,6 +18,8 @@ import (
 )
 
 const httpProviderMaxOutputTokens = 16000
+
+var errSSEDone = errors.New("sse stream complete")
 
 type openAIService struct {
 	apiKey     string
@@ -35,13 +40,14 @@ func NewOpenAIService(apiKey, model string, toolServer *mcp.ToolServer) *openAIS
 	}
 }
 
-func (s *openAIService) SendMessage(ctx context.Context, history []Message, chatCtx ChatContext, cb StreamCallbacks) error {
+func (s *openAIService) SendMessage(ctx context.Context, history transcript, chatCtx ChatContext, cb StreamCallbacks) (transcript, error) {
 	messages := []openAIMessage{{
 		Role:    "system",
 		Content: systemPrompt + "\n\n" + dynamicContext(chatCtx),
 	}}
 	messages = append(messages, toOpenAIMessages(history)...)
 	tools := toOpenAITools(s.toolServer.GetToolsForRole(chatCtx.Role))
+	finalHistory := cloneTranscript(history)
 
 	for iteration := 0; iteration < maxToolIterations; iteration++ {
 		req := openAIChatRequest{
@@ -49,35 +55,48 @@ func (s *openAIService) SendMessage(ctx context.Context, history []Message, chat
 			Messages:            messages,
 			MaxCompletionTokens: httpProviderMaxOutputTokens,
 			Tools:               tools,
+			Stream:              true,
 		}
 		if iteration == maxToolIterations-1 {
 			req.ToolChoice = "none"
 		}
 
-		message, finishReason, err := s.chat(ctx, req)
+		message, finishReason, err := s.chatStream(ctx, req, cb)
 		if err != nil {
-			return err
+			return finalHistory, err
 		}
 		if len(message.ToolCalls) == 0 {
-			if message.Content != "" && cb.OnText != nil {
-				cb.OnText(message.Content)
+			if finishReason == "tool_calls" {
+				return finalHistory, fmt.Errorf("model requested tool use but sent no complete tool calls")
 			}
 			if finishReason == "length" && cb.OnText != nil {
 				cb.OnText("\n\n_(Reply truncated at the length limit - ask me to continue.)_")
 			}
-			return nil
+			if message.Content != "" {
+				finalHistory = append(finalHistory, openAIMessageToTranscript(message))
+			}
+			return finalHistory, nil
 		}
 
 		messages = append(messages, message)
+		finalHistory = append(finalHistory, openAIMessageToTranscript(message))
+		var toolResultBlocks []transcriptBlock
 		for _, toolCall := range message.ToolCalls {
-			messages = append(messages, s.runOpenAITool(ctx, toolCall, chatCtx, cb))
+			result, transcriptBlock := s.runOpenAITool(ctx, toolCall, chatCtx, cb)
+			messages = append(messages, result)
+			toolResultBlocks = append(toolResultBlocks, transcriptBlock)
 		}
+		if len(toolResultBlocks) == 0 {
+			return finalHistory, fmt.Errorf("model requested tool use but sent no tool calls")
+		}
+		finalHistory = append(finalHistory, transcriptMessage{Role: agentRoleUser, Content: toolResultBlocks})
 	}
 
-	return fmt.Errorf("agent loop exceeded %d iterations", maxToolIterations)
+	return finalHistory, fmt.Errorf("agent loop exceeded %d iterations", maxToolIterations)
 }
 
-func (s *openAIService) chat(ctx context.Context, payload openAIChatRequest) (openAIMessage, string, error) {
+func (s *openAIService) chatStream(ctx context.Context, payload openAIChatRequest, cb StreamCallbacks) (openAIMessage, string, error) {
+	payload.Stream = true
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(payload); err != nil {
 		return openAIMessage{}, "", err
@@ -88,35 +107,91 @@ func (s *openAIService) chat(ctx context.Context, payload openAIChatRequest) (op
 	}
 	req.Header.Set("Authorization", "Bearer "+s.apiKey)
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return openAIMessage{}, "", fmt.Errorf("openai chat: %w", err)
+		return openAIMessage{}, "", fmt.Errorf("openai chat stream: %w", err)
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
+	if resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+		return openAIMessage{}, "", fmt.Errorf("openai chat stream: %s", providerErrorMessage(data))
+	}
+
+	message := openAIMessage{Role: "assistant"}
+	toolCalls := make(map[int]*openAIToolCall)
+	var toolOrder []int
+	finishReason := ""
+
+	err = readSSE(resp.Body, func(data string) error {
+		if strings.TrimSpace(data) == "[DONE]" {
+			return errSSEDone
+		}
+		var parsed openAIChatStreamResponse
+		if err := json.Unmarshal([]byte(data), &parsed); err != nil {
+			return fmt.Errorf("decode openai stream: %w", err)
+		}
+		if parsed.Error != nil {
+			return fmt.Errorf("openai chat stream: %s", parsed.Error.Message)
+		}
+		for _, choice := range parsed.Choices {
+			if choice.FinishReason != "" {
+				finishReason = choice.FinishReason
+			}
+			delta := choice.Delta
+			if delta.Role != "" {
+				message.Role = delta.Role
+			}
+			if delta.Content != "" {
+				message.Content += delta.Content
+				if cb.OnText != nil {
+					cb.OnText(delta.Content)
+				}
+			}
+			for _, toolDelta := range delta.ToolCalls {
+				call := toolCalls[toolDelta.Index]
+				if call == nil {
+					call = &openAIToolCall{Type: "function"}
+					toolCalls[toolDelta.Index] = call
+					toolOrder = append(toolOrder, toolDelta.Index)
+				}
+				if toolDelta.ID != "" {
+					call.ID = toolDelta.ID
+				}
+				if toolDelta.Type != "" {
+					call.Type = toolDelta.Type
+				}
+				if toolDelta.Function.Name != "" {
+					call.Function.Name += toolDelta.Function.Name
+				}
+				if toolDelta.Function.Arguments != "" {
+					call.Function.Arguments += toolDelta.Function.Arguments
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errSSEDone) {
 		return openAIMessage{}, "", err
 	}
-	if resp.StatusCode >= 300 {
-		return openAIMessage{}, "", fmt.Errorf("openai chat: %s", providerErrorMessage(data))
-	}
 
-	var parsed openAIChatResponse
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		return openAIMessage{}, "", fmt.Errorf("decode openai chat: %w", err)
+	sort.Ints(toolOrder)
+	for _, index := range toolOrder {
+		call := toolCalls[index]
+		if call == nil || call.ID == "" || call.Function.Name == "" {
+			continue
+		}
+		if call.Type == "" {
+			call.Type = "function"
+		}
+		message.ToolCalls = append(message.ToolCalls, *call)
 	}
-	if parsed.Error != nil {
-		return openAIMessage{}, "", fmt.Errorf("openai chat: %s", parsed.Error.Message)
-	}
-	if len(parsed.Choices) == 0 {
-		return openAIMessage{}, "", fmt.Errorf("openai chat: response had no choices")
-	}
-	return parsed.Choices[0].Message, parsed.Choices[0].FinishReason, nil
+	return message, finishReason, nil
 }
 
-func (s *openAIService) runOpenAITool(ctx context.Context, toolCall openAIToolCall, chatCtx ChatContext, cb StreamCallbacks) openAIMessage {
+func (s *openAIService) runOpenAITool(ctx context.Context, toolCall openAIToolCall, chatCtx ChatContext, cb StreamCallbacks) (openAIMessage, transcriptBlock) {
 	name := toolCall.Function.Name
 	if cb.OnToolStart != nil {
 		cb.OnToolStart(name, toolLabel(name))
@@ -132,7 +207,14 @@ func (s *openAIService) runOpenAITool(ctx context.Context, toolCall openAIToolCa
 		if cb.OnToolEnd != nil {
 			cb.OnToolEnd(name, false)
 		}
-		return openAIMessage{Role: "tool", ToolCallID: toolCall.ID, Content: "Error: " + err.Error()}
+		content := "Error: " + err.Error()
+		return openAIMessage{Role: "tool", ToolCallID: toolCall.ID, Content: content}, transcriptBlock{
+			Type:      blockTypeToolResult,
+			ToolUseID: toolCall.ID,
+			Name:      name,
+			Content:   content,
+			IsError:   true,
+		}
 	}
 	if result.StructuredData != nil && mcp.ToolsWithUI[name] && cb.OnToolResult != nil {
 		cb.OnToolResult(name, result.StructuredData)
@@ -140,7 +222,12 @@ func (s *openAIService) runOpenAITool(ctx context.Context, toolCall openAIToolCa
 	if cb.OnToolEnd != nil {
 		cb.OnToolEnd(name, true)
 	}
-	return openAIMessage{Role: "tool", ToolCallID: toolCall.ID, Content: result.Text}
+	return openAIMessage{Role: "tool", ToolCallID: toolCall.ID, Content: result.Text}, transcriptBlock{
+		Type:      blockTypeToolResult,
+		ToolUseID: toolCall.ID,
+		Name:      name,
+		Content:   result.Text,
+	}
 }
 
 type openAIChatRequest struct {
@@ -149,14 +236,33 @@ type openAIChatRequest struct {
 	Tools               []openAITool    `json:"tools,omitempty"`
 	ToolChoice          any             `json:"tool_choice,omitempty"`
 	MaxCompletionTokens int             `json:"max_completion_tokens,omitempty"`
+	Stream              bool            `json:"stream,omitempty"`
 }
 
-type openAIChatResponse struct {
+type openAIChatStreamResponse struct {
 	Choices []struct {
-		Message      openAIMessage `json:"message"`
-		FinishReason string        `json:"finish_reason"`
+		Delta        openAIMessageDelta `json:"delta"`
+		FinishReason string             `json:"finish_reason"`
 	} `json:"choices"`
 	Error *providerError `json:"error,omitempty"`
+}
+
+type openAIMessageDelta struct {
+	Role      string                `json:"role,omitempty"`
+	Content   string                `json:"content,omitempty"`
+	ToolCalls []openAIToolCallDelta `json:"tool_calls,omitempty"`
+}
+
+type openAIToolCallDelta struct {
+	Index    int                     `json:"index"`
+	ID       string                  `json:"id,omitempty"`
+	Type     string                  `json:"type,omitempty"`
+	Function openAIFunctionCallDelta `json:"function,omitempty"`
+}
+
+type openAIFunctionCallDelta struct {
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments,omitempty"`
 }
 
 type openAIMessage struct {
@@ -188,22 +294,71 @@ type openAIFunctionTool struct {
 	Parameters  map[string]interface{} `json:"parameters"`
 }
 
-func toOpenAIMessages(messages []Message) []openAIMessage {
+func toOpenAIMessages(messages transcript) []openAIMessage {
 	out := make([]openAIMessage, 0, len(messages))
 	for _, m := range messages {
-		text := messageText(m.Content)
-		if text == "" {
-			continue
-		}
 		switch m.Role {
-		case "assistant":
+		case agentRoleAssistant:
 			if len(out) == 0 {
 				continue
 			}
-			out = append(out, openAIMessage{Role: "assistant", Content: text})
+			message := openAIMessage{Role: "assistant"}
+			for _, block := range m.Content {
+				switch block.Type {
+				case blockTypeText:
+					message.Content += block.Text
+				case blockTypeToolUse:
+					message.ToolCalls = append(message.ToolCalls, openAIToolCall{
+						ID:   block.ID,
+						Type: "function",
+						Function: openAIFunctionCall{
+							Name:      block.Name,
+							Arguments: rawJSONString(block.Input),
+						},
+					})
+				}
+			}
+			if message.Content != "" || len(message.ToolCalls) > 0 {
+				out = append(out, message)
+			}
 		default:
-			out = append(out, openAIMessage{Role: "user", Content: text})
+			var userText strings.Builder
+			for _, block := range m.Content {
+				switch block.Type {
+				case blockTypeText:
+					userText.WriteString(block.Text)
+				case blockTypeToolResult:
+					out = append(out, openAIMessage{
+						Role:       "tool",
+						ToolCallID: block.ToolUseID,
+						Content:    block.Content,
+					})
+				}
+			}
+			if userText.Len() > 0 {
+				out = append(out, openAIMessage{Role: "user", Content: userText.String()})
+			}
 		}
+	}
+	return out
+}
+
+func openAIMessageToTranscript(message openAIMessage) transcriptMessage {
+	out := transcriptMessage{Role: agentRoleAssistant}
+	if message.Content != "" {
+		out.Content = append(out.Content, transcriptBlock{Type: blockTypeText, Text: message.Content})
+	}
+	for _, call := range message.ToolCalls {
+		input := json.RawMessage(call.Function.Arguments)
+		if len(input) == 0 || string(input) == "null" {
+			input = json.RawMessage("{}")
+		}
+		out.Content = append(out.Content, transcriptBlock{
+			Type:  blockTypeToolUse,
+			ID:    call.ID,
+			Name:  call.Function.Name,
+			Input: input,
+		})
 	}
 	return out
 }
@@ -242,24 +397,25 @@ func NewGeminiService(apiKey, model string, toolServer *mcp.ToolServer) *geminiS
 	}
 }
 
-func (s *geminiService) SendMessage(ctx context.Context, history []Message, chatCtx ChatContext, cb StreamCallbacks) error {
+func (s *geminiService) SendMessage(ctx context.Context, history transcript, chatCtx ChatContext, cb StreamCallbacks) (transcript, error) {
 	contents := toGeminiContents(history)
 	tools := toGeminiTools(s.toolServer.GetToolsForRole(chatCtx.Role))
 	system := geminiContent{Parts: []geminiPart{{Text: systemPrompt + "\n\n" + dynamicContext(chatCtx)}}}
+	finalHistory := cloneTranscript(history)
 
 	for iteration := 0; iteration < maxToolIterations; iteration++ {
 		useTools := iteration != maxToolIterations-1
-		resp, err := s.generate(ctx, geminiGenerateRequest{
+		resp, err := s.streamGenerate(ctx, geminiGenerateRequest{
 			SystemInstruction: &system,
 			Contents:          contents,
 			Tools:             enabledGeminiTools(tools, useTools),
 			GenerationConfig:  &geminiGenerationConfig{MaxOutputTokens: httpProviderMaxOutputTokens},
-		})
+		}, cb)
 		if err != nil {
-			return err
+			return finalHistory, err
 		}
 		if len(resp.Candidates) == 0 {
-			return fmt.Errorf("gemini: response had no candidates")
+			return finalHistory, fmt.Errorf("gemini: response had no candidates")
 		}
 
 		content := resp.Candidates[0].Content
@@ -268,34 +424,38 @@ func (s *geminiService) SendMessage(ctx context.Context, history []Message, chat
 		}
 		functionCalls := geminiFunctionCalls(content)
 		if len(functionCalls) == 0 {
-			text := geminiText(content)
-			if text != "" && cb.OnText != nil {
-				cb.OnText(text)
-			}
 			if resp.Candidates[0].FinishReason == "MAX_TOKENS" && cb.OnText != nil {
 				cb.OnText("\n\n_(Reply truncated at the length limit - ask me to continue.)_")
 			}
-			return nil
+			if len(content.Parts) > 0 {
+				finalHistory = append(finalHistory, geminiContentToTranscript(content))
+			}
+			return finalHistory, nil
 		}
 
 		contents = append(contents, content)
+		finalHistory = append(finalHistory, geminiContentToTranscript(content))
 		resultParts := make([]geminiPart, 0, len(functionCalls))
+		toolResultBlocks := make([]transcriptBlock, 0, len(functionCalls))
 		for _, call := range functionCalls {
-			resultParts = append(resultParts, s.runGeminiTool(ctx, call, chatCtx, cb))
+			result, transcriptBlock := s.runGeminiTool(ctx, call, chatCtx, cb)
+			resultParts = append(resultParts, result)
+			toolResultBlocks = append(toolResultBlocks, transcriptBlock)
 		}
 		contents = append(contents, geminiContent{Role: "user", Parts: resultParts})
+		finalHistory = append(finalHistory, transcriptMessage{Role: agentRoleUser, Content: toolResultBlocks})
 	}
 
-	return fmt.Errorf("agent loop exceeded %d iterations", maxToolIterations)
+	return finalHistory, fmt.Errorf("agent loop exceeded %d iterations", maxToolIterations)
 }
 
-func (s *geminiService) generate(ctx context.Context, payload geminiGenerateRequest) (geminiGenerateResponse, error) {
+func (s *geminiService) streamGenerate(ctx context.Context, payload geminiGenerateRequest, cb StreamCallbacks) (geminiGenerateResponse, error) {
 	var body bytes.Buffer
 	if err := json.NewEncoder(&body).Encode(payload); err != nil {
 		return geminiGenerateResponse{}, err
 	}
 	endpoint := fmt.Sprintf(
-		"https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent",
+		"https://generativelanguage.googleapis.com/v1beta/models/%s:streamGenerateContent?alt=sse",
 		url.PathEscape(s.model),
 	)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &body)
@@ -303,33 +463,65 @@ func (s *geminiService) generate(ctx context.Context, payload geminiGenerateRequ
 		return geminiGenerateResponse{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("x-goog-api-key", s.apiKey)
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return geminiGenerateResponse{}, fmt.Errorf("gemini generate: %w", err)
+		return geminiGenerateResponse{}, fmt.Errorf("gemini stream generate: %w", err)
 	}
 	defer resp.Body.Close()
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
-	if err != nil {
+	if resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+		return geminiGenerateResponse{}, fmt.Errorf("gemini stream generate: %s", providerErrorMessage(data))
+	}
+
+	var aggregated geminiGenerateResponse
+	content := geminiContent{Role: "model"}
+	finishReason := ""
+
+	err = readSSE(resp.Body, func(data string) error {
+		if strings.TrimSpace(data) == "[DONE]" {
+			return errSSEDone
+		}
+		var chunk geminiGenerateResponse
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			return fmt.Errorf("decode gemini stream: %w", err)
+		}
+		if chunk.Error != nil {
+			return fmt.Errorf("gemini stream generate: %s", chunk.Error.Message)
+		}
+		if len(chunk.Candidates) == 0 {
+			return nil
+		}
+		candidate := chunk.Candidates[0]
+		if candidate.FinishReason != "" {
+			finishReason = candidate.FinishReason
+		}
+		if candidate.Content.Role != "" {
+			content.Role = candidate.Content.Role
+		}
+		for _, part := range candidate.Content.Parts {
+			content.Parts = append(content.Parts, part)
+			if part.Text != "" && !part.Thought && cb.OnText != nil {
+				cb.OnText(part.Text)
+			}
+		}
+		return nil
+	})
+	if err != nil && !errors.Is(err, errSSEDone) {
 		return geminiGenerateResponse{}, err
 	}
-	if resp.StatusCode >= 300 {
-		return geminiGenerateResponse{}, fmt.Errorf("gemini generate: %s", providerErrorMessage(data))
-	}
 
-	var parsed geminiGenerateResponse
-	if err := json.Unmarshal(data, &parsed); err != nil {
-		return geminiGenerateResponse{}, fmt.Errorf("decode gemini response: %w", err)
-	}
-	if parsed.Error != nil {
-		return geminiGenerateResponse{}, fmt.Errorf("gemini generate: %s", parsed.Error.Message)
-	}
-	return parsed, nil
+	aggregated.Candidates = append(aggregated.Candidates, struct {
+		Content      geminiContent `json:"content"`
+		FinishReason string        `json:"finishReason"`
+	}{Content: content, FinishReason: finishReason})
+	return aggregated, nil
 }
 
-func (s *geminiService) runGeminiTool(ctx context.Context, call geminiFunctionCall, chatCtx ChatContext, cb StreamCallbacks) geminiPart {
+func (s *geminiService) runGeminiTool(ctx context.Context, call geminiFunctionCall, chatCtx ChatContext, cb StreamCallbacks) (geminiPart, transcriptBlock) {
 	if cb.OnToolStart != nil {
 		cb.OnToolStart(call.Name, toolLabel(call.Name))
 	}
@@ -344,11 +536,18 @@ func (s *geminiService) runGeminiTool(ctx context.Context, call geminiFunctionCa
 		if cb.OnToolEnd != nil {
 			cb.OnToolEnd(call.Name, false)
 		}
+		content := "Error: " + err.Error()
 		return geminiPart{FunctionResponse: &geminiFunctionResponse{
-			Name:     call.Name,
-			ID:       call.ID,
-			Response: map[string]any{"error": err.Error()},
-		}}
+				Name:     call.Name,
+				ID:       call.ID,
+				Response: map[string]any{"error": err.Error()},
+			}}, transcriptBlock{
+				Type:      blockTypeToolResult,
+				ToolUseID: call.ID,
+				Name:      call.Name,
+				Content:   content,
+				IsError:   true,
+			}
 	}
 	if result.StructuredData != nil && mcp.ToolsWithUI[call.Name] && cb.OnToolResult != nil {
 		cb.OnToolResult(call.Name, result.StructuredData)
@@ -357,10 +556,15 @@ func (s *geminiService) runGeminiTool(ctx context.Context, call geminiFunctionCa
 		cb.OnToolEnd(call.Name, true)
 	}
 	return geminiPart{FunctionResponse: &geminiFunctionResponse{
-		Name:     call.Name,
-		ID:       call.ID,
-		Response: map[string]any{"response": result.Text},
-	}}
+			Name:     call.Name,
+			ID:       call.ID,
+			Response: map[string]any{"response": result.Text},
+		}}, transcriptBlock{
+			Type:      blockTypeToolResult,
+			ToolUseID: call.ID,
+			Name:      call.Name,
+			Content:   result.Text,
+		}
 }
 
 type geminiGenerateRequest struct {
@@ -417,24 +621,98 @@ type geminiFunctionDeclaration struct {
 	Parameters  map[string]interface{} `json:"parameters"`
 }
 
-func toGeminiContents(messages []Message) []geminiContent {
+func toGeminiContents(messages transcript) []geminiContent {
 	out := make([]geminiContent, 0, len(messages))
 	for _, m := range messages {
-		text := messageText(m.Content)
-		if text == "" {
-			continue
-		}
 		switch m.Role {
-		case "assistant":
+		case agentRoleAssistant:
 			if len(out) == 0 {
 				continue
 			}
-			out = append(out, geminiContent{Role: "model", Parts: []geminiPart{{Text: text}}})
+			content := geminiContent{Role: "model"}
+			for _, block := range m.Content {
+				switch block.Type {
+				case blockTypeText:
+					if block.Text != "" {
+						content.Parts = append(content.Parts, geminiPart{Text: block.Text})
+					}
+				case blockTypeToolUse:
+					content.Parts = append(content.Parts, geminiPart{FunctionCall: &geminiFunctionCall{
+						Name: block.Name,
+						Args: rawJSONMap(block.Input),
+						ID:   block.ID,
+					}})
+				}
+			}
+			if len(content.Parts) > 0 {
+				out = append(out, content)
+			}
 		default:
-			out = append(out, geminiContent{Role: "user", Parts: []geminiPart{{Text: text}}})
+			content := geminiContent{Role: "user"}
+			for _, block := range m.Content {
+				switch block.Type {
+				case blockTypeText:
+					if block.Text != "" {
+						content.Parts = append(content.Parts, geminiPart{Text: block.Text})
+					}
+				case blockTypeToolResult:
+					name := block.Name
+					if name == "" {
+						name = toolNameForResult(messages, block.ToolUseID)
+					}
+					content.Parts = append(content.Parts, geminiPart{FunctionResponse: &geminiFunctionResponse{
+						Name:     name,
+						ID:       block.ToolUseID,
+						Response: geminiToolResponse(block),
+					}})
+				}
+			}
+			if len(content.Parts) > 0 {
+				out = append(out, content)
+			}
 		}
 	}
 	return out
+}
+
+func geminiContentToTranscript(content geminiContent) transcriptMessage {
+	out := transcriptMessage{Role: agentRoleAssistant}
+	for _, part := range content.Parts {
+		if part.Text != "" && !part.Thought {
+			out.Content = append(out.Content, transcriptBlock{Type: blockTypeText, Text: part.Text})
+		}
+		if part.FunctionCall != nil {
+			input, err := json.Marshal(part.FunctionCall.Args)
+			if err != nil || len(input) == 0 || string(input) == "null" {
+				input = []byte("{}")
+			}
+			out.Content = append(out.Content, transcriptBlock{
+				Type:  blockTypeToolUse,
+				ID:    part.FunctionCall.ID,
+				Name:  part.FunctionCall.Name,
+				Input: json.RawMessage(input),
+			})
+		}
+	}
+	return out
+}
+
+func geminiToolResponse(block transcriptBlock) map[string]any {
+	if block.IsError {
+		return map[string]any{"error": strings.TrimPrefix(block.Content, "Error: ")}
+	}
+	return map[string]any{"response": block.Content}
+}
+
+func toolNameForResult(messages transcript, toolUseID string) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		for _, block := range messages[i].Content {
+			if block.Type == blockTypeToolUse && block.ID == toolUseID {
+				return block.Name
+			}
+		}
+	}
+	return ""
 }
 
 func toGeminiTools(tools []mcp.Tool) []geminiTool {
@@ -472,9 +750,71 @@ func geminiFunctionCalls(content geminiContent) []geminiFunctionCall {
 func geminiText(content geminiContent) string {
 	var sb strings.Builder
 	for _, part := range content.Parts {
-		sb.WriteString(part.Text)
+		if !part.Thought {
+			sb.WriteString(part.Text)
+		}
 	}
 	return sb.String()
+}
+
+func readSSE(r io.Reader, handle func(data string) error) error {
+	reader := bufio.NewReader(r)
+	var data strings.Builder
+	flush := func() error {
+		if data.Len() == 0 {
+			return nil
+		}
+		payload := strings.TrimSuffix(data.String(), "\n")
+		data.Reset()
+		if strings.TrimSpace(payload) == "" {
+			return nil
+		}
+		return handle(payload)
+	}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			line = strings.TrimRight(line, "\r\n")
+			switch {
+			case line == "":
+				if flushErr := flush(); flushErr != nil {
+					return flushErr
+				}
+			case strings.HasPrefix(line, "data:"):
+				value := strings.TrimPrefix(line, "data:")
+				value = strings.TrimPrefix(value, " ")
+				data.WriteString(value)
+				data.WriteByte('\n')
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return flush()
+			}
+			return err
+		}
+	}
+}
+
+func rawJSONString(raw json.RawMessage) string {
+	raw = normalizedRawJSON(raw)
+	return string(raw)
+}
+
+func rawJSONMap(raw json.RawMessage) map[string]any {
+	value := rawJSONValue(raw)
+	if m, ok := value.(map[string]any); ok {
+		return m
+	}
+	return map[string]any{}
+}
+
+func normalizedRawJSON(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 || string(raw) == "null" || !json.Valid(raw) {
+		return json.RawMessage("{}")
+	}
+	return raw
 }
 
 type providerError struct {

--- a/server/internal/ai/http_providers_test.go
+++ b/server/internal/ai/http_providers_test.go
@@ -1,0 +1,81 @@
+package ai
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestProviderNeutralTranscriptConvertersPreserveToolContext(t *testing.T) {
+	history := transcript{
+		textTranscriptMessage(agentRoleUser, "find dune"),
+		{
+			Role: agentRoleAssistant,
+			Content: []transcriptBlock{
+				{Type: blockTypeText, Text: "I'll check."},
+				{Type: blockTypeToolUse, ID: "call_1", Name: "search_movies", Input: []byte(`{"query":"Dune"}`)},
+			},
+		},
+		{
+			Role: agentRoleUser,
+			Content: []transcriptBlock{
+				{Type: blockTypeToolResult, ToolUseID: "call_1", Name: "search_movies", Content: "Dune (2021)"},
+			},
+		},
+		textTranscriptMessage(agentRoleAssistant, "Dune (2021) is available."),
+	}
+
+	openAIMessages := toOpenAIMessages(history)
+	if len(openAIMessages) != 4 {
+		t.Fatalf("expected 4 OpenAI messages, got %d", len(openAIMessages))
+	}
+	if openAIMessages[1].Role != "assistant" || len(openAIMessages[1].ToolCalls) != 1 {
+		t.Fatalf("expected assistant tool call, got %#v", openAIMessages[1])
+	}
+	if got := openAIMessages[1].ToolCalls[0].Function.Arguments; got != `{"query":"Dune"}` {
+		t.Fatalf("unexpected OpenAI tool args: %s", got)
+	}
+	if openAIMessages[2].Role != "tool" || openAIMessages[2].ToolCallID != "call_1" {
+		t.Fatalf("expected OpenAI tool result message, got %#v", openAIMessages[2])
+	}
+
+	geminiContents := toGeminiContents(history)
+	if len(geminiContents) != 4 {
+		t.Fatalf("expected 4 Gemini contents, got %d", len(geminiContents))
+	}
+	if call := geminiContents[1].Parts[1].FunctionCall; call == nil || call.Name != "search_movies" || call.Args["query"] != "Dune" {
+		t.Fatalf("expected Gemini function call with args, got %#v", geminiContents[1].Parts[1])
+	}
+	if response := geminiContents[2].Parts[0].FunctionResponse; response == nil || response.Name != "search_movies" || response.ID != "call_1" {
+		t.Fatalf("expected Gemini function response with name/id, got %#v", geminiContents[2].Parts[0])
+	}
+
+	anthropicMessages := toSDKMessages(history)
+	if len(anthropicMessages) != 4 {
+		t.Fatalf("expected 4 Anthropic messages, got %d", len(anthropicMessages))
+	}
+	if anthropicMessages[1].Content[1].OfToolUse == nil {
+		t.Fatalf("expected Anthropic tool_use block, got %#v", anthropicMessages[1].Content[1])
+	}
+	if anthropicMessages[2].Content[0].OfToolResult == nil {
+		t.Fatalf("expected Anthropic tool_result block, got %#v", anthropicMessages[2].Content[0])
+	}
+}
+
+func TestReadSSEHandlesMultilineEventsAndDone(t *testing.T) {
+	body := strings.NewReader("data: first\ndata: second\n\n: keepalive\n\ndata: [DONE]\n\n")
+	var events []string
+	err := readSSE(body, func(data string) error {
+		events = append(events, data)
+		if data == "[DONE]" {
+			return errSSEDone
+		}
+		return nil
+	})
+	if !errors.Is(err, errSSEDone) {
+		t.Fatalf("expected errSSEDone, got %v", err)
+	}
+	if len(events) != 2 || events[0] != "first\nsecond" || events[1] != "[DONE]" {
+		t.Fatalf("unexpected SSE events: %#v", events)
+	}
+}

--- a/server/internal/ai/service.go
+++ b/server/internal/ai/service.go
@@ -92,7 +92,7 @@ func NewService(apiKey, model string, toolServer *mcp.ToolServer) *Service {
 // SendMessage runs the full agent loop with tool execution, streaming text and
 // tool activity back through cb. It returns the final transcript (including
 // tool_use/tool_result blocks) so the caller can persist conversation state.
-func (s *Service) SendMessage(ctx context.Context, history []anthropic.MessageParam, chatCtx ChatContext, cb StreamCallbacks) ([]anthropic.MessageParam, error) {
+func (s *Service) SendMessage(ctx context.Context, history transcript, chatCtx ChatContext, cb StreamCallbacks) (transcript, error) {
 	params := anthropic.MessageNewParams{
 		Model:     s.model,
 		MaxTokens: maxTokens,
@@ -106,13 +106,14 @@ func (s *Service) SendMessage(ctx context.Context, history []anthropic.MessagePa
 			// Volatile context goes after the breakpoint to keep the prefix stable.
 			{Text: dynamicContext(chatCtx)},
 		},
-		Messages: history,
+		Messages: toSDKMessages(history),
 		Tools:    toSDKTools(s.toolServer.GetToolsForRole(chatCtx.Role)),
 	}
 	if supportsAnthropicAdaptiveThinking(s.model) {
 		params.Thinking = anthropic.ThinkingConfigParamUnion{OfAdaptive: &anthropic.ThinkingConfigAdaptiveParam{}}
 	}
 
+	finalHistory := cloneTranscript(history)
 	for iteration := 0; iteration < maxToolIterations; iteration++ {
 		if iteration == maxToolIterations-1 {
 			params.ToolChoice = anthropic.ToolChoiceUnionParam{OfNone: &anthropic.ToolChoiceNoneParam{}}
@@ -120,35 +121,40 @@ func (s *Service) SendMessage(ctx context.Context, history []anthropic.MessagePa
 
 		message, err := s.streamOne(ctx, params, cb)
 		if err != nil {
-			return params.Messages, err
+			return finalHistory, err
 		}
 
 		params.Messages = append(params.Messages, message.ToParam())
+		finalHistory = append(finalHistory, anthropicMessageToTranscript(*message))
 
 		if message.StopReason != anthropic.StopReasonToolUse {
 			if message.StopReason == anthropic.StopReasonMaxTokens && cb.OnText != nil {
 				cb.OnText("\n\n_(Reply truncated at the length limit — ask me to continue.)_")
 			}
-			return params.Messages, nil
+			return finalHistory, nil
 		}
 
 		var toolResults []anthropic.ContentBlockParamUnion
+		var toolResultBlocks []transcriptBlock
 		for _, block := range message.Content {
 			toolUse, ok := block.AsAny().(anthropic.ToolUseBlock)
 			if !ok {
 				continue
 			}
-			toolResults = append(toolResults, s.runTool(ctx, toolUse, chatCtx, cb))
+			result, transcriptBlock := s.runTool(ctx, toolUse, chatCtx, cb)
+			toolResults = append(toolResults, result)
+			toolResultBlocks = append(toolResultBlocks, transcriptBlock)
 		}
 		if len(toolResults) == 0 {
 			// stop_reason said tool_use but no tool blocks arrived; bail out
 			// rather than re-sending an identical request forever.
-			return params.Messages, fmt.Errorf("model requested tool use but sent no tool blocks")
+			return finalHistory, fmt.Errorf("model requested tool use but sent no tool blocks")
 		}
 		params.Messages = append(params.Messages, anthropic.NewUserMessage(toolResults...))
+		finalHistory = append(finalHistory, transcriptMessage{Role: agentRoleUser, Content: toolResultBlocks})
 	}
 
-	return params.Messages, fmt.Errorf("agent loop exceeded %d iterations", maxToolIterations)
+	return finalHistory, fmt.Errorf("agent loop exceeded %d iterations", maxToolIterations)
 }
 
 func supportsAnthropicAdaptiveThinking(model anthropic.Model) bool {
@@ -181,8 +187,9 @@ func (s *Service) streamOne(ctx context.Context, params anthropic.MessageNewPara
 	return &message, nil
 }
 
-// runTool executes one tool call and returns its tool_result block.
-func (s *Service) runTool(ctx context.Context, toolUse anthropic.ToolUseBlock, chatCtx ChatContext, cb StreamCallbacks) anthropic.ContentBlockParamUnion {
+// runTool executes one tool call and returns provider-specific and neutral
+// tool_result blocks.
+func (s *Service) runTool(ctx context.Context, toolUse anthropic.ToolUseBlock, chatCtx ChatContext, cb StreamCallbacks) (anthropic.ContentBlockParamUnion, transcriptBlock) {
 	if cb.OnToolStart != nil {
 		cb.OnToolStart(toolUse.Name, toolLabel(toolUse.Name))
 	}
@@ -197,7 +204,14 @@ func (s *Service) runTool(ctx context.Context, toolUse anthropic.ToolUseBlock, c
 		if cb.OnToolEnd != nil {
 			cb.OnToolEnd(toolUse.Name, false)
 		}
-		return anthropic.NewToolResultBlock(toolUse.ID, fmt.Sprintf("Error: %s", err.Error()), true)
+		content := fmt.Sprintf("Error: %s", err.Error())
+		return anthropic.NewToolResultBlock(toolUse.ID, content, true), transcriptBlock{
+			Type:      blockTypeToolResult,
+			ToolUseID: toolUse.ID,
+			Name:      toolUse.Name,
+			Content:   content,
+			IsError:   true,
+		}
 	}
 
 	if result.StructuredData != nil && mcp.ToolsWithUI[toolUse.Name] && cb.OnToolResult != nil {
@@ -206,7 +220,12 @@ func (s *Service) runTool(ctx context.Context, toolUse anthropic.ToolUseBlock, c
 	if cb.OnToolEnd != nil {
 		cb.OnToolEnd(toolUse.Name, true)
 	}
-	return anthropic.NewToolResultBlock(toolUse.ID, result.Text, false)
+	return anthropic.NewToolResultBlock(toolUse.ID, result.Text, false), transcriptBlock{
+		Type:      blockTypeToolResult,
+		ToolUseID: toolUse.ID,
+		Name:      toolUse.Name,
+		Content:   result.Text,
+	}
 }
 
 // dynamicContext renders per-request context placed after the cache breakpoint.
@@ -233,29 +252,83 @@ func latestUserText(messages []Message) string {
 	return ""
 }
 
-// toSDKMessages converts client-supplied history into SDK message params.
-// Client history carries plain text (string content or text blocks); it is
-// the fallback when no server-side conversation state exists.
-func toSDKMessages(messages []Message) []anthropic.MessageParam {
+// toSDKMessages converts the provider-neutral transcript into Anthropic SDK
+// message params.
+func toSDKMessages(messages transcript) []anthropic.MessageParam {
 	out := make([]anthropic.MessageParam, 0, len(messages))
 	for _, m := range messages {
-		text := messageText(m.Content)
-		if text == "" {
+		blocks := toSDKContentBlocks(m.Content)
+		if len(blocks) == 0 {
 			continue
 		}
 		switch m.Role {
-		case "assistant":
+		case agentRoleAssistant:
 			// The API requires the first message to be from the user; drop
 			// leading assistant text (e.g. a client-side welcome message).
 			if len(out) == 0 {
 				continue
 			}
-			out = append(out, anthropic.NewAssistantMessage(anthropic.NewTextBlock(text)))
+			out = append(out, anthropic.NewAssistantMessage(blocks...))
 		default:
-			out = append(out, anthropic.NewUserMessage(anthropic.NewTextBlock(text)))
+			out = append(out, anthropic.NewUserMessage(blocks...))
 		}
 	}
 	return out
+}
+
+func toSDKContentBlocks(blocks []transcriptBlock) []anthropic.ContentBlockParamUnion {
+	out := make([]anthropic.ContentBlockParamUnion, 0, len(blocks))
+	for _, block := range blocks {
+		switch block.Type {
+		case blockTypeText:
+			if block.Text != "" {
+				out = append(out, anthropic.NewTextBlock(block.Text))
+			}
+		case blockTypeToolUse:
+			out = append(out, anthropic.NewToolUseBlock(block.ID, rawJSONValue(block.Input), block.Name))
+		case blockTypeToolResult:
+			out = append(out, anthropic.NewToolResultBlock(block.ToolUseID, block.Content, block.IsError))
+		}
+	}
+	return out
+}
+
+func anthropicMessageToTranscript(message anthropic.Message) transcriptMessage {
+	out := transcriptMessage{Role: string(message.Role)}
+	if out.Role == "" {
+		out.Role = agentRoleAssistant
+	}
+	for _, block := range message.Content {
+		switch v := block.AsAny().(type) {
+		case anthropic.TextBlock:
+			if v.Text != "" {
+				out.Content = append(out.Content, transcriptBlock{Type: blockTypeText, Text: v.Text})
+			}
+		case anthropic.ToolUseBlock:
+			input := append(json.RawMessage(nil), v.Input...)
+			if len(input) == 0 || string(input) == "null" {
+				input = json.RawMessage("{}")
+			}
+			out.Content = append(out.Content, transcriptBlock{
+				Type:  blockTypeToolUse,
+				ID:    v.ID,
+				Name:  v.Name,
+				Input: input,
+			})
+		}
+	}
+	return out
+}
+
+func rawJSONValue(raw json.RawMessage) any {
+	if len(raw) == 0 || string(raw) == "null" {
+		return map[string]any{}
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil || value == nil {
+		return map[string]any{}
+	}
+	return value
 }
 
 func messageText(content interface{}) string {


### PR DESCRIPTION
## Summary
- stream OpenAI and Gemini provider responses instead of buffering non-streaming calls
- persist provider-neutral tool transcripts across Anthropic, OpenAI, and Gemini conversations
- add project agent workflow guidance requiring PRs from a freshly fetched main

## Tests
- go test ./...

Base check: fetched origin/main first; local main was even with origin/main before branching.