### PR TITLE
Add media-request approval workflow and per-request options

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -4,6 +4,9 @@ import 'package:app_links/app_links.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'core/network/websocket_client.dart';
+import 'core/providers/realtime_provider.dart';
+import 'core/storage/preferences.dart';
 import 'core/theme/app_theme.dart';
 import 'features/auth/logic/auth_provider.dart';
 import 'navigation/app_router.dart';
@@ -18,6 +21,7 @@ class CantinarrApp extends ConsumerStatefulWidget {
 class _CantinarrAppState extends ConsumerState<CantinarrApp> {
   late final AppLinks _appLinks;
   StreamSubscription<Uri>? _linkSubscription;
+  final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 
   @override
   void initState() {
@@ -98,9 +102,42 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp> {
     super.dispose();
   }
 
+  /// Shows an in-app toast for an approval decision pushed over the socket.
+  void _showDecisionSnack(WsEvent event) {
+    final messenger = _scaffoldMessengerKey.currentState;
+    if (messenger == null) return;
+    final data = event.data;
+    final approved = data['decision'] == 'approved';
+    final rawTitle = (data['title'] as String?)?.trim();
+    final label = rawTitle == null || rawTitle.isEmpty ? 'Your request' : rawTitle;
+    final reason = (data['reason'] as String?)?.trim();
+    final text = approved
+        ? 'Approved: $label'
+        : (reason == null || reason.isEmpty
+            ? 'Denied: $label'
+            : 'Denied: $label — $reason');
+    messenger
+      ..clearSnackBars()
+      ..showSnackBar(SnackBar(
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: approved ? AppTheme.available : AppTheme.error,
+        content: Text(text, style: const TextStyle(color: Colors.white)),
+      ));
+  }
+
   @override
   Widget build(BuildContext context) {
     final authState = ref.watch(authProvider);
+
+    // Surface approval decisions pushed over the socket as a toast (unless the
+    // user muted them). Registered before any early return so the listen stays
+    // unconditional across rebuilds.
+    ref.listen(requestDecisionEventsProvider, (_, next) {
+      final event = next.valueOrNull;
+      if (event == null) return;
+      if (!ref.read(requestNotificationsEnabledProvider)) return;
+      _showDecisionSnack(event);
+    });
 
     // Show blank screen while restoring session to prevent login flash
     if (authState.isLoading) {
@@ -117,6 +154,7 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp> {
       title: 'Cantinarr',
       theme: AppTheme.dark,
       debugShowCheckedModeBanner: false,
+      scaffoldMessengerKey: _scaffoldMessengerKey,
       routerConfig: router,
     );
   }

--- a/app/lib/core/providers/realtime_provider.dart
+++ b/app/lib/core/providers/realtime_provider.dart
@@ -45,3 +45,12 @@ final arrQueueChangedProvider =
       e.data['instance_id'] == key.instanceId &&
       e.data['service_type'] == key.serviceType);
 });
+
+/// Approval decisions for the current user's own requests
+/// (`request_decision` events). The backend pushes these only to the
+/// requesting user, carrying `decision` ('approved'|'denied'), `title`,
+/// `media_type`, and an optional `reason`. Used to surface an in-app toast.
+final requestDecisionEventsProvider = StreamProvider.autoDispose<WsEvent>((ref) {
+  final events = ref.watch(realtimeEventsProvider);
+  return events.where((e) => e.type == 'request_decision');
+});

--- a/app/lib/core/storage/preferences.dart
+++ b/app/lib/core/storage/preferences.dart
@@ -5,3 +5,30 @@ import 'package:shared_preferences/shared_preferences.dart';
 final sharedPreferencesProvider = FutureProvider<SharedPreferences>(
   (_) => SharedPreferences.getInstance(),
 );
+
+const _requestNotificationsKey = 'request_notifications_enabled';
+
+/// Whether in-app notifications for request approvals/denials are shown.
+/// Stored locally on the device and defaults to enabled; users can mute them
+/// from Settings without affecting the passively-updated request status.
+class RequestNotificationsNotifier extends StateNotifier<bool> {
+  RequestNotificationsNotifier() : super(true) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = prefs.getBool(_requestNotificationsKey) ?? true;
+  }
+
+  Future<void> set(bool value) async {
+    state = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_requestNotificationsKey, value);
+  }
+}
+
+final requestNotificationsEnabledProvider =
+    StateNotifierProvider<RequestNotificationsNotifier, bool>(
+  (ref) => RequestNotificationsNotifier(),
+);

--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../core/network/backend_client.dart';
+import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/horizontal_item_row.dart';
 import '../../../core/widgets/media_card.dart';
@@ -12,6 +13,7 @@ import '../../discover/data/discover_api_service.dart';
 import '../../request/data/request_service.dart';
 import '../../request/logic/request_provider.dart';
 import '../../request/ui/request_button.dart';
+import '../../request/ui/request_options_sheet.dart';
 import '../../request/ui/request_status_sheet.dart';
 import '../logic/media_detail_provider.dart';
 import 'season_grid.dart';
@@ -57,6 +59,17 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // Live-update the request button when an approval decision for THIS title
+    // arrives over the socket (complements the global toast).
+    ref.listen(requestDecisionEventsProvider, (_, next) {
+      final event = next.valueOrNull;
+      if (event == null) return;
+      final tmdb = (event.data['tmdb_id'] as num?)?.toInt();
+      if (tmdb == widget.id &&
+          event.data['media_type'] == widget.mediaType.name) {
+        _requestNotifier.checkStatus();
+      }
+    });
     return ListenableBuilder(
       listenable: _detailNotifier,
       builder: (context, _) {
@@ -110,13 +123,7 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                           status: _requestNotifier.state.status,
                           isRequesting: _requestNotifier.state.isRequesting,
                           error: _requestNotifier.state.error,
-                          onRequest: () {
-                            final s = _detailNotifier.state;
-                            _requestNotifier.request(
-                              title: s.title,
-                              tvdbId: s.tvDetail?.externalIds?.tvdbId,
-                            );
-                          },
+                          onRequest: () => _onRequest(),
                         ),
                       ),
                     ),
@@ -296,6 +303,38 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
   void _openTrailer(String key) {
     final url = Uri.parse('https://www.youtube.com/watch?v=$key');
     launchUrl(url, mode: LaunchMode.externalApplication);
+  }
+
+  /// Handle a request tap: if the user may choose options (season scope /
+  /// quality), present the picker first; otherwise submit immediately to keep
+  /// the one-tap experience.
+  Future<void> _onRequest() async {
+    final s = _detailNotifier.state;
+    final title = s.title;
+    final tvdbId = s.tvDetail?.externalIds?.tvdbId;
+
+    final options = await _requestNotifier.fetchOptions();
+    String? seasonScope;
+    int? qualityProfileId;
+    if (options != null && options.hasChoices) {
+      if (!mounted) return;
+      final result = await showModalBottomSheet<RequestOptionsResult>(
+        context: context,
+        backgroundColor: Colors.transparent,
+        isScrollControlled: true,
+        builder: (_) => RequestOptionsSheet(options: options),
+      );
+      if (result == null) return; // cancelled
+      seasonScope = result.seasonScope;
+      qualityProfileId = result.qualityProfileId;
+    }
+
+    await _requestNotifier.request(
+      title: title,
+      tvdbId: tvdbId,
+      seasonScope: seasonScope,
+      qualityProfileId: qualityProfileId,
+    );
   }
 
   void _showStatusSheet(

--- a/app/lib/features/request/data/request_service.dart
+++ b/app/lib/features/request/data/request_service.dart
@@ -6,6 +6,9 @@ enum RequestStatus {
   /// Not on the server, can be requested.
   unavailable('Not Available', 'Request'),
 
+  /// Awaiting an administrator's approval.
+  pending('Pending Approval', 'Pending'),
+
   /// Request has been submitted, waiting for processing.
   requested('Requested', 'Requested'),
 
@@ -16,11 +19,75 @@ enum RequestStatus {
   available('Available on Plex', 'Watch Now'),
 
   /// Partially available (some seasons/episodes).
-  partial('Partially Available', 'Request More');
+  partial('Partially Available', 'Request More'),
+
+  /// An administrator declined the request; it can be requested again.
+  denied('Request Denied', 'Request');
 
   const RequestStatus(this.label, this.buttonLabel);
   final String label;
   final String buttonLabel;
+}
+
+/// The TV season-scope choices a user may attach to a request. The string
+/// values mirror the backend's season_scope enum.
+class SeasonScope {
+  static const String all = 'all';
+  static const String first = 'first';
+  static const String latest = 'latest';
+  static const String pilot = 'pilot';
+
+  /// Selectable choices, in display order.
+  static const List<({String value, String label})> choices = [
+    (value: pilot, label: 'Pilot only'),
+    (value: first, label: 'First season'),
+    (value: latest, label: 'Most recent season'),
+    (value: all, label: 'Entire series'),
+  ];
+
+  static String labelFor(String value) =>
+      choices.firstWhere((c) => c.value == value, orElse: () => choices.last).label;
+}
+
+/// An arr quality profile the user may pick for a request.
+class QualityProfileOption {
+  final int id;
+  final String name;
+  const QualityProfileOption({required this.id, required this.name});
+
+  factory QualityProfileOption.fromJson(Map<String, dynamic> json) =>
+      QualityProfileOption(
+        id: json['id'] as int? ?? 0,
+        name: json['name'] as String? ?? '',
+      );
+}
+
+/// What the current user is permitted to choose for a request, plus the
+/// available quality profiles (only populated when quality choice is allowed).
+class RequestOptions {
+  final bool canChooseSeason;
+  final bool canChooseQuality;
+  final String defaultSeasonScope;
+  final List<QualityProfileOption> qualityProfiles;
+
+  const RequestOptions({
+    required this.canChooseSeason,
+    required this.canChooseQuality,
+    required this.defaultSeasonScope,
+    required this.qualityProfiles,
+  });
+
+  bool get hasChoices =>
+      canChooseSeason || (canChooseQuality && qualityProfiles.isNotEmpty);
+
+  factory RequestOptions.fromJson(Map<String, dynamic> json) => RequestOptions(
+        canChooseSeason: json['can_choose_season'] as bool? ?? false,
+        canChooseQuality: json['can_choose_quality'] as bool? ?? false,
+        defaultSeasonScope: json['default_season_scope'] as String? ?? SeasonScope.all,
+        qualityProfiles: ((json['quality_profiles'] as List?) ?? const [])
+            .map((e) => QualityProfileOption.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
 }
 
 /// Routes media requests through the Cantinarr backend.
@@ -32,7 +99,8 @@ class RequestService {
 
   RequestService({required Dio backendDio}) : _backendDio = backendDio;
 
-  /// Check the current status of a media item.
+  /// Check the current status of a media item for the current user (surfaces
+  /// the user's own pending/denied state ahead of live availability).
   Future<RequestStatus> checkStatus(int tmdbId, MediaType mediaType) async {
     try {
       final resp = await _backendDio.get(
@@ -50,12 +118,30 @@ class RequestService {
     }
   }
 
-  /// Submit a request for a media item.
-  Future<bool> request({
+  /// Fetch the option set the current user may choose for [mediaType].
+  /// Returns null on error (the caller then submits with no options).
+  Future<RequestOptions?> fetchOptions(MediaType mediaType) async {
+    try {
+      final resp = await _backendDio.get(
+        '/api/requests/options',
+        queryParameters: {'media_type': mediaType.name},
+      );
+      return RequestOptions.fromJson(resp.data as Map<String, dynamic>);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Submit a request for a media item. Returns the resulting [RequestStatus]
+  /// (e.g. [RequestStatus.pending] when approval is required), or null on
+  /// failure.
+  Future<RequestStatus?> request({
     required int tmdbId,
     required MediaType mediaType,
     String? title,
     int? tvdbId,
+    String? seasonScope,
+    int? qualityProfileId,
   }) async {
     try {
       final body = <String, dynamic>{
@@ -64,10 +150,20 @@ class RequestService {
       };
       if (title != null) body['title'] = title;
       if (tvdbId != null && tvdbId != 0) body['tvdb_id'] = tvdbId;
+      if (seasonScope != null) body['season_scope'] = seasonScope;
+      if (qualityProfileId != null && qualityProfileId != 0) {
+        body['quality_profile_id'] = qualityProfileId;
+      }
       final resp = await _backendDio.post('/api/requests', data: body);
-      return resp.statusCode == 200 || resp.statusCode == 201;
+      if (resp.statusCode != 200 && resp.statusCode != 201) return null;
+      final data = resp.data as Map<String, dynamic>?;
+      final statusName = data?['status'] as String? ?? 'requested';
+      return RequestStatus.values.firstWhere(
+        (s) => s.name == statusName,
+        orElse: () => RequestStatus.requested,
+      );
     } catch (_) {
-      return false;
+      return null;
     }
   }
 }

--- a/app/lib/features/request/logic/request_provider.dart
+++ b/app/lib/features/request/logic/request_provider.dart
@@ -57,21 +57,33 @@ class RequestNotifier extends ChangeNotifier {
     }
   }
 
-  /// One-tap request action.
-  Future<void> request({String? title, int? tvdbId}) async {
+  /// Fetch the option set the current user may choose for this item.
+  Future<RequestOptions?> fetchOptions() => _service.fetchOptions(_mediaType);
+
+  /// Submit the request, optionally with chosen season scope / quality. The
+  /// resulting status (which may be [RequestStatus.pending]) is reflected in
+  /// state rather than assuming "requested".
+  Future<void> request({
+    String? title,
+    int? tvdbId,
+    String? seasonScope,
+    int? qualityProfileId,
+  }) async {
     if (state.isRequesting) return;
     state = state.copyWith(isRequesting: true, error: null);
 
-    final success = await _service.request(
+    final status = await _service.request(
       tmdbId: _tmdbId,
       mediaType: _mediaType,
       title: title,
       tvdbId: tvdbId,
+      seasonScope: seasonScope,
+      qualityProfileId: qualityProfileId,
     );
 
-    if (success) {
+    if (status != null) {
       state = state.copyWith(
-        status: RequestStatus.requested,
+        status: status,
         isRequesting: false,
       );
     } else {

--- a/app/lib/features/request/ui/request_button.dart
+++ b/app/lib/features/request/ui/request_button.dart
@@ -45,6 +45,12 @@ class RequestButton extends StatelessWidget {
   Widget _buildButton() {
     final (color, icon, enabled) = switch (status) {
       RequestStatus.unavailable => (AppTheme.accent, Icons.add, true),
+      RequestStatus.pending => (
+          AppTheme.requested,
+          Icons.hourglass_empty,
+          false
+        ),
+      RequestStatus.denied => (AppTheme.accent, Icons.add, true),
       RequestStatus.requested => (
           AppTheme.requested,
           Icons.hourglass_top,

--- a/app/lib/features/request/ui/request_options_sheet.dart
+++ b/app/lib/features/request/ui/request_options_sheet.dart
@@ -1,0 +1,186 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/request_service.dart';
+
+/// The user's picks from [RequestOptionsSheet]. Null fields mean "use the
+/// server default".
+class RequestOptionsResult {
+  final String? seasonScope;
+  final int? qualityProfileId;
+  const RequestOptionsResult({this.seasonScope, this.qualityProfileId});
+}
+
+/// Pre-submit sheet that lets a permitted user choose request options
+/// (TV season scope and/or quality profile). Only shown when there is
+/// something to choose; popping with a result submits, popping with null
+/// cancels.
+class RequestOptionsSheet extends StatefulWidget {
+  final RequestOptions options;
+  const RequestOptionsSheet({super.key, required this.options});
+
+  @override
+  State<RequestOptionsSheet> createState() => _RequestOptionsSheetState();
+}
+
+class _RequestOptionsSheetState extends State<RequestOptionsSheet> {
+  late String _seasonScope;
+  int? _qualityProfileId;
+
+  @override
+  void initState() {
+    super.initState();
+    _seasonScope = widget.options.defaultSeasonScope;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final o = widget.options;
+    return Container(
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 16,
+        bottom: 24 + MediaQuery.of(context).viewInsets.bottom,
+      ),
+      decoration: const BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppTheme.textSecondary,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          const Text(
+            'Request options',
+            style: TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          if (o.canChooseSeason) ...[
+            const _SectionLabel('Seasons'),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: SeasonScope.choices
+                  .map((c) => ChoiceChip(
+                        label: Text(c.label),
+                        selected: _seasonScope == c.value,
+                        onSelected: (_) =>
+                            setState(() => _seasonScope = c.value),
+                        showCheckmark: false,
+                        selectedColor: AppTheme.accent,
+                        backgroundColor: AppTheme.surfaceVariant,
+                        labelStyle: TextStyle(
+                          color: _seasonScope == c.value
+                              ? Colors.white
+                              : AppTheme.textPrimary,
+                          fontSize: 13,
+                        ),
+                        side: const BorderSide(color: AppTheme.border),
+                      ))
+                  .toList(),
+            ),
+            const SizedBox(height: 16),
+          ],
+          if (o.canChooseQuality && o.qualityProfiles.isNotEmpty) ...[
+            const _SectionLabel('Quality'),
+            const SizedBox(height: 8),
+            DropdownButtonFormField<int?>(
+              initialValue: _qualityProfileId,
+              isExpanded: true,
+              dropdownColor: AppTheme.surfaceVariant,
+              decoration: InputDecoration(
+                contentPadding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              items: [
+                const DropdownMenuItem<int?>(
+                  value: null,
+                  child: Text('Default'),
+                ),
+                ...o.qualityProfiles.map(
+                  (p) => DropdownMenuItem<int?>(
+                    value: p.id,
+                    child: Text(p.name),
+                  ),
+                ),
+              ],
+              onChanged: (v) => setState(() => _qualityProfileId = v),
+            ),
+            const SizedBox(height: 16),
+          ],
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: AppTheme.textPrimary,
+                    side: const BorderSide(color: AppTheme.border),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text('Cancel'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: () => Navigator.of(context).pop(
+                    RequestOptionsResult(
+                      seasonScope: o.canChooseSeason ? _seasonScope : null,
+                      qualityProfileId: _qualityProfileId,
+                    ),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppTheme.accent,
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text('Request'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  const _SectionLabel(this.text);
+
+  @override
+  Widget build(BuildContext context) => Text(
+        text,
+        style: const TextStyle(
+          color: AppTheme.textSecondary,
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+        ),
+      );
+}

--- a/app/lib/features/request/ui/request_status_sheet.dart
+++ b/app/lib/features/request/ui/request_status_sheet.dart
@@ -80,6 +80,10 @@ class RequestStatusSheet extends StatelessWidget {
   String get _statusMessage => switch (status) {
         RequestStatus.unavailable =>
           'This title is not yet on the server. Tap Request to add it!',
+        RequestStatus.pending =>
+          'Your request is awaiting approval from an administrator. You\'ll be notified once it\'s reviewed.',
+        RequestStatus.denied =>
+          'An administrator declined this request. You can request it again.',
         RequestStatus.requested =>
           'Your request has been received! The server is searching for this title and will start downloading it soon.',
         RequestStatus.downloading =>
@@ -99,6 +103,8 @@ class _StatusIcon extends StatelessWidget {
   Widget build(BuildContext context) {
     final (icon, color) = switch (status) {
       RequestStatus.unavailable => (Icons.add_circle_outline, AppTheme.accent),
+      RequestStatus.pending => (Icons.hourglass_empty, AppTheme.requested),
+      RequestStatus.denied => (Icons.block, AppTheme.error),
       RequestStatus.requested => (Icons.hourglass_top, AppTheme.requested),
       RequestStatus.downloading => (Icons.downloading, AppTheme.downloading),
       RequestStatus.available => (Icons.check_circle, AppTheme.available),

--- a/app/lib/features/settings/data/request_settings_service.dart
+++ b/app/lib/features/settings/data/request_settings_service.dart
@@ -1,0 +1,229 @@
+import 'package:dio/dio.dart';
+
+/// An arr quality profile (id + name) offered for selection.
+class QualityProfile {
+  final int id;
+  final String name;
+  const QualityProfile({required this.id, required this.name});
+
+  factory QualityProfile.fromJson(Map<String, dynamic> json) => QualityProfile(
+        id: json['id'] as int? ?? 0,
+        name: json['name'] as String? ?? '',
+      );
+}
+
+/// System-wide request defaults.
+class GlobalRequestSettings {
+  final bool requireApproval;
+  final bool allowSeasonChoice;
+  final String defaultSeasonScope;
+  final bool allowQualityChoice;
+  final int defaultQualityRadarr;
+  final int defaultQualitySonarr;
+
+  const GlobalRequestSettings({
+    required this.requireApproval,
+    required this.allowSeasonChoice,
+    required this.defaultSeasonScope,
+    required this.allowQualityChoice,
+    required this.defaultQualityRadarr,
+    required this.defaultQualitySonarr,
+  });
+
+  factory GlobalRequestSettings.fromJson(Map<String, dynamic> json) =>
+      GlobalRequestSettings(
+        requireApproval: json['require_approval'] as bool? ?? false,
+        allowSeasonChoice: json['allow_season_choice'] as bool? ?? true,
+        defaultSeasonScope: json['default_season_scope'] as String? ?? 'all',
+        allowQualityChoice: json['allow_quality_choice'] as bool? ?? false,
+        defaultQualityRadarr: json['default_quality_radarr'] as int? ?? 0,
+        defaultQualitySonarr: json['default_quality_sonarr'] as int? ?? 0,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'require_approval': requireApproval,
+        'allow_season_choice': allowSeasonChoice,
+        'default_season_scope': defaultSeasonScope,
+        'allow_quality_choice': allowQualityChoice,
+        'default_quality_radarr': defaultQualityRadarr,
+        'default_quality_sonarr': defaultQualitySonarr,
+      };
+
+  GlobalRequestSettings copyWith({
+    bool? requireApproval,
+    bool? allowSeasonChoice,
+    String? defaultSeasonScope,
+    bool? allowQualityChoice,
+    int? defaultQualityRadarr,
+    int? defaultQualitySonarr,
+  }) =>
+      GlobalRequestSettings(
+        requireApproval: requireApproval ?? this.requireApproval,
+        allowSeasonChoice: allowSeasonChoice ?? this.allowSeasonChoice,
+        defaultSeasonScope: defaultSeasonScope ?? this.defaultSeasonScope,
+        allowQualityChoice: allowQualityChoice ?? this.allowQualityChoice,
+        defaultQualityRadarr: defaultQualityRadarr ?? this.defaultQualityRadarr,
+        defaultQualitySonarr: defaultQualitySonarr ?? this.defaultQualitySonarr,
+      );
+}
+
+/// Global defaults plus the arr quality profiles available for selection.
+class AdminRequestSettings {
+  final GlobalRequestSettings settings;
+  final List<QualityProfile> radarrProfiles;
+  final List<QualityProfile> sonarrProfiles;
+
+  const AdminRequestSettings({
+    required this.settings,
+    required this.radarrProfiles,
+    required this.sonarrProfiles,
+  });
+
+  factory AdminRequestSettings.fromJson(Map<String, dynamic> json) =>
+      AdminRequestSettings(
+        settings: GlobalRequestSettings.fromJson(
+            json['settings'] as Map<String, dynamic>? ?? const {}),
+        radarrProfiles: _profiles(json['radarr_profiles']),
+        sonarrProfiles: _profiles(json['sonarr_profiles']),
+      );
+
+  static List<QualityProfile> _profiles(dynamic raw) =>
+      ((raw as List?) ?? const [])
+          .map((e) => QualityProfile.fromJson(e as Map<String, dynamic>))
+          .toList();
+}
+
+/// One user's per-user overrides. A null field means "inherit the global
+/// default" for that option.
+class UserRequestSettings {
+  final bool? requireApproval;
+  final bool? allowSeasonChoice;
+  final String? seasonScope;
+  final bool? allowQualityChoice;
+  final int? qualityProfileRadarr;
+  final int? qualityProfileSonarr;
+
+  const UserRequestSettings({
+    this.requireApproval,
+    this.allowSeasonChoice,
+    this.seasonScope,
+    this.allowQualityChoice,
+    this.qualityProfileRadarr,
+    this.qualityProfileSonarr,
+  });
+
+  factory UserRequestSettings.fromJson(Map<String, dynamic> json) =>
+      UserRequestSettings(
+        requireApproval: json['require_approval'] as bool?,
+        allowSeasonChoice: json['allow_season_choice'] as bool?,
+        seasonScope: json['season_scope'] as String?,
+        allowQualityChoice: json['allow_quality_choice'] as bool?,
+        qualityProfileRadarr: json['quality_profile_radarr'] as int?,
+        qualityProfileSonarr: json['quality_profile_sonarr'] as int?,
+      );
+
+  /// Serializes including nulls so the backend stores NULL (= inherit).
+  Map<String, dynamic> toJson() => {
+        'require_approval': requireApproval,
+        'allow_season_choice': allowSeasonChoice,
+        'season_scope': seasonScope,
+        'allow_quality_choice': allowQualityChoice,
+        'quality_profile_radarr': qualityProfileRadarr,
+        'quality_profile_sonarr': qualityProfileSonarr,
+      };
+}
+
+/// One row of the admin approval queue.
+class PendingRequestItem {
+  final int id;
+  final int userId;
+  final String username;
+  final int tmdbId;
+  final int tvdbId;
+  final String mediaType;
+  final String title;
+  final String seasonScope;
+  final int qualityProfileId;
+  final DateTime? requestedAt;
+
+  const PendingRequestItem({
+    required this.id,
+    required this.userId,
+    required this.username,
+    required this.tmdbId,
+    required this.tvdbId,
+    required this.mediaType,
+    required this.title,
+    required this.seasonScope,
+    required this.qualityProfileId,
+    required this.requestedAt,
+  });
+
+  bool get isTv => mediaType == 'tv';
+
+  factory PendingRequestItem.fromJson(Map<String, dynamic> json) =>
+      PendingRequestItem(
+        id: json['id'] as int? ?? 0,
+        userId: json['user_id'] as int? ?? 0,
+        username: json['username'] as String? ?? '',
+        tmdbId: json['tmdb_id'] as int? ?? 0,
+        tvdbId: json['tvdb_id'] as int? ?? 0,
+        mediaType: json['media_type'] as String? ?? 'movie',
+        title: json['title'] as String? ?? '',
+        seasonScope: json['season_scope'] as String? ?? '',
+        qualityProfileId: json['quality_profile_id'] as int? ?? 0,
+        requestedAt:
+            DateTime.tryParse(json['requested_at'] as String? ?? '')?.toLocal(),
+      );
+}
+
+/// Admin API client for media-request settings + the approval queue.
+class RequestSettingsService {
+  final Dio _dio;
+
+  RequestSettingsService({required Dio backendDio}) : _dio = backendDio;
+
+  Future<AdminRequestSettings> getAdminSettings() async {
+    final resp = await _dio.get('/api/admin/request-settings');
+    return AdminRequestSettings.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<AdminRequestSettings> updateGlobalSettings(
+      GlobalRequestSettings settings) async {
+    final resp =
+        await _dio.put('/api/admin/request-settings', data: settings.toJson());
+    return AdminRequestSettings.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<UserRequestSettings> getUserSettings(int userId) async {
+    final resp = await _dio.get('/api/admin/users/$userId/request-settings');
+    return UserRequestSettings.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<void> updateUserSettings(
+      int userId, UserRequestSettings settings) async {
+    await _dio.put('/api/admin/users/$userId/request-settings',
+        data: settings.toJson());
+  }
+
+  Future<List<PendingRequestItem>> listPending() async {
+    final resp = await _dio.get('/api/admin/requests');
+    return ((resp.data as List?) ?? const [])
+        .map((e) => PendingRequestItem.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<void> approve(int id, {String? seasonScope, int? qualityProfileId}) async {
+    final body = <String, dynamic>{};
+    if (seasonScope != null) body['season_scope'] = seasonScope;
+    if (qualityProfileId != null && qualityProfileId != 0) {
+      body['quality_profile_id'] = qualityProfileId;
+    }
+    await _dio.post('/api/admin/requests/$id/approve', data: body);
+  }
+
+  Future<void> deny(int id, {String? reason}) async {
+    await _dio.post('/api/admin/requests/$id/deny',
+        data: {if (reason != null && reason.isNotEmpty) 'reason': reason});
+  }
+}

--- a/app/lib/features/settings/ui/pending_requests_screen.dart
+++ b/app/lib/features/settings/ui/pending_requests_screen.dart
@@ -1,0 +1,389 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/request_settings_service.dart';
+import '../../request/data/request_service.dart';
+
+/// Admin approval queue: approve (optionally modifying options) or deny
+/// pending media requests.
+class PendingRequestsScreen extends ConsumerStatefulWidget {
+  const PendingRequestsScreen({super.key});
+
+  @override
+  ConsumerState<PendingRequestsScreen> createState() =>
+      _PendingRequestsScreenState();
+}
+
+class _PendingRequestsScreenState
+    extends ConsumerState<PendingRequestsScreen> {
+  late final RequestSettingsService _service;
+  List<PendingRequestItem>? _pending;
+  AdminRequestSettings? _admin;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _service = RequestSettingsService(
+        backendDio: ref.read(backendClientProvider),
+      );
+      _load();
+    });
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = _pending == null;
+      _error = null;
+    });
+    try {
+      final pending = await _service.listPending();
+      final admin = await _service.getAdminSettings();
+      if (!mounted) return;
+      setState(() {
+        _pending = pending;
+        _admin = admin;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _approve(PendingRequestItem item) async {
+    final admin = _admin;
+    if (admin == null) return;
+    final profiles = item.isTv ? admin.sonarrProfiles : admin.radarrProfiles;
+
+    String chosenScope =
+        item.seasonScope.isNotEmpty ? item.seasonScope : SeasonScope.all;
+    int? chosenProfile;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (dialogContext, setDialogState) {
+            return AlertDialog(
+              backgroundColor: AppTheme.surface,
+              title: Text(
+                'Approve ${item.title}',
+                style: const TextStyle(color: AppTheme.textPrimary),
+              ),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (item.isTv) ...[
+                    const Text(
+                      'Season scope',
+                      style: TextStyle(
+                          color: AppTheme.textSecondary, fontSize: 13),
+                    ),
+                    const SizedBox(height: 4),
+                    DropdownButtonFormField<String>(
+                      initialValue: chosenScope,
+                      dropdownColor: AppTheme.surfaceVariant,
+                      style: const TextStyle(color: AppTheme.textPrimary),
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        isDense: true,
+                      ),
+                      items: SeasonScope.choices
+                          .map((c) => DropdownMenuItem<String>(
+                                value: c.value,
+                                child: Text(c.label),
+                              ))
+                          .toList(),
+                      onChanged: (v) {
+                        if (v != null) {
+                          setDialogState(() => chosenScope = v);
+                        }
+                      },
+                    ),
+                    const SizedBox(height: 16),
+                  ],
+                  const Text(
+                    'Quality profile',
+                    style:
+                        TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+                  ),
+                  const SizedBox(height: 4),
+                  DropdownButtonFormField<int?>(
+                    initialValue: chosenProfile,
+                    dropdownColor: AppTheme.surfaceVariant,
+                    style: const TextStyle(color: AppTheme.textPrimary),
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      isDense: true,
+                    ),
+                    items: [
+                      const DropdownMenuItem<int?>(
+                        value: null,
+                        child: Text('Default'),
+                      ),
+                      ...profiles.map((p) => DropdownMenuItem<int?>(
+                            value: p.id,
+                            child: Text(p.name),
+                          )),
+                    ],
+                    onChanged: (v) => setDialogState(() => chosenProfile = v),
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(false),
+                  child: const Text('Cancel'),
+                ),
+                ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppTheme.available,
+                    foregroundColor: Colors.white,
+                  ),
+                  onPressed: () => Navigator.of(dialogContext).pop(true),
+                  child: const Text('Approve'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    if (confirmed != true) return;
+    if (!mounted) return;
+    try {
+      await _service.approve(
+        item.id,
+        seasonScope: item.isTv ? chosenScope : null,
+        qualityProfileId: chosenProfile,
+      );
+      if (!mounted) return;
+      await _load();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Approved ${item.title}')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_friendlyError(e))),
+      );
+    }
+  }
+
+  Future<void> _deny(PendingRequestItem item) async {
+    final controller = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          backgroundColor: AppTheme.surface,
+          title: Text(
+            'Deny ${item.title}',
+            style: const TextStyle(color: AppTheme.textPrimary),
+          ),
+          content: TextField(
+            controller: controller,
+            autofocus: true,
+            style: const TextStyle(color: AppTheme.textPrimary),
+            decoration: const InputDecoration(
+              labelText: 'Reason (optional)',
+              labelStyle: TextStyle(color: AppTheme.textSecondary),
+              border: OutlineInputBorder(),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.error,
+                foregroundColor: Colors.white,
+              ),
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Deny'),
+            ),
+          ],
+        );
+      },
+    );
+
+    final reason = controller.text.trim();
+    controller.dispose();
+    if (confirmed != true) return;
+    if (!mounted) return;
+    try {
+      await _service.deny(item.id, reason: reason.isEmpty ? null : reason);
+      if (!mounted) return;
+      await _load();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Denied ${item.title}')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_friendlyError(e))),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Pending Requests')),
+      body: _isLoading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent))
+          : _error != null && _pending == null
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(_error!,
+                            style: const TextStyle(color: AppTheme.error),
+                            textAlign: TextAlign.center),
+                        const SizedBox(height: 12),
+                        ElevatedButton(
+                            onPressed: _load, child: const Text('Retry')),
+                      ],
+                    ),
+                  ),
+                )
+              : RefreshIndicator(
+                  color: AppTheme.accent,
+                  onRefresh: _load,
+                  child: (_pending?.isEmpty ?? true)
+                      ? ListView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          children: const [
+                            SizedBox(height: 120),
+                            Center(
+                              child: Text(
+                                'No pending requests.',
+                                style:
+                                    TextStyle(color: AppTheme.textSecondary),
+                              ),
+                            ),
+                          ],
+                        )
+                      : ListView.separated(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          itemCount: _pending!.length,
+                          separatorBuilder: (_, __) =>
+                              const Divider(color: AppTheme.border, height: 1),
+                          itemBuilder: (context, index) {
+                            final item = _pending![index];
+                            return _PendingTile(
+                              item: item,
+                              onApprove: () => _approve(item),
+                              onDeny: () => _deny(item),
+                            );
+                          },
+                        ),
+                ),
+    );
+  }
+}
+
+class _PendingTile extends StatelessWidget {
+  final PendingRequestItem item;
+  final VoidCallback onApprove;
+  final VoidCallback onDeny;
+
+  const _PendingTile({
+    required this.item,
+    required this.onApprove,
+    required this.onDeny,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final showScope = item.isTv && item.seasonScope.isNotEmpty;
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      title: Text(
+        item.title,
+        style: const TextStyle(
+          color: AppTheme.textPrimary,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 2),
+          Text(
+            'Requested by ${item.username}',
+            style: const TextStyle(
+                color: AppTheme.textSecondary, fontSize: 13),
+          ),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              _chip(item.isTv ? 'TV' : 'Movie'),
+              if (showScope) _chip(SeasonScope.labelFor(item.seasonScope)),
+            ],
+          ),
+        ],
+      ),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.check_circle_outline),
+            color: AppTheme.available,
+            tooltip: 'Approve',
+            onPressed: onApprove,
+          ),
+          IconButton(
+            icon: const Icon(Icons.cancel_outlined),
+            color: AppTheme.error,
+            tooltip: 'Deny',
+            onPressed: onDeny,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _chip(String label) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: AppTheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: AppTheme.border),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: AppTheme.textSecondary,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/settings/ui/request_settings_screen.dart
+++ b/app/lib/features/settings/ui/request_settings_screen.dart
@@ -1,0 +1,303 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/request_settings_service.dart';
+import '../../request/data/request_service.dart';
+
+/// Admin screen for editing the global media-request defaults.
+class RequestSettingsScreen extends ConsumerStatefulWidget {
+  const RequestSettingsScreen({super.key});
+
+  @override
+  ConsumerState<RequestSettingsScreen> createState() =>
+      _RequestSettingsScreenState();
+}
+
+class _RequestSettingsScreenState
+    extends ConsumerState<RequestSettingsScreen> {
+  late final RequestSettingsService _service;
+
+  AdminRequestSettings? _admin;
+  GlobalRequestSettings? _edited;
+  bool _isLoading = true;
+  String? _error;
+  bool _saving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _service = RequestSettingsService(
+        backendDio: ref.read(backendClientProvider),
+      );
+      _load();
+    });
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = _admin == null;
+      _error = null;
+    });
+    try {
+      final admin = await _service.getAdminSettings();
+      if (!mounted) return;
+      setState(() {
+        _admin = admin;
+        _edited = admin.settings;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    final edited = _edited;
+    if (edited == null || _saving) return;
+    setState(() => _saving = true);
+    try {
+      final admin = await _service.updateGlobalSettings(edited);
+      if (!mounted) return;
+      setState(() {
+        _admin = admin;
+        _edited = admin.settings;
+        _saving = false;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Saved')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _saving = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_friendlyError(e))),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Request Defaults')),
+      body: _isLoading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent))
+          : (_admin == null || _edited == null)
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(_error ?? 'Something went wrong',
+                            style: const TextStyle(color: AppTheme.error),
+                            textAlign: TextAlign.center),
+                        const SizedBox(height: 12),
+                        ElevatedButton(
+                            onPressed: _load, child: const Text('Retry')),
+                      ],
+                    ),
+                  ),
+                )
+              : _buildBody(_admin!, _edited!),
+    );
+  }
+
+  Widget _buildBody(AdminRequestSettings admin, GlobalRequestSettings edited) {
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: [
+        const Padding(
+          padding: EdgeInsets.fromLTRB(16, 8, 16, 4),
+          child: Text(
+            'These defaults apply to every user unless overridden per user. '
+            'Changes take effect on new requests.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        const _SectionLabel('Approval'),
+        SwitchListTile(
+          value: edited.requireApproval,
+          activeThumbColor: AppTheme.accent,
+          onChanged: (v) => setState(
+              () => _edited = edited.copyWith(requireApproval: v)),
+          title: const Text(
+            'Require approval for new requests',
+            style: TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+          ),
+          subtitle: const Text(
+            'New requests wait in a queue for an admin to approve.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        const _SectionLabel('Seasons'),
+        SwitchListTile(
+          value: edited.allowSeasonChoice,
+          activeThumbColor: AppTheme.accent,
+          onChanged: (v) => setState(
+              () => _edited = edited.copyWith(allowSeasonChoice: v)),
+          title: const Text(
+            'Let users choose seasons',
+            style: TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+          ),
+          subtitle: const Text(
+            'Allow users to pick which seasons to request for a show.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        ListTile(
+          title: const Text(
+            'Default season scope',
+            style: TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+          ),
+          trailing: DropdownButton<String>(
+            value: edited.defaultSeasonScope,
+            dropdownColor: AppTheme.surface,
+            underline: const SizedBox.shrink(),
+            style: const TextStyle(color: AppTheme.textPrimary, fontSize: 14),
+            items: [
+              for (final c in SeasonScope.choices)
+                DropdownMenuItem<String>(
+                  value: c.value,
+                  child: Text(c.label),
+                ),
+            ],
+            onChanged: (v) {
+              if (v == null) return;
+              setState(
+                  () => _edited = edited.copyWith(defaultSeasonScope: v));
+            },
+          ),
+        ),
+        const _SectionLabel('Quality'),
+        SwitchListTile(
+          value: edited.allowQualityChoice,
+          activeThumbColor: AppTheme.accent,
+          onChanged: (v) => setState(
+              () => _edited = edited.copyWith(allowQualityChoice: v)),
+          title: const Text(
+            'Let users choose quality',
+            style: TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+          ),
+          subtitle: const Text(
+            'Off by default. When off, users get the default profile below.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        _qualityTile(
+          label: 'Default Radarr quality',
+          value: edited.defaultQualityRadarr,
+          profiles: admin.radarrProfiles,
+          onChanged: (v) => setState(
+              () => _edited = edited.copyWith(defaultQualityRadarr: v)),
+        ),
+        _qualityTile(
+          label: 'Default Sonarr quality',
+          value: edited.defaultQualitySonarr,
+          profiles: admin.sonarrProfiles,
+          onChanged: (v) => setState(
+              () => _edited = edited.copyWith(defaultQualitySonarr: v)),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+          child: SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.accent,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              onPressed: _saving ? null : _save,
+              child: _saving
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        color: Colors.white,
+                        strokeWidth: 2,
+                      ),
+                    )
+                  : const Text('Save'),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _qualityTile({
+    required String label,
+    required int value,
+    required List<QualityProfile> profiles,
+    required ValueChanged<int> onChanged,
+  }) {
+    // Guard against a stored value that no longer matches a known profile.
+    final hasValue =
+        value == 0 || profiles.any((p) => p.id == value);
+    return ListTile(
+      title: Text(
+        label,
+        style: const TextStyle(
+            color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+      ),
+      trailing: DropdownButton<int>(
+        value: hasValue ? value : 0,
+        dropdownColor: AppTheme.surface,
+        underline: const SizedBox.shrink(),
+        style: const TextStyle(color: AppTheme.textPrimary, fontSize: 14),
+        items: [
+          const DropdownMenuItem<int>(
+            value: 0,
+            child: Text('Server default'),
+          ),
+          for (final p in profiles)
+            DropdownMenuItem<int>(
+              value: p.id,
+              child: Text(p.name),
+            ),
+        ],
+        onChanged: (v) {
+          if (v == null) return;
+          onChanged(v);
+        },
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  const _SectionLabel(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Text(
+        text.toUpperCase(),
+        style: const TextStyle(
+          color: AppTheme.accent,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import '../../../core/storage/preferences.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
 import 'about_sheet.dart';
@@ -177,6 +178,18 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               onTap: () => context.push('/settings/ai-tools'),
             ),
             _SettingsTile(
+              icon: Icons.playlist_add_check_circle_outlined,
+              title: 'Pending Requests',
+              subtitle: 'Approve or deny requests awaiting review',
+              onTap: () => context.push('/settings/requests'),
+            ),
+            _SettingsTile(
+              icon: Icons.tune,
+              title: 'Request Settings',
+              subtitle: 'Approval, season, and quality defaults',
+              onTap: () => context.push('/settings/request-settings'),
+            ),
+            _SettingsTile(
               icon: Icons.people_outline,
               title: 'Users',
               subtitle: 'Manage accounts, roles, and invites',
@@ -195,6 +208,26 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               onTap: () => context.push('/settings/devices'),
             ),
           ],
+
+          const SizedBox(height: 16),
+
+          // Notifications
+          _SectionHeader(title: 'Notifications'),
+          SwitchListTile(
+            value: ref.watch(requestNotificationsEnabledProvider),
+            onChanged: (v) => ref
+                .read(requestNotificationsEnabledProvider.notifier)
+                .set(v),
+            activeThumbColor: AppTheme.accent,
+            secondary: const Icon(Icons.notifications_active_outlined,
+                color: AppTheme.textSecondary),
+            title: const Text('Request updates',
+                style: TextStyle(
+                    color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
+            subtitle: const Text(
+                'Notify me when a request is approved or denied',
+                style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+          ),
 
           const SizedBox(height: 16),
 

--- a/app/lib/features/settings/ui/user_request_settings_screen.dart
+++ b/app/lib/features/settings/ui/user_request_settings_screen.dart
@@ -1,0 +1,371 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/request_settings_service.dart';
+import '../../request/data/request_service.dart';
+
+/// Admin screen for editing one user's per-user request overrides. A null
+/// value for any option means "inherit the global default".
+class UserRequestSettingsScreen extends ConsumerStatefulWidget {
+  const UserRequestSettingsScreen({
+    super.key,
+    required this.userId,
+    required this.username,
+  });
+
+  final int userId;
+  final String username;
+
+  @override
+  ConsumerState<UserRequestSettingsScreen> createState() =>
+      _UserRequestSettingsScreenState();
+}
+
+class _UserRequestSettingsScreenState
+    extends ConsumerState<UserRequestSettingsScreen> {
+  late final RequestSettingsService _service;
+
+  bool _isLoading = true;
+  String? _error;
+  bool _saving = false;
+
+  GlobalRequestSettings? _global;
+  List<QualityProfile> _radarrProfiles = const [];
+  List<QualityProfile> _sonarrProfiles = const [];
+
+  // Mutable working fields mirroring UserRequestSettings (null = inherit).
+  bool? _requireApproval;
+  bool? _allowSeasonChoice;
+  String? _seasonScope;
+  bool? _allowQualityChoice;
+  int? _qualityRadarr;
+  int? _qualitySonarr;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _service = RequestSettingsService(
+        backendDio: ref.read(backendClientProvider),
+      );
+      _load();
+    });
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final user = await _service.getUserSettings(widget.userId);
+      final admin = await _service.getAdminSettings();
+      if (!mounted) return;
+      setState(() {
+        _global = admin.settings;
+        _radarrProfiles = admin.radarrProfiles;
+        _sonarrProfiles = admin.sonarrProfiles;
+        _requireApproval = user.requireApproval;
+        _allowSeasonChoice = user.allowSeasonChoice;
+        _seasonScope = user.seasonScope;
+        _allowQualityChoice = user.allowQualityChoice;
+        _qualityRadarr = user.qualityProfileRadarr;
+        _qualitySonarr = user.qualityProfileSonarr;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = _friendlyError(e);
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    if (_saving) return;
+    setState(() => _saving = true);
+    try {
+      await _service.updateUserSettings(
+        widget.userId,
+        UserRequestSettings(
+          requireApproval: _requireApproval,
+          allowSeasonChoice: _allowSeasonChoice,
+          seasonScope: _seasonScope,
+          allowQualityChoice: _allowQualityChoice,
+          qualityProfileRadarr: _qualityRadarr,
+          qualityProfileSonarr: _qualitySonarr,
+        ),
+      );
+      if (!mounted) return;
+      setState(() => _saving = false);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Saved')));
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _saving = false);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(_friendlyError(e))));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Request Settings — ${widget.username}')),
+      body: _isLoading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent))
+          : _error != null && _global == null
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(_error!,
+                            style: const TextStyle(color: AppTheme.error),
+                            textAlign: TextAlign.center),
+                        const SizedBox(height: 12),
+                        ElevatedButton(
+                            onPressed: _load, child: const Text('Retry')),
+                      ],
+                    ),
+                  ),
+                )
+              : _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    final global = _global!;
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: [
+        const Padding(
+          padding: EdgeInsets.fromLTRB(16, 8, 16, 12),
+          child: Text(
+            'Override the global request defaults for this user. Inherit keeps '
+            'the global default.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        _TriBool(
+          title: 'Require approval',
+          subtitle: 'Requests from this user must be approved before being sent.',
+          value: _requireApproval,
+          inheritedDefault: global.requireApproval,
+          onChanged: (v) => setState(() => _requireApproval = v),
+        ),
+        const Divider(color: AppTheme.border),
+        _TriBool(
+          title: 'Allow season choice',
+          subtitle: 'Let this user pick which seasons to request for TV.',
+          value: _allowSeasonChoice,
+          inheritedDefault: global.allowSeasonChoice,
+          onChanged: (v) => setState(() => _allowSeasonChoice = v),
+        ),
+        _seasonScopeField(global),
+        const Divider(color: AppTheme.border),
+        _TriBool(
+          title: 'Allow quality choice',
+          subtitle: 'Let this user pick a quality profile for requests.',
+          value: _allowQualityChoice,
+          inheritedDefault: global.allowQualityChoice,
+          onChanged: (v) => setState(() => _allowQualityChoice = v),
+        ),
+        _qualityField(
+          label: 'Radarr quality',
+          profiles: _radarrProfiles,
+          value: _qualityRadarr,
+          onChanged: (v) => setState(() => _qualityRadarr = v),
+        ),
+        _qualityField(
+          label: 'Sonarr quality',
+          profiles: _sonarrProfiles,
+          value: _qualitySonarr,
+          onChanged: (v) => setState(() => _qualitySonarr = v),
+        ),
+        const SizedBox(height: 24),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.accent,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              onPressed: _saving ? null : _save,
+              child: _saving
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                          strokeWidth: 2, color: Colors.white),
+                    )
+                  : const Text('Save'),
+            ),
+          ),
+        ),
+        const SizedBox(height: 32),
+      ],
+    );
+  }
+
+  Widget _seasonScopeField(GlobalRequestSettings global) {
+    final inheritedLabel = SeasonScope.labelFor(global.defaultSeasonScope);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+      child: DropdownButtonFormField<String?>(
+        initialValue: _seasonScope,
+        isExpanded: true,
+        dropdownColor: AppTheme.surfaceVariant,
+        decoration: const InputDecoration(
+          labelText: 'Default season scope',
+          labelStyle: TextStyle(color: AppTheme.textSecondary),
+          enabledBorder: OutlineInputBorder(
+            borderSide: BorderSide(color: AppTheme.border),
+          ),
+          focusedBorder: OutlineInputBorder(
+            borderSide: BorderSide(color: AppTheme.accent),
+          ),
+        ),
+        style: const TextStyle(color: AppTheme.textPrimary),
+        items: [
+          DropdownMenuItem<String?>(
+            value: null,
+            child: Text('Inherit ($inheritedLabel)',
+                style: const TextStyle(color: AppTheme.textSecondary)),
+          ),
+          ...SeasonScope.choices.map(
+            (c) => DropdownMenuItem<String?>(
+              value: c.value,
+              child: Text(c.label),
+            ),
+          ),
+        ],
+        onChanged: (v) => setState(() => _seasonScope = v),
+      ),
+    );
+  }
+
+  Widget _qualityField({
+    required String label,
+    required List<QualityProfile> profiles,
+    required int? value,
+    required ValueChanged<int?> onChanged,
+  }) {
+    // Guard against a stored id that's no longer in the profile list.
+    final hasValue = value != null && profiles.any((p) => p.id == value);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+      child: DropdownButtonFormField<int?>(
+        initialValue: hasValue ? value : null,
+        isExpanded: true,
+        dropdownColor: AppTheme.surfaceVariant,
+        decoration: InputDecoration(
+          labelText: label,
+          labelStyle: const TextStyle(color: AppTheme.textSecondary),
+          enabledBorder: const OutlineInputBorder(
+            borderSide: BorderSide(color: AppTheme.border),
+          ),
+          focusedBorder: const OutlineInputBorder(
+            borderSide: BorderSide(color: AppTheme.accent),
+          ),
+        ),
+        style: const TextStyle(color: AppTheme.textPrimary),
+        items: [
+          const DropdownMenuItem<int?>(
+            value: null,
+            child: Text('Inherit',
+                style: TextStyle(color: AppTheme.textSecondary)),
+          ),
+          ...profiles.map(
+            (p) => DropdownMenuItem<int?>(
+              value: p.id,
+              child: Text(p.name),
+            ),
+          ),
+        ],
+        onChanged: onChanged,
+      ),
+    );
+  }
+}
+
+/// A three-way (inherit / on / off) selector backed by a nullable boolean.
+class _TriBool extends StatelessWidget {
+  final String title;
+  final String? subtitle;
+  final bool? value;
+  final bool inheritedDefault;
+  final ValueChanged<bool?> onChanged;
+
+  const _TriBool({
+    required this.title,
+    this.subtitle,
+    required this.value,
+    required this.inheritedDefault,
+    required this.onChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final inheritLabel = 'Inherit (${inheritedDefault ? 'On' : 'Off'})';
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(
+              color: AppTheme.textPrimary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          if (subtitle != null) ...[
+            const SizedBox(height: 2),
+            Text(
+              subtitle!,
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
+          ],
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            children: [
+              _chip(inheritLabel, value == null, () => onChanged(null)),
+              _chip('On', value == true, () => onChanged(true)),
+              _chip('Off', value == false, () => onChanged(false)),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _chip(String label, bool selected, VoidCallback onTap) {
+    return ChoiceChip(
+      label: Text(label),
+      selected: selected,
+      onSelected: (_) => onTap(),
+      backgroundColor: AppTheme.surfaceVariant,
+      selectedColor: AppTheme.accent,
+      side: const BorderSide(color: AppTheme.border),
+      labelStyle: TextStyle(
+        color: selected ? Colors.white : AppTheme.textSecondary,
+        fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+      ),
+    );
+  }
+}

--- a/app/lib/features/settings/ui/users_screen.dart
+++ b/app/lib/features/settings/ui/users_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/data/auth_service.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -303,6 +304,10 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
             onChangeRole: (role) => _changeRole(user, role),
             onDelete: () => _deleteUser(user),
             onResendInvite: () => _resendInvite(user),
+            onRequestSettings: () => context.push(
+              '/settings/users/${user.id}/request-settings',
+              extra: user.username,
+            ),
             onSetAuthMethods: ({bool? passwordEnabled, bool? passkeyEnabled}) =>
                 _setAuthMethods(
               user,
@@ -324,6 +329,7 @@ class _UserTile extends StatelessWidget {
     required this.onDelete,
     required this.onResendInvite,
     required this.onSetAuthMethods,
+    required this.onRequestSettings,
   });
 
   final UserSummary user;
@@ -333,6 +339,7 @@ class _UserTile extends StatelessWidget {
   final VoidCallback onResendInvite;
   final void Function({bool? passwordEnabled, bool? passkeyEnabled})
       onSetAuthMethods;
+  final VoidCallback onRequestSettings;
 
   /// A user who has never connected a device is stuck in "invited limbo":
   /// either their invite is still pending or the link was lost/expired.
@@ -416,6 +423,9 @@ class _UserTile extends StatelessWidget {
           case 'resend_invite':
             onResendInvite();
             break;
+          case 'request_settings':
+            onRequestSettings();
+            break;
           case 'enable_password':
             onSetAuthMethods(passwordEnabled: true);
             break;
@@ -434,6 +444,15 @@ class _UserTile extends StatelessWidget {
         }
       },
       itemBuilder: (context) => [
+        if (!isSelf)
+          const PopupMenuItem(
+            value: 'request_settings',
+            child: ListTile(
+              leading: Icon(Icons.tune),
+              title: Text('Request settings…'),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
         if (_needsInvite)
           PopupMenuItem(
             value: 'resend_invite',

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -25,7 +25,10 @@ import '../features/settings/ui/ai_tools_screen.dart';
 import '../features/settings/ui/credentials_screen.dart';
 import '../features/settings/ui/devices_screen.dart';
 import '../features/settings/ui/instance_edit_screen.dart';
+import '../features/settings/ui/pending_requests_screen.dart';
+import '../features/settings/ui/request_settings_screen.dart';
 import '../features/settings/ui/settings_screen.dart';
+import '../features/settings/ui/user_request_settings_screen.dart';
 import '../features/settings/ui/users_screen.dart';
 import '../features/setup_wizard/ui/plex_setup_guide.dart';
 import '../features/setup_wizard/ui/setup_wizard_screen.dart';
@@ -332,6 +335,25 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         path: '/settings/users',
         parentNavigatorKey: _rootNavigatorKey,
         builder: (_, __) => const UsersScreen(),
+      ),
+      GoRoute(
+        path: '/settings/users/:userId/request-settings',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) {
+          final userId = int.parse(state.pathParameters['userId']!);
+          final username = state.extra as String? ?? '';
+          return UserRequestSettingsScreen(userId: userId, username: username);
+        },
+      ),
+      GoRoute(
+        path: '/settings/requests',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (_, __) => const PendingRequestsScreen(),
+      ),
+      GoRoute(
+        path: '/settings/request-settings',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (_, __) => const RequestSettingsScreen(),
       ),
       GoRoute(
         path: '/settings/devices',

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -104,8 +104,13 @@ func main() {
 	// Tautulli handler (Plex monitoring)
 	tautulliHandler := tautulli.NewHandler(instanceStore, registry)
 
+	// WebSocket hub (built before the request service so request approvals
+	// and denials can push realtime events to the requester).
+	wsHub := ws.NewHub(authService, registry, instanceStore)
+	go wsHub.Run(context.Background())
+
 	// Request service
-	requestService := request.NewService(database, registry, bridge)
+	requestService := request.NewService(database, registry, bridge, wsHub)
 	requestHandler := request.NewHandler(requestService)
 
 	// Proxy handler
@@ -119,10 +124,6 @@ func main() {
 	apiCache := cache.New()
 	defer apiCache.Close()
 	discoverHandler := discover.NewHandler(creds, apiCache)
-
-	// WebSocket hub
-	wsHub := ws.NewHub(authService, registry, instanceStore)
-	go wsHub.Run(context.Background())
 
 	// Router
 	router := api.NewRouter(cfg, authHandler, authService, requestHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -141,6 +141,15 @@ func NewRouter(
 			r.With(auth.RequirePermission(auth.PermissionAIToolsManage)).Get("/ai-tools", aiToolsHandler.List)
 			r.With(auth.RequirePermission(auth.PermissionAIToolsManage)).Put("/ai-tools/debug", aiToolsHandler.UpdateDebug)
 			r.With(auth.RequirePermission(auth.PermissionAIToolsManage)).Put("/ai-tools/{name}", aiToolsHandler.Update)
+
+			// Media request management: approval queue + request defaults
+			r.With(auth.RequirePermission(auth.PermissionRequestsManage)).Get("/requests", requestHandler.ListPending)
+			r.With(auth.RequirePermission(auth.PermissionRequestsManage)).Post("/requests/{id}/approve", requestHandler.Approve)
+			r.With(auth.RequirePermission(auth.PermissionRequestsManage)).Post("/requests/{id}/deny", requestHandler.Deny)
+			r.With(auth.RequirePermission(auth.PermissionRequestsManage)).Get("/request-settings", requestHandler.GetSettings)
+			r.With(auth.RequirePermission(auth.PermissionRequestsManage)).Put("/request-settings", requestHandler.UpdateSettings)
+			r.With(auth.RequirePermission(auth.PermissionRequestsManage)).Get("/users/{userID}/request-settings", requestHandler.GetUserSettings)
+			r.With(auth.RequirePermission(auth.PermissionRequestsManage)).Put("/users/{userID}/request-settings", requestHandler.UpdateUserSettings)
 		})
 
 		// Config route (authenticated)
@@ -155,6 +164,7 @@ func NewRouter(
 			r.Use(auth.RequirePermission(auth.PermissionMediaRequest))
 			r.Post("/requests", requestHandler.Create)
 			r.Get("/requests", requestHandler.List)
+			r.Get("/requests/options", requestHandler.Options)
 			r.Get("/requests/{tmdb_id}/status", requestHandler.GetStatus)
 		})
 

--- a/server/internal/auth/permissions.go
+++ b/server/internal/auth/permissions.go
@@ -16,6 +16,7 @@ const (
 	PermissionAIChat            Permission = "ai:chat"
 	PermissionMCPAccess         Permission = "mcp:access"
 	PermissionUsersManage       Permission = "users:manage"
+	PermissionRequestsManage    Permission = "requests:manage"
 	PermissionCredentialsManage Permission = "credentials:manage"
 	PermissionAIToolsManage     Permission = "ai_tools:manage"
 	PermissionInstancesManage   Permission = "instances:manage"
@@ -79,6 +80,7 @@ func allPermissions() map[Permission]bool {
 		PermissionAIChat:            true,
 		PermissionMCPAccess:         true,
 		PermissionUsersManage:       true,
+		PermissionRequestsManage:    true,
 		PermissionCredentialsManage: true,
 		PermissionAIToolsManage:     true,
 		PermissionInstancesManage:   true,

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -24,11 +24,30 @@ CREATE TABLE IF NOT EXISTS request_log (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER REFERENCES users(id),
     tmdb_id INTEGER NOT NULL,
+    tvdb_id INTEGER,
     media_type TEXT NOT NULL,
     title TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'requested',
+    season_scope TEXT,
+    quality_profile_id INTEGER,
+    approved_by INTEGER REFERENCES users(id),
+    decided_at DATETIME,
+    deny_reason TEXT,
     requested_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     completed_at DATETIME
+);
+
+-- Per-user request policy overrides. Any NULL column means "inherit the
+-- global default" (stored in the settings table under 'request_settings').
+-- Out of the box a user has no row here, so every option inherits.
+CREATE TABLE IF NOT EXISTS user_request_settings (
+    user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    require_approval BOOLEAN,
+    allow_season_choice BOOLEAN,
+    season_scope_override TEXT,
+    allow_quality_choice BOOLEAN,
+    quality_profile_radarr INTEGER,
+    quality_profile_sonarr INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS tmdb_tvdb_cache (
@@ -178,6 +197,14 @@ func Open(dbPath string) (*sql.DB, error) {
 			},
 		},
 		{alter: "ALTER TABLE refresh_tokens ADD COLUMN superseded_at DATETIME"},
+		// Media-request approval queue + per-request option capture. All
+		// nullable so existing rows (already fulfilled) keep their meaning.
+		{alter: "ALTER TABLE request_log ADD COLUMN tvdb_id INTEGER"},
+		{alter: "ALTER TABLE request_log ADD COLUMN season_scope TEXT"},
+		{alter: "ALTER TABLE request_log ADD COLUMN quality_profile_id INTEGER"},
+		{alter: "ALTER TABLE request_log ADD COLUMN approved_by INTEGER REFERENCES users(id)"},
+		{alter: "ALTER TABLE request_log ADD COLUMN decided_at DATETIME"},
+		{alter: "ALTER TABLE request_log ADD COLUMN deny_reason TEXT"},
 	}
 	for _, m := range migrations {
 		if _, err := db.Exec(m.alter); err != nil {

--- a/server/internal/mcp/server.go
+++ b/server/internal/mcp/server.go
@@ -170,7 +170,7 @@ func (s *ToolServer) ExecuteTool(ctx context.Context, name string, input json.Ra
 	case "get_recommendations":
 		return s.getRecommendations(input)
 	case "check_request_status":
-		return s.checkRequestStatus(input)
+		return s.checkRequestStatus(input, callCtx.UserID)
 	case "request_media":
 		return s.requestMedia(input, callCtx.UserID)
 	case "list_my_requests":

--- a/server/internal/mcp/tools.go
+++ b/server/internal/mcp/tools.go
@@ -516,7 +516,7 @@ func (s *ToolServer) getRecommendations(input json.RawMessage) (*ToolResult, err
 	}, nil
 }
 
-func (s *ToolServer) checkRequestStatus(input json.RawMessage) (*ToolResult, error) {
+func (s *ToolServer) checkRequestStatus(input json.RawMessage, userID int64) (*ToolResult, error) {
 	var params struct {
 		TmdbID    int    `json:"tmdb_id"`
 		MediaType string `json:"media_type"`
@@ -524,7 +524,7 @@ func (s *ToolServer) checkRequestStatus(input json.RawMessage) (*ToolResult, err
 	if err := json.Unmarshal(input, &params); err != nil {
 		return nil, fmt.Errorf("parse input: %w", err)
 	}
-	status, err := s.request.GetStatus(params.TmdbID, params.MediaType)
+	status, err := s.request.GetUserStatus(userID, params.TmdbID, params.MediaType)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/request/handler.go
+++ b/server/internal/request/handler.go
@@ -2,6 +2,8 @@ package request
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"strconv"
 
@@ -45,6 +47,12 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) GetStatus(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
 	tmdbIDStr := chi.URLParam(r, "tmdb_id")
 	tmdbID, err := strconv.Atoi(tmdbIDStr)
 	if err != nil {
@@ -57,7 +65,7 @@ func (h *Handler) GetStatus(w http.ResponseWriter, r *http.Request) {
 		mediaType = "movie" // default
 	}
 
-	resp, err := h.service.GetStatus(tmdbID, mediaType)
+	resp, err := h.service.GetUserStatus(claims.UserID, tmdbID, mediaType)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -84,6 +92,154 @@ func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, requests)
+}
+
+// Options reports the option set the current user may choose for a request.
+func (h *Handler) Options(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	mediaType := r.URL.Query().Get("media_type")
+	if mediaType == "" {
+		mediaType = "movie"
+	}
+
+	isAdmin := auth.HasPermission(claims.Role, auth.PermissionAdmin)
+	opts, err := h.service.GetRequestOptions(claims.UserID, isAdmin, mediaType)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, opts)
+}
+
+// ListPending returns the admin approval queue.
+func (h *Handler) ListPending(w http.ResponseWriter, r *http.Request) {
+	pending, err := h.service.ListPending()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to fetch pending requests"})
+		return
+	}
+	if pending == nil {
+		pending = []PendingRequest{}
+	}
+	writeJSON(w, http.StatusOK, pending)
+}
+
+// Approve fulfills a pending request, optionally overriding its options.
+func (h *Handler) Approve(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request id"})
+		return
+	}
+	var override DecisionOverride
+	if err := decodeOptional(r, &override); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	resp, err := h.service.ApproveRequest(claims.UserID, id, &override)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// Deny rejects a pending request with an optional reason.
+func (h *Handler) Deny(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request id"})
+		return
+	}
+	var body struct {
+		Reason string `json:"reason"`
+	}
+	if err := decodeOptional(r, &body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if err := h.service.DenyRequest(claims.UserID, id, body.Reason); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+// GetSettings returns the global request defaults + arr quality profiles.
+func (h *Handler) GetSettings(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, h.service.GetAdminSettings())
+}
+
+// UpdateSettings persists the global request defaults.
+func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
+	var settings GlobalSettings
+	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if err := h.service.SetGlobalSettings(settings); err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, h.service.GetAdminSettings())
+}
+
+// GetUserSettings returns one user's per-user request overrides.
+func (h *Handler) GetUserSettings(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "userID"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid user id"})
+		return
+	}
+	dto, err := h.service.GetUserSettingsDTO(id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, dto)
+}
+
+// UpdateUserSettings persists one user's per-user request overrides.
+func (h *Handler) UpdateUserSettings(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "userID"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid user id"})
+		return
+	}
+	var dto UserSettingsDTO
+	if err := json.NewDecoder(r.Body).Decode(&dto); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if err := h.service.SetUserSettings(id, dto); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, dto)
+}
+
+// decodeOptional decodes a JSON body, tolerating an empty body.
+func decodeOptional(r *http.Request, v interface{}) error {
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -11,17 +12,49 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/tmdb"
 )
 
+// Request status values stored in request_log.status and returned to clients.
+const (
+	StatusUnavailable = "unavailable"
+	StatusRequested   = "requested"
+	StatusDownloading = "downloading"
+	StatusAvailable   = "available"
+	StatusPartial     = "partial"
+	StatusPending     = "pending"
+	StatusDenied      = "denied"
+)
+
+// Season scope choices a user (or admin) can attach to a TV request.
+const (
+	SeasonScopeAll    = "all"
+	SeasonScopeFirst  = "first"
+	SeasonScopeLatest = "latest"
+	SeasonScopePilot  = "pilot"
+)
+
+// requestSettingsKey is the settings-table key holding the global request
+// defaults (JSON blob), mirroring the toolsettings storage pattern.
+const requestSettingsKey = "request_settings"
+
+// Notifier delivers realtime events about request decisions. The websocket
+// hub satisfies this; it is optional and may be nil.
+type Notifier interface {
+	NotifyUser(userID int64, eventType string, data map[string]interface{})
+	NotifyAdmins(eventType string, data map[string]interface{})
+}
+
 type Service struct {
 	db       *sql.DB
 	registry *instance.Registry
 	bridge   *tmdb.Bridge
+	notifier Notifier
 }
 
-func NewService(db *sql.DB, registry *instance.Registry, bridge *tmdb.Bridge) *Service {
+func NewService(db *sql.DB, registry *instance.Registry, bridge *tmdb.Bridge, notifier Notifier) *Service {
 	return &Service{
 		db:       db,
 		registry: registry,
 		bridge:   bridge,
+		notifier: notifier,
 	}
 }
 
@@ -48,10 +81,12 @@ func (s *Service) getSonarr() *sonarr.Client {
 }
 
 type CreateRequest struct {
-	TmdbID    int    `json:"tmdb_id"`
-	MediaType string `json:"media_type"`
-	Title     string `json:"title"`
-	TvdbID    int    `json:"tvdb_id"`
+	TmdbID           int    `json:"tmdb_id"`
+	MediaType        string `json:"media_type"`
+	Title            string `json:"title"`
+	TvdbID           int    `json:"tvdb_id"`
+	SeasonScope      string `json:"season_scope"`
+	QualityProfileID int    `json:"quality_profile_id"`
 }
 
 type CreateResponse struct {
@@ -70,148 +105,480 @@ type RequestLog struct {
 	MediaType   string    `json:"media_type"`
 	Title       string    `json:"title"`
 	Status      string    `json:"status"`
+	DenyReason  string    `json:"deny_reason,omitempty"`
 	RequestedAt time.Time `json:"requested_at"`
 }
 
-func (s *Service) CreateMediaRequest(userID int64, req *CreateRequest) (*CreateResponse, error) {
-	switch req.MediaType {
-	case "movie":
-		return s.requestMovie(userID, req.TmdbID)
-	case "tv":
-		return s.requestTV(userID, req)
-	default:
-		return nil, fmt.Errorf("unsupported media type: %s", req.MediaType)
+// PendingRequest is one row of the admin approval queue.
+type PendingRequest struct {
+	ID               int64     `json:"id"`
+	UserID           int64     `json:"user_id"`
+	Username         string    `json:"username"`
+	TmdbID           int       `json:"tmdb_id"`
+	TvdbID           int       `json:"tvdb_id"`
+	MediaType        string    `json:"media_type"`
+	Title            string    `json:"title"`
+	SeasonScope      string    `json:"season_scope"`
+	QualityProfileID int       `json:"quality_profile_id"`
+	RequestedAt      time.Time `json:"requested_at"`
+}
+
+// QualityProfile is an arr quality profile offered for selection.
+type QualityProfile struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// RequestOptions tells the client what the current user may choose for a request.
+type RequestOptions struct {
+	CanChooseSeason    bool             `json:"can_choose_season"`
+	CanChooseQuality   bool             `json:"can_choose_quality"`
+	DefaultSeasonScope string           `json:"default_season_scope"`
+	QualityProfiles    []QualityProfile `json:"quality_profiles"`
+}
+
+// DecisionOverride lets an admin tweak options when approving a request.
+type DecisionOverride struct {
+	SeasonScope      string `json:"season_scope"`
+	QualityProfileID int    `json:"quality_profile_id"`
+}
+
+// GlobalSettings holds the system-wide request defaults (settings table).
+type GlobalSettings struct {
+	RequireApproval      bool   `json:"require_approval"`
+	AllowSeasonChoice    bool   `json:"allow_season_choice"`
+	DefaultSeasonScope   string `json:"default_season_scope"`
+	AllowQualityChoice   bool   `json:"allow_quality_choice"`
+	DefaultQualityRadarr int    `json:"default_quality_radarr"`
+	DefaultQualitySonarr int    `json:"default_quality_sonarr"`
+}
+
+func defaultGlobalSettings() GlobalSettings {
+	return GlobalSettings{
+		RequireApproval:    false,
+		AllowSeasonChoice:  true,
+		DefaultSeasonScope: SeasonScopeAll,
+		AllowQualityChoice: false,
 	}
 }
 
-func (s *Service) requestMovie(userID int64, tmdbID int) (*CreateResponse, error) {
+// UserSettingsDTO is the per-user override payload. A nil field means the user
+// inherits the global default for that option.
+type UserSettingsDTO struct {
+	RequireApproval      *bool   `json:"require_approval"`
+	AllowSeasonChoice    *bool   `json:"allow_season_choice"`
+	SeasonScope          *string `json:"season_scope"`
+	AllowQualityChoice   *bool   `json:"allow_quality_choice"`
+	QualityProfileRadarr *int    `json:"quality_profile_radarr"`
+	QualityProfileSonarr *int    `json:"quality_profile_sonarr"`
+}
+
+// AdminSettingsView is the global-settings editor payload: the current
+// defaults plus the arr quality profiles an admin chooses among.
+type AdminSettingsView struct {
+	Settings       GlobalSettings   `json:"settings"`
+	RadarrProfiles []QualityProfile `json:"radarr_profiles"`
+	SonarrProfiles []QualityProfile `json:"sonarr_profiles"`
+}
+
+// effective is the resolved option set for one user: global default, then the
+// per-user override, then the admin bypass.
+type effective struct {
+	RequiresApproval   bool
+	AllowSeasonChoice  bool
+	SeasonScope        string
+	AllowQualityChoice bool
+	QualityRadarr      int
+	QualitySonarr      int
+}
+
+// resolvedRequest is a request whose options have all been resolved server-side.
+type resolvedRequest struct {
+	userID           int64
+	tmdbID           int
+	tvdbID           int
+	mediaType        string
+	title            string
+	seasonScope      string
+	qualityProfileID int
+}
+
+// GetGlobalSettings returns the stored global request defaults, falling back
+// to the built-in defaults for any missing field.
+func (s *Service) GetGlobalSettings() GlobalSettings {
+	g := defaultGlobalSettings()
+	var v string
+	if err := s.db.QueryRow("SELECT value FROM settings WHERE key = ?", requestSettingsKey).Scan(&v); err == nil && v != "" {
+		_ = json.Unmarshal([]byte(v), &g)
+	}
+	if !validSeasonScope(g.DefaultSeasonScope) {
+		g.DefaultSeasonScope = SeasonScopeAll
+	}
+	return g
+}
+
+func (s *Service) SetGlobalSettings(g GlobalSettings) error {
+	if !validSeasonScope(g.DefaultSeasonScope) {
+		g.DefaultSeasonScope = SeasonScopeAll
+	}
+	data, err := json.Marshal(g)
+	if err != nil {
+		return fmt.Errorf("encode request settings: %w", err)
+	}
+	if _, err := s.db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", requestSettingsKey, string(data)); err != nil {
+		return fmt.Errorf("save request settings: %w", err)
+	}
+	return nil
+}
+
+// GetUserSettingsDTO loads a user's per-user overrides; absent columns/rows
+// are returned as nil (inherit).
+func (s *Service) GetUserSettingsDTO(userID int64) (UserSettingsDTO, error) {
+	var dto UserSettingsDTO
+	var ra, asc, aqc sql.NullBool
+	var ss sql.NullString
+	var qr, qs sql.NullInt64
+	err := s.db.QueryRow(
+		"SELECT require_approval, allow_season_choice, season_scope_override, allow_quality_choice, quality_profile_radarr, quality_profile_sonarr FROM user_request_settings WHERE user_id = ?",
+		userID,
+	).Scan(&ra, &asc, &ss, &aqc, &qr, &qs)
+	if err == sql.ErrNoRows {
+		return dto, nil
+	}
+	if err != nil {
+		return dto, fmt.Errorf("load user request settings: %w", err)
+	}
+	if ra.Valid {
+		v := ra.Bool
+		dto.RequireApproval = &v
+	}
+	if asc.Valid {
+		v := asc.Bool
+		dto.AllowSeasonChoice = &v
+	}
+	if ss.Valid {
+		v := ss.String
+		dto.SeasonScope = &v
+	}
+	if aqc.Valid {
+		v := aqc.Bool
+		dto.AllowQualityChoice = &v
+	}
+	if qr.Valid {
+		v := int(qr.Int64)
+		dto.QualityProfileRadarr = &v
+	}
+	if qs.Valid {
+		v := int(qs.Int64)
+		dto.QualityProfileSonarr = &v
+	}
+	return dto, nil
+}
+
+// SetUserSettings upserts a user's per-user overrides. Nil fields persist as
+// NULL (inherit the global default).
+func (s *Service) SetUserSettings(userID int64, dto UserSettingsDTO) error {
+	if dto.SeasonScope != nil && *dto.SeasonScope != "" && !validSeasonScope(*dto.SeasonScope) {
+		return fmt.Errorf("invalid season scope: %s", *dto.SeasonScope)
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO user_request_settings
+			(user_id, require_approval, allow_season_choice, season_scope_override, allow_quality_choice, quality_profile_radarr, quality_profile_sonarr)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(user_id) DO UPDATE SET
+			require_approval = excluded.require_approval,
+			allow_season_choice = excluded.allow_season_choice,
+			season_scope_override = excluded.season_scope_override,
+			allow_quality_choice = excluded.allow_quality_choice,
+			quality_profile_radarr = excluded.quality_profile_radarr,
+			quality_profile_sonarr = excluded.quality_profile_sonarr`,
+		userID, dto.RequireApproval, dto.AllowSeasonChoice, dto.SeasonScope, dto.AllowQualityChoice, dto.QualityProfileRadarr, dto.QualityProfileSonarr,
+	)
+	if err != nil {
+		return fmt.Errorf("save user request settings: %w", err)
+	}
+	return nil
+}
+
+// userIsAdmin reports whether the user has the admin role.
+func (s *Service) userIsAdmin(userID int64) bool {
+	var role string
+	if err := s.db.QueryRow("SELECT role FROM users WHERE id = ?", userID).Scan(&role); err != nil {
+		return false
+	}
+	return role == "admin"
+}
+
+// effectiveSettings resolves the option set for a user: global default, then
+// per-user override, then admin bypass (admins never need approval and may
+// always choose options).
+func (s *Service) effectiveSettings(userID int64, isAdmin bool) (effective, error) {
+	g := s.GetGlobalSettings()
+	dto, err := s.GetUserSettingsDTO(userID)
+	if err != nil {
+		return effective{}, err
+	}
+	eff := effective{
+		RequiresApproval:   g.RequireApproval,
+		AllowSeasonChoice:  g.AllowSeasonChoice,
+		SeasonScope:        g.DefaultSeasonScope,
+		AllowQualityChoice: g.AllowQualityChoice,
+		QualityRadarr:      g.DefaultQualityRadarr,
+		QualitySonarr:      g.DefaultQualitySonarr,
+	}
+	if dto.RequireApproval != nil {
+		eff.RequiresApproval = *dto.RequireApproval
+	}
+	if dto.AllowSeasonChoice != nil {
+		eff.AllowSeasonChoice = *dto.AllowSeasonChoice
+	}
+	if dto.SeasonScope != nil && *dto.SeasonScope != "" {
+		eff.SeasonScope = *dto.SeasonScope
+	}
+	if dto.AllowQualityChoice != nil {
+		eff.AllowQualityChoice = *dto.AllowQualityChoice
+	}
+	if dto.QualityProfileRadarr != nil && *dto.QualityProfileRadarr != 0 {
+		eff.QualityRadarr = *dto.QualityProfileRadarr
+	}
+	if dto.QualityProfileSonarr != nil && *dto.QualityProfileSonarr != 0 {
+		eff.QualitySonarr = *dto.QualityProfileSonarr
+	}
+	if !validSeasonScope(eff.SeasonScope) {
+		eff.SeasonScope = SeasonScopeAll
+	}
+	if isAdmin {
+		eff.RequiresApproval = false
+		eff.AllowSeasonChoice = true
+		eff.AllowQualityChoice = true
+	}
+	return eff, nil
+}
+
+func (s *Service) CreateMediaRequest(userID int64, req *CreateRequest) (*CreateResponse, error) {
+	if req.MediaType != "movie" && req.MediaType != "tv" {
+		return nil, fmt.Errorf("unsupported media type: %s", req.MediaType)
+	}
+
+	isAdmin := s.userIsAdmin(userID)
+	eff, err := s.effectiveSettings(userID, isAdmin)
+	if err != nil {
+		return nil, err
+	}
+
+	resolved := &resolvedRequest{
+		userID:    userID,
+		tmdbID:    req.TmdbID,
+		tvdbID:    req.TvdbID,
+		mediaType: req.MediaType,
+		title:     req.Title,
+	}
+
+	// Season scope (TV only). Honor the client's choice only when allowed;
+	// otherwise the resolved default stands. Movies keep an empty scope so the
+	// stored row / admin queue don't show a meaningless value.
+	if req.MediaType == "tv" {
+		resolved.seasonScope = eff.SeasonScope
+		if req.SeasonScope != "" && eff.AllowSeasonChoice && validSeasonScope(req.SeasonScope) {
+			resolved.seasonScope = req.SeasonScope
+		}
+	}
+
+	// Quality profile. Default per service; honor the client's choice only
+	// when allowed (out of the box non-admins cannot choose).
+	if req.MediaType == "tv" {
+		resolved.qualityProfileID = eff.QualitySonarr
+	} else {
+		resolved.qualityProfileID = eff.QualityRadarr
+	}
+	if req.QualityProfileID != 0 && eff.AllowQualityChoice {
+		resolved.qualityProfileID = req.QualityProfileID
+	}
+
+	if eff.RequiresApproval {
+		return s.createPending(resolved)
+	}
+
+	status, title, err := s.addToArr(resolved)
+	if err != nil {
+		return nil, err
+	}
+	resolved.title = title
+	s.logRequest(resolved, title, status)
+	return &CreateResponse{Success: true, Status: status, Title: title}, nil
+}
+
+// createPending records a request awaiting admin approval without touching the
+// arr services. The stored options are replayed verbatim on approval.
+func (s *Service) createPending(r *resolvedRequest) (*CreateResponse, error) {
+	// Insert atomically only when no pending row already exists for this
+	// user+title, so a double-submit can't create duplicate queue entries
+	// (the check + insert is one statement under the single-writer DB).
+	res, err := s.db.Exec(
+		`INSERT INTO request_log (user_id, tmdb_id, tvdb_id, media_type, title, status, season_scope, quality_profile_id)
+		 SELECT ?, ?, ?, ?, ?, ?, ?, ?
+		 WHERE NOT EXISTS (
+		     SELECT 1 FROM request_log WHERE user_id = ? AND tmdb_id = ? AND media_type = ? AND status = ?
+		 )`,
+		r.userID, r.tmdbID, sqlNullInt(r.tvdbID), r.mediaType, r.title, StatusPending, sqlNullStr(r.seasonScope), sqlNullInt(r.qualityProfileID),
+		r.userID, r.tmdbID, r.mediaType, StatusPending,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("save pending request: %w", err)
+	}
+
+	// Cache the tvdb mapping so TV status checks resolve while pending.
+	if r.mediaType == "tv" && r.tvdbID != 0 {
+		s.db.Exec("INSERT OR REPLACE INTO tmdb_tvdb_cache (tmdb_id, tvdb_id) VALUES (?, ?)", r.tmdbID, r.tvdbID)
+	}
+
+	// Only notify admins when a new row was actually queued (not a duplicate).
+	if n, _ := res.RowsAffected(); n > 0 && s.notifier != nil {
+		s.notifier.NotifyAdmins("request_pending", map[string]interface{}{
+			"tmdb_id":    r.tmdbID,
+			"media_type": r.mediaType,
+			"title":      r.title,
+		})
+	}
+	return &CreateResponse{Success: true, Status: StatusPending, Title: r.title}, nil
+}
+
+// addToArr performs the actual Radarr/Sonarr add and returns the resulting
+// status + canonical title. It does NOT write to request_log; callers decide
+// whether to insert a new row or update an existing (pending) one.
+func (s *Service) addToArr(r *resolvedRequest) (status string, title string, err error) {
+	switch r.mediaType {
+	case "movie":
+		return s.addMovie(r)
+	case "tv":
+		return s.addSeries(r)
+	default:
+		return "", "", fmt.Errorf("unsupported media type: %s", r.mediaType)
+	}
+}
+
+func (s *Service) addMovie(r *resolvedRequest) (string, string, error) {
 	radarrClient := s.getRadarr()
 	if radarrClient == nil {
-		return nil, fmt.Errorf("radarr is not configured")
+		return "", "", fmt.Errorf("radarr is not configured")
 	}
 
-	// Check if already in Radarr
-	existing, err := radarrClient.GetMovieByTMDB(tmdbID)
+	existing, err := radarrClient.GetMovieByTMDB(r.tmdbID)
 	if err == nil && existing != nil {
-		status := "requested"
+		status := StatusRequested
 		if existing.HasFile {
-			status = "available"
+			status = StatusAvailable
 		}
-		s.logRequest(userID, tmdbID, "movie", existing.Title, status)
-		return &CreateResponse{Success: true, Status: status, Title: existing.Title}, nil
+		return status, existing.Title, nil
 	}
 
-	// Lookup movie
-	lookup, err := radarrClient.LookupByTMDB(tmdbID)
+	lookup, err := radarrClient.LookupByTMDB(r.tmdbID)
 	if err != nil {
-		return nil, fmt.Errorf("movie lookup failed: %w", err)
+		return "", "", fmt.Errorf("movie lookup failed: %w", err)
 	}
 
-	// Get defaults
 	profiles, err := radarrClient.GetQualityProfiles()
 	if err != nil || len(profiles) == 0 {
-		return nil, fmt.Errorf("no quality profiles available")
+		return "", "", fmt.Errorf("no quality profiles available")
 	}
 	folders, err := radarrClient.GetRootFolders()
 	if err != nil || len(folders) == 0 {
-		return nil, fmt.Errorf("no root folders available")
+		return "", "", fmt.Errorf("no root folders available")
+	}
+
+	profileID := r.qualityProfileID
+	if profileID == 0 || !radarrProfileExists(profiles, profileID) {
+		profileID = profiles[0].ID
 	}
 
 	addReq := &radarr.AddMovieRequest{
 		Title:            lookup.Title,
 		TmdbID:           lookup.TmdbID,
 		Year:             lookup.Year,
-		QualityProfileID: profiles[0].ID,
+		QualityProfileID: profileID,
 		RootFolderPath:   folders[0].Path,
 		Monitored:        true,
 	}
 	addReq.AddOptions.SearchForMovie = true
 
 	if err := radarrClient.AddMovie(addReq); err != nil {
-		return nil, fmt.Errorf("add movie failed: %w", err)
+		return "", "", fmt.Errorf("add movie failed: %w", err)
 	}
-
-	s.logRequest(userID, tmdbID, "movie", lookup.Title, "requested")
-	return &CreateResponse{Success: true, Status: "requested", Title: lookup.Title}, nil
+	return StatusRequested, lookup.Title, nil
 }
 
-func (s *Service) requestTV(userID int64, req *CreateRequest) (*CreateResponse, error) {
+func (s *Service) addSeries(r *resolvedRequest) (string, string, error) {
 	sonarrClient := s.getSonarr()
 	if sonarrClient == nil {
-		return nil, fmt.Errorf("sonarr is not configured")
+		return "", "", fmt.Errorf("sonarr is not configured")
 	}
 
-	tvdbID := req.TvdbID
-	title := req.Title
-
-	// Cache the client-provided TVDB ID so getTVStatus works without TMDB calls
+	tvdbID := r.tvdbID
 	if tvdbID != 0 {
-		s.db.Exec(
-			"INSERT OR REPLACE INTO tmdb_tvdb_cache (tmdb_id, tvdb_id) VALUES (?, ?)",
-			req.TmdbID, tvdbID,
-		)
+		s.db.Exec("INSERT OR REPLACE INTO tmdb_tvdb_cache (tmdb_id, tvdb_id) VALUES (?, ?)", r.tmdbID, tvdbID)
 	}
 
-	// Check if already in Sonarr
 	if tvdbID != 0 {
 		existing, err := sonarrClient.GetSeriesByTVDB(tvdbID)
 		if err == nil && existing != nil {
-			status := "requested"
+			status := StatusRequested
 			if existing.Statistics != nil && existing.Statistics.PercentOfEpisodes >= 100 {
-				status = "available"
+				status = StatusAvailable
 			} else if existing.Statistics != nil && existing.Statistics.EpisodeFileCount > 0 {
-				status = "partial"
+				status = StatusPartial
 			}
-			s.logRequest(userID, req.TmdbID, "tv", existing.Title, status)
-			return &CreateResponse{Success: true, Status: status, Title: existing.Title}, nil
+			return status, existing.Title, nil
 		}
 	}
 
-	// Lookup series
 	var lookup *sonarr.LookupResult
 	var err error
 	if tvdbID != 0 {
 		lookup, err = sonarrClient.LookupByTVDB(tvdbID)
 	}
 	if lookup == nil || err != nil {
-		// Fallback to title search
-		if title == "" {
-			return nil, fmt.Errorf("series lookup failed: no TVDB ID or title provided")
+		if r.title == "" {
+			return "", "", fmt.Errorf("series lookup failed: no TVDB ID or title provided")
 		}
-		lookup, err = sonarrClient.LookupByTitle(title)
+		lookup, err = sonarrClient.LookupByTitle(r.title)
 		if err != nil {
-			return nil, fmt.Errorf("series lookup failed: %w", err)
+			return "", "", fmt.Errorf("series lookup failed: %w", err)
 		}
 		tvdbID = lookup.TvdbID
 	}
+	// Persist the resolved TVDB id so an approved title-only request stores it.
+	r.tvdbID = tvdbID
 
-	// Get defaults
 	profiles, err := sonarrClient.GetQualityProfiles()
 	if err != nil || len(profiles) == 0 {
-		return nil, fmt.Errorf("no quality profiles available")
+		return "", "", fmt.Errorf("no quality profiles available")
 	}
 	folders, err := sonarrClient.GetRootFolders()
 	if err != nil || len(folders) == 0 {
-		return nil, fmt.Errorf("no root folders available")
+		return "", "", fmt.Errorf("no root folders available")
+	}
+
+	profileID := r.qualityProfileID
+	if profileID == 0 || !sonarrProfileExists(profiles, profileID) {
+		profileID = profiles[0].ID
 	}
 
 	addReq := &sonarr.AddSeriesRequest{
 		Title:            lookup.Title,
 		TvdbID:           tvdbID,
 		Year:             lookup.Year,
-		QualityProfileID: profiles[0].ID,
+		QualityProfileID: profileID,
 		RootFolderPath:   folders[0].Path,
 		Monitored:        true,
 		SeasonFolder:     true,
 	}
 	addReq.AddOptions.SearchForMissingEpisodes = true
+	addReq.AddOptions.Monitor = sonarrMonitor(r.seasonScope)
 
 	if err := sonarrClient.AddSeries(addReq); err != nil {
-		return nil, fmt.Errorf("add series failed: %w", err)
+		return "", "", fmt.Errorf("add series failed: %w", err)
 	}
-
-	s.logRequest(userID, req.TmdbID, "tv", lookup.Title, "requested")
-	return &CreateResponse{Success: true, Status: "requested", Title: lookup.Title}, nil
+	return StatusRequested, lookup.Title, nil
 }
 
 func (s *Service) GetStatus(tmdbID int, mediaType string) (*StatusResponse, error) {
@@ -221,26 +588,50 @@ func (s *Service) GetStatus(tmdbID int, mediaType string) (*StatusResponse, erro
 	case "tv":
 		return s.getTVStatus(tmdbID)
 	default:
-		return &StatusResponse{Status: "unavailable"}, nil
+		return &StatusResponse{Status: StatusUnavailable}, nil
 	}
+}
+
+// GetUserStatus surfaces a user's own pending/denied request first, then falls
+// back to the live arr availability that GetStatus reports.
+func (s *Service) GetUserStatus(userID int64, tmdbID int, mediaType string) (*StatusResponse, error) {
+	var status string
+	err := s.db.QueryRow(
+		"SELECT status FROM request_log WHERE user_id = ? AND tmdb_id = ? AND media_type = ? ORDER BY requested_at DESC, id DESC LIMIT 1",
+		userID, tmdbID, mediaType,
+	).Scan(&status)
+	if err == nil {
+		// A pending request isn't in the arr yet, so always surface it.
+		if status == StatusPending {
+			return &StatusResponse{Status: StatusPending}, nil
+		}
+		// A denied request shows "denied" only while the title isn't otherwise
+		// available; if it later lands in the arr, prefer the live state.
+		if status == StatusDenied {
+			if live, lerr := s.GetStatus(tmdbID, mediaType); lerr == nil && live != nil && live.Status != StatusUnavailable {
+				return live, nil
+			}
+			return &StatusResponse{Status: StatusDenied}, nil
+		}
+	}
+	return s.GetStatus(tmdbID, mediaType)
 }
 
 func (s *Service) getMovieStatus(tmdbID int) (*StatusResponse, error) {
 	radarrClient := s.getRadarr()
 	if radarrClient == nil {
-		return &StatusResponse{Status: "unavailable"}, nil
+		return &StatusResponse{Status: StatusUnavailable}, nil
 	}
 
 	movie, err := radarrClient.GetMovieByTMDB(tmdbID)
 	if err != nil || movie == nil {
-		return &StatusResponse{Status: "unavailable"}, nil
+		return &StatusResponse{Status: StatusUnavailable}, nil
 	}
 
 	if movie.HasFile {
-		return &StatusResponse{Status: "available", Progress: 1.0}, nil
+		return &StatusResponse{Status: StatusAvailable, Progress: 1.0}, nil
 	}
 
-	// Check queue for download progress
 	queue, err := radarrClient.GetQueue()
 	if err == nil {
 		for _, item := range queue {
@@ -249,61 +640,59 @@ func (s *Service) getMovieStatus(tmdbID int) (*StatusResponse, error) {
 				if item.Size > 0 {
 					progress = (item.Size - item.Sizeleft) / item.Size
 				}
-				return &StatusResponse{Status: "downloading", Progress: progress}, nil
+				return &StatusResponse{Status: StatusDownloading, Progress: progress}, nil
 			}
 		}
 	}
 
 	if movie.Monitored {
-		return &StatusResponse{Status: "requested", Progress: 0}, nil
+		return &StatusResponse{Status: StatusRequested, Progress: 0}, nil
 	}
 
-	return &StatusResponse{Status: "unavailable"}, nil
+	return &StatusResponse{Status: StatusUnavailable}, nil
 }
 
 func (s *Service) getTVStatus(tmdbID int) (*StatusResponse, error) {
 	sonarrClient := s.getSonarr()
 	if sonarrClient == nil {
-		return &StatusResponse{Status: "unavailable"}, nil
+		return &StatusResponse{Status: StatusUnavailable}, nil
 	}
 
-	// Check cache for tvdb_id
 	var tvdbID int
 	err := s.db.QueryRow("SELECT tvdb_id FROM tmdb_tvdb_cache WHERE tmdb_id = ?", tmdbID).Scan(&tvdbID)
 	if err != nil || tvdbID == 0 {
-		// Try to resolve
 		bridgeResult, err := s.bridge.ResolveTVDBID(tmdbID)
 		if err != nil {
-			return &StatusResponse{Status: "unavailable"}, nil
+			return &StatusResponse{Status: StatusUnavailable}, nil
 		}
 		tvdbID = bridgeResult.TVDBID
 	}
 
 	series, err := sonarrClient.GetSeriesByTVDB(tvdbID)
 	if err != nil || series == nil {
-		return &StatusResponse{Status: "unavailable"}, nil
+		return &StatusResponse{Status: StatusUnavailable}, nil
 	}
 
 	if series.Statistics != nil {
 		if series.Statistics.PercentOfEpisodes >= 100 {
-			return &StatusResponse{Status: "available", Progress: 1.0}, nil
+			return &StatusResponse{Status: StatusAvailable, Progress: 1.0}, nil
 		}
 		if series.Statistics.EpisodeFileCount > 0 {
 			progress := series.Statistics.PercentOfEpisodes / 100.0
-			return &StatusResponse{Status: "partial", Progress: progress}, nil
+			return &StatusResponse{Status: StatusPartial, Progress: progress}, nil
 		}
 	}
 
 	if series.Monitored {
-		return &StatusResponse{Status: "requested", Progress: 0}, nil
+		return &StatusResponse{Status: StatusRequested, Progress: 0}, nil
 	}
 
-	return &StatusResponse{Status: "unavailable"}, nil
+	return &StatusResponse{Status: StatusUnavailable}, nil
 }
 
 func (s *Service) GetRequests(userID int64) ([]RequestLog, error) {
 	rows, err := s.db.Query(
-		"SELECT tmdb_id, media_type, title, status, requested_at FROM request_log WHERE user_id = ? ORDER BY requested_at DESC",
+		"SELECT tmdb_id, media_type, title, status, COALESCE(deny_reason, ''), requested_at FROM request_log WHERE user_id = ? ORDER BY requested_at DESC",
 		userID,
 	)
 	if err != nil {
@@ -314,7 +703,7 @@ func (s *Service) GetRequests(userID int64) ([]RequestLog, error) {
 	var requests []RequestLog
 	for rows.Next() {
 		var r RequestLog
-		if err := rows.Scan(&r.TmdbID, &r.MediaType, &r.Title, &r.Status, &r.RequestedAt); err != nil {
+		if err := rows.Scan(&r.TmdbID, &r.MediaType, &r.Title, &r.Status, &r.DenyReason, &r.RequestedAt); err != nil {
 			return nil, fmt.Errorf("scan request: %w", err)
 		}
 		requests = append(requests, r)
@@ -322,9 +711,249 @@ func (s *Service) GetRequests(userID int64) ([]RequestLog, error) {
 	return requests, rows.Err()
 }
 
-func (s *Service) logRequest(userID int64, tmdbID int, mediaType, title, status string) {
-	s.db.Exec(
-		"INSERT INTO request_log (user_id, tmdb_id, media_type, title, status) VALUES (?, ?, ?, ?, ?)",
-		userID, tmdbID, mediaType, title, status,
+// ListPending returns the admin approval queue (oldest first).
+func (s *Service) ListPending() ([]PendingRequest, error) {
+	rows, err := s.db.Query(
+		`SELECT r.id, r.user_id, COALESCE(u.username, ''), r.tmdb_id, COALESCE(r.tvdb_id, 0), r.media_type, r.title, COALESCE(r.season_scope, ''), COALESCE(r.quality_profile_id, 0), r.requested_at
+		 FROM request_log r LEFT JOIN users u ON u.id = r.user_id
+		 WHERE r.status = ? ORDER BY r.requested_at ASC`,
+		StatusPending,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("query pending requests: %w", err)
+	}
+	defer rows.Close()
+
+	var out []PendingRequest
+	for rows.Next() {
+		var p PendingRequest
+		if err := rows.Scan(&p.ID, &p.UserID, &p.Username, &p.TmdbID, &p.TvdbID, &p.MediaType, &p.Title, &p.SeasonScope, &p.QualityProfileID, &p.RequestedAt); err != nil {
+			return nil, fmt.Errorf("scan pending request: %w", err)
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
+}
+
+// loadRequest reads a request_log row into a resolvedRequest plus its status.
+func (s *Service) loadRequest(requestID int64) (*resolvedRequest, string, error) {
+	var r resolvedRequest
+	var status string
+	err := s.db.QueryRow(
+		"SELECT user_id, tmdb_id, COALESCE(tvdb_id, 0), media_type, title, status, COALESCE(season_scope, ''), COALESCE(quality_profile_id, 0) FROM request_log WHERE id = ?",
+		requestID,
+	).Scan(&r.userID, &r.tmdbID, &r.tvdbID, &r.mediaType, &r.title, &status, &r.seasonScope, &r.qualityProfileID)
+	if err == sql.ErrNoRows {
+		return nil, "", fmt.Errorf("request not found")
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("load request: %w", err)
+	}
+	return &r, status, nil
+}
+
+// ApproveRequest fulfills a pending request (optionally with admin overrides)
+// and marks the row approved. The arr add reuses the normal add path.
+func (s *Service) ApproveRequest(adminID, requestID int64, override *DecisionOverride) (*CreateResponse, error) {
+	r, status, err := s.loadRequest(requestID)
+	if err != nil {
+		return nil, err
+	}
+	if status != StatusPending {
+		return nil, fmt.Errorf("request is not pending")
+	}
+	if override != nil {
+		if override.SeasonScope != "" && validSeasonScope(override.SeasonScope) {
+			r.seasonScope = override.SeasonScope
+		}
+		if override.QualityProfileID != 0 {
+			r.qualityProfileID = override.QualityProfileID
+		}
+	}
+
+	newStatus, title, err := s.addToArr(r)
+	if err != nil {
+		// Leave the row pending so the admin can retry after fixing config.
+		return nil, err
+	}
+
+	res, err := s.db.Exec(
+		"UPDATE request_log SET status = ?, title = ?, tvdb_id = ?, season_scope = ?, quality_profile_id = ?, approved_by = ?, decided_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?",
+		newStatus, title, sqlNullInt(r.tvdbID), sqlNullStr(r.seasonScope), sqlNullInt(r.qualityProfileID), adminID, requestID, StatusPending,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("update request: %w", err)
+	}
+	// Lost a race with a concurrent decision: skip the duplicate notification.
+	if n, _ := res.RowsAffected(); n == 0 {
+		return &CreateResponse{Success: true, Status: newStatus, Title: title}, nil
+	}
+
+	if s.notifier != nil {
+		s.notifier.NotifyUser(r.userID, "request_decision", map[string]interface{}{
+			"decision":   "approved",
+			"tmdb_id":    r.tmdbID,
+			"media_type": r.mediaType,
+			"title":      title,
+			"status":     newStatus,
+		})
+	}
+	return &CreateResponse{Success: true, Status: newStatus, Title: title}, nil
+}
+
+// DenyRequest marks a pending request denied and notifies the requester.
+func (s *Service) DenyRequest(adminID, requestID int64, reason string) error {
+	r, status, err := s.loadRequest(requestID)
+	if err != nil {
+		return err
+	}
+	if status != StatusPending {
+		return fmt.Errorf("request is not pending")
+	}
+	res, err := s.db.Exec(
+		"UPDATE request_log SET status = ?, deny_reason = ?, approved_by = ?, decided_at = CURRENT_TIMESTAMP WHERE id = ? AND status = ?",
+		StatusDenied, sqlNullStr(reason), adminID, requestID, StatusPending,
+	)
+	if err != nil {
+		return fmt.Errorf("update request: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return nil // already decided by a concurrent action
+	}
+	if s.notifier != nil {
+		s.notifier.NotifyUser(r.userID, "request_decision", map[string]interface{}{
+			"decision":   "denied",
+			"tmdb_id":    r.tmdbID,
+			"media_type": r.mediaType,
+			"title":      r.title,
+			"reason":     reason,
+			"status":     StatusDenied,
+		})
+	}
+	return nil
+}
+
+// GetRequestOptions reports what the current user may choose for a request and
+// (when allowed) the available quality profiles for the relevant service.
+func (s *Service) GetRequestOptions(userID int64, isAdmin bool, mediaType string) (*RequestOptions, error) {
+	eff, err := s.effectiveSettings(userID, isAdmin)
+	if err != nil {
+		return nil, err
+	}
+	opts := &RequestOptions{
+		CanChooseSeason:    eff.AllowSeasonChoice && mediaType == "tv",
+		CanChooseQuality:   eff.AllowQualityChoice,
+		DefaultSeasonScope: eff.SeasonScope,
+		QualityProfiles:    []QualityProfile{},
+	}
+	if eff.AllowQualityChoice {
+		opts.QualityProfiles = s.qualityProfiles(mediaType)
+	}
+	return opts, nil
+}
+
+// qualityProfiles fetches the selectable quality profiles for a media type.
+func (s *Service) qualityProfiles(mediaType string) []QualityProfile {
+	out := []QualityProfile{}
+	if mediaType == "tv" {
+		if c := s.getSonarr(); c != nil {
+			if ps, err := c.GetQualityProfiles(); err == nil {
+				for _, p := range ps {
+					out = append(out, QualityProfile{ID: p.ID, Name: p.Name})
+				}
+			}
+		}
+		return out
+	}
+	if c := s.getRadarr(); c != nil {
+		if ps, err := c.GetQualityProfiles(); err == nil {
+			for _, p := range ps {
+				out = append(out, QualityProfile{ID: p.ID, Name: p.Name})
+			}
+		}
+	}
+	return out
+}
+
+// GetAdminSettings returns the global defaults plus both arrs' quality profiles
+// for the admin settings editor.
+func (s *Service) GetAdminSettings() *AdminSettingsView {
+	return &AdminSettingsView{
+		Settings:       s.GetGlobalSettings(),
+		RadarrProfiles: s.qualityProfiles("movie"),
+		SonarrProfiles: s.qualityProfiles("tv"),
+	}
+}
+
+// insertRequest writes a request_log row and returns its id.
+func (s *Service) insertRequest(r *resolvedRequest, title, status string) (int64, error) {
+	res, err := s.db.Exec(
+		"INSERT INTO request_log (user_id, tmdb_id, tvdb_id, media_type, title, status, season_scope, quality_profile_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+		r.userID, r.tmdbID, sqlNullInt(r.tvdbID), r.mediaType, title, status, sqlNullStr(r.seasonScope), sqlNullInt(r.qualityProfileID),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// logRequest records a fulfilled request without failing the caller (the arr
+// add already succeeded; a history-row failure should not surface as an error).
+func (s *Service) logRequest(r *resolvedRequest, title, status string) {
+	_, _ = s.insertRequest(r, title, status)
+}
+
+// sqlNullInt / sqlNullStr map zero values to NULL for nullable columns.
+func sqlNullInt(v int) interface{} {
+	if v == 0 {
+		return nil
+	}
+	return v
+}
+
+func sqlNullStr(v string) interface{} {
+	if v == "" {
+		return nil
+	}
+	return v
+}
+
+func validSeasonScope(scope string) bool {
+	switch scope {
+	case SeasonScopeAll, SeasonScopeFirst, SeasonScopeLatest, SeasonScopePilot:
+		return true
+	}
+	return false
+}
+
+// sonarrMonitor maps a season scope to Sonarr's addOptions.monitor enum.
+func sonarrMonitor(scope string) string {
+	switch scope {
+	case SeasonScopeFirst:
+		return "firstSeason"
+	case SeasonScopeLatest:
+		return "lastSeason"
+	case SeasonScopePilot:
+		return "pilot"
+	default:
+		return "all"
+	}
+}
+
+func radarrProfileExists(profiles []radarr.QualityProfile, id int) bool {
+	for _, p := range profiles {
+		if p.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func sonarrProfileExists(profiles []sonarr.QualityProfile, id int) bool {
+	for _, p := range profiles {
+		if p.ID == id {
+			return true
+		}
+	}
+	return false
 }

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -72,6 +72,10 @@ type AddSeriesRequest struct {
 	SeasonFolder     bool   `json:"seasonFolder"`
 	AddOptions       struct {
 		SearchForMissingEpisodes bool `json:"searchForMissingEpisodes"`
+		// Monitor is Sonarr's monitor scope applied at add time: one of
+		// all/future/missing/existing/firstSeason/lastSeason/pilot/none.
+		// Empty means Sonarr's default (all).
+		Monitor string `json:"monitor,omitempty"`
 	} `json:"addOptions"`
 }
 

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -124,6 +124,9 @@ func (h *Hub) Run(ctx context.Context) {
 				if msg.adminOnly && !client.isAdmin {
 					continue
 				}
+				if msg.userID != 0 && client.userID != msg.userID {
+					continue
+				}
 				select {
 				case client.send <- msg.data:
 				default:
@@ -136,31 +139,53 @@ func (h *Hub) Run(ctx context.Context) {
 	}
 }
 
-// outboundMessage pairs a marshaled event with its audience.
+// outboundMessage pairs a marshaled event with its audience. When userID is
+// non-zero the event is delivered only to that user's connected clients.
 type outboundMessage struct {
 	data      []byte
 	adminOnly bool
+	userID    int64
 }
 
 // Broadcast sends an event to all connected clients.
 func (h *Hub) Broadcast(event Event) {
-	h.enqueue(event, false)
+	h.enqueue(event, false, 0)
 }
 
 // BroadcastAdmin sends an event only to clients authenticated as admins.
 // Used for payloads whose REST equivalents sit behind the admin middleware
 // (e.g. download-client queue contents).
 func (h *Hub) BroadcastAdmin(event Event) {
-	h.enqueue(event, true)
+	h.enqueue(event, true, 0)
 }
 
-func (h *Hub) enqueue(event Event, adminOnly bool) {
+// BroadcastUser sends an event only to the connected clients of one user.
+// A non-positive userID would otherwise degrade to a global broadcast, so it
+// is dropped.
+func (h *Hub) BroadcastUser(userID int64, event Event) {
+	if userID <= 0 {
+		return
+	}
+	h.enqueue(event, false, userID)
+}
+
+// NotifyUser delivers an event to a single user (implements request.Notifier).
+func (h *Hub) NotifyUser(userID int64, eventType string, data map[string]interface{}) {
+	h.BroadcastUser(userID, Event{Type: eventType, Data: data})
+}
+
+// NotifyAdmins delivers an event to all admin clients (implements request.Notifier).
+func (h *Hub) NotifyAdmins(eventType string, data map[string]interface{}) {
+	h.BroadcastAdmin(Event{Type: eventType, Data: data})
+}
+
+func (h *Hub) enqueue(event Event, adminOnly bool, userID int64) {
 	data, err := json.Marshal(event)
 	if err != nil {
 		log.Printf("websocket: marshal event: %v", err)
 		return
 	}
-	h.broadcast <- outboundMessage{data: data, adminOnly: adminOnly}
+	h.broadcast <- outboundMessage{data: data, adminOnly: adminOnly, userID: userID}
 }
 
 // ServeWS handles WebSocket upgrade with JWT auth via subprotocol.


### PR DESCRIPTION
## Summary

Adds an optional **admin approval workflow** and **per-request options** to the media-request system. Out-of-the-box behavior is unchanged (tap-to-request, auto-fulfilled), but admins can now require approval and control what users may choose.

Previously every request went straight to Radarr/Sonarr with no review and a blindly-picked quality profile. Now requests can require approval, users can pick a TV season scope and (when permitted) a quality profile, and admins manage it all.

## What's new

**Approval queue** — when a user requires approval, the request queues in `request_log` as `pending` instead of hitting the arr. Admins approve/deny from a new **Pending Requests** screen and may modify options before approving. Approve replays the stored options through the *same* add path, so arr logic stays in one place.

**Season scope (TV)** — user picks Pilot / First season / Most-recent season / Entire series → mapped to Sonarr's `addOptions.monitor` (`pilot`/`firstSeason`/`lastSeason`/`all`) + search.

**Quality profile** — selectable per request; **non-admins cannot choose quality out of the box** (server-enforced — client-supplied values are ignored when not allowed).

**Admin control matrix** (3-tier: global default → per-user override → admin bypass), stored in a new `user_request_settings` table (NULL = inherit):
- Approval required — global default + per-user override
- Season choosing — global on/off + per-user override + default scope
- Quality choosing — global default + per-user enable toggle

**Notifications** — decisions push to the requester over the existing WebSocket as an in-app toast (mutable in Settings) and refresh the request button live; status is also surfaced passively (`pending`/`denied`).

## Implementation notes

Backend (Go):
- New `requests:manage` permission; admin approve/deny + global/per-user request-settings endpoints under `/api/admin`
- New `user_request_settings` table and approval columns on `request_log` (added to both `initSQL` and the additive ALTER migration — backwards-compatible, no manual migration)
- Atomic pending insert + guarded decision updates (`WHERE status='pending'`) to avoid double-submit / concurrent-approve races
- `sonarr.AddSeriesRequest` gains `addOptions.monitor`; per-user WebSocket broadcast added to the hub
- MCP tool signatures preserved; the MCP status tool is now user-aware

Frontend (Flutter):
- `RequestStatus` gains `pending`/`denied`; pre-submit options picker (skipped when there's nothing to choose, preserving one-tap)
- Three admin screens: global defaults, pending queue (modify-before-approve), per-user overrides (tri-state Inherit/On/Off)
- Decision notifications with a mute toggle

## Defaults (easy to change)
Approval **off**; season-choosing **on**, default scope = entire series; quality-choosing **off**. "Most recent season" maps to Sonarr `lastSeason` (can target a not-yet-aired season — expected).

## Verification
- Backend: `go build`, `go vet`, `go test ./...` all pass
- Frontend: `flutter analyze` clean (0 errors / 0 warnings)
- Reviewed with a multi-agent adversarial pass (security/gating, lifecycle, arr mapping, API-contract parity, frontend); all findings were low-severity and the actionable ones are fixed in this branch
- ⚠️ Not yet exercised manually in a running app — recommend a quick smoke test (request → picker → approve → toast) before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)