### PR TITLE
Add admin user management: list, role changes, deletion

### DIFF
--- a/app/lib/features/auth/data/auth_service.dart
+++ b/app/lib/features/auth/data/auth_service.dart
@@ -134,6 +134,50 @@ class AuthService {
     );
   }
 
+  /// List all user accounts (admin only).
+  Future<List<UserSummary>> listUsers(
+    String serverUrl,
+    String accessToken,
+  ) async {
+    final dio = _createDio(serverUrl);
+    final resp = await dio.get(
+      '/api/admin/users',
+      options: Options(headers: {'Authorization': 'Bearer $accessToken'}),
+    );
+    return (resp.data as List<dynamic>)
+        .map((u) => UserSummary.fromJson(u as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Change a user's role (admin only).
+  Future<UserSummary> updateUserRole(
+    String serverUrl,
+    String accessToken,
+    int userId,
+    String role,
+  ) async {
+    final dio = _createDio(serverUrl);
+    final resp = await dio.patch(
+      '/api/admin/users/$userId',
+      data: {'role': role},
+      options: Options(headers: {'Authorization': 'Bearer $accessToken'}),
+    );
+    return UserSummary.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Delete a user account (admin only).
+  Future<void> deleteUser(
+    String serverUrl,
+    String accessToken,
+    int userId,
+  ) async {
+    final dio = _createDio(serverUrl);
+    await dio.delete(
+      '/api/admin/users/$userId',
+      options: Options(headers: {'Authorization': 'Bearer $accessToken'}),
+    );
+  }
+
   // ─── Passkey API Methods ─────────────────────────────
 
   /// Begin passkey registration (authenticated).
@@ -296,6 +340,45 @@ class DeviceInfo {
         deviceName: json['device_name'] as String,
         createdAt: json['created_at'] as String,
         lastSeenAt: json['last_seen_at'] as String,
+      );
+}
+
+/// Enriched user account returned by the admin users endpoint.
+class UserSummary {
+  final int id;
+  final String username;
+  final String role;
+  final List<String> permissions;
+  final String createdAt;
+  final int deviceCount;
+  final bool hasPassword;
+  final bool hasPendingInvite;
+
+  const UserSummary({
+    required this.id,
+    required this.username,
+    required this.role,
+    required this.permissions,
+    required this.createdAt,
+    required this.deviceCount,
+    required this.hasPassword,
+    required this.hasPendingInvite,
+  });
+
+  bool get isAdmin => role == 'admin';
+
+  factory UserSummary.fromJson(Map<String, dynamic> json) => UserSummary(
+        id: json['id'] as int,
+        username: json['username'] as String,
+        role: json['role'] as String,
+        permissions: (json['permissions'] as List<dynamic>?)
+                ?.map((p) => p as String)
+                .toList() ??
+            const [],
+        createdAt: json['created_at'] as String? ?? '',
+        deviceCount: json['device_count'] as int? ?? 0,
+        hasPassword: json['has_password'] as bool? ?? false,
+        hasPendingInvite: json['has_pending_invite'] as bool? ?? false,
       );
 }
 

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -285,6 +285,28 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     await _authService.revokeDevice(conn.serverUrl, conn.accessToken, deviceId);
   }
 
+  /// List all user accounts (admin only).
+  Future<List<UserSummary>> listUsers() async {
+    final conn = state.valueOrNull?.connection;
+    if (conn == null) throw Exception('Not authenticated');
+    return _authService.listUsers(conn.serverUrl, conn.accessToken);
+  }
+
+  /// Change a user's role (admin only).
+  Future<UserSummary> updateUserRole(int userId, String role) async {
+    final conn = state.valueOrNull?.connection;
+    if (conn == null) throw Exception('Not authenticated');
+    return _authService.updateUserRole(
+        conn.serverUrl, conn.accessToken, userId, role);
+  }
+
+  /// Delete a user account (admin only).
+  Future<void> deleteUser(int userId) async {
+    final conn = state.valueOrNull?.connection;
+    if (conn == null) throw Exception('Not authenticated');
+    await _authService.deleteUser(conn.serverUrl, conn.accessToken, userId);
+  }
+
   // ─── Passkey Methods ─────────────────────────────────
 
   /// Register a new passkey for the current user.

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -161,6 +161,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               onTap: () => context.push('/settings/ai-tools'),
             ),
             _SettingsTile(
+              icon: Icons.people_outline,
+              title: 'Users',
+              subtitle: 'Manage accounts, roles, and invites',
+              onTap: () => context.push('/settings/users'),
+            ),
+            _SettingsTile(
               icon: Icons.link,
               title: 'Generate Connect Link',
               subtitle: 'Create a link to invite a new user',

--- a/app/lib/features/settings/ui/users_screen.dart
+++ b/app/lib/features/settings/ui/users_screen.dart
@@ -1,0 +1,323 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../auth/data/auth_service.dart';
+import '../../auth/logic/auth_provider.dart';
+
+/// Admin screen for managing user accounts: change roles, remove users, and
+/// see who still has an outstanding connect-link invite.
+class UsersScreen extends ConsumerStatefulWidget {
+  const UsersScreen({super.key});
+
+  @override
+  ConsumerState<UsersScreen> createState() => _UsersScreenState();
+}
+
+class _UsersScreenState extends ConsumerState<UsersScreen> {
+  List<UserSummary>? _users;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadUsers();
+  }
+
+  Future<void> _loadUsers() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final users = await ref.read(authProvider.notifier).listUsers();
+      setState(() {
+        _users = users;
+        _isLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _error = 'Failed to load users';
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _changeRole(UserSummary user, String newRole) async {
+    if (newRole == user.role) return;
+    try {
+      await ref.read(authProvider.notifier).updateUserRole(user.id, newRole);
+      await _loadUsers();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              newRole == 'admin'
+                  ? '${user.username} is now an admin'
+                  : '${user.username} is now a user',
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(_friendlyError(e, 'Failed to change role'))),
+        );
+      }
+    }
+  }
+
+  Future<void> _deleteUser(UserSummary user) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Remove User'),
+        content: Text(
+          'Remove "${user.username}"? This deletes their account, devices, '
+          'and any pending invites. This cannot be undone.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(backgroundColor: AppTheme.error),
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    try {
+      await ref.read(authProvider.notifier).deleteUser(user.id);
+      await _loadUsers();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Removed ${user.username}')),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(_friendlyError(e, 'Failed to remove user'))),
+        );
+      }
+    }
+  }
+
+  String _friendlyError(Object e, String fallback) {
+    final msg = e.toString();
+    // Surface the backend's error message when present.
+    final match = RegExp(r'"error":"([^"]+)"').firstMatch(msg);
+    return match != null ? match.group(1)! : fallback;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Users')),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!, style: const TextStyle(color: AppTheme.error)),
+            const SizedBox(height: 16),
+            ElevatedButton(onPressed: _loadUsers, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+
+    final users = _users ?? [];
+    if (users.isEmpty) {
+      return const Center(
+        child: Text(
+          'No users yet',
+          style: TextStyle(color: AppTheme.textSecondary),
+        ),
+      );
+    }
+
+    final currentUserId = ref.read(authProvider).valueOrNull?.user?.id;
+
+    return RefreshIndicator(
+      onRefresh: _loadUsers,
+      child: ListView.separated(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: users.length,
+        separatorBuilder: (_, __) =>
+            const Divider(height: 1, color: AppTheme.border),
+        itemBuilder: (context, index) {
+          final user = users[index];
+          return _UserTile(
+            user: user,
+            isSelf: user.id == currentUserId,
+            onChangeRole: (role) => _changeRole(user, role),
+            onDelete: () => _deleteUser(user),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _UserTile extends StatelessWidget {
+  const _UserTile({
+    required this.user,
+    required this.isSelf,
+    required this.onChangeRole,
+    required this.onDelete,
+  });
+
+  final UserSummary user;
+  final bool isSelf;
+  final ValueChanged<String> onChangeRole;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: user.isAdmin
+            ? AppTheme.accent.withValues(alpha: 0.2)
+            : AppTheme.surfaceVariant,
+        child: Icon(
+          user.isAdmin ? Icons.admin_panel_settings : Icons.person,
+          color: user.isAdmin ? AppTheme.accent : AppTheme.textSecondary,
+          size: 20,
+        ),
+      ),
+      title: Row(
+        children: [
+          Flexible(
+            child: Text(
+              user.username,
+              style: const TextStyle(
+                color: AppTheme.textPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (isSelf) ...[
+            const SizedBox(width: 8),
+            _Tag(label: 'You', color: AppTheme.accent),
+          ],
+        ],
+      ),
+      subtitle: Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: Wrap(
+          spacing: 6,
+          runSpacing: 4,
+          children: [
+            _Tag(
+              label: user.isAdmin ? 'Admin' : 'User',
+              color: user.isAdmin ? AppTheme.accent : AppTheme.textSecondary,
+            ),
+            if (user.hasPendingInvite)
+              _Tag(label: 'Invited', color: AppTheme.requested),
+            _Tag(
+              label: user.deviceCount == 1
+                  ? '1 device'
+                  : '${user.deviceCount} devices',
+              color: user.deviceCount > 0
+                  ? AppTheme.available
+                  : AppTheme.unavailable,
+            ),
+          ],
+        ),
+      ),
+      trailing: _buildMenu(context),
+    );
+  }
+
+  Widget _buildMenu(BuildContext context) {
+    return PopupMenuButton<String>(
+      icon: const Icon(Icons.more_vert, color: AppTheme.textSecondary),
+      onSelected: (value) {
+        switch (value) {
+          case 'make_admin':
+            onChangeRole('admin');
+            break;
+          case 'make_user':
+            onChangeRole('user');
+            break;
+          case 'delete':
+            onDelete();
+            break;
+        }
+      },
+      itemBuilder: (context) => [
+        if (!user.isAdmin)
+          const PopupMenuItem(
+            value: 'make_admin',
+            child: ListTile(
+              leading: Icon(Icons.arrow_upward),
+              title: Text('Make admin'),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+        if (user.isAdmin && !isSelf)
+          const PopupMenuItem(
+            value: 'make_user',
+            child: ListTile(
+              leading: Icon(Icons.arrow_downward),
+              title: Text('Make user'),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+        if (!isSelf)
+          const PopupMenuItem(
+            value: 'delete',
+            child: ListTile(
+              leading: Icon(Icons.delete_outline, color: AppTheme.error),
+              title: Text('Remove', style: TextStyle(color: AppTheme.error)),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _Tag extends StatelessWidget {
+  const _Tag({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -25,6 +25,7 @@ import '../features/settings/ui/credentials_screen.dart';
 import '../features/settings/ui/devices_screen.dart';
 import '../features/settings/ui/instance_edit_screen.dart';
 import '../features/settings/ui/settings_screen.dart';
+import '../features/settings/ui/users_screen.dart';
 import '../features/setup_wizard/ui/plex_setup_guide.dart';
 import '../features/setup_wizard/ui/setup_wizard_screen.dart';
 import '../features/shell/ui/app_shell.dart';
@@ -318,6 +319,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         path: '/settings/ai-tools',
         parentNavigatorKey: _rootNavigatorKey,
         builder: (_, __) => const AiToolsScreen(),
+      ),
+      GoRoute(
+        path: '/settings/users',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (_, __) => const UsersScreen(),
       ),
       GoRoute(
         path: '/settings/devices',

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -122,6 +122,11 @@ func NewRouter(
 			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Get("/devices", authHandler.HandleListDevices)
 			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Delete("/devices/{deviceID}", authHandler.HandleRevokeDevice)
 
+			// User management
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Get("/users", authHandler.HandleListUsers)
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Patch("/users/{userID}", authHandler.HandleUpdateUserRole)
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Delete("/users/{userID}", authHandler.HandleDeleteUser)
+
 			// Credential management
 			r.With(auth.RequirePermission(auth.PermissionCredentialsManage)).Get("/credentials", credHandler.Get)
 			r.With(auth.RequirePermission(auth.PermissionCredentialsManage)).Put("/credentials", credHandler.Update)

--- a/server/internal/auth/handler.go
+++ b/server/internal/auth/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -150,6 +151,76 @@ func (h *Handler) HandleRevokeDevice(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
+}
+
+func (h *Handler) HandleListUsers(w http.ResponseWriter, r *http.Request) {
+	users, err := h.service.ListUsers()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to list users"})
+		return
+	}
+	writeJSON(w, http.StatusOK, users)
+}
+
+func (h *Handler) HandleUpdateUserRole(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseInt(chi.URLParam(r, "userID"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid user ID"})
+		return
+	}
+
+	var req UpdateUserRoleRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	user, err := h.service.UpdateUserRole(userID, req.Role)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrInvalidRole):
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid role"})
+		case errors.Is(err, ErrUserNotFound):
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
+		case errors.Is(err, ErrLastAdmin):
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "cannot demote the last admin"})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to update role"})
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, user)
+}
+
+func (h *Handler) HandleDeleteUser(w http.ResponseWriter, r *http.Request) {
+	claims := GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	userID, err := strconv.ParseInt(chi.URLParam(r, "userID"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid user ID"})
+		return
+	}
+
+	if err := h.service.DeleteUser(claims.UserID, userID); err != nil {
+		switch {
+		case errors.Is(err, ErrUserNotFound):
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
+		case errors.Is(err, ErrCannotDeleteSelf):
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "you cannot delete your own account"})
+		case errors.Is(err, ErrLastAdmin):
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "cannot delete the last admin"})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete user"})
+		}
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "deleted"})
 }
 
 func (h *Handler) AuthStatus(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/auth/models.go
+++ b/server/internal/auth/models.go
@@ -11,6 +11,25 @@ type User struct {
 	CreatedAt    time.Time    `json:"created_at"`
 }
 
+// UserSummary is an enriched view of a user for admin user-management screens.
+// It augments the base account with device and invite state so admins can tell
+// active accounts apart from pending invites at a glance.
+type UserSummary struct {
+	ID               int64        `json:"id"`
+	Username         string       `json:"username"`
+	Role             string       `json:"role"`
+	Permissions      []Permission `json:"permissions"`
+	CreatedAt        time.Time    `json:"created_at"`
+	DeviceCount      int          `json:"device_count"`
+	HasPassword      bool         `json:"has_password"`
+	HasPendingInvite bool         `json:"has_pending_invite"`
+}
+
+// UpdateUserRoleRequest changes a user's role.
+type UpdateUserRoleRequest struct {
+	Role string `json:"role"`
+}
+
 type Device struct {
 	ID         string     `json:"id"`
 	UserID     int64      `json:"user_id"`

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -30,6 +30,10 @@ var (
 	ErrDeviceRevoked        = errors.New("device has been revoked")
 	ErrDeviceNotFound       = errors.New("device not found")
 	ErrSetupAlreadyComplete = errors.New("setup has already been completed")
+	ErrUserNotFound         = errors.New("user not found")
+	ErrInvalidRole          = errors.New("invalid role")
+	ErrLastAdmin            = errors.New("cannot remove the last admin")
+	ErrCannotDeleteSelf     = errors.New("cannot delete your own account")
 )
 
 type Claims struct {
@@ -393,26 +397,167 @@ func (s *Service) RevokeDevice(deviceID string) error {
 	return nil
 }
 
-func (s *Service) ListUsers() ([]User, error) {
-	rows, err := s.db.Query("SELECT id, username, password_hash, role, created_at FROM users ORDER BY id")
+// ListUsers returns every account enriched with device counts, password state,
+// and whether an unredeemed connect-link invite is still outstanding.
+func (s *Service) ListUsers() ([]UserSummary, error) {
+	rows, err := s.db.Query(`
+		SELECT
+			u.id,
+			u.username,
+			u.role,
+			u.created_at,
+			u.password_hash != '' AS has_password,
+			(SELECT COUNT(*) FROM devices d WHERE d.user_id = u.id AND d.revoked_at IS NULL) AS device_count,
+			EXISTS(
+				SELECT 1 FROM connect_tokens ct
+				WHERE ct.user_id = u.id AND ct.redeemed_at IS NULL AND ct.expires_at > ?
+			) AS has_pending_invite
+		FROM users u
+		ORDER BY u.id
+	`, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("query users: %w", err)
 	}
 	defer rows.Close()
 
-	var users []User
+	var users []UserSummary
 	for rows.Next() {
-		var u User
-		if err := rows.Scan(&u.ID, &u.Username, &u.PasswordHash, &u.Role, &u.CreatedAt); err != nil {
+		var u UserSummary
+		if err := rows.Scan(
+			&u.ID, &u.Username, &u.Role, &u.CreatedAt,
+			&u.HasPassword, &u.DeviceCount, &u.HasPendingInvite,
+		); err != nil {
 			return nil, fmt.Errorf("scan user: %w", err)
 		}
 		u.Permissions = PermissionsForRole(u.Role)
 		users = append(users, u)
 	}
 	if users == nil {
-		users = []User{}
+		users = []UserSummary{}
 	}
 	return users, nil
+}
+
+// UpdateUserRole changes a user's role. It rejects unknown roles and refuses to
+// demote the last remaining admin so an install can never be locked out.
+func (s *Service) UpdateUserRole(userID int64, role string) (*UserSummary, error) {
+	if role != RoleAdmin && role != RoleUser {
+		return nil, ErrInvalidRole
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	var currentRole string
+	if err := tx.QueryRow("SELECT role FROM users WHERE id = ?", userID).Scan(&currentRole); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrUserNotFound
+		}
+		return nil, fmt.Errorf("load user: %w", err)
+	}
+
+	if currentRole == RoleAdmin && role != RoleAdmin {
+		var adminCount int
+		if err := tx.QueryRow("SELECT COUNT(*) FROM users WHERE role = ?", RoleAdmin).Scan(&adminCount); err != nil {
+			return nil, fmt.Errorf("count admins: %w", err)
+		}
+		if adminCount <= 1 {
+			return nil, ErrLastAdmin
+		}
+	}
+
+	if _, err := tx.Exec("UPDATE users SET role = ? WHERE id = ?", role, userID); err != nil {
+		return nil, fmt.Errorf("update role: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit role change: %w", err)
+	}
+
+	return s.userSummaryByID(userID)
+}
+
+// DeleteUser removes a user and all of their dependent records (devices,
+// tokens, passkeys). It refuses to delete the acting admin's own account or the
+// last remaining admin.
+func (s *Service) DeleteUser(actorID, userID int64) error {
+	if actorID == userID {
+		return ErrCannotDeleteSelf
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	var role string
+	if err := tx.QueryRow("SELECT role FROM users WHERE id = ?", userID).Scan(&role); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrUserNotFound
+		}
+		return fmt.Errorf("load user: %w", err)
+	}
+
+	if role == RoleAdmin {
+		var adminCount int
+		if err := tx.QueryRow("SELECT COUNT(*) FROM users WHERE role = ?", RoleAdmin).Scan(&adminCount); err != nil {
+			return fmt.Errorf("count admins: %w", err)
+		}
+		if adminCount <= 1 {
+			return ErrLastAdmin
+		}
+	}
+
+	// Clear references that lack ON DELETE CASCADE before removing the user.
+	// Deleting the user then cascades passkeys and OAuth grants automatically.
+	if _, err := tx.Exec("DELETE FROM refresh_tokens WHERE user_id = ?", userID); err != nil {
+		return fmt.Errorf("delete refresh tokens: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM connect_tokens WHERE user_id = ? OR created_by = ?", userID, userID); err != nil {
+		return fmt.Errorf("delete connect tokens: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM devices WHERE user_id = ?", userID); err != nil {
+		return fmt.Errorf("delete devices: %w", err)
+	}
+	if _, err := tx.Exec("DELETE FROM users WHERE id = ?", userID); err != nil {
+		return fmt.Errorf("delete user: %w", err)
+	}
+
+	return tx.Commit()
+}
+
+func (s *Service) userSummaryByID(userID int64) (*UserSummary, error) {
+	var u UserSummary
+	err := s.db.QueryRow(`
+		SELECT
+			u.id,
+			u.username,
+			u.role,
+			u.created_at,
+			u.password_hash != '' AS has_password,
+			(SELECT COUNT(*) FROM devices d WHERE d.user_id = u.id AND d.revoked_at IS NULL) AS device_count,
+			EXISTS(
+				SELECT 1 FROM connect_tokens ct
+				WHERE ct.user_id = u.id AND ct.redeemed_at IS NULL AND ct.expires_at > ?
+			) AS has_pending_invite
+		FROM users u
+		WHERE u.id = ?
+	`, time.Now(), userID).Scan(
+		&u.ID, &u.Username, &u.Role, &u.CreatedAt,
+		&u.HasPassword, &u.DeviceCount, &u.HasPendingInvite,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrUserNotFound
+		}
+		return nil, fmt.Errorf("load user summary: %w", err)
+	}
+	u.Permissions = PermissionsForRole(u.Role)
+	return &u, nil
 }
 
 func (s *Service) ValidateToken(tokenStr string) (*Claims, error) {

--- a/server/internal/auth/service_test.go
+++ b/server/internal/auth/service_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +21,143 @@ func setupTestService(t *testing.T) *Service {
 		t.Fatalf("ensure admin: %v", err)
 	}
 	return svc
+}
+
+func TestListUsers_ReportsDeviceAndInviteState(t *testing.T) {
+	svc := setupTestService(t)
+
+	// admin logs in -> gets an active device
+	if _, err := svc.Login("admin", "testpass123"); err != nil {
+		t.Fatalf("login: %v", err)
+	}
+
+	// Invite a new user via connect link (unredeemed -> pending invite)
+	if _, err := svc.CreateConnectToken(1, "guest", "http://example.com"); err != nil {
+		t.Fatalf("create connect token: %v", err)
+	}
+
+	users, err := svc.ListUsers()
+	if err != nil {
+		t.Fatalf("list users: %v", err)
+	}
+	if len(users) != 2 {
+		t.Fatalf("expected 2 users, got %d", len(users))
+	}
+
+	byName := map[string]UserSummary{}
+	for _, u := range users {
+		byName[u.Username] = u
+	}
+
+	admin := byName["admin"]
+	if admin.Role != RoleAdmin || admin.DeviceCount != 1 || !admin.HasPassword || admin.HasPendingInvite {
+		t.Fatalf("unexpected admin summary: %+v", admin)
+	}
+
+	guest := byName["guest"]
+	if guest.Role != RoleUser || guest.DeviceCount != 0 || guest.HasPassword || !guest.HasPendingInvite {
+		t.Fatalf("unexpected guest summary: %+v", guest)
+	}
+}
+
+func TestUpdateUserRole_PromoteAndDemote(t *testing.T) {
+	svc := setupTestService(t)
+	if _, err := svc.CreateConnectToken(1, "guest", "http://example.com"); err != nil {
+		t.Fatalf("create connect token: %v", err)
+	}
+
+	var guestID int64
+	if err := svc.db.QueryRow("SELECT id FROM users WHERE username = ?", "guest").Scan(&guestID); err != nil {
+		t.Fatalf("load guest: %v", err)
+	}
+
+	updated, err := svc.UpdateUserRole(guestID, RoleAdmin)
+	if err != nil {
+		t.Fatalf("promote: %v", err)
+	}
+	if updated.Role != RoleAdmin {
+		t.Fatalf("role = %q, want %q", updated.Role, RoleAdmin)
+	}
+
+	if _, err := svc.UpdateUserRole(guestID, "superuser"); err != ErrInvalidRole {
+		t.Fatalf("expected ErrInvalidRole, got %v", err)
+	}
+
+	if _, err := svc.UpdateUserRole(guestID, RoleUser); err != nil {
+		t.Fatalf("demote: %v", err)
+	}
+}
+
+func TestUpdateUserRole_CannotDemoteLastAdmin(t *testing.T) {
+	svc := setupTestService(t)
+
+	var adminID int64
+	if err := svc.db.QueryRow("SELECT id FROM users WHERE username = ?", "admin").Scan(&adminID); err != nil {
+		t.Fatalf("load admin: %v", err)
+	}
+
+	if _, err := svc.UpdateUserRole(adminID, RoleUser); err != ErrLastAdmin {
+		t.Fatalf("expected ErrLastAdmin, got %v", err)
+	}
+}
+
+func TestDeleteUser_RemovesUserAndDevices(t *testing.T) {
+	svc := setupTestService(t)
+
+	// Invite a guest and redeem the link so they have a device + refresh token.
+	tok, err := svc.CreateConnectToken(1, "guest", "http://example.com")
+	if err != nil {
+		t.Fatalf("create connect token: %v", err)
+	}
+	token := tok.Link[strings.Index(tok.Link, "token=")+len("token=") : strings.Index(tok.Link, "&server=")]
+	resp, err := svc.RedeemConnectToken(token, "Guest Phone")
+	if err != nil {
+		t.Fatalf("redeem token: %v", err)
+	}
+
+	if err := svc.DeleteUser(1, resp.User.ID); err != nil {
+		t.Fatalf("delete user: %v", err)
+	}
+
+	var count int
+	if err := svc.db.QueryRow("SELECT COUNT(*) FROM users WHERE id = ?", resp.User.ID).Scan(&count); err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if count != 0 {
+		t.Fatal("user was not deleted")
+	}
+	if err := svc.db.QueryRow("SELECT COUNT(*) FROM devices WHERE user_id = ?", resp.User.ID).Scan(&count); err != nil {
+		t.Fatalf("count devices: %v", err)
+	}
+	if count != 0 {
+		t.Fatal("devices were not cleaned up")
+	}
+}
+
+func TestDeleteUser_Guards(t *testing.T) {
+	svc := setupTestService(t)
+
+	var adminID int64
+	if err := svc.db.QueryRow("SELECT id FROM users WHERE username = ?", "admin").Scan(&adminID); err != nil {
+		t.Fatalf("load admin: %v", err)
+	}
+
+	if err := svc.DeleteUser(adminID, adminID); err != ErrCannotDeleteSelf {
+		t.Fatalf("expected ErrCannotDeleteSelf, got %v", err)
+	}
+
+	// Promote a second admin so the self-delete guard isn't what's tripping,
+	// then ensure the last-admin guard still protects the remaining admin.
+	if _, err := svc.CreateConnectToken(adminID, "second", "http://example.com"); err != nil {
+		t.Fatalf("create token: %v", err)
+	}
+	var secondID int64
+	if err := svc.db.QueryRow("SELECT id FROM users WHERE username = ?", "second").Scan(&secondID); err != nil {
+		t.Fatalf("load second: %v", err)
+	}
+	if err := svc.DeleteUser(secondID, adminID); err != ErrLastAdmin {
+		t.Fatalf("expected ErrLastAdmin, got %v", err)
+	}
 }
 
 func TestHashToken_Deterministic(t *testing.T) {


### PR DESCRIPTION
Refine user management beyond device-only controls. Admins can now see
every account, promote/demote between admin and user, and remove users.

Backend:
- Wire up GET/PATCH/DELETE /api/admin/users (the previously unexposed
  ListUsers method now returns enriched summaries).
- Enrich the user listing with active device counts, password state, and
  whether an unredeemed connect-link invite is still outstanding, so
  pending invites are distinguishable from active accounts.
- Guardrails: reject unknown roles, refuse to demote or delete the last
  admin, and refuse self-deletion. Deletion clears non-cascading
  references (devices, connect tokens, refresh tokens) in a transaction.

Frontend:
- New admin Users screen with role menu, pending/device tags, and
  removal, linked from Settings. Backend error messages surface in
  snackbars.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014CgpZuYHdBjynCi7XNzHsY