### PR TITLE
Fix navigation reset on auth-state changes (Settings glitch)

### DIFF
--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -47,13 +47,20 @@ final _rootNavigatorKey = GlobalKey<NavigatorState>();
 /// Outer ShellRoute provides the drawer + search bar.
 /// Inner StatefulShellRoutes provide per-module bottom nav.
 final appRouterProvider = Provider<GoRouter>((ref) {
-  final authState = ref.watch(authProvider);
+  // Re-run redirects when auth state changes WITHOUT rebuilding the router.
+  // Watching authProvider here would create a brand-new GoRouter on every auth
+  // change (token refresh, profile reload, etc.), which resets navigation to
+  // the initial route. A refreshListenable keeps the router instance stable.
+  final authRefresh = ValueNotifier<int>(0);
+  ref.onDispose(authRefresh.dispose);
+  ref.listen(authProvider, (_, __) => authRefresh.value++);
 
   return GoRouter(
     navigatorKey: _rootNavigatorKey,
     initialLocation: '/dashboard/movies',
+    refreshListenable: authRefresh,
     redirect: (context, state) {
-      final auth = authState.valueOrNull;
+      final auth = ref.read(authProvider).valueOrNull;
       final isAuthenticated = auth?.isAuthenticated ?? false;
       final isAuthRoute = state.matchedLocation == '/login';
       final pendingPasskey = auth?.pendingPasskeyOffer ?? false;

--- a/app/test/navigation/app_router_test.dart
+++ b/app/test/navigation/app_router_test.dart
@@ -1,0 +1,56 @@
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/navigation/app_router.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  test('router instance stays stable across auth state changes', () {
+    final container = ProviderContainer(
+      overrides: [
+        authProvider.overrideWith(() => _FakeAuthNotifier(_authedState)),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final first = container.read(appRouterProvider);
+    expect(first, isA<GoRouter>());
+
+    // An auth-state change (e.g. token refresh or profile reload) must NOT
+    // recreate the router — recreating it resets navigation to the initial
+    // route, which is what bounced the user out of nested screens.
+    (container.read(authProvider.notifier) as _FakeAuthNotifier).push(
+      AuthState(
+        connection: _authedState.connection!.copyWith(accessToken: 'access2'),
+        user: _authedState.user,
+      ),
+    );
+
+    final second = container.read(appRouterProvider);
+    expect(identical(first, second), isTrue,
+        reason: 'auth changes should refresh redirects, not rebuild the router');
+  });
+}
+
+const _authedState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(ai: true),
+  ),
+  user: UserProfile(id: 1, username: 'tester', role: 'user'),
+);
+
+class _FakeAuthNotifier extends AuthNotifier {
+  _FakeAuthNotifier(this._initial);
+
+  final AuthState _initial;
+
+  @override
+  Future<AuthState> build() async => _initial;
+
+  void push(AuthState next) => state = AsyncData(next);
+}


### PR DESCRIPTION
## Problem
Opening **Settings** flashed the screen then bounced back to the dashboard — it wouldn't stay open. Introduced by the passwordless-auth work (#69): the Settings screen's `initState` calls `refreshUser()`, which mutates auth state right after the screen opens.

## Root cause
`appRouterProvider` did `ref.watch(authProvider)`, so **any** auth-state change rebuilt the provider and produced a **brand-new `GoRouter`**, which `MaterialApp.router` swaps in — resetting navigation to the initial route (`/dashboard/movies`). The same latent reset also fired on every token refresh (`updateTokens`), profile reload, and config refresh, so it wasn't specific to Settings.

## Fix
Build the `GoRouter` **once** and re-run redirects via a `refreshListenable` that ticks on auth changes (reading `authProvider` inside `redirect` via `ref.read`), instead of recreating the router. This is the standard GoRouter + Riverpod pattern and keeps the router instance stable.

## Tests
- New `test/navigation/app_router_test.dart` asserts the router instance is stable across auth-state changes. **Verified to fail before this fix** (router recreated) and pass after.
- `flutter analyze` clean; `flutter test` — 27 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)