### PR TITLE
feat(push): self-hosted push notifications (server + Flutter iOS)

### DIFF
--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7884E8692EC3CC0700C636F2 /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		F217F28F4FD79198DB298EA1 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		FBC9AEFBEC2C6FF7B7AE276E /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -145,6 +146,7 @@
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
+				7884E8692EC3CC0700C636F2 /* Runner.entitlements */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -474,6 +476,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -656,6 +659,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -678,6 +682,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -1,16 +1,111 @@
 import Flutter
 import UIKit
+import UserNotifications
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  /// Method channel shared with the Dart `PushService`. Created once the
+  /// implicit Flutter engine is initialized.
+  private var pushChannel: FlutterMethodChannel?
+
+  /// The most recently obtained APNs device token, hex-encoded. Cached so a
+  /// late Dart `getApnsToken` call can retrieve it even if the channel wasn't
+  /// ready when the token first arrived from APNs.
+  private var apnsToken: String?
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // Show foreground notifications natively (no flutter_local_notifications).
+    UNUserNotificationCenter.current().delegate = self
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+
+    // The application registrar vends the implicit engine's binary messenger,
+    // which is the correct messenger for app-level channels (the root view
+    // controller may not exist yet under the UIScene lifecycle).
+    let messenger = engineBridge.applicationRegistrar.messenger()
+    let channel = FlutterMethodChannel(
+      name: "codes.julian.cantinarr/push",
+      binaryMessenger: messenger
+    )
+    channel.setMethodCallHandler { [weak self] call, result in
+      self?.handleMethodCall(call, result: result)
+    }
+    pushChannel = channel
+
+    // If a token arrived before the channel existed, deliver it now.
+    if let token = apnsToken {
+      channel.invokeMethod("onApnsToken", arguments: token)
+    }
+  }
+
+  // MARK: - Dart -> Native
+
+  private func handleMethodCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "requestPermission":
+      requestNotificationPermission { granted in result(granted) }
+    case "getApnsToken":
+      // Returns the cached token (or nil if not yet registered).
+      result(apnsToken)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  /// Requests notification authorization and, if granted, registers with APNs.
+  /// `completion` reports whether authorization was granted.
+  private func requestNotificationPermission(completion: @escaping (Bool) -> Void) {
+    UNUserNotificationCenter.current().requestAuthorization(
+      options: [.alert, .sound, .badge]
+    ) { granted, error in
+      if let error = error {
+        NSLog("Notification authorization error: \(error.localizedDescription)")
+      }
+      if granted {
+        DispatchQueue.main.async {
+          UIApplication.shared.registerForRemoteNotifications()
+        }
+      }
+      completion(granted)
+    }
+  }
+
+  // MARK: - APNs registration callbacks
+
+  override func application(
+    _ application: UIApplication,
+    didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+  ) {
+    // Let Flutter forward the raw token to any registered plugins first.
+    super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+
+    let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+    apnsToken = token
+    pushChannel?.invokeMethod("onApnsToken", arguments: token)
+  }
+
+  override func application(
+    _ application: UIApplication,
+    didFailToRegisterForRemoteNotificationsWithError error: Error
+  ) {
+    super.application(application, didFailToRegisterForRemoteNotificationsWithError: error)
+    NSLog("Failed to register for remote notifications: \(error.localizedDescription)")
+  }
+
+  // MARK: - UNUserNotificationCenterDelegate
+
+  override func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification,
+    withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+  ) {
+    // Present notifications while the app is in the foreground.
+    completionHandler([.banner, .sound, .badge])
   }
 }

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -79,6 +79,10 @@
 				</array>
 			</dict>
 		</array>
+		<key>UIBackgroundModes</key>
+		<array>
+			<string>remote-notification</string>
+		</array>
 		<key>UIStatusBarHidden</key>
 		<false/>
 		<key>ITSAppUsesNonExemptEncryption</key>

--- a/app/ios/Runner/Runner.entitlements
+++ b/app/ios/Runner/Runner.entitlements
@@ -2,9 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- APNs environment. Use "development" for debug/local device builds.
-	     Switch to "production" for TestFlight and App Store distribution. -->
+	<!-- APNs environment. Set to "production" for TestFlight + App Store (current).
+	     For debug/local device builds, switch to "development" AND set the gateway's
+	     APNS_ENV=sandbox so the token environment matches. -->
 	<key>aps-environment</key>
-	<string>development</string>
+	<string>production</string>
 </dict>
 </plist>

--- a/app/ios/Runner/Runner.entitlements
+++ b/app/ios/Runner/Runner.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- APNs environment. Use "development" for debug/local device builds.
+	     Switch to "production" for TestFlight and App Store distribution. -->
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/models/backend_connection.dart';
 import '../../../core/models/user_profile.dart';
 import '../../../core/storage/secure_storage.dart';
+import '../../notifications/push_service.dart';
 import '../data/auth_service.dart';
 import '../data/passkey_service.dart';
 import '../data/server_status.dart';
@@ -94,6 +95,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         instances: config.instances,
       );
 
+      _registerForPush();
       return AuthState(connection: connection, user: authResp.user);
     } catch (e) {
       debugPrint('Session restore failed: $e');
@@ -140,6 +142,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         user: authResp.user,
         pendingPasskeyOffer: await _shouldOfferPasskey(normalizedUrl),
       ));
+      _registerForPush();
     } catch (e) {
       state = AsyncData(AuthState(error: _parseSetupError(e)));
     }
@@ -188,6 +191,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         user: authResp.user,
         pendingPasskeyOffer: offerPasskey,
       ));
+      _registerForPush();
     } catch (e) {
       state = AsyncData(AuthState(error: _parseError(e)));
     }
@@ -222,6 +226,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       );
 
       state = AsyncData(AuthState(connection: connection, user: authResp.user));
+      _registerForPush();
     } catch (e) {
       state = AsyncData(AuthState(error: _parseConnectError(e)));
     }
@@ -432,6 +437,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       );
 
       state = AsyncData(AuthState(connection: connection, user: authResp.user));
+      _registerForPush();
     } catch (e) {
       state = AsyncData(AuthState(error: _parsePasskeyLoginError(e)));
     }
@@ -468,8 +474,11 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     state = AsyncData(current.copyWith(connection: updated));
   }
 
-  /// Called when auth has expired (refresh rejected). Clears state.
+  /// Called when auth has expired (refresh rejected) or on logout. Clears
+  /// state. Best-effort unregisters push first, while the device id and tokens
+  /// are still available.
   Future<void> onAuthExpired() async {
+    await ref.read(pushServiceProvider).unregister();
     await _clearStorage();
     state = const AsyncData(AuthState());
   }
@@ -514,6 +523,16 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     await _storage.delete(key: StorageKeys.jwt);
     await _storage.delete(key: StorageKeys.refreshToken);
     await _storage.delete(key: StorageKeys.deviceId);
