### PR TITLE
chore(compose): wire push-gateway env into docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to `.env` (next to docker-compose.yml) and fill in the values.
+# Docker Compose auto-loads `.env` and injects these into the cantinarr container.
+# `.env` is gitignored — never commit real secrets.
+
+# Per-app key for the self-hosted push gateway (push.julian.codes), issued by the
+# gateway's admin API. Required to ENABLE push notifications; without it the
+# server logs "Push notifications disabled" and no pushes are sent.
+# Rotate anytime via the gateway: POST /v1/apps/cantinarr/rotate-key.
+CANTINARR_PUSH_API_KEY=
+
+# Optional: override the gateway URL (defaults to https://push.julian.codes in
+# docker-compose.yml). Only set this if you self-host the gateway elsewhere.
+# CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,12 @@ services:
       - "8585:8585"
     volumes:
       - ./config:/config
+    environment:
+      # Self-hosted push gateway (https://push.julian.codes). Push notifications
+      # are enabled only when BOTH the URL and the API key are set. The API key
+      # is a secret — put it in a .env file next to this compose file:
+      #     CANTINARR_PUSH_API_KEY=pgk_...
+      # .env is gitignored; see .env.example. Leave the key unset to disable push.
+      - CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
+      - CANTINARR_PUSH_API_KEY=${CANTINARR_PUSH_API_KEY:-}
     restart: unless-stopped


### PR DESCRIPTION
Enables push notifications on Docker deploys, which were silently disabled because the compose file never passed the push env vars (server logged `Push notifications disabled (CANTINARR_PUSH_GATEWAY_URL/CANTINARR_PUSH_API_KEY unset)`).

- `docker-compose.yml`: adds an `environment:` block — `CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes` (committed; not secret) and `CANTINARR_PUSH_API_KEY=${CANTINARR_PUSH_API_KEY:-}` (read from a gitignored `.env`, so the secret is never committed).
- `.env.example`: documents the key; copy to `.env` next to the compose file and set `CANTINARR_PUSH_API_KEY=pgk_…`.

Deploy: set the key in `.env`, `docker compose up -d`, then cold-launch the app once so the device token propagates to the gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)