### PR TITLE
feat(push): zero-config auto-enrollment with the push gateway

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,12 +2,17 @@
 # Docker Compose auto-loads `.env` and injects these into the cantinarr container.
 # `.env` is gitignored — never commit real secrets.
 
-# Per-app key for the self-hosted push gateway (push.julian.codes), issued by the
-# gateway's admin API. Required to ENABLE push notifications; without it the
-# server logs "Push notifications disabled" and no pushes are sent.
-# Rotate anytime via the gateway: POST /v1/apps/cantinarr/rotate-key.
+# Push is ENABLED by the gateway URL in docker-compose.yml (defaults to
+# https://push.julian.codes). You normally set NOTHING here: with no API key the
+# server auto-enrolls on first start and persists its own per-instance key in the
+# DB. These are optional overrides:
+
+# Pin a specific per-app key instead of auto-enrolling (rotate via the gateway:
+# POST /v1/apps/<tenant>/rotate-key). Leave blank to auto-enroll.
 CANTINARR_PUSH_API_KEY=
 
-# Optional: override the gateway URL (defaults to https://push.julian.codes in
-# docker-compose.yml). Only set this if you self-host the gateway elsewhere.
+# Only if the gateway uses gated enrollment — the shared enroll token.
+CANTINARR_PUSH_ENROLL_TOKEN=
+
+# Only if you self-host your own gateway elsewhere (overrides the compose default).
 # CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,13 @@ services:
     volumes:
       - ./config:/config
     environment:
-      # Self-hosted push gateway (https://push.julian.codes). Push notifications
-      # are enabled only when BOTH the URL and the API key are set. The API key
-      # is a secret — put it in a .env file next to this compose file:
-      #     CANTINARR_PUSH_API_KEY=pgk_...
-      # .env is gitignored; see .env.example. Leave the key unset to disable push.
+      # Self-hosted push gateway (https://push.julian.codes). Setting the URL
+      # ENABLES push: with no API key, the server auto-enrolls on first start and
+      # persists its own key in the DB (./config volume) — zero manual setup.
+      # Set CANTINARR_PUSH_API_KEY (in a gitignored .env) only to override; set
+      # CANTINARR_PUSH_ENROLL_TOKEN only if the gateway uses gated enrollment.
+      # Blank the URL to disable push entirely.
       - CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
       - CANTINARR_PUSH_API_KEY=${CANTINARR_PUSH_API_KEY:-}
+      - CANTINARR_PUSH_ENROLL_TOKEN=${CANTINARR_PUSH_ENROLL_TOKEN:-}
     restart: unless-stopped

--- a/server/.env.example
+++ b/server/.env.example
@@ -6,7 +6,12 @@ CANTINARR_PORT=8585
 CANTINARR_SERVER_NAME=Cantinarr
 CANTINARR_JWT_SECRET=
 
-# Push notifications (self-hosted push gateway). Both must be set to enable
-# push; leave either blank to disable. The per-app key is a secret.
+# Push notifications via the self-hosted push gateway.
+# Setting the gateway URL ENABLES push. The API key is OPTIONAL: leave it blank
+# and the server auto-enrolls with the gateway on first start, persisting the
+# issued key (encrypted, in the DB) — zero manual key handling. Set it only to
+# override with a specific key. CANTINARR_PUSH_ENROLL_TOKEN is needed only if the
+# gateway uses gated enrollment. Blank the URL to disable push entirely.
 CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
 CANTINARR_PUSH_API_KEY=