+  }
+
+  /// Fire-and-forget push registration. Must never block or throw into the
+  /// auth flow (the service swallows its own errors; this guards the rest).
+  void _registerForPush() {
+    try {
+      ref.read(pushServiceProvider).registerForPush();
+    } catch (e) {
+      debugPrint('Push registration kickoff failed: $e');
+    }
   }
 
   String _normalizeUrl(String url) {

--- a/app/lib/features/notifications/notification_prefs.dart
+++ b/app/lib/features/notifications/notification_prefs.dart
@@ -1,0 +1,43 @@
+/// A user's push-notification preferences. Each flag toggles one category of
+/// push notification the server may send to this user's devices.
+class NotificationPrefs {
+  final bool requestDecision;
+  final bool requestPending;
+  final bool newMovie;
+  final bool newEpisode;
+
+  const NotificationPrefs({
+    required this.requestDecision,
+    required this.requestPending,
+    required this.newMovie,
+    required this.newEpisode,
+  });
+
+  factory NotificationPrefs.fromJson(Map<String, dynamic> json) =>
+      NotificationPrefs(
+        requestDecision: json['request_decision'] as bool? ?? false,
+        requestPending: json['request_pending'] as bool? ?? false,
+        newMovie: json['new_movie'] as bool? ?? false,
+        newEpisode: json['new_episode'] as bool? ?? false,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'request_decision': requestDecision,
+        'request_pending': requestPending,
+        'new_movie': newMovie,
+        'new_episode': newEpisode,
+      };
+
+  NotificationPrefs copyWith({
+    bool? requestDecision,
+    bool? requestPending,
+    bool? newMovie,
+    bool? newEpisode,
+  }) =>
+      NotificationPrefs(
+        requestDecision: requestDecision ?? this.requestDecision,
+        requestPending: requestPending ?? this.requestPending,
+        newMovie: newMovie ?? this.newMovie,
+        newEpisode: newEpisode ?? this.newEpisode,
+      );
+}

--- a/app/lib/features/notifications/notification_prefs_service.dart
+++ b/app/lib/features/notifications/notification_prefs_service.dart
@@ -1,0 +1,28 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/network/backend_client.dart';
+import 'notification_prefs.dart';
+
+/// API client for the current user's push-notification preferences.
+class NotificationPrefsService {
+  final Dio _dio;
+
+  NotificationPrefsService({required Dio backendDio}) : _dio = backendDio;
+
+  Future<NotificationPrefs> getPreferences() async {
+    final resp = await _dio.get('/api/notifications/preferences');
+    return NotificationPrefs.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<NotificationPrefs> updatePreferences(NotificationPrefs prefs) async {
+    final resp =
+        await _dio.put('/api/notifications/preferences', data: prefs.toJson());
+    return NotificationPrefs.fromJson(resp.data as Map<String, dynamic>);
+  }
+}
+
+final notificationPrefsServiceProvider = Provider<NotificationPrefsService>(
+  (ref) => NotificationPrefsService(
+    backendDio: ref.watch(backendClientProvider),
+  ),
+);

--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -1,0 +1,111 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/network/backend_client.dart';
+import '../../core/storage/secure_storage.dart';
+
+/// Bridges native APNs registration to the Cantinarr backend.
+///
+/// On iOS this owns a [MethodChannel] to the native `AppDelegate`, which
+/// requests notification authorization, registers with APNs, and reports the
+/// device token back. The token is then sent to the backend's device registry.
+///
+/// This is a pure platform-channel integration (no Firebase): foreground
+/// notification presentation is handled natively by the
+/// `UNUserNotificationCenterDelegate`. All operations are best-effort and must
+/// never block or break the auth flow, so failures are logged and swallowed.
+class PushService {
+  PushService(this._ref) {
+    // Listen for tokens pushed from native (initial registration and APNs
+    // token rotation). Re-register whenever the token changes.
+    _channel.setMethodCallHandler(_handleNativeCall);
+  }
+
+  static const _channel = MethodChannel('codes.julian.cantinarr/push');
+
+  final Ref _ref;
+
+  /// The last APNs token successfully sent to the backend, used to avoid
+  /// redundant registration calls when the token hasn't changed.
+  String? _registeredToken;
+
+  bool get _isSupported => !kIsWeb && Platform.isIOS;
+
+  Future<dynamic> _handleNativeCall(MethodCall call) async {
+    if (call.method == 'onApnsToken') {
+      final token = call.arguments as String?;
+      if (token != null && token.isNotEmpty && token != _registeredToken) {
+        await _sendToken(token);
+      }
+    }
+    return null;
+  }
+
+  /// Requests notification permission, obtains the APNs token, and registers
+  /// the device with the backend. Safe to call repeatedly; a no-op on
+  /// unsupported platforms.
+  Future<void> registerForPush() async {
+    if (!_isSupported) return;
+    try {
+      final granted =
+          await _channel.invokeMethod<bool>('requestPermission') ?? false;
+      if (!granted) {
+        debugPrint('Push: notification permission not granted');
+        return;
+      }
+      // The token may already be cached natively from a prior launch; the
+      // native side also fires onApnsToken once registration completes.
+      final token = await _channel.invokeMethod<String>('getApnsToken');
+      if (token != null && token.isNotEmpty) {
+        await _sendToken(token);
+      }
+    } catch (e) {
+      debugPrint('Push: registerForPush failed: $e');
+    }
+  }
+
+  /// Removes this device's push token from the backend. Best-effort; call
+  /// before clearing auth state on logout.
+  Future<void> unregister() async {
+    if (!_isSupported) return;
+    try {
+      final storage = _ref.read(storageServiceProvider);
+      final deviceId = await storage.read(key: StorageKeys.deviceId);
+      if (deviceId == null || deviceId.isEmpty) return;
+
+      final dio = _ref.read(backendClientProvider);
+      await dio.delete('/api/devices/push-token/$deviceId');
+      _registeredToken = null;
+    } catch (e) {
+      debugPrint('Push: unregister failed: $e');
+    }
+  }
+
+  /// POSTs the APNs token to the backend device registry.
+  Future<void> _sendToken(String token) async {
+    try {
+      final storage = _ref.read(storageServiceProvider);
+      final deviceId = await storage.read(key: StorageKeys.deviceId);
+      if (deviceId == null || deviceId.isEmpty) {
+        debugPrint('Push: no device id; skipping token registration');
+        return;
+      }
+
+      final dio = _ref.read(backendClientProvider);
+      await dio.post('/api/devices/push-token', data: {
+        'device_id': deviceId,
+        'apns_token': token,
+        'platform': 'ios',
+      });
+      _registeredToken = token;
+    } catch (e) {
+      debugPrint('Push: failed to send token: $e');
+    }
+  }
+}
+
+/// Provides the app-wide [PushService].
+final pushServiceProvider = Provider<PushService>(PushService.new);

--- a/app/lib/features/notifications/ui/notification_preferences_screen.dart
+++ b/app/lib/features/notifications/ui/notification_preferences_screen.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../notification_prefs.dart';
+import '../notification_prefs_service.dart';
+
+/// Lets the current user choose which push notifications they receive. Loads
+/// the saved preferences on open and persists each toggle immediately,
+/// reverting the switch if the server rejects the change.
+class NotificationPreferencesScreen extends ConsumerStatefulWidget {
+  const NotificationPreferencesScreen({super.key});
+
+  @override
+  ConsumerState<NotificationPreferencesScreen> createState() =>
+      _NotificationPreferencesScreenState();
+}
+
+class _NotificationPreferencesScreenState
+    extends ConsumerState<NotificationPreferencesScreen> {
+  bool _isLoading = true;
+  String? _error;
+  NotificationPrefs? _prefs;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final prefs =
+          await ref.read(notificationPrefsServiceProvider).getPreferences();
+      if (!mounted) return;
+      setState(() {
+        _prefs = prefs;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = _friendlyError(e);
+        _isLoading = false;
+      });
+    }
+  }
+
+  /// Applies [updated] optimistically, then persists it. On failure the UI
+  /// reverts to [previous] and surfaces the error.
+  Future<void> _save(
+      NotificationPrefs updated, NotificationPrefs previous) async {
+    setState(() => _prefs = updated);
+    try {
+      final saved = await ref
+          .read(notificationPrefsServiceProvider)
+          .updatePreferences(updated);
+      if (!mounted) return;
+      setState(() => _prefs = saved);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _prefs = previous);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(_friendlyError(e))));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notification Preferences')),
+      body: _isLoading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent))
+          : _error != null && _prefs == null
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(_error!,
+                            style: const TextStyle(color: AppTheme.error),
+                            textAlign: TextAlign.center),
+                        const SizedBox(height: 12),
+                        ElevatedButton(
+                            onPressed: _load, child: const Text('Retry')),
+                      ],
+                    ),
+                  ),
+                )
+              : _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    final prefs = _prefs!;
+    final isAdmin = ref.watch(authProvider).valueOrNull?.user?.isAdmin ?? false;
+
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: [
+        const Padding(
+          padding: EdgeInsets.fromLTRB(16, 8, 16, 12),
+          child: Text(
+            'Choose which push notifications you receive on this account.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        _toggle(
+          title: 'Request approved or denied',
+          subtitle: 'When your request is approved or denied',
+          value: prefs.requestDecision,
+          onChanged: (v) => _save(prefs.copyWith(requestDecision: v), prefs),
+        ),
+        if (isAdmin)
+          _toggle(
+            title: 'New requests to review',
+            subtitle: 'When someone submits a request needing approval',
+            value: prefs.requestPending,
+            onChanged: (v) => _save(prefs.copyWith(requestPending: v), prefs),
+          ),
+        _toggle(
+          title: 'New movie available',
+          subtitle: 'When a movie finishes downloading',
+          value: prefs.newMovie,
+          onChanged: (v) => _save(prefs.copyWith(newMovie: v), prefs),
+        ),
+        _toggle(
+          title: 'New episode available',
+          subtitle: 'When a new episode is available',
+          value: prefs.newEpisode,
+          onChanged: (v) => _save(prefs.copyWith(newEpisode: v), prefs),
+        ),
+        const SizedBox(height: 32),
+      ],
+    );
+  }
+
+  Widget _toggle({
+    required String title,
+    required String subtitle,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+  }) {
+    return SwitchListTile(
+      value: value,
+      onChanged: onChanged,
+      activeThumbColor: AppTheme.accent,
+      title: Text(title,
+          style: const TextStyle(
+              color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
+      subtitle: Text(subtitle,
+          style: const TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+    );
+  }
+}

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -213,11 +213,16 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
           // Notifications
           _SectionHeader(title: 'Notifications'),
+          _SettingsTile(
+            icon: Icons.notifications_outlined,
+            title: 'Notification Preferences',
+            subtitle: 'Choose which push notifications you receive',
+            onTap: () => context.push('/settings/notifications'),
+          ),
           SwitchListTile(
             value: ref.watch(requestNotificationsEnabledProvider),
-            onChanged: (v) => ref
-                .read(requestNotificationsEnabledProvider.notifier)
-                .set(v),
+            onChanged: (v) =>
+                ref.read(requestNotificationsEnabledProvider.notifier).set(v),
             activeThumbColor: AppTheme.accent,
             secondary: const Icon(Icons.notifications_active_outlined,
                 color: AppTheme.textSecondary),
@@ -225,7 +230,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 style: TextStyle(
                     color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
             subtitle: const Text(
-                'Notify me when a request is approved or denied',
+                'Show an in-app banner when a request is approved or denied',
                 style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
           ),
 

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -16,6 +16,7 @@ import '../features/downloads/ui/downloads_history_screen.dart';
 import '../features/downloads/ui/downloads_module_shell.dart';
 import '../features/downloads/ui/downloads_queue_screen.dart';
 import '../features/media_detail/ui/media_detail_screen.dart';
+import '../features/notifications/ui/notification_preferences_screen.dart';
 import '../features/radarr/ui/radarr_calendar_screen.dart';
 import '../features/radarr/ui/radarr_history_screen.dart';
 import '../features/radarr/ui/radarr_home_screen.dart';
@@ -368,6 +369,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         path: '/settings/devices',
         parentNavigatorKey: _rootNavigatorKey,
         builder: (_, __) => const DevicesScreen(),
+      ),
+      GoRoute(
+        path: '/settings/notifications',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (_, __) => const NotificationPreferencesScreen(),
       ),
       GoRoute(
         path: '/settings/passkeys',

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,3 +5,8 @@
 CANTINARR_PORT=8585
 CANTINARR_SERVER_NAME=Cantinarr
 CANTINARR_JWT_SECRET=
+
+# Push notifications (self-hosted push gateway). Both must be set to enable
+# push; leave either blank to disable. The per-app key is a secret.
+CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
+CANTINARR_PUSH_API_KEY=

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -106,14 +106,10 @@ func main() {
 	// Tautulli handler (Plex monitoring)
 	tautulliHandler := tautulli.NewHandler(instanceStore, registry)
 
-	// WebSocket hub (built before the request service so request approvals
-	// and denials can push realtime events to the requester).
-	wsHub := ws.NewHub(authService, registry, instanceStore)
-	go wsHub.Run(context.Background())
-
 	// Push notifications via the self-hosted gateway. Disabled (client nil) when
 	// either the gateway URL or API key is unset; the handler and notifier are
-	// still built (nil-safe) so wiring stays uniform.
+	// still built (nil-safe) so wiring stays uniform. Built before the hub and
+	// request service so both can dispatch pushes.
 	var pushClient *push.Client
 	if cfg.PushGatewayURL != "" && cfg.PushAPIKey != "" {
 		pushClient = push.NewClient(cfg.PushGatewayURL, cfg.PushAPIKey)
@@ -124,12 +120,31 @@ func main() {
 	logger := slog.Default()
 	pushHandler := push.NewHandler(database, pushClient, logger)
 
+	// One push notifier drives both the request-decision/pending fan-out and the
+	// new-content (movie/episode available) pushes. nil when push is disabled so
+	// the hub's content notifier and the request composite both no-op.
+	var pushNotifier *push.Notifier
+	if pushClient != nil {
+		pushNotifier = push.NewNotifier(database, pushClient, logger)
+	}
+
+	// WebSocket hub (built before the request service so request approvals and
+	// denials can push realtime events to the requester). The push notifier is
+	// passed so download completions also fan out to opted-in devices; passing
+	// an untyped nil keeps new-content pushes off when push is disabled.
+	var contentNotifier ws.ContentNotifier
+	if pushNotifier != nil {
+		contentNotifier = pushNotifier
+	}
+	wsHub := ws.NewHub(authService, registry, instanceStore, contentNotifier)
+	go wsHub.Run(context.Background())
+
 	// Request service. Request decisions fan out to both the WebSocket hub
 	// (live clients) and the push gateway (offline devices). The push notifier
 	// is only added to the fan-out when push is configured.
 	var notifier request.Notifier
-	if pushClient != nil {
-		notifier = push.NewComposite(wsHub, push.NewNotifier(database, pushClient, logger))
+	if pushNotifier != nil {
+		notifier = push.NewComposite(wsHub, pushNotifier)
 	} else {
 		notifier = push.NewComposite(wsHub)
 	}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -23,6 +24,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/mcp"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
+	"github.com/windoze95/cantinarr-server/internal/push"
 	"github.com/windoze95/cantinarr-server/internal/request"
 	"github.com/windoze95/cantinarr-server/internal/secrets"
 	"github.com/windoze95/cantinarr-server/internal/tautulli"
@@ -109,8 +111,29 @@ func main() {
 	wsHub := ws.NewHub(authService, registry, instanceStore)
 	go wsHub.Run(context.Background())
 
-	// Request service
-	requestService := request.NewService(database, registry, bridge, wsHub)
+	// Push notifications via the self-hosted gateway. Disabled (client nil) when
+	// either the gateway URL or API key is unset; the handler and notifier are
+	// still built (nil-safe) so wiring stays uniform.
+	var pushClient *push.Client
+	if cfg.PushGatewayURL != "" && cfg.PushAPIKey != "" {
+		pushClient = push.NewClient(cfg.PushGatewayURL, cfg.PushAPIKey)
+		log.Printf("Push notifications enabled via %s", cfg.PushGatewayURL)
+	} else {
+		log.Println("Push notifications disabled (CANTINARR_PUSH_GATEWAY_URL/CANTINARR_PUSH_API_KEY unset)")
+	}
+	logger := slog.Default()
+	pushHandler := push.NewHandler(database, pushClient, logger)
+
+	// Request service. Request decisions fan out to both the WebSocket hub
+	// (live clients) and the push gateway (offline devices). The push notifier
+	// is only added to the fan-out when push is configured.
+	var notifier request.Notifier
+	if pushClient != nil {
+		notifier = push.NewComposite(wsHub, push.NewNotifier(database, pushClient, logger))
+	} else {
+		notifier = push.NewComposite(wsHub)
+	}
+	requestService := request.NewService(database, registry, bridge, notifier)
 	requestHandler := request.NewHandler(requestService)
 
 	// Proxy handler
@@ -126,7 +149,7 @@ func main() {
 	discoverHandler := discover.NewHandler(creds, apiCache)
 
 	// Router
-	router := api.NewRouter(cfg, authHandler, authService, requestHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer)
+	router := api.NewRouter(cfg, authHandler, authService, requestHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler)
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	log.Printf("Cantinarr server starting on %s", addr)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -160,12 +160,15 @@ func NewRouter(
 			r.Get("/config", configHandler(cfg, instanceStore, creds))
 		})
 
-		// Device push-token routes (authenticated). Any signed-in user may
-		// register/clear the APNs token for one of their own devices.
+		// Device push-token + notification preference routes (authenticated).
+		// Any signed-in user may register/clear the APNs token for one of their
+		// own devices and read/update their own notification preferences.
 		r.Group(func(r chi.Router) {
 			r.Use(authService.AuthMiddleware)
 			r.Post("/devices/push-token", pushHandler.Register)
 			r.Delete("/devices/push-token/{deviceID}", pushHandler.Delete)
+			r.Get("/notifications/preferences", pushHandler.GetPreferences)
+			r.Put("/notifications/preferences", pushHandler.UpdatePreferences)
 		})
 
 		// Request routes (authenticated)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -18,6 +18,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/mcp"
 	"github.com/windoze95/cantinarr-server/internal/mcpserver"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
+	"github.com/windoze95/cantinarr-server/internal/push"
 	"github.com/windoze95/cantinarr-server/internal/request"
 	"github.com/windoze95/cantinarr-server/internal/tautulli"
 	"github.com/windoze95/cantinarr-server/internal/web"
@@ -40,6 +41,7 @@ func NewRouter(
 	creds *credentials.Registry,
 	credHandler *credentials.Handler,
 	toolServer *mcp.ToolServer,
+	pushHandler *push.Handler,
 ) http.Handler {
 	r := chi.NewRouter()
 
@@ -156,6 +158,14 @@ func NewRouter(
 		r.Group(func(r chi.Router) {
 			r.Use(authService.AuthMiddleware)
 			r.Get("/config", configHandler(cfg, instanceStore, creds))
+		})
+
+		// Device push-token routes (authenticated). Any signed-in user may
+		// register/clear the APNs token for one of their own devices.
+		r.Group(func(r chi.Router) {
+			r.Use(authService.AuthMiddleware)
+			r.Post("/devices/push-token", pushHandler.Register)
+			r.Delete("/devices/push-token/{deviceID}", pushHandler.Delete)
 		})
 
 		// Request routes (authenticated)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -28,6 +28,10 @@ type Config struct {
 	// AndroidPackageName and AndroidCertFingerprints are served in assetlinks.json.
 	AndroidPackageName      string
 	AndroidCertFingerprints []string
+	// PushGatewayURL and PushAPIKey configure the self-hosted push gateway. When
+	// either is empty, push notifications are disabled.
+	PushGatewayURL string
+	PushAPIKey     string
 }
 
 func Load() (*Config, error) {
@@ -46,6 +50,8 @@ func Load() (*Config, error) {
 		),
 		AppleAppIDs:        splitEnvList(os.Getenv("CANTINARR_APPLE_APP_IDS")),
 		AndroidPackageName: os.Getenv("CANTINARR_ANDROID_PACKAGE_NAME"),
+		PushGatewayURL:     strings.TrimRight(os.Getenv("CANTINARR_PUSH_GATEWAY_URL"), "/"),
+		PushAPIKey:         os.Getenv("CANTINARR_PUSH_API_KEY"),
 	}
 
 	if cfg.ServerName == "" {

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -90,6 +90,18 @@ CREATE TABLE IF NOT EXISTS push_tokens (
     UNIQUE(device_id)
 );
 
+-- Per-user push notification preferences. A missing row means "all defaults",
+-- so a user only gets a row once they change something. Defaults match the
+-- self-service API: request_decision off, request_pending/new_movie/new_episode
+-- on. Kept separate from user_request_settings (admin-managed request policy).
+CREATE TABLE IF NOT EXISTS notification_prefs (
+    user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    request_decision INTEGER NOT NULL DEFAULT 0,
+    request_pending  INTEGER NOT NULL DEFAULT 1,
+    new_movie        INTEGER NOT NULL DEFAULT 1,
+    new_episode      INTEGER NOT NULL DEFAULT 1
+);
+
 CREATE TABLE IF NOT EXISTS connect_tokens (
     token TEXT PRIMARY KEY,
     user_id INTEGER NOT NULL REFERENCES users(id),

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -79,6 +79,17 @@ CREATE TABLE IF NOT EXISTS devices (
     revoked_at DATETIME
 );
 
+CREATE TABLE IF NOT EXISTS push_tokens (
+    id TEXT PRIMARY KEY,
+    device_id TEXT NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    user_id INTEGER NOT NULL,
+    platform TEXT NOT NULL DEFAULT 'ios',
+    token TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_seen_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(device_id)
+);
+
 CREATE TABLE IF NOT EXISTS connect_tokens (
     token TEXT PRIMARY KEY,
     user_id INTEGER NOT NULL REFERENCES users(id),

--- a/server/internal/push/client.go
+++ b/server/internal/push/client.go
@@ -54,12 +54,30 @@ func (c *Client) DeleteDevice(ctx context.Context, deviceID string) error {
 	return c.do(ctx, http.MethodDelete, "/v1/devices", body, nil)
 }
 
+// SendOptions carries optional per-send tuning. The zero value is valid and
+// reproduces the default high-priority send.
+type SendOptions struct {
+	// CollapseID, when set, is passed to the gateway as the APNs collapse id so
+	// repeat notifications about the same subject coalesce on-device into a
+	// single alert. Empty means no collapsing.
+	CollapseID string
+}
+
 // Send fans a high-priority notification out to the given users' devices. data
 // is delivered as the APNs payload's custom data.
 func (c *Client) Send(ctx context.Context, userIDs []int64, title, body string, data map[string]any) error {
+	return c.SendWithOptions(ctx, userIDs, title, body, data, SendOptions{})
+}
+
+// SendWithOptions is Send with explicit per-send options (e.g. a collapse id).
+func (c *Client) SendWithOptions(ctx context.Context, userIDs []int64, title, body string, data map[string]any, opts SendOptions) error {
 	ids := make([]string, len(userIDs))
 	for i, id := range userIDs {
 		ids[i] = strconv.FormatInt(id, 10)
+	}
+	options := map[string]any{"priority": "high"}
+	if opts.CollapseID != "" {
+		options["collapse_id"] = opts.CollapseID
 	}
 	payload := map[string]any{
 		"to": map[string]any{"user_ids": ids},
@@ -68,7 +86,7 @@ func (c *Client) Send(ctx context.Context, userIDs []int64, title, body string, 
 			"body":  body,
 		},
 		"data":    data,
-		"options": map[string]any{"priority": "high"},
+		"options": options,
 	}
 	return c.do(ctx, http.MethodPost, "/v1/notifications", payload, nil)
 }

--- a/server/internal/push/client.go
+++ b/server/internal/push/client.go
@@ -1,0 +1,112 @@
+// Package push integrates Cantinarr with the self-hosted push gateway. The
+// Client speaks the gateway's /v1 HTTP API (Bearer per-app key) to register
+// device tokens and fan notifications out to APNs. Cantinarr user IDs are
+// int64; the gateway treats user ids as opaque strings, so they are converted
+// to decimal strings on the wire.
+package push
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Client talks to the push gateway's /v1 API using a per-app bearer key.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewClient builds a gateway client. baseURL is the gateway origin (no trailing
+// slash) and apiKey is the per-app bearer key.
+func NewClient(baseURL, apiKey string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// RegisterDevice upserts a device token with the gateway. The gateway defaults
+// the APNs topic from the tenant, so no topic is sent.
+func (c *Client) RegisterDevice(ctx context.Context, userID int64, deviceID, platform, token string) error {
+	body := map[string]any{
+		"user_id":   strconv.FormatInt(userID, 10),
+		"device_id": deviceID,
+		"platform":  platform,
+		"token":     token,
+	}
+	return c.do(ctx, http.MethodPost, "/v1/devices", body, nil)
+}
+
+// DeleteDevice removes a device's token from the gateway by caller device id.
+func (c *Client) DeleteDevice(ctx context.Context, deviceID string) error {
+	body := map[string]any{"device_id": deviceID}
+	return c.do(ctx, http.MethodDelete, "/v1/devices", body, nil)
+}
+
+// Send fans a high-priority notification out to the given users' devices. data
+// is delivered as the APNs payload's custom data.
+func (c *Client) Send(ctx context.Context, userIDs []int64, title, body string, data map[string]any) error {
+	ids := make([]string, len(userIDs))
+	for i, id := range userIDs {
+		ids[i] = strconv.FormatInt(id, 10)
+	}
+	payload := map[string]any{
+		"to": map[string]any{"user_ids": ids},
+		"notification": map[string]any{
+			"title": title,
+			"body":  body,
+		},
+		"data":    data,
+		"options": map[string]any{"priority": "high"},
+	}
+	return c.do(ctx, http.MethodPost, "/v1/notifications", payload, nil)
+}
+
+// do executes a request with an optional JSON body, fails on non-2xx status
+// (including a snippet of the response body), and decodes JSON into out when
+// out is non-nil.
+func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request body: %w", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("push gateway %s %s returned status %d: %s",
+			method, path, resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}

--- a/server/internal/push/client_test.go
+++ b/server/internal/push/client_test.go
@@ -1,0 +1,130 @@
+package push
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// capturedRequest records what a mock gateway received.
+type capturedRequest struct {
+	method string
+	path   string
+	auth   string
+	body   map[string]any
+}
+
+// newMockGateway returns an httptest server that records the last request into
+// got and replies with the given status + body. It NEVER calls the real
+// gateway.
+func newMockGateway(t *testing.T, status int, respBody string, got *capturedRequest) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.method = r.Method
+		got.path = r.URL.Path
+		got.auth = r.Header.Get("Authorization")
+		raw, _ := io.ReadAll(r.Body)
+		got.body = map[string]any{}
+		_ = json.Unmarshal(raw, &got.body)
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, respBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestClientRegisterDevice(t *testing.T) {
+	var got capturedRequest
+	srv := newMockGateway(t, http.StatusOK, `{"id":"d1","created":true}`, &got)
+
+	c := NewClient(srv.URL, "pgk_test")
+	if err := c.RegisterDevice(context.Background(), 42, "device-1", "ios", "abc123"); err != nil {
+		t.Fatalf("RegisterDevice: %v", err)
+	}
+
+	if got.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", got.method)
+	}
+	if got.path != "/v1/devices" {
+		t.Errorf("path = %q, want /v1/devices", got.path)
+	}
+	if got.auth != "Bearer pgk_test" {
+		t.Errorf("auth = %q, want Bearer pgk_test", got.auth)
+	}
+	// int64 user id must be sent as a string.
+	if got.body["user_id"] != "42" {
+		t.Errorf("user_id = %v, want \"42\"", got.body["user_id"])
+	}
+	if got.body["device_id"] != "device-1" || got.body["platform"] != "ios" || got.body["token"] != "abc123" {
+		t.Errorf("unexpected body: %v", got.body)
+	}
+	// The gateway defaults the topic; we must not send one.
+	if _, ok := got.body["topic"]; ok {
+		t.Errorf("body should not include a topic: %v", got.body)
+	}
+}
+
+func TestClientDeleteDevice(t *testing.T) {
+	var got capturedRequest
+	srv := newMockGateway(t, http.StatusNoContent, "", &got)
+
+	c := NewClient(srv.URL, "pgk_test")
+	if err := c.DeleteDevice(context.Background(), "device-1"); err != nil {
+		t.Fatalf("DeleteDevice: %v", err)
+	}
+
+	if got.method != http.MethodDelete {
+		t.Errorf("method = %q, want DELETE", got.method)
+	}
+	if got.path != "/v1/devices" {
+		t.Errorf("path = %q, want /v1/devices", got.path)
+	}
+	if got.auth != "Bearer pgk_test" {
+		t.Errorf("auth = %q, want Bearer pgk_test", got.auth)
+	}
+	if got.body["device_id"] != "device-1" {
+		t.Errorf("device_id = %v, want device-1", got.body["device_id"])
+	}
+}
+
+func TestClientSend(t *testing.T) {
+	var got capturedRequest
+	srv := newMockGateway(t, http.StatusOK, `{"sent":1,"failed":0}`, &got)
+
+	c := NewClient(srv.URL, "pgk_test")
+	err := c.Send(context.Background(), []int64{7, 9}, "Title", "Body", map[string]any{"type": "request_decision"})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if got.method != http.MethodPost || got.path != "/v1/notifications" {
+		t.Errorf("method/path = %q %q, want POST /v1/notifications", got.method, got.path)
+	}
+	to, _ := got.body["to"].(map[string]any)
+	ids, _ := to["user_ids"].([]any)
+	if len(ids) != 2 || ids[0] != "7" || ids[1] != "9" {
+		t.Errorf("user_ids = %v, want [\"7\" \"9\"]", ids)
+	}
+	notif, _ := got.body["notification"].(map[string]any)
+	if notif["title"] != "Title" || notif["body"] != "Body" {
+		t.Errorf("notification = %v, want title/body Title/Body", notif)
+	}
+	opts, _ := got.body["options"].(map[string]any)
+	if opts["priority"] != "high" {
+		t.Errorf("priority = %v, want high", opts["priority"])
+	}
+}
+
+func TestClientSendNon2xxIsError(t *testing.T) {
+	var got capturedRequest
+	srv := newMockGateway(t, http.StatusUnauthorized, `{"error":{"code":"unauthorized"}}`, &got)
+
+	c := NewClient(srv.URL, "pgk_bad")
+	err := c.Send(context.Background(), []int64{1}, "t", "b", nil)
+	if err == nil {
+		t.Fatal("expected error for non-2xx response, got nil")
+	}
+}

--- a/server/internal/push/composite.go
+++ b/server/internal/push/composite.go
@@ -1,0 +1,46 @@
+package push
+
+// notifier is the subset of request.Notifier the composite fans out to. It is
+// duplicated here (rather than importing request) so the push package stays
+// free of a dependency on request, which already depends on this package's
+// interface shape.
+type notifier interface {
+	NotifyUser(userID int64, eventType string, data map[string]interface{})
+	NotifyAdmins(eventType string, data map[string]interface{})
+}
+
+// Composite fans request events out to several notifiers (e.g. the WebSocket
+// hub for live clients and the push notifier for offline devices). nil members
+// are skipped, so callers can wire whichever sinks are configured.
+type Composite struct {
+	targets []notifier
+}
+
+// NewComposite builds a Composite from the given notifiers, dropping nil ones.
+// Pass an untyped nil for a sink that is not configured; the *Notifier and
+// *ws.Hub methods are themselves nil-receiver safe, but a typed-nil interface
+// value would still pass the nil check, so prefer untyped nils here.
+func NewComposite(targets ...notifier) *Composite {
+	live := make([]notifier, 0, len(targets))
+	for _, t := range targets {
+		if t == nil {
+			continue
+		}
+		live = append(live, t)
+	}
+	return &Composite{targets: live}
+}
+
+// NotifyUser fans the event out to every target.
+func (c *Composite) NotifyUser(userID int64, eventType string, data map[string]interface{}) {
+	for _, t := range c.targets {
+		t.NotifyUser(userID, eventType, data)
+	}
+}
+
+// NotifyAdmins fans the event out to every target.
+func (c *Composite) NotifyAdmins(eventType string, data map[string]interface{}) {
+	for _, t := range c.targets {
+		t.NotifyAdmins(eventType, data)
+	}
+}

--- a/server/internal/push/composite_test.go
+++ b/server/internal/push/composite_test.go
@@ -1,0 +1,46 @@
+package push
+
+import "testing"
+
+// recordingNotifier records the events it receives.
+type recordingNotifier struct {
+	userEvents  []string
+	adminEvents []string
+}
+
+func (r *recordingNotifier) NotifyUser(userID int64, eventType string, data map[string]interface{}) {
+	r.userEvents = append(r.userEvents, eventType)
+}
+
+func (r *recordingNotifier) NotifyAdmins(eventType string, data map[string]interface{}) {
+	r.adminEvents = append(r.adminEvents, eventType)
+}
+
+func TestCompositeFansOut(t *testing.T) {
+	a := &recordingNotifier{}
+	b := &recordingNotifier{}
+	c := NewComposite(a, b)
+
+	c.NotifyUser(1, "request_decision", nil)
+	c.NotifyAdmins("request_pending", nil)
+
+	for _, n := range []*recordingNotifier{a, b} {
+		if len(n.userEvents) != 1 || n.userEvents[0] != "request_decision" {
+			t.Errorf("user events = %v, want [request_decision]", n.userEvents)
+		}
+		if len(n.adminEvents) != 1 || n.adminEvents[0] != "request_pending" {
+			t.Errorf("admin events = %v, want [request_pending]", n.adminEvents)
+		}
+	}
+}
+
+func TestCompositeSkipsNil(t *testing.T) {
+	a := &recordingNotifier{}
+	c := NewComposite(a, nil)
+
+	// Must not panic on the nil member.
+	c.NotifyUser(1, "request_decision", nil)
+	if len(a.userEvents) != 1 {
+		t.Errorf("user events = %v, want one", a.userEvents)
+	}
+}

--- a/server/internal/push/handler.go
+++ b/server/internal/push/handler.go
@@ -14,12 +14,13 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/auth"
 )
 
-// Handler serves the device push-token endpoints. A nil client disables
-// gateway registration (the local row is still stored), so the handler works
-// even when push is not configured.
+// Handler serves the device push-token endpoints and the per-user notification
+// preferences endpoints. A nil client disables gateway registration (the local
+// row is still stored), so the handler works even when push is not configured.
 type Handler struct {
 	db     *sql.DB
 	client *Client
+	prefs  *PrefsStore
 	logger *slog.Logger
 }
 
@@ -28,7 +29,7 @@ func NewHandler(db *sql.DB, client *Client, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Handler{db: db, client: client, logger: logger}
+	return &Handler{db: db, client: client, prefs: NewPrefsStore(db), logger: logger}
 }
 
 // RegisterTokenRequest is the POST /api/devices/push-token body.
@@ -127,6 +128,46 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+// GetPreferences returns the calling user's notification preferences, applying
+// the defaults for a user who has never changed them.
+func (h *Handler) GetPreferences(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	prefs, err := h.prefs.Get(claims.UserID)
+	if err != nil {
+		h.logger.Error("push: get notification prefs", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to load preferences"})
+		return
+	}
+	writeJSON(w, http.StatusOK, prefs)
+}
+
+// UpdatePreferences replaces the calling user's notification preferences. The
+// body is the same four-boolean shape returned by GetPreferences; the stored
+// preferences are echoed back. Unknown fields are ignored and missing fields
+// default to false (a PUT replaces the full set).
+func (h *Handler) UpdatePreferences(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	var prefs Prefs
+	if err := json.NewDecoder(r.Body).Decode(&prefs); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if err := h.prefs.Set(claims.UserID, prefs); err != nil {
+		h.logger.Error("push: set notification prefs", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save preferences"})
+		return
+	}
+	writeJSON(w, http.StatusOK, prefs)
 }
 
 // deviceBelongsToUser reports whether device_id names a (non-revoked) device

--- a/server/internal/push/handler.go
+++ b/server/internal/push/handler.go
@@ -1,0 +1,176 @@
+package push
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/auth"
+)
+
+// Handler serves the device push-token endpoints. A nil client disables
+// gateway registration (the local row is still stored), so the handler works
+// even when push is not configured.
+type Handler struct {
+	db     *sql.DB
+	client *Client
+	logger *slog.Logger
+}
+
+// NewHandler builds the push-token endpoint handler.
+func NewHandler(db *sql.DB, client *Client, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{db: db, client: client, logger: logger}
+}
+
+// RegisterTokenRequest is the POST /api/devices/push-token body.
+type RegisterTokenRequest struct {
+	DeviceID  string `json:"device_id"`
+	APNSToken string `json:"apns_token"`
+	Platform  string `json:"platform"`
+}
+
+// Register upserts the caller's APNs token for one of their own devices and
+// registers it with the gateway. Gateway errors are logged but do not fail the
+// request once the local row is stored.
+func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	var req RegisterTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if req.DeviceID == "" || req.APNSToken == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "device_id and apns_token required"})
+		return
+	}
+	platform := req.Platform
+	if platform == "" {
+		platform = "ios"
+	}
+
+	// The device must exist and belong to the caller. This both authorizes the
+	// write and guarantees the push_tokens FK (device_id -> devices.id) holds.
+	if !h.deviceBelongsToUser(req.DeviceID, claims.UserID) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "device not found"})
+		return
+	}
+
+	if err := h.upsertToken(claims.UserID, req.DeviceID, platform, req.APNSToken); err != nil {
+		h.logger.Error("push: upsert token", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save token"})
+		return
+	}
+
+	// Register with the gateway. Failures here are non-fatal: the token is
+	// stored locally and will be retried on the next registration.
+	if h.client != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		if err := h.client.RegisterDevice(ctx, claims.UserID, req.DeviceID, platform, req.APNSToken); err != nil {
+			h.logger.Error("push: register device with gateway", "err", err, "device_id", req.DeviceID)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+// Delete removes the caller's push token for one of their own devices and
+// deregisters it from the gateway.
+func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	deviceID := chi.URLParam(r, "deviceID")
+	if deviceID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "device_id required"})
+		return
+	}
+
+	// Ownership-checked delete: only remove a row that belongs to the caller.
+	res, err := h.db.Exec(
+		"DELETE FROM push_tokens WHERE device_id = ? AND user_id = ?",
+		deviceID, claims.UserID,
+	)
+	if err != nil {
+		h.logger.Error("push: delete token", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to delete token"})
+		return
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "token not found"})
+		return
+	}
+
+	if h.client != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		if err := h.client.DeleteDevice(ctx, deviceID); err != nil {
+			h.logger.Error("push: delete device from gateway", "err", err, "device_id", deviceID)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]bool{"success": true})
+}
+
+// deviceBelongsToUser reports whether device_id names a (non-revoked) device
+// owned by the user.
+func (h *Handler) deviceBelongsToUser(deviceID string, userID int64) bool {
+	var owner int64
+	err := h.db.QueryRow(
+		"SELECT user_id FROM devices WHERE id = ? AND revoked_at IS NULL",
+		deviceID,
+	).Scan(&owner)
+	return err == nil && owner == userID
+}
+
+// upsertToken stores (or refreshes) the APNs token for a device. The UNIQUE
+// (device_id) constraint makes re-registration replace the prior token.
+func (h *Handler) upsertToken(userID int64, deviceID, platform, token string) error {
+	id, err := newID()
+	if err != nil {
+		return err
+	}
+	_, err = h.db.Exec(
+		`INSERT INTO push_tokens (id, device_id, user_id, platform, token, last_seen_at)
+		 VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		 ON CONFLICT(device_id) DO UPDATE SET
+			user_id = excluded.user_id,
+			platform = excluded.platform,
+			token = excluded.token,
+			last_seen_at = CURRENT_TIMESTAMP`,
+		id, deviceID, userID, platform, token,
+	)
+	return err
+}
+
+// newID returns a random hex id for a push_tokens row.
+func newID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/server/internal/push/handler_test.go
+++ b/server/internal/push/handler_test.go
@@ -1,0 +1,113 @@
+package push
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/auth"
+)
+
+// withUser returns a request carrying authenticated claims for userID.
+func withUser(r *http.Request, userID int64) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), auth.ClaimsKey, &auth.Claims{UserID: userID, Role: "user"}))
+}
+
+func TestGetPreferencesDefaults(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (7, 'alice', '', 'user')")
+	h := NewHandler(database, nil, nil)
+
+	rr := httptest.NewRecorder()
+	req := withUser(httptest.NewRequest(http.MethodGet, "/api/notifications/preferences", nil), 7)
+	h.GetPreferences(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var got Prefs
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true}
+	if got != want {
+		t.Errorf("prefs = %+v, want %+v", got, want)
+	}
+}
+
+func TestGetPreferencesUnauthorized(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	h := NewHandler(database, nil, nil)
+
+	rr := httptest.NewRecorder()
+	// No claims in context.
+	req := httptest.NewRequest(http.MethodGet, "/api/notifications/preferences", nil)
+	h.GetPreferences(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestUpdatePreferencesRoundTrip(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (7, 'alice', '', 'user')")
+	h := NewHandler(database, nil, nil)
+
+	body := `{"request_decision":true,"request_pending":false,"new_movie":false,"new_episode":true}`
+	rr := httptest.NewRecorder()
+	req := withUser(httptest.NewRequest(http.MethodPut, "/api/notifications/preferences", strings.NewReader(body)), 7)
+	h.UpdatePreferences(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var got Prefs
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	want := Prefs{RequestDecision: true, RequestPending: false, NewMovie: false, NewEpisode: true}
+	if got != want {
+		t.Errorf("echoed prefs = %+v, want %+v", got, want)
+	}
+
+	// The change must persist for a subsequent GET.
+	rr2 := httptest.NewRecorder()
+	h.GetPreferences(rr2, withUser(httptest.NewRequest(http.MethodGet, "/", nil), 7))
+	var stored Prefs
+	if err := json.Unmarshal(rr2.Body.Bytes(), &stored); err != nil {
+		t.Fatalf("decode stored: %v", err)
+	}
+	if stored != want {
+		t.Errorf("stored prefs = %+v, want %+v", stored, want)
+	}
+}
+
+func TestUpdatePreferencesInvalidBody(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (7, 'alice', '', 'user')")
+	h := NewHandler(database, nil, nil)
+
+	rr := httptest.NewRecorder()
+	req := withUser(httptest.NewRequest(http.MethodPut, "/", strings.NewReader("not json")), 7)
+	h.UpdatePreferences(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}

--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -1,0 +1,143 @@
+package push
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// Notifier turns request events into push notifications via the gateway. It
+// implements request.Notifier. Sends are fire-and-forget so a slow or failing
+// gateway never blocks an approval/denial.
+type Notifier struct {
+	db     *sql.DB
+	client *Client
+	logger *slog.Logger
+}
+
+// NewNotifier builds a push notifier. A nil client makes every method a no-op,
+// so callers can wire it unconditionally and gate on configuration elsewhere.
+func NewNotifier(db *sql.DB, client *Client, logger *slog.Logger) *Notifier {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Notifier{db: db, client: client, logger: logger}
+}
+
+// NotifyUser pushes the outcome of a request decision to the requesting user.
+// Only "request_decision" events produce a notification.
+func (n *Notifier) NotifyUser(userID int64, eventType string, data map[string]interface{}) {
+	if n == nil || n.client == nil || eventType != "request_decision" {
+		return
+	}
+
+	title, body := decisionMessage(data)
+	if title == "" {
+		return
+	}
+
+	n.send([]int64{userID}, title, body, passthrough("request_decision", data))
+}
+
+// NotifyAdmins pushes a new pending request to every admin. Only
+// "request_pending" events produce a notification.
+func (n *Notifier) NotifyAdmins(eventType string, data map[string]interface{}) {
+	if n == nil || n.client == nil || eventType != "request_pending" {
+		return
+	}
+
+	title := str(data["title"])
+	if title == "" {
+		title = "a title"
+	}
+
+	adminIDs, err := n.adminIDs()
+	if err != nil {
+		n.logger.Error("push: resolve admin ids", "err", err)
+		return
+	}
+	if len(adminIDs) == 0 {
+		return
+	}
+
+	n.send(adminIDs, "New request", title, passthrough("request_pending", data))
+}
+
+// send dispatches a notification in the background with panic recovery, so a
+// failed delivery (or a marshalling bug) can never take down the caller.
+func (n *Notifier) send(userIDs []int64, title, body string, data map[string]any) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				n.logger.Error("push: send panicked", "err", fmt.Sprint(r))
+			}
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := n.client.Send(ctx, userIDs, title, body, data); err != nil {
+			n.logger.Error("push: send notification", "err", err, "title", title)
+		}
+	}()
+}
+
+// adminIDs returns the ids of all admin users.
+func (n *Notifier) adminIDs() ([]int64, error) {
+	rows, err := n.db.Query("SELECT id FROM users WHERE role = 'admin'")
+	if err != nil {
+		return nil, fmt.Errorf("query admin ids: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan admin id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// decisionMessage derives the alert title/body from a request_decision payload.
+// An unrecognized decision yields an empty title so no notification is sent.
+func decisionMessage(data map[string]interface{}) (title, body string) {
+	mediaTitle := str(data["title"])
+	if mediaTitle == "" {
+		mediaTitle = "Your request"
+	}
+	switch str(data["decision"]) {
+	case "approved":
+		return "Request approved", mediaTitle + " is on the way"
+	case "denied":
+		body = mediaTitle + " was denied"
+		if reason := str(data["reason"]); reason != "" {
+			body += ": " + reason
+		}
+		return "Request denied", body
+	default:
+		return "", ""
+	}
+}
+
+// passthrough copies the event fields the client uses to route a notification
+// tap (type + media identity) into the APNs custom-data payload.
+func passthrough(eventType string, data map[string]interface{}) map[string]any {
+	out := map[string]any{"type": eventType}
+	if v, ok := data["tmdb_id"]; ok {
+		out["tmdb_id"] = v
+	}
+	if v := str(data["media_type"]); v != "" {
+		out["media_type"] = v
+	}
+	return out
+}
+
+// str reads a string value from a map[string]interface{}, returning "" when the
+// key is absent or not a string.
+func str(v interface{}) string {
+	s, _ := v.(string)
+	return s
+}

--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -10,10 +10,11 @@ import (
 
 // Notifier turns request events into push notifications via the gateway. It
 // implements request.Notifier. Sends are fire-and-forget so a slow or failing
-// gateway never blocks an approval/denial.
+// gateway never blocks an approval/denial. Every notification is filtered by
+// the recipient's per-category preferences before dispatch.
 type Notifier struct {
-	db     *sql.DB
 	client *Client
+	prefs  *PrefsStore
 	logger *slog.Logger
 }
 
@@ -23,13 +24,17 @@ func NewNotifier(db *sql.DB, client *Client, logger *slog.Logger) *Notifier {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Notifier{db: db, client: client, logger: logger}
+	return &Notifier{client: client, prefs: NewPrefsStore(db), logger: logger}
 }
 
 // NotifyUser pushes the outcome of a request decision to the requesting user.
-// Only "request_decision" events produce a notification.
+// Only "request_decision" events produce a notification, and only when the
+// requester has opted into that category (off by default).
 func (n *Notifier) NotifyUser(userID int64, eventType string, data map[string]interface{}) {
-	if n == nil || n.client == nil || eventType != "request_decision" {
+	if n == nil || n.client == nil || eventType != CategoryRequestDecision {
+		return
+	}
+	if !n.prefs.optedIn(userID, CategoryRequestDecision) {
 		return
 	}
 
@@ -38,13 +43,14 @@ func (n *Notifier) NotifyUser(userID int64, eventType string, data map[string]in
 		return
 	}
 
-	n.send([]int64{userID}, title, body, passthrough("request_decision", data))
+	n.send([]int64{userID}, title, body, passthrough(CategoryRequestDecision, data))
 }
 
-// NotifyAdmins pushes a new pending request to every admin. Only
-// "request_pending" events produce a notification.
+// NotifyAdmins pushes a new pending request to every admin who has opted into
+// the request_pending category (on by default). Only "request_pending" events
+// produce a notification.
 func (n *Notifier) NotifyAdmins(eventType string, data map[string]interface{}) {
-	if n == nil || n.client == nil || eventType != "request_pending" {
+	if n == nil || n.client == nil || eventType != CategoryRequestPending {
 		return
 	}
 
@@ -53,21 +59,64 @@ func (n *Notifier) NotifyAdmins(eventType string, data map[string]interface{}) {
 		title = "a title"
 	}
 
-	adminIDs, err := n.adminIDs()
+	recipients, err := n.prefs.usersOptedInto(CategoryRequestPending)
 	if err != nil {
-		n.logger.Error("push: resolve admin ids", "err", err)
+		n.logger.Error("push: resolve request_pending recipients", "err", err)
 		return
 	}
-	if len(adminIDs) == 0 {
+	if len(recipients) == 0 {
 		return
 	}
 
-	n.send(adminIDs, "New request", title, passthrough("request_pending", data))
+	n.send(recipients, "New request", title, passthrough(CategoryRequestPending, data))
+}
+
+// NotifyNewMovie pushes a "movie became available" alert to every user opted
+// into the new_movie category (on by default). A collapse id keeps repeat
+// availability pings for the same movie from stacking on-device.
+func (n *Notifier) NotifyNewMovie(title string, tmdbID int) {
+	n.notifyNewContent(CategoryNewMovie, "movie", "New movie available", title+" is ready to watch", title, tmdbID)
+}
+
+// NotifyNewEpisode pushes a "new episode available" alert to every user opted
+// into the new_episode category (on by default).
+func (n *Notifier) NotifyNewEpisode(seriesTitle string, tmdbID int) {
+	n.notifyNewContent(CategoryNewEpisode, "tv", "New episode available", "New on "+seriesTitle, seriesTitle, tmdbID)
+}
+
+// notifyNewContent is the shared body for the new-content notifications: it
+// resolves the opted-in audience for the category and dispatches one collapsed
+// push carrying the media identity for tap routing.
+func (n *Notifier) notifyNewContent(category, mediaType, title, body, mediaTitle string, tmdbID int) {
+	if n == nil || n.client == nil || mediaTitle == "" {
+		return
+	}
+	recipients, err := n.prefs.usersOptedInto(category)
+	if err != nil {
+		n.logger.Error("push: resolve new-content recipients", "err", err, "category", category)
+		return
+	}
+	if len(recipients) == 0 {
+		return
+	}
+	data := map[string]any{
+		"type":       category,
+		"tmdb_id":    tmdbID,
+		"media_type": mediaType,
+	}
+	n.sendWithOptions(recipients, title, body, data, SendOptions{
+		CollapseID: fmt.Sprintf("%s:%d", category, tmdbID),
+	})
 }
 
 // send dispatches a notification in the background with panic recovery, so a
 // failed delivery (or a marshalling bug) can never take down the caller.
 func (n *Notifier) send(userIDs []int64, title, body string, data map[string]any) {
+	n.sendWithOptions(userIDs, title, body, data, SendOptions{})
+}
+
+// sendWithOptions is send with explicit gateway options (e.g. a collapse id).
+func (n *Notifier) sendWithOptions(userIDs []int64, title, body string, data map[string]any, opts SendOptions) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -76,29 +125,10 @@ func (n *Notifier) send(userIDs []int64, title, body string, data map[string]any
 		}()
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if err := n.client.Send(ctx, userIDs, title, body, data); err != nil {
+		if err := n.client.SendWithOptions(ctx, userIDs, title, body, data, opts); err != nil {
 			n.logger.Error("push: send notification", "err", err, "title", title)
 		}
 	}()
-}
-
-// adminIDs returns the ids of all admin users.
-func (n *Notifier) adminIDs() ([]int64, error) {
-	rows, err := n.db.Query("SELECT id FROM users WHERE role = 'admin'")
-	if err != nil {
-		return nil, fmt.Errorf("query admin ids: %w", err)
-	}
-	defer rows.Close()
-
-	var ids []int64
-	for rows.Next() {
-		var id int64
-		if err := rows.Scan(&id); err != nil {
-			return nil, fmt.Errorf("scan admin id: %w", err)
-		}
-		ids = append(ids, id)
-	}
-	return ids, rows.Err()
 }
 
 // decisionMessage derives the alert title/body from a request_decision payload.

--- a/server/internal/push/notifier_test.go
+++ b/server/internal/push/notifier_test.go
@@ -1,0 +1,175 @@
+package push
+
+import (
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/db"
+)
+
+// dbOpen opens an in-memory database with the full schema, registered for
+// cleanup. The schema includes the users table the admin query relies on.
+func dbOpen(t *testing.T) (*sql.DB, error) {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(func() { database.Close() })
+	return database, nil
+}
+
+// mustExec runs a statement, failing the test on error.
+func mustExec(t *testing.T, database *sql.DB, query string, args ...any) {
+	t.Helper()
+	if _, err := database.Exec(query, args...); err != nil {
+		t.Fatalf("exec %q: %v", query, err)
+	}
+}
+
+// notificationCapture records POST /v1/notifications bodies as they arrive,
+// signaling a channel so a test can wait out the fire-and-forget goroutine.
+type notificationCapture struct {
+	ch chan map[string]any
+}
+
+func newNotifierTestGateway(t *testing.T) (*Client, *notificationCapture) {
+	t.Helper()
+	cap := &notificationCapture{ch: make(chan map[string]any, 4)}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/notifications" {
+			raw, _ := io.ReadAll(r.Body)
+			body := map[string]any{}
+			_ = json.Unmarshal(raw, &body)
+			cap.ch <- body
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"sent":1,"failed":0}`)
+	}))
+	t.Cleanup(srv.Close)
+	return NewClient(srv.URL, "pgk_test"), cap
+}
+
+// waitForNotification returns the next captured notification body, failing if
+// none arrives in time.
+func (c *notificationCapture) waitForNotification(t *testing.T) map[string]any {
+	t.Helper()
+	select {
+	case body := <-c.ch:
+		return body
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for notification")
+		return nil
+	}
+}
+
+// userIDsOf extracts to.user_ids from a captured notification body.
+func userIDsOf(t *testing.T, body map[string]any) []string {
+	t.Helper()
+	to, _ := body["to"].(map[string]any)
+	raw, _ := to["user_ids"].([]any)
+	ids := make([]string, len(raw))
+	for i, v := range raw {
+		ids[i], _ = v.(string)
+	}
+	return ids
+}
+
+func TestNotifyUserRequestDecision(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+
+	client, cap := newNotifierTestGateway(t)
+	n := NewNotifier(database, client, nil)
+
+	n.NotifyUser(42, "request_decision", map[string]interface{}{
+		"decision":   "approved",
+		"tmdb_id":    603,
+		"media_type": "movie",
+		"title":      "The Matrix",
+		"status":     "requested",
+	})
+
+	body := cap.waitForNotification(t)
+
+	ids := userIDsOf(t, body)
+	if len(ids) != 1 || ids[0] != "42" {
+		t.Errorf("user_ids = %v, want [\"42\"]", ids)
+	}
+	notif, _ := body["notification"].(map[string]any)
+	if notif["title"] == "" || notif["title"] == nil {
+		t.Errorf("expected non-empty title, got %v", notif["title"])
+	}
+	data, _ := body["data"].(map[string]any)
+	if data["type"] != "request_decision" {
+		t.Errorf("data.type = %v, want request_decision", data["type"])
+	}
+}
+
+func TestNotifyUserIgnoresOtherEvents(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	client, cap := newNotifierTestGateway(t)
+	n := NewNotifier(database, client, nil)
+
+	n.NotifyUser(42, "request_status_changed", map[string]interface{}{"title": "X"})
+
+	select {
+	case <-cap.ch:
+		t.Fatal("unexpected notification for non-decision event")
+	case <-time.After(200 * time.Millisecond):
+		// expected: nothing sent
+	}
+}
+
+func TestNotifyAdminsResolvesAdminIDs(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Two admins and one regular user; only admins should be targeted.
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'admin1', '', 'admin')")
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (2, 'admin2', '', 'admin')")
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (3, 'bob', '', 'user')")
+
+	client, cap := newNotifierTestGateway(t)
+	n := NewNotifier(database, client, nil)
+
+	n.NotifyAdmins("request_pending", map[string]interface{}{
+		"tmdb_id":    603,
+		"media_type": "movie",
+		"title":      "The Matrix",
+	})
+
+	body := cap.waitForNotification(t)
+	ids := userIDsOf(t, body)
+	if len(ids) != 2 {
+		t.Fatalf("admin user_ids = %v, want 2 ids", ids)
+	}
+	want := map[string]bool{"1": true, "2": true}
+	for _, id := range ids {
+		if !want[id] {
+			t.Errorf("unexpected admin id %q in %v", id, ids)
+		}
+	}
+}
+
+func TestNotifierDisabledClientIsNoop(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// A nil client must make every call a harmless no-op (no panic).
+	n := NewNotifier(database, nil, nil)
+	n.NotifyUser(1, "request_decision", map[string]interface{}{"decision": "approved", "title": "X"})
+	n.NotifyAdmins("request_pending", map[string]interface{}{"title": "X"})
+}

--- a/server/internal/push/notifier_test.go
+++ b/server/internal/push/notifier_test.go
@@ -85,6 +85,10 @@ func TestNotifyUserRequestDecision(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
+	// request_decision is off by default, so the requester must opt in to be
+	// notified about their own decision.
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (42, 'req', '', 'user')")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, request_decision) VALUES (42, 1)")
 
 	client, cap := newNotifierTestGateway(t)
 	n := NewNotifier(database, client, nil)
@@ -113,6 +117,55 @@ func TestNotifyUserRequestDecision(t *testing.T) {
 	}
 }
 
+func TestNotifyUserRequestDecisionSuppressedByDefault(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// No prefs row: request_decision defaults to off, so nothing is sent.
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (42, 'req', '', 'user')")
+
+	client, cap := newNotifierTestGateway(t)
+	n := NewNotifier(database, client, nil)
+
+	n.NotifyUser(42, "request_decision", map[string]interface{}{
+		"decision": "approved",
+		"title":    "The Matrix",
+	})
+
+	select {
+	case <-cap.ch:
+		t.Fatal("unexpected notification: request_decision is off by default")
+	case <-time.After(200 * time.Millisecond):
+		// expected: suppressed
+	}
+}
+
+func TestNotifyUserRequestDecisionSuppressedWhenOff(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Explicitly opted out.
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (42, 'req', '', 'user')")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, request_decision) VALUES (42, 0)")
+
+	client, cap := newNotifierTestGateway(t)
+	n := NewNotifier(database, client, nil)
+
+	n.NotifyUser(42, "request_decision", map[string]interface{}{
+		"decision": "approved",
+		"title":    "The Matrix",
+	})
+
+	select {
+	case <-cap.ch:
+		t.Fatal("unexpected notification: request_decision pref is off")
+	case <-time.After(200 * time.Millisecond):
+		// expected: suppressed
+	}
+}
+
 func TestNotifyUserIgnoresOtherEvents(t *testing.T) {
 	database, err := dbOpen(t)
 	if err != nil {
@@ -136,7 +189,8 @@ func TestNotifyAdminsResolvesAdminIDs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	// Two admins and one regular user; only admins should be targeted.
+	// Two admins and one regular user, none with a prefs row. request_pending
+	// defaults on for admins, so both admins (and only admins) are targeted.
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'admin1', '', 'admin')")
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (2, 'admin2', '', 'admin')")
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (3, 'bob', '', 'user')")
@@ -163,6 +217,32 @@ func TestNotifyAdminsResolvesAdminIDs(t *testing.T) {
 	}
 }
 
+func TestNotifyAdminsHonorsOptOutAndRole(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// admin1 opts out of request_pending; admin2 keeps the default (on). A
+	// non-admin who opts in must still be excluded (request_pending is
+	// admin-only). Only admin2 should be targeted.
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'admin1', '', 'admin')")
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (2, 'admin2', '', 'admin')")
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (3, 'bob', '', 'user')")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, request_pending) VALUES (1, 0)")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, request_pending) VALUES (3, 1)")
+
+	client, cap := newNotifierTestGateway(t)
+	n := NewNotifier(database, client, nil)
+
+	n.NotifyAdmins("request_pending", map[string]interface{}{"title": "The Matrix"})
+
+	body := cap.waitForNotification(t)
+	ids := userIDsOf(t, body)
+	if len(ids) != 1 || ids[0] != "2" {
+		t.Errorf("request_pending recipients = %v, want [\"2\"]", ids)
+	}
+}
+
 func TestNotifierDisabledClientIsNoop(t *testing.T) {
 	database, err := dbOpen(t)
 	if err != nil {
@@ -172,4 +252,112 @@ func TestNotifierDisabledClientIsNoop(t *testing.T) {
 	n := NewNotifier(database, nil, nil)
 	n.NotifyUser(1, "request_decision", map[string]interface{}{"decision": "approved", "title": "X"})
 	n.NotifyAdmins("request_pending", map[string]interface{}{"title": "X"})
+	n.NotifyNewMovie("The Matrix", 603)
+	n.NotifyNewEpisode("Severance", 95396)
+}
+
+func TestNotifyNewMovieReachesOptedInUsers(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// alice keeps the default (new_movie on), bob opts out, carol opts in.
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'alice', '', 'user')")
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (2, 'bob', '', 'user')")
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (3, 'carol', '', 'user')")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, new_movie) VALUES (2, 0)")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, new_movie) VALUES (3, 1)")
+
+	client, cap := newNotifierTestGateway(t)
+	n := NewNotifier(database, client, nil)
+
+	n.NotifyNewMovie("The Matrix", 603)
+
+	body := cap.waitForNotification(t)
+	ids := userIDsOf(t, body)
+	got := map[string]bool{}
+	for _, id := range ids {
+		got[id] = true
+	}
+	if len(ids) != 2 || !got["1"] || !got["3"] {
+		t.Errorf("new_movie recipients = %v, want alice(1) and carol(3)", ids)
+	}
+	notif, _ := body["notification"].(map[string]any)
+	if notif["title"] != "New movie available" {
+		t.Errorf("title = %v, want \"New movie available\"", notif["title"])
+	}
+	if notif["body"] != "The Matrix is ready to watch" {
+		t.Errorf("body = %v, want \"The Matrix is ready to watch\"", notif["body"])
+	}
+	data, _ := body["data"].(map[string]any)
+	if data["type"] != "new_movie" || data["media_type"] != "movie" {
+		t.Errorf("data = %v, want type/media_type new_movie/movie", data)
+	}
+	// tmdb_id arrives as a JSON number.
+	if num, ok := data["tmdb_id"].(float64); !ok || int(num) != 603 {
+		t.Errorf("data.tmdb_id = %v, want 603", data["tmdb_id"])
+	}
+	opts, _ := body["options"].(map[string]any)
+	if opts["collapse_id"] != "new_movie:603" {
+		t.Errorf("collapse_id = %v, want new_movie:603", opts["collapse_id"])
+	}
+}
+
+func TestNotifyNewEpisodeReachesOptedInUsers(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// Default (no row) means new_episode on for a regular user.
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'alice', '', 'user')")
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (2, 'bob', '', 'user')")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, new_episode) VALUES (2, 0)")
+
+	client, cap := newNotifierTestGateway(t)
+	n := NewNotifier(database, client, nil)
+
+	n.NotifyNewEpisode("Severance", 95396)
+
+	body := cap.waitForNotification(t)
+	ids := userIDsOf(t, body)
+	if len(ids) != 1 || ids[0] != "1" {
+		t.Errorf("new_episode recipients = %v, want [\"1\"]", ids)
+	}
+	notif, _ := body["notification"].(map[string]any)
+	if notif["title"] != "New episode available" {
+		t.Errorf("title = %v, want \"New episode available\"", notif["title"])
+	}
+	if notif["body"] != "New on Severance" {
+		t.Errorf("body = %v, want \"New on Severance\"", notif["body"])
+	}
+	data, _ := body["data"].(map[string]any)
+	if data["type"] != "new_episode" || data["media_type"] != "tv" {
+		t.Errorf("data = %v, want type/media_type new_episode/tv", data)
+	}
+	opts, _ := body["options"].(map[string]any)
+	if opts["collapse_id"] != "new_episode:95396" {
+		t.Errorf("collapse_id = %v, want new_episode:95396", opts["collapse_id"])
+	}
+}
+
+func TestNotifyNewContentNoRecipientsIsNoop(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// The only user has opted out, so no push is sent.
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'alice', '', 'user')")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, new_movie) VALUES (1, 0)")
+
+	client, cap := newNotifierTestGateway(t)
+	n := NewNotifier(database, client, nil)
+
+	n.NotifyNewMovie("The Matrix", 603)
+
+	select {
+	case <-cap.ch:
+		t.Fatal("unexpected notification: no users opted into new_movie")
+	case <-time.After(200 * time.Millisecond):
+		// expected: nothing sent
+	}
 }

--- a/server/internal/push/prefs.go
+++ b/server/internal/push/prefs.go
@@ -1,0 +1,160 @@
+package push
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// Prefs is a user's per-category push notification preferences. Each field
+// gates one notification category; see the category constants below.
+type Prefs struct {
+	RequestDecision bool `json:"request_decision"`
+	RequestPending  bool `json:"request_pending"`
+	NewMovie        bool `json:"new_movie"`
+	NewEpisode      bool `json:"new_episode"`
+}
+
+// Notification categories. These are the wire values used by the preferences
+// API and the column names in notification_prefs.
+const (
+	CategoryRequestDecision = "request_decision"
+	CategoryRequestPending  = "request_pending"
+	CategoryNewMovie        = "new_movie"
+	CategoryNewEpisode      = "new_episode"
+)
+
+// defaultPrefs is the preference set applied when a user has no row. It must
+// match the notification_prefs column defaults and the documented API
+// defaults: request_decision off, everything else on.
+var defaultPrefs = Prefs{
+	RequestDecision: false,
+	RequestPending:  true,
+	NewMovie:        true,
+	NewEpisode:      true,
+}
+
+// categoryColumn maps a category to its notification_prefs column and the
+// default applied when a user has no row. Centralizing this keeps the store's
+// SQL and the defaults in one place.
+var categoryColumn = map[string]struct {
+	column     string
+	defaultVal bool
+}{
+	CategoryRequestDecision: {"request_decision", defaultPrefs.RequestDecision},
+	CategoryRequestPending:  {"request_pending", defaultPrefs.RequestPending},
+	CategoryNewMovie:        {"new_movie", defaultPrefs.NewMovie},
+	CategoryNewEpisode:      {"new_episode", defaultPrefs.NewEpisode},
+}
+
+// PrefsStore reads and writes per-user notification preferences. It is safe to
+// build with any *sql.DB carrying the notification_prefs table.
+type PrefsStore struct {
+	db *sql.DB
+}
+
+// NewPrefsStore builds a preferences store over the given database.
+func NewPrefsStore(db *sql.DB) *PrefsStore {
+	return &PrefsStore{db: db}
+}
+
+// Get returns a user's preferences, applying the defaults for any user without
+// a row.
+func (s *PrefsStore) Get(userID int64) (Prefs, error) {
+	p := defaultPrefs
+	err := s.db.QueryRow(
+		`SELECT request_decision, request_pending, new_movie, new_episode
+		 FROM notification_prefs WHERE user_id = ?`,
+		userID,
+	).Scan(&p.RequestDecision, &p.RequestPending, &p.NewMovie, &p.NewEpisode)
+	if err == sql.ErrNoRows {
+		return defaultPrefs, nil
+	}
+	if err != nil {
+		return Prefs{}, fmt.Errorf("query notification prefs: %w", err)
+	}
+	return p, nil
+}
+
+// Set upserts a user's preferences.
+func (s *PrefsStore) Set(userID int64, p Prefs) error {
+	_, err := s.db.Exec(
+		`INSERT INTO notification_prefs
+		   (user_id, request_decision, request_pending, new_movie, new_episode)
+		 VALUES (?, ?, ?, ?, ?)
+		 ON CONFLICT(user_id) DO UPDATE SET
+		   request_decision = excluded.request_decision,
+		   request_pending  = excluded.request_pending,
+		   new_movie        = excluded.new_movie,
+		   new_episode      = excluded.new_episode`,
+		userID, p.RequestDecision, p.RequestPending, p.NewMovie, p.NewEpisode,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert notification prefs: %w", err)
+	}
+	return nil
+}
+
+// usersOptedInto returns the ids of every user opted into a category, applying
+// the category default for users without a row (LEFT JOIN + COALESCE). The
+// request_pending category is additionally limited to admins, since only
+// admins act on pending requests.
+func (s *PrefsStore) usersOptedInto(category string) ([]int64, error) {
+	col, ok := categoryColumn[category]
+	if !ok {
+		return nil, fmt.Errorf("unknown notification category %q", category)
+	}
+	def := 0
+	if col.defaultVal {
+		def = 1
+	}
+	// Column names come from the trusted categoryColumn table, never user input.
+	query := fmt.Sprintf(
+		`SELECT u.id FROM users u
+		 LEFT JOIN notification_prefs p ON p.user_id = u.id
+		 WHERE COALESCE(p.%s, %d) = 1`,
+		col.column, def,
+	)
+	if category == CategoryRequestPending {
+		query += " AND u.role = 'admin'"
+	}
+
+	rows, err := s.db.Query(query)
+	if err != nil {
+		return nil, fmt.Errorf("query opted-in users: %w", err)
+	}
+	defer rows.Close()
+
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan opted-in user id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// optedIn reports whether a single user is opted into a category, applying the
+// category default when the user has no row. Errors (and unknown categories)
+// fail closed by returning false.
+func (s *PrefsStore) optedIn(userID int64, category string) bool {
+	col, ok := categoryColumn[category]
+	if !ok {
+		return false
+	}
+	def := 0
+	if col.defaultVal {
+		def = 1
+	}
+	var enabled int
+	query := fmt.Sprintf(
+		`SELECT COALESCE(
+		   (SELECT %s FROM notification_prefs WHERE user_id = ?), %d)`,
+		col.column, def,
+	)
+	if err := s.db.QueryRow(query, userID).Scan(&enabled); err != nil {
+		return false
+	}
+	return enabled == 1
+}

--- a/server/internal/push/prefs_test.go
+++ b/server/internal/push/prefs_test.go
@@ -1,0 +1,158 @@
+package push
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestPrefsGetDefaultsForMissingRow(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'alice', '', 'user')")
+
+	store := NewPrefsStore(database)
+	got, err := store.Get(1)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true}
+	if got != want {
+		t.Errorf("default prefs = %+v, want %+v", got, want)
+	}
+}
+
+func TestPrefsSetThenGet(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'alice', '', 'user')")
+
+	store := NewPrefsStore(database)
+	want := Prefs{RequestDecision: true, RequestPending: false, NewMovie: false, NewEpisode: true}
+	if err := store.Set(1, want); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := store.Get(1)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != want {
+		t.Errorf("after Set, prefs = %+v, want %+v", got, want)
+	}
+
+	// Set is an upsert: a second call replaces the row.
+	want2 := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: false}
+	if err := store.Set(1, want2); err != nil {
+		t.Fatalf("Set (upsert): %v", err)
+	}
+	got2, err := store.Get(1)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got2 != want2 {
+		t.Errorf("after upsert, prefs = %+v, want %+v", got2, want2)
+	}
+}
+
+func TestUsersOptedIntoDefaultBehavior(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// alice: no row (defaults). bob: opts out of new_movie. An admin with no
+	// row is opted into request_pending by default; a regular user never is.
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'alice', '', 'user')")
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (2, 'bob', '', 'user')")
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (3, 'admin', '', 'admin')")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, new_movie) VALUES (2, 0)")
+
+	store := NewPrefsStore(database)
+
+	// new_movie on by default => alice + admin included, bob excluded.
+	got, err := store.usersOptedInto(CategoryNewMovie)
+	if err != nil {
+		t.Fatalf("usersOptedInto(new_movie): %v", err)
+	}
+	if !equalIDs(got, []int64{1, 3}) {
+		t.Errorf("new_movie opted-in = %v, want [1 3]", got)
+	}
+
+	// new_episode on by default and untouched => everyone included.
+	got, err = store.usersOptedInto(CategoryNewEpisode)
+	if err != nil {
+		t.Fatalf("usersOptedInto(new_episode): %v", err)
+	}
+	if !equalIDs(got, []int64{1, 2, 3}) {
+		t.Errorf("new_episode opted-in = %v, want [1 2 3]", got)
+	}
+
+	// request_pending: admin-only, on by default => just the admin.
+	got, err = store.usersOptedInto(CategoryRequestPending)
+	if err != nil {
+		t.Fatalf("usersOptedInto(request_pending): %v", err)
+	}
+	if !equalIDs(got, []int64{3}) {
+		t.Errorf("request_pending opted-in = %v, want [3]", got)
+	}
+
+	// request_decision: off by default => nobody without an explicit opt-in.
+	got, err = store.usersOptedInto(CategoryRequestDecision)
+	if err != nil {
+		t.Fatalf("usersOptedInto(request_decision): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("request_decision opted-in = %v, want none", got)
+	}
+}
+
+func TestOptedInSingleUser(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'alice', '', 'user')")
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (2, 'bob', '', 'user')")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, request_decision) VALUES (1, 1)")
+
+	store := NewPrefsStore(database)
+
+	if !store.optedIn(1, CategoryRequestDecision) {
+		t.Error("alice opted into request_decision, want true")
+	}
+	// bob has no row: request_decision defaults off.
+	if store.optedIn(2, CategoryRequestDecision) {
+		t.Error("bob has no row, request_decision defaults off, want false")
+	}
+	// new_movie is on by default for a user without a row.
+	if !store.optedIn(2, CategoryNewMovie) {
+		t.Error("bob has no row, new_movie defaults on, want true")
+	}
+	// Unknown category fails closed.
+	if store.optedIn(1, "bogus") {
+		t.Error("unknown category should be false")
+	}
+}
+
+func TestUsersOptedIntoUnknownCategory(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	store := NewPrefsStore(database)
+	if _, err := store.usersOptedInto("bogus"); err == nil {
+		t.Error("expected error for unknown category")
+	}
+}
+
+// equalIDs compares two id slices order-independently.
+func equalIDs(got, want []int64) bool {
+	g := append([]int64(nil), got...)
+	w := append([]int64(nil), want...)
+	sort.Slice(g, func(i, j int) bool { return g[i] < g[j] })
+	sort.Slice(w, func(i, j int) bool { return w[i] < w[j] })
+	return reflect.DeepEqual(g, w)
+}

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -38,6 +38,14 @@ type Event struct {
 	Data map[string]interface{} `json:"data"`
 }
 
+// ContentNotifier pushes new-content alerts to opted-in users. *push.Notifier
+// satisfies it. Declared here (rather than importing push) so the hub stays
+// decoupled from the push package and easy to test with a fake.
+type ContentNotifier interface {
+	NotifyNewMovie(title string, tmdbID int)
+	NotifyNewEpisode(seriesTitle string, tmdbID int)
+}
+
 // Client represents a connected WebSocket client.
 type Client struct {
 	hub     *Hub
@@ -60,6 +68,10 @@ type Hub struct {
 	registry    *instance.Registry
 	store       *instance.Store
 
+	// content pushes new-movie/new-episode notifications to opted-in users
+	// when a download completes. nil when push is not configured.
+	content ContentNotifier
+
 	// Previous polling state for detecting transitions
 	prevRadarrQueue map[string]map[int]float64 // instanceID -> movieId -> progress
 	prevSonarrQueue map[string]map[int]float64 // instanceID -> seriesId -> progress
@@ -81,8 +93,9 @@ type Hub struct {
 	pollMu sync.Mutex
 }
 
-// NewHub creates a new WebSocket hub.
-func NewHub(authService *auth.Service, registry *instance.Registry, store *instance.Store) *Hub {
+// NewHub creates a new WebSocket hub. content pushes new-content alerts when a
+// download completes; pass nil (or a nil *push.Notifier) when push is disabled.
+func NewHub(authService *auth.Service, registry *instance.Registry, store *instance.Store, content ContentNotifier) *Hub {
 	return &Hub{
 		clients:            make(map[*Client]bool),
 		broadcast:          make(chan outboundMessage, 256),
@@ -91,6 +104,7 @@ func NewHub(authService *auth.Service, registry *instance.Registry, store *insta
 		authService:        authService,
 		registry:           registry,
 		store:              store,
+		content:            content,
 		prevRadarrQueue:    make(map[string]map[int]float64),
 		prevSonarrQueue:    make(map[string]map[int]float64),
 		prevArrQueueHash:   make(map[string]string),
@@ -480,6 +494,9 @@ func (h *Hub) pollRadarrInstance(instanceID string, client *radarr.Client) {
 							"instance_id": instanceID,
 						},
 					})
+					if h.content != nil {
+						h.content.NotifyNewMovie(movie.Title, movie.TmdbID)
+					}
 				}
 			}
 		}
@@ -547,6 +564,9 @@ func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
 						"instance_id": instanceID,
 					},
 				})
+				if h.content != nil {
+					h.content.NotifyNewEpisode(series.Title, series.TmdbID)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
Wires Cantinarr to receive push notifications from the self-hosted push gateway (https://push.julian.codes), so users are reached when the app/WebSocket is closed.

## Server (Go)
- New `push_tokens` table; new `internal/push` package: gateway HTTP client (`/v1` API, per-app Bearer key), a `request.Notifier` implementation, a composite fan-out (WebSocket hub + push gateway), and the JWT-authed `/api/devices/push-token` POST/DELETE handler (device-ownership checked).
- Request decisions now fan out to BOTH live clients (WebSocket) and offline devices (push): `request_decision` → requesting user, `request_pending` → admins.
- New config `CANTINARR_PUSH_GATEWAY_URL` / `CANTINARR_PUSH_API_KEY` (push disabled when unset). Sends are fire-and-forget and nil-safe.

## Flutter (iOS)
- `AppDelegate` registers for APNs and bridges the device token to Dart via a `MethodChannel` (no Firebase — pure platform channel). New `PushService` registers on login / clears on logout, hooked into all auth entry points.
- `Runner.entitlements` (`aps-environment=production`) wired across Debug/Release/Profile + `UIBackgroundModes` remote-notification.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` (incl. mock-gateway unit tests for the client + notifier), `gofmt` — all clean.
- `flutter analyze` — clean for the new code (no new issues).

## Deploy / test (TestFlight)
1. Set `CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes` and `CANTINARR_PUSH_API_KEY=<the Cantinarr app key>` on the server, run this branch.
2. Build for TestFlight (production APNs); confirm the Push Notifications capability + signing in Xcode.
3. Submit/approve/deny a request → push delivered. Gateway is on `APNS_ENV=production` to match the TestFlight token environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)