### PR TITLE
Fix: non-admin users can't load Radarr/Sonarr data (instance proxy was admin-only)

### DIFF
--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -219,18 +219,25 @@ func NewRouter(
 			r.Get("/ai/available", aiHandler.Available)
 		})
 
-		// Instance CRUD routes (admin only)
+		// Instance routes (authenticated)
 		r.Group(func(r chi.Router) {
 			r.Use(authService.AuthMiddleware)
-			r.Use(auth.RequirePermission(auth.PermissionInstancesManage))
 
-			r.Get("/instances", instanceHandler.List)
-			r.Post("/instances", instanceHandler.Create)
-			r.Put("/instances/{instanceID}", instanceHandler.Update)
-			r.Delete("/instances/{instanceID}", instanceHandler.Delete)
+			// Instance CRUD — admin only
+			r.Group(func(r chi.Router) {
+				r.Use(auth.RequirePermission(auth.PermissionInstancesManage))
+				r.Get("/instances", instanceHandler.List)
+				r.Post("/instances", instanceHandler.Create)
+				r.Put("/instances/{instanceID}", instanceHandler.Update)
+				r.Delete("/instances/{instanceID}", instanceHandler.Delete)
+			})
 
-			// Instance proxy — forward to specific instance
-			r.HandleFunc("/instances/{instanceID}/*", proxyHandler.InstanceProxy())
+			// Instance proxy — forward to specific instance. Read-only
+			// Radarr/Sonarr browsing is allowed for non-admins (arr:browse);
+			// every other request (writes, commands, interactive search, config,
+			// and non-arr services) requires instances:manage. See
+			// auth.RequireArrProxyAccess.
+			r.With(auth.RequireArrProxyAccess).HandleFunc("/instances/{instanceID}/*", proxyHandler.InstanceProxy())
 		})
 
 		// Download client routes (admin only)

--- a/server/internal/auth/arr_proxy.go
+++ b/server/internal/auth/arr_proxy.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+)
+
+// arrReadResources is the allowlist of Radarr/Sonarr v3 resources a non-admin
+// user may read (GET) through the instance proxy. It is deliberately limited to
+// browsing data and excludes every credential-bearing or privileged endpoint:
+// indexers, download clients, notifications, import lists, and config/host
+// (which carries the instance's own API key) are all absent, as are interactive
+// indexer search ("release") and command endpoints. Those remain admin-only.
+var arrReadResources = map[string]bool{
+	"movie":          true, // Radarr: library list, detail, lookup
+	"series":         true, // Sonarr: library list, detail, lookup
+	"episode":        true, // Sonarr: episodes for a series
+	"calendar":       true, // upcoming / aired releases
+	"queue":          true, // active download queue (progress only)
+	"history":        true, // grab / import history
+	"wanted":         true, // wanted/missing, wanted/cutoff
+	"qualityprofile": true, // profile names shown on items
+	"rootfolder":     true, // root folder list
+}
+
+// isArrReadResource reports whether forwardPath — the portion of an instance
+// proxy request after the "/api/v3/" marker, e.g. "movie/123" or
+// "wanted/missing" — targets an allowlisted read resource.
+func isArrReadResource(forwardPath string) bool {
+	// Reject path traversal so an allowlisted prefix can't be used to reach a
+	// non-allowlisted endpoint (e.g. "movie/../config/host") once the reverse
+	// proxy forwards the path to Radarr/Sonarr.
+	if forwardPath == "" || strings.Contains(forwardPath, "..") {
+		return false
+	}
+	resource := forwardPath
+	if i := strings.IndexByte(forwardPath, '/'); i >= 0 {
+		resource = forwardPath[:i]
+	}
+	return arrReadResources[resource]
+}
+
+// isArrReadPath reports whether urlPath is a Radarr/Sonarr read path. urlPath is
+// the full incoming request path, e.g. "/api/instances/<id>/api/v3/movie".
+// Anything that is not a v3 path (other services proxied through the same route,
+// such as download clients) returns false and therefore requires admin access.
+func isArrReadPath(urlPath string) bool {
+	const marker = "/api/v3/"
+	i := strings.Index(urlPath, marker)
+	if i < 0 {
+		return false
+	}
+	return isArrReadResource(urlPath[i+len(marker):])
+}
+
+// RequireArrProxyAccess authorizes instance-proxy requests. A GET to an
+// allowlisted Radarr/Sonarr read resource requires arr:browse (held by the user
+// role), giving non-admins read-only access to their library, calendar, queue,
+// history, and wanted lists. Every other request — any write, command,
+// interactive search, config endpoint, or non-arr service — requires the
+// admin-level instances:manage. It must run after AuthMiddleware.
+func RequireArrProxyAccess(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims := GetClaims(r.Context())
+		if claims == nil {
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+			return
+		}
+
+		required := PermissionInstancesManage
+		if r.Method == http.MethodGet && isArrReadPath(r.URL.Path) {
+			required = PermissionArrBrowse
+		}
+
+		if !HasPermission(claims.Role, required) {
+			http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/internal/auth/arr_proxy_test.go
+++ b/server/internal/auth/arr_proxy_test.go
@@ -1,0 +1,106 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsArrReadPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// Allowlisted read resources.
+		{"/api/instances/abc/api/v3/movie", true},
+		{"/api/instances/abc/api/v3/movie/123", true},
+		{"/api/instances/abc/api/v3/movie/lookup", true},
+		{"/api/instances/abc/api/v3/series", true},
+		{"/api/instances/abc/api/v3/episode", true},
+		{"/api/instances/abc/api/v3/calendar", true},
+		{"/api/instances/abc/api/v3/queue", true},
+		{"/api/instances/abc/api/v3/history", true},
+		{"/api/instances/abc/api/v3/wanted/missing", true},
+		{"/api/instances/abc/api/v3/qualityprofile", true},
+		{"/api/instances/abc/api/v3/rootfolder", true},
+
+		// Privileged / credential-bearing — must NOT be user-readable.
+		{"/api/instances/abc/api/v3/config/host", false},
+		{"/api/instances/abc/api/v3/notification", false},
+		{"/api/instances/abc/api/v3/downloadclient", false},
+		{"/api/instances/abc/api/v3/indexer", false},
+		{"/api/instances/abc/api/v3/importlist", false},
+		{"/api/instances/abc/api/v3/system/status", false},
+		{"/api/instances/abc/api/v3/command", false},
+		{"/api/instances/abc/api/v3/release", false},
+
+		// Path traversal must not escape the allowlist.
+		{"/api/instances/abc/api/v3/movie/../config/host", false},
+
+		// Non-arr / non-v3 proxy paths (e.g. download clients) are not reads.
+		{"/api/instances/abc/api/v2/torrents/info", false},
+		{"/api/instances/abc/", false},
+		{"/api/instances/abc/api/v3/", false},
+	}
+	for _, tt := range tests {
+		if got := isArrReadPath(tt.path); got != tt.want {
+			t.Errorf("isArrReadPath(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestRequireArrProxyAccess(t *testing.T) {
+	tests := []struct {
+		name   string
+		role   string
+		method string
+		path   string
+		want   int
+	}{
+		{"user reads movie library", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/movie", http.StatusOK},
+		{"user reads calendar", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/calendar", http.StatusOK},
+		{"user reads series", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/series", http.StatusOK},
+		{"user reads queue", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/queue", http.StatusOK},
+		{"user cannot read config", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/config/host", http.StatusForbidden},
+		{"user cannot add movie", RoleUser, http.MethodPost, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
+		{"user cannot delete movie", RoleUser, http.MethodDelete, "/api/instances/abc/api/v3/movie/1", http.StatusForbidden},
+		{"user cannot interactive search", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/release", http.StatusForbidden},
+		{"admin reads config", RoleAdmin, http.MethodGet, "/api/instances/abc/api/v3/config/host", http.StatusOK},
+		{"admin adds movie", RoleAdmin, http.MethodPost, "/api/instances/abc/api/v3/movie", http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nextCalled := false
+			h := RequireArrProxyAccess(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req = req.WithContext(context.WithValue(req.Context(), ClaimsKey, &Claims{Role: tt.role}))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.want)
+			}
+			if wantNext := tt.want == http.StatusOK; nextCalled != wantNext {
+				t.Fatalf("nextCalled = %v, want %v", nextCalled, wantNext)
+			}
+		})
+	}
+}
+
+func TestRequireArrProxyAccess_RequiresClaims(t *testing.T) {
+	h := RequireArrProxyAccess(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("handler should not run without claims")
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/api/instances/abc/api/v3/movie", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}

--- a/server/internal/auth/permissions.go
+++ b/server/internal/auth/permissions.go
@@ -22,6 +22,7 @@ const (
 	PermissionInstancesManage   Permission = "instances:manage"
 	PermissionArrRead           Permission = "arr:read"
 	PermissionArrSearch         Permission = "arr:search"
+	PermissionArrBrowse         Permission = "arr:browse"
 	PermissionDownloadsRead     Permission = "downloads:read"
 	PermissionDownloadsManage   Permission = "downloads:manage"
 	PermissionMonitoringRead    Permission = "monitoring:read"
@@ -37,6 +38,12 @@ var rolePermissions = map[string]map[Permission]bool{
 		PermissionMediaRequest:  true,
 		PermissionAIChat:        true,
 		PermissionMCPAccess:     true,
+		// Read-only Radarr/Sonarr browsing through the app's REST instance
+		// proxy: library, calendar, queue, history, and wanted lists. Enforced
+		// by RequireArrProxyAccess. Intentionally distinct from arr:read, which
+		// gates the admin-only MCP AI tools; writes, interactive search, and
+		// config stay admin-only (instances:manage / arr:search).
+		PermissionArrBrowse: true,
 	},
 }
 
@@ -86,6 +93,7 @@ func allPermissions() map[Permission]bool {
 		PermissionInstancesManage:   true,
 		PermissionArrRead:           true,
 		PermissionArrSearch:         true,
+		PermissionArrBrowse:         true,
 		PermissionDownloadsRead:     true,
 		PermissionDownloadsManage:   true,
 		PermissionMonitoringRead:    true,


### PR DESCRIPTION
## Problem

Non-admin (`user` role) accounts saw **no Radarr/Sonarr data anywhere** in the app — Library, Releases, Calendar, Queue, History, and Wanted all failed with `DioException [bad response]` (an HTTP **403**, not a network error). TV Shows / discovery worked because those use Trakt/TMDB (`media:discover`), which the user role already has.

**Root cause:** the instance proxy route (`/api/instances/{id}/*`), which the app uses to reach Radarr/Sonarr, was gated on the admin-only `instances:manage` permission. The `user` role never had it, so every proxied read returned 403.

## Fix

- New `arr:browse` permission, granted to the `user` role.
- New `RequireArrProxyAccess` middleware on the proxy route:
  - **GET** to a default-deny allowlist of read-only Radarr/Sonarr v3 resources (`movie`, `series`, `episode`, `calendar`, `queue`, `history`, `wanted`, `qualityprofile`, `rootfolder`) → requires `arr:browse`.
  - Everything else (writes, `command`, interactive `release` search, `config`/`indexer`/`downloadclient`/`notification`, non-arr proxied services) and all instance CRUD → still requires `instances:manage` (admin).
  - Path traversal (e.g. `movie/../config/host`) is rejected so the allowlist can't be escaped.

## Why a new permission instead of reusing `arr:read`

`arr:read` gates the MCP **AI tools**, which are intentionally "Admin only" (and tested as such). Reusing it would have exposed those AI tools to normal users. `arr:browse` keeps the app-UI surface and the AI-tool surface independent.

## Not changed (still admin-only)

Adding/editing/deleting items, triggering searches, interactive release search + grab, Radarr/Sonarr config, and the aggregate download-client view (`/api/downloads/*`, `downloads:read`).

## Testing

- `go test ./...` — all green (including the unchanged MCP admin-gating tests).
- New table tests for the allowlist and middleware: user vs admin, reads vs writes, config endpoints, and path traversal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