+CANTINARR_PUSH_ENROLL_TOKEN=

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -62,7 +62,7 @@ func main() {
 	if err := secrets.VerifyKeyIdentity(database, cipher); err != nil {
 		log.Fatalf("Encryption key check failed: %v", err)
 	}
-	secretSettings := append([]string{"jwt_secret"}, credentials.AllKeys...)
+	secretSettings := append([]string{"jwt_secret", "push_api_key"}, credentials.AllKeys...)
 	if n, err := secrets.EncryptExisting(database, cipher, secretSettings); err != nil {
 		log.Fatalf("Failed to encrypt existing secrets: %v", err)
 	} else if n > 0 {
@@ -111,11 +111,19 @@ func main() {
 	// still built (nil-safe) so wiring stays uniform. Built before the hub and
 	// request service so both can dispatch pushes.
 	var pushClient *push.Client
-	if cfg.PushGatewayURL != "" && cfg.PushAPIKey != "" {
-		pushClient = push.NewClient(cfg.PushGatewayURL, cfg.PushAPIKey)
-		log.Printf("Push notifications enabled via %s", cfg.PushGatewayURL)
+	if cfg.PushGatewayURL != "" {
+		// Resolve the gateway key: explicit env key, else a key auto-enrolled on a
+		// previous start, else self-enroll now. Failure is non-fatal — push stays
+		// off this run and is retried on the next start.
+		apiKey, err := ensurePushAPIKey(database, cipher, cfg)
+		if err != nil {
+			log.Printf("Push notifications disabled: %v", err)
+		} else {
+			pushClient = push.NewClient(cfg.PushGatewayURL, apiKey)
+			log.Printf("Push notifications enabled via %s", cfg.PushGatewayURL)
+		}
 	} else {
-		log.Println("Push notifications disabled (CANTINARR_PUSH_GATEWAY_URL/CANTINARR_PUSH_API_KEY unset)")
+		log.Println("Push notifications disabled (CANTINARR_PUSH_GATEWAY_URL unset)")
 	}
 	logger := slog.Default()
 	pushHandler := push.NewHandler(database, pushClient, logger)
@@ -200,4 +208,40 @@ func ensureJWTSecret(database *sql.DB, cipher *secrets.Cipher) (string, error) {
 
 	log.Println("Generated and persisted JWT secret")
 	return secret, nil
+}
+
+// ensurePushAPIKey resolves the push-gateway API key when a gateway URL is set:
+// an explicit CANTINARR_PUSH_API_KEY wins; otherwise a key auto-enrolled on a
+// previous start is loaded from the settings table; otherwise the server self-
+// enrolls with the gateway once and persists the issued key (encrypted at rest,
+// like the JWT secret). This gives self-hosters push with zero manual key
+// handling. To force re-enrollment, delete the 'push_api_key' settings row.
+func ensurePushAPIKey(database *sql.DB, cipher *secrets.Cipher, cfg *config.Config) (string, error) {
+	if cfg.PushAPIKey != "" {
+		return cfg.PushAPIKey, nil // explicit operator override; not persisted
+	}
+
+	var stored string
+	if err := database.QueryRow("SELECT value FROM settings WHERE key = 'push_api_key'").Scan(&stored); err == nil {
+		return cipher.Decrypt(stored)
+	}
+
+	// No key yet: self-enroll with the gateway and persist the issued key.
+	name := cfg.ServerName
+	if name == "" {
+		name = "Cantinarr"
+	}
+	res, err := push.Enroll(cfg.PushGatewayURL, name, cfg.PushEnrollToken)
+	if err != nil {
+		return "", fmt.Errorf("auto-enroll with push gateway: %w", err)
+	}
+	enc, err := cipher.Encrypt(res.APIKey)
+	if err != nil {
+		return "", fmt.Errorf("encrypt push key: %w", err)
+	}
+	if _, err := database.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('push_api_key', ?)", enc); err != nil {
+		return "", fmt.Errorf("persist push key: %w", err)
+	}
+	log.Printf("Auto-enrolled with push gateway %s (tenant %s); key persisted", cfg.PushGatewayURL, res.TenantID)
+	return res.APIKey, nil
 }

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -28,10 +28,15 @@ type Config struct {
 	// AndroidPackageName and AndroidCertFingerprints are served in assetlinks.json.
 	AndroidPackageName      string
 	AndroidCertFingerprints []string
-	// PushGatewayURL and PushAPIKey configure the self-hosted push gateway. When
-	// either is empty, push notifications are disabled.
-	PushGatewayURL string
-	PushAPIKey     string
+	// PushGatewayURL enables the self-hosted push gateway when set (empty =
+	// disabled). PushAPIKey is an explicit per-app key and is optional: if it is
+	// empty while the gateway URL is set, the server auto-enrolls with the gateway
+	// on first start and persists the issued key (see ensurePushAPIKey). An
+	// explicit key always wins. PushEnrollToken is sent as X-Enroll-Token during
+	// auto-enroll, needed only when the gateway uses gated enrollment.
+	PushGatewayURL  string
+	PushAPIKey      string
+	PushEnrollToken string
 }
 
 func Load() (*Config, error) {
@@ -52,6 +57,7 @@ func Load() (*Config, error) {
 		AndroidPackageName: os.Getenv("CANTINARR_ANDROID_PACKAGE_NAME"),
 		PushGatewayURL:     strings.TrimRight(os.Getenv("CANTINARR_PUSH_GATEWAY_URL"), "/"),
 		PushAPIKey:         os.Getenv("CANTINARR_PUSH_API_KEY"),
+		PushEnrollToken:    os.Getenv("CANTINARR_PUSH_ENROLL_TOKEN"),
 	}
 
 	if cfg.ServerName == "" {

--- a/server/internal/push/client.go
+++ b/server/internal/push/client.go
@@ -36,6 +36,51 @@ func NewClient(baseURL, apiKey string) *Client {
 	}
 }
 
+// EnrollResponse is the gateway's reply to POST /v1/enroll.
+type EnrollResponse struct {
+	TenantID string `json:"tenant_id"`
+	APIKey   string `json:"api_key"`
+}
+
+// Enroll self-registers a new tenant with the gateway and returns its tenant id
+// and per-app API key. It uses no bearer auth (enrollment is unauthenticated);
+// when the gateway runs in gated mode, pass the shared enrollToken (sent as the
+// X-Enroll-Token header). Used for zero-config auto-enrollment on first start.
+func Enroll(baseURL, name, enrollToken string) (EnrollResponse, error) {
+	var out EnrollResponse
+	body, err := json.Marshal(map[string]string{"name": name})
+	if err != nil {
+		return out, fmt.Errorf("marshal enroll body: %w", err)
+	}
+	url := strings.TrimRight(baseURL, "/") + "/v1/enroll"
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return out, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if enrollToken != "" {
+		req.Header.Set("X-Enroll-Token", enrollToken)
+	}
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return out, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return out, fmt.Errorf("enroll: gateway returned status %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return out, fmt.Errorf("decode enroll response: %w", err)
+	}
+	if out.APIKey == "" {
+		return out, fmt.Errorf("enroll: gateway returned an empty api_key")
+	}
+	return out, nil
+}
+
 // RegisterDevice upserts a device token with the gateway. The gateway defaults
 // the APNs topic from the tenant, so no topic is sent.
 func (c *Client) RegisterDevice(ctx context.Context, userID int64, deviceID, platform, token string) error {

--- a/server/internal/push/enroll_test.go
+++ b/server/internal/push/enroll_test.go
@@ -1,0 +1,67 @@
+package push
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestEnroll_Success(t *testing.T) {
+	var gotToken, gotPath, gotMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotMethod = r.URL.Path, r.Method
+		gotToken = r.Header.Get("X-Enroll-Token")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tenant_id":"t-abc","api_key":"pgk_xyz"}`))
+	}))
+	defer srv.Close()
+
+	res, err := Enroll(srv.URL, "My Instance", "secret-tok")
+	if err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if res.APIKey != "pgk_xyz" || res.TenantID != "t-abc" {
+		t.Fatalf("unexpected response: %#v", res)
+	}
+	if gotPath != "/v1/enroll" || gotMethod != http.MethodPost {
+		t.Fatalf("hit %s %s, want POST /v1/enroll", gotMethod, gotPath)
+	}
+	if gotToken != "secret-tok" {
+		t.Fatalf("X-Enroll-Token = %q, want secret-tok", gotToken)
+	}
+}
+
+func TestEnroll_NoTokenHeaderWhenEmpty(t *testing.T) {
+	hadHeader := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadHeader = r.Header["X-Enroll-Token"]
+		_, _ = w.Write([]byte(`{"tenant_id":"t","api_key":"pgk_1"}`))
+	}))
+	defer srv.Close()
+	if _, err := Enroll(srv.URL, "x", ""); err != nil {
+		t.Fatalf("Enroll: %v", err)
+	}
+	if hadHeader {
+		t.Fatal("X-Enroll-Token should be absent when enrollToken is empty")
+	}
+}
+
+func TestEnroll_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"code":"enrollment_closed"}}`, http.StatusForbidden)
+	}))
+	defer srv.Close()
+	if _, err := Enroll(srv.URL, "x", ""); err == nil {
+		t.Fatal("expected error on 403, got nil")
+	}
+}
+
+func TestEnroll_EmptyKeyRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tenant_id":"t-1","api_key":""}`))
+	}))
+	defer srv.Close()
+	if _, err := Enroll(srv.URL, "x", ""); err == nil {
+		t.Fatal("expected error on empty api_key")
+	}
+}


### PR DESCRIPTION
Self-hosters now get push with **zero manual key handling**. With the gateway URL set (the compose default) and no API key, the server auto-enrolls on first start (`POST /v1/enroll`), persists the issued per-instance key encrypted at rest (same pattern as the JWT secret), and reuses it on later starts.

- `push.Enroll` (unit-tested) + `ensurePushAPIKey` (env key > stored key > self-enroll); failure is non-fatal.
- New optional `CANTINARR_PUSH_ENROLL_TOKEN` for gated gateways; `push_api_key` added to the secrets-migration set.
- `docker-compose.yml` / `.env.example`: a blank key now means *auto-enroll*, not *disabled*.
- Verified: `go build/vet/test` + gofmt clean; 4 new Enroll tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)