### PR TITLE
feat(push): runtime resilience, prune-learning, status UI + test button

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -53,8 +53,54 @@ import UserNotifications
     case "getApnsToken":
       // Returns the cached token (or nil if not yet registered).
       result(apnsToken)
+    case "getAuthorizationStatus":
+      fetchAuthorizationStatus { status in result(status) }
+    case "openNotificationSettings":
+      openNotificationSettings { opened in result(opened) }
     default:
       result(FlutterMethodNotImplemented)
+    }
+  }
+
+  /// Reports the current notification authorization status as a string the
+  /// Dart side can interpret: `authorized`, `denied`, `notDetermined`,
+  /// `provisional`, or `ephemeral`.
+  private func fetchAuthorizationStatus(completion: @escaping (String) -> Void) {
+    UNUserNotificationCenter.current().getNotificationSettings { settings in
+      let status: String
+      switch settings.authorizationStatus {
+      case .authorized:
+        status = "authorized"
+      case .denied:
+        status = "denied"
+      case .notDetermined:
+        status = "notDetermined"
+      case .provisional:
+        status = "provisional"
+      case .ephemeral:
+        status = "ephemeral"
+      @unknown default:
+        status = "notDetermined"
+      }
+      completion(status)
+    }
+  }
+
+  /// Opens this app's page in the system Settings so the user can toggle
+  /// notification permissions. `completion` reports whether the URL opened.
+  private func openNotificationSettings(completion: @escaping (Bool) -> Void) {
+    guard let url = URL(string: UIApplication.openSettingsURLString) else {
+      completion(false)
+      return
+    }
+    DispatchQueue.main.async {
+      if UIApplication.shared.canOpenURL(url) {
+        UIApplication.shared.open(url, options: [:]) { success in
+          completion(success)
+        }
+      } else {
+        completion(false)
+      }
     }
   }
 

--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -67,6 +67,44 @@ class PushService {
     }
   }
 
+  /// Returns the current notification authorization status as reported by the
+  /// OS: one of `authorized`, `denied`, `notDetermined`, `provisional`, or
+  /// `ephemeral`. Off-iOS (or on any failure) reports `notDetermined`.
+  Future<String> authorizationStatus() async {
+    if (!_isSupported) return 'notDetermined';
+    try {
+      return await _channel.invokeMethod<String>('getAuthorizationStatus') ??
+          'notDetermined';
+    } catch (e) {
+      debugPrint('Push: authorizationStatus failed: $e');
+      return 'notDetermined';
+    }
+  }
+
+  /// Opens this app's page in the system Settings so the user can change
+  /// notification permissions. A no-op on unsupported platforms.
+  Future<void> openSystemSettings() async {
+    if (!_isSupported) return;
+    try {
+      await _channel.invokeMethod<bool>('openNotificationSettings');
+    } catch (e) {
+      debugPrint('Push: openSystemSettings failed: $e');
+    }
+  }
+
+  /// Asks the backend to send a test push notification to this account's
+  /// registered devices. Returns how many were delivered or failed. Throws on
+  /// any error (including a 503 when push isn't configured) so the caller can
+  /// surface the failure.
+  Future<({int sent, int failed})> sendTest() async {
+    final dio = _ref.read(backendClientProvider);
+    final resp = await dio.post('/api/notifications/test');
+    final data = resp.data as Map<String, dynamic>? ?? const {};
+    final sent = (data['sent'] as num?)?.toInt() ?? 0;
+    final failed = (data['failed'] as num?)?.toInt() ?? 0;
+    return (sent: sent, failed: failed);
+  }
+
   /// Removes this device's push token from the backend. Best-effort; call
   /// before clearing auth state on logout.
   Future<void> unregister() async {

--- a/app/lib/features/notifications/ui/notification_preferences_screen.dart
+++ b/app/lib/features/notifications/ui/notification_preferences_screen.dart
@@ -1,9 +1,13 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../notification_prefs.dart';
 import '../notification_prefs_service.dart';
+import '../push_service.dart';
 
 /// Lets the current user choose which push notifications they receive. Loads
 /// the saved preferences on open and persists each toggle immediately,
@@ -17,20 +21,53 @@ class NotificationPreferencesScreen extends ConsumerStatefulWidget {
 }
 
 class _NotificationPreferencesScreenState
-    extends ConsumerState<NotificationPreferencesScreen> {
+    extends ConsumerState<NotificationPreferencesScreen>
+    with WidgetsBindingObserver {
   bool _isLoading = true;
   String? _error;
   NotificationPrefs? _prefs;
 
+  /// Whether the push status section is shown at all (iOS only).
+  static final bool _pushSupported = !kIsWeb && Platform.isIOS;
+
+  /// Current OS notification authorization status. Mirrors the strings from
+  /// [PushService.authorizationStatus]: `authorized`, `denied`,
+  /// `notDetermined`, `provisional`, or `ephemeral`.
+  String _authStatus = 'notDetermined';
+  bool _sendingTest = false;
+
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Returning from the system Settings app (where the user may have changed
+    // the permission) resumes us; re-read the status so the UI stays accurate.
+    if (state == AppLifecycleState.resumed && _pushSupported) {
+      _refreshAuthStatus();
+    }
   }
 
   String _friendlyError(Object e) {
     final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
     return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _refreshAuthStatus() async {
+    if (!_pushSupported) return;
+    final status = await ref.read(pushServiceProvider).authorizationStatus();
+    if (!mounted) return;
+    setState(() => _authStatus = status);
   }
 
   Future<void> _load() async {
@@ -41,9 +78,13 @@ class _NotificationPreferencesScreenState
     try {
       final prefs =
           await ref.read(notificationPrefsServiceProvider).getPreferences();
+      final status = _pushSupported
+          ? await ref.read(pushServiceProvider).authorizationStatus()
+          : 'notDetermined';
       if (!mounted) return;
       setState(() {
         _prefs = prefs;
+        _authStatus = status;
         _isLoading = false;
       });
     } catch (e) {
@@ -52,6 +93,29 @@ class _NotificationPreferencesScreenState
         _error = _friendlyError(e);
         _isLoading = false;
       });
+    }
+  }
+
+  /// Requests permission via the native channel, then refreshes the status.
+  Future<void> _enableNotifications() async {
+    await ref.read(pushServiceProvider).registerForPush();
+    await _refreshAuthStatus();
+  }
+
+  Future<void> _sendTest() async {
+    setState(() => _sendingTest = true);
+    try {
+      final result = await ref.read(pushServiceProvider).sendTest();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Test sent (${result.sent} delivered)')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(_friendlyError(e))));
+    } finally {
+      if (mounted) setState(() => _sendingTest = false);
     }
   }
 
@@ -109,6 +173,7 @@ class _NotificationPreferencesScreenState
     return ListView(
       padding: const EdgeInsets.symmetric(vertical: 8),
       children: [
+        if (_pushSupported) ..._buildStatusSection(),
         const Padding(
           padding: EdgeInsets.fromLTRB(16, 8, 16, 12),
           child: Text(
@@ -146,6 +211,105 @@ class _NotificationPreferencesScreenState
     );
   }
 
+  /// The push status block shown above the category toggles: current
+  /// permission state plus the relevant affordance (enable / open Settings)
+  /// and a "Send test notification" button.
+  List<Widget> _buildStatusSection() {
+    final authorized =
+        _authStatus == 'authorized' || _authStatus == 'provisional';
+    final denied = _authStatus == 'denied';
+    final notDetermined =
+        _authStatus == 'notDetermined' || _authStatus == 'ephemeral';
+
+    return [
+      const _SectionHeader(title: 'Status'),
+      _statusRow(),
+      if (denied)
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Notifications are turned off. Enable them in iOS Settings to '
+                'receive push notifications.',
+                style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+              ),
+              const SizedBox(height: 12),
+              OutlinedButton.icon(
+                onPressed: () =>
+                    ref.read(pushServiceProvider).openSystemSettings(),
+                icon: const Icon(Icons.settings_outlined, size: 18),
+                label: const Text('Open iOS Settings'),
+              ),
+            ],
+          ),
+        ),
+      if (notDetermined)
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+          child: Align(
+            alignment: Alignment.centerLeft,
+            child: ElevatedButton.icon(
+              onPressed: _enableNotifications,
+              icon: const Icon(Icons.notifications_active_outlined, size: 18),
+              label: const Text('Enable notifications'),
+            ),
+          ),
+        ),
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: OutlinedButton.icon(
+            onPressed: (authorized && !_sendingTest) ? _sendTest : null,
+            icon: _sendingTest
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(
+                        strokeWidth: 2, color: AppTheme.accent),
+                  )
+                : const Icon(Icons.send_outlined, size: 18),
+            label: const Text('Send test notification'),
+          ),
+        ),
+      ),
+      const SizedBox(height: 8),
+    ];
+  }
+
+  /// A single row summarising the current permission state with an icon.
+  Widget _statusRow() {
+    final IconData icon;
+    final Color color;
+    final String label;
+    switch (_authStatus) {
+      case 'authorized':
+      case 'provisional':
+        icon = Icons.check_circle;
+        color = AppTheme.available;
+        label = 'Granted';
+        break;
+      case 'denied':
+        icon = Icons.cancel;
+        color = AppTheme.error;
+        label = 'Denied';
+        break;
+      default:
+        icon = Icons.help_outline;
+        color = AppTheme.textSecondary;
+        label = 'Not yet requested';
+    }
+    return ListTile(
+      leading: Icon(icon, color: color),
+      title: const Text('Notification permission',
+          style: TextStyle(
+              color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
+      subtitle: Text(label, style: TextStyle(color: color, fontSize: 13)),
+    );
+  }
+
   Widget _toggle({
     required String title,
     required String subtitle,
@@ -161,6 +325,28 @@ class _NotificationPreferencesScreenState
               color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
       subtitle: Text(subtitle,
           style: const TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+    );
+  }
+}
+
+/// Small uppercase accent header, matching the settings screen sections.
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  const _SectionHeader({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Text(
+        title.toUpperCase(),
+        style: const TextStyle(
+          color: AppTheme.accent,
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 1.2,
+        ),
+      ),
     );
   }
 }

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -106,34 +106,39 @@ func main() {
 	// Tautulli handler (Plex monitoring)
 	tautulliHandler := tautulli.NewHandler(instanceStore, registry)
 
-	// Push notifications via the self-hosted gateway. Disabled (client nil) when
-	// either the gateway URL or API key is unset; the handler and notifier are
-	// still built (nil-safe) so wiring stays uniform. Built before the hub and
-	// request service so both can dispatch pushes.
-	var pushClient *push.Client
+	// Server-lifetime context: drives the WebSocket hub and the push manager's
+	// background enrollment retry.
+	ctx := context.Background()
+	logger := slog.Default()
+
+	// Push notifications via the self-hosted gateway. A single push.Manager owns
+	// the lazily-built gateway client: the key is resolved (explicit env key > a
+	// key auto-enrolled on a previous start > self-enroll) on first use, and a
+	// gateway that was down at boot — or tokens registered while push was off —
+	// self-heal without a restart. The manager is nil (and push disabled) only
+	// when no gateway URL is set; this keeps the hub's content notifier and the
+	// request composite off exactly as before.
+	var pushManager *push.Manager
 	if cfg.PushGatewayURL != "" {
-		// Resolve the gateway key: explicit env key, else a key auto-enrolled on a
-		// previous start, else self-enroll now. Failure is non-fatal — push stays
-		// off this run and is retried on the next start.
-		apiKey, err := ensurePushAPIKey(database, cipher, cfg)
-		if err != nil {
-			log.Printf("Push notifications disabled: %v", err)
-		} else {
-			pushClient = push.NewClient(cfg.PushGatewayURL, apiKey)
-			log.Printf("Push notifications enabled via %s", cfg.PushGatewayURL)
-		}
+		pushManager = push.NewManager(database, cipher, cfg.PushGatewayURL, cfg.PushAPIKey, cfg.PushEnrollToken, cfg.ServerName, logger)
+		// Try once now (non-blocking) and keep retrying in the background until
+		// the gateway is reachable; both are no-ops once enrolled.
+		go pushManager.Ensure(ctx)
+		pushManager.StartRetry(ctx)
+		log.Printf("Push notifications enabled via %s", cfg.PushGatewayURL)
 	} else {
 		log.Println("Push notifications disabled (CANTINARR_PUSH_GATEWAY_URL unset)")
 	}
-	logger := slog.Default()
-	pushHandler := push.NewHandler(database, pushClient, logger)
+	pushHandler := push.NewHandler(database, pushManager, logger)
 
 	// One push notifier drives both the request-decision/pending fan-out and the
-	// new-content (movie/episode available) pushes. nil when push is disabled so
-	// the hub's content notifier and the request composite both no-op.
+	// new-content (movie/episode available) pushes. It is built only when push is
+	// configured (gateway URL set) so the hub's content notifier and the request
+	// composite stay off otherwise; it no-ops on its own while the gateway is
+	// unreachable (manager.Client() == nil).
 	var pushNotifier *push.Notifier
-	if pushClient != nil {
-		pushNotifier = push.NewNotifier(database, pushClient, logger)
+	if pushManager != nil {
+		pushNotifier = push.NewNotifier(database, pushManager, logger)
 	}
 
 	// WebSocket hub (built before the request service so request approvals and
@@ -145,7 +150,7 @@ func main() {
 		contentNotifier = pushNotifier
 	}
 	wsHub := ws.NewHub(authService, registry, instanceStore, contentNotifier)
-	go wsHub.Run(context.Background())
+	go wsHub.Run(ctx)
 
 	// Request service. Request decisions fan out to both the WebSocket hub
 	// (live clients) and the push gateway (offline devices). The push notifier
@@ -208,40 +213,4 @@ func ensureJWTSecret(database *sql.DB, cipher *secrets.Cipher) (string, error) {
 
 	log.Println("Generated and persisted JWT secret")
 	return secret, nil
-}
-
-// ensurePushAPIKey resolves the push-gateway API key when a gateway URL is set:
-// an explicit CANTINARR_PUSH_API_KEY wins; otherwise a key auto-enrolled on a
-// previous start is loaded from the settings table; otherwise the server self-
-// enrolls with the gateway once and persists the issued key (encrypted at rest,
-// like the JWT secret). This gives self-hosters push with zero manual key
-// handling. To force re-enrollment, delete the 'push_api_key' settings row.
-func ensurePushAPIKey(database *sql.DB, cipher *secrets.Cipher, cfg *config.Config) (string, error) {
-	if cfg.PushAPIKey != "" {
-		return cfg.PushAPIKey, nil // explicit operator override; not persisted
-	}
-
-	var stored string
-	if err := database.QueryRow("SELECT value FROM settings WHERE key = 'push_api_key'").Scan(&stored); err == nil {
-		return cipher.Decrypt(stored)
-	}
-
-	// No key yet: self-enroll with the gateway and persist the issued key.
-	name := cfg.ServerName
-	if name == "" {
-		name = "Cantinarr"
-	}
-	res, err := push.Enroll(cfg.PushGatewayURL, name, cfg.PushEnrollToken)
-	if err != nil {
-		return "", fmt.Errorf("auto-enroll with push gateway: %w", err)
-	}
-	enc, err := cipher.Encrypt(res.APIKey)
-	if err != nil {
-		return "", fmt.Errorf("encrypt push key: %w", err)
-	}
-	if _, err := database.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('push_api_key', ?)", enc); err != nil {
-		return "", fmt.Errorf("persist push key: %w", err)
-	}
-	log.Printf("Auto-enrolled with push gateway %s (tenant %s); key persisted", cfg.PushGatewayURL, res.TenantID)
-	return res.APIKey, nil
 }

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -162,13 +162,15 @@ func NewRouter(
 
 		// Device push-token + notification preference routes (authenticated).
 		// Any signed-in user may register/clear the APNs token for one of their
-		// own devices and read/update their own notification preferences.
+		// own devices, read/update their own notification preferences, and fire
+		// a test push to their own devices.
 		r.Group(func(r chi.Router) {
 			r.Use(authService.AuthMiddleware)
 			r.Post("/devices/push-token", pushHandler.Register)
 			r.Delete("/devices/push-token/{deviceID}", pushHandler.Delete)
 			r.Get("/notifications/preferences", pushHandler.GetPreferences)
 			r.Put("/notifications/preferences", pushHandler.UpdatePreferences)
+			r.Post("/notifications/test", pushHandler.TestPush)
 		})
 
 		// Request routes (authenticated)

--- a/server/internal/push/client.go
+++ b/server/internal/push/client.go
@@ -108,14 +108,37 @@ type SendOptions struct {
 	CollapseID string
 }
 
+// SendResponse is the gateway's reply to POST /v1/notifications: per-send
+// counts plus a per-device result list. The results let Cantinarr learn which
+// of its stored tokens the gateway pruned (token rejected by APNs) so it can
+// drop the matching local rows.
+type SendResponse struct {
+	Sent    int          `json:"sent"`
+	Failed  int          `json:"failed"`
+	Results []SendResult `json:"results"`
+}
+
+// SendResult is one device's delivery outcome within a SendResponse. Pruned is
+// true when the gateway dropped the token (e.g. APNs reported it unregistered);
+// callers should delete the matching local push_tokens row to match.
+type SendResult struct {
+	DeviceID string `json:"device_id"`
+	Token    string `json:"token"`
+	Platform string `json:"platform"`
+	OK       bool   `json:"ok"`
+	Pruned   bool   `json:"pruned"`
+	Error    string `json:"error"`
+}
+
 // Send fans a high-priority notification out to the given users' devices. data
-// is delivered as the APNs payload's custom data.
-func (c *Client) Send(ctx context.Context, userIDs []int64, title, body string, data map[string]any) error {
+// is delivered as the APNs payload's custom data. The parsed gateway response
+// is returned so callers can react to per-device results (e.g. pruned tokens).
+func (c *Client) Send(ctx context.Context, userIDs []int64, title, body string, data map[string]any) (*SendResponse, error) {
 	return c.SendWithOptions(ctx, userIDs, title, body, data, SendOptions{})
 }
 
 // SendWithOptions is Send with explicit per-send options (e.g. a collapse id).
-func (c *Client) SendWithOptions(ctx context.Context, userIDs []int64, title, body string, data map[string]any, opts SendOptions) error {
+func (c *Client) SendWithOptions(ctx context.Context, userIDs []int64, title, body string, data map[string]any, opts SendOptions) (*SendResponse, error) {
 	ids := make([]string, len(userIDs))
 	for i, id := range userIDs {
 		ids[i] = strconv.FormatInt(id, 10)
@@ -133,7 +156,11 @@ func (c *Client) SendWithOptions(ctx context.Context, userIDs []int64, title, bo
 		"data":    data,
 		"options": options,
 	}
-	return c.do(ctx, http.MethodPost, "/v1/notifications", payload, nil)
+	var out SendResponse
+	if err := c.do(ctx, http.MethodPost, "/v1/notifications", payload, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
 }
 
 // do executes a request with an optional JSON body, fails on non-2xx status

--- a/server/internal/push/client_test.go
+++ b/server/internal/push/client_test.go
@@ -95,9 +95,12 @@ func TestClientSend(t *testing.T) {
 	srv := newMockGateway(t, http.StatusOK, `{"sent":1,"failed":0}`, &got)
 
 	c := NewClient(srv.URL, "pgk_test")
-	err := c.Send(context.Background(), []int64{7, 9}, "Title", "Body", map[string]any{"type": "request_decision"})
+	resp, err := c.Send(context.Background(), []int64{7, 9}, "Title", "Body", map[string]any{"type": "request_decision"})
 	if err != nil {
 		t.Fatalf("Send: %v", err)
+	}
+	if resp == nil || resp.Sent != 1 || resp.Failed != 0 {
+		t.Errorf("response = %+v, want sent=1 failed=0", resp)
 	}
 
 	if got.method != http.MethodPost || got.path != "/v1/notifications" {
@@ -123,8 +126,11 @@ func TestClientSendNon2xxIsError(t *testing.T) {
 	srv := newMockGateway(t, http.StatusUnauthorized, `{"error":{"code":"unauthorized"}}`, &got)
 
 	c := NewClient(srv.URL, "pgk_bad")
-	err := c.Send(context.Background(), []int64{1}, "t", "b", nil)
+	resp, err := c.Send(context.Background(), []int64{1}, "t", "b", nil)
 	if err == nil {
 		t.Fatal("expected error for non-2xx response, got nil")
+	}
+	if resp != nil {
+		t.Errorf("response = %+v, want nil on error", resp)
 	}
 }

--- a/server/internal/push/handler.go
+++ b/server/internal/push/handler.go
@@ -14,22 +14,27 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/auth"
 )
 
-// Handler serves the device push-token endpoints and the per-user notification
-// preferences endpoints. A nil client disables gateway registration (the local
-// row is still stored), so the handler works even when push is not configured.
+// Handler serves the device push-token endpoints, the per-user notification
+// preferences endpoints, and the test-push endpoint. It holds the push Manager
+// rather than a static client: a registration kicks gateway enrollment if
+// needed (self-healing after a gateway that was down at boot), and gateway work
+// no-ops cleanly while push is unconfigured — the local token row is still
+// stored, so the handler works even when push is not configured. A nil manager
+// means push is disabled.
 type Handler struct {
 	db     *sql.DB
-	client *Client
+	mgr    *Manager
 	prefs  *PrefsStore
 	logger *slog.Logger
 }
 
-// NewHandler builds the push-token endpoint handler.
-func NewHandler(db *sql.DB, client *Client, logger *slog.Logger) *Handler {
+// NewHandler builds the push-token endpoint handler. A nil manager disables all
+// gateway interaction (local rows are still stored).
+func NewHandler(db *sql.DB, mgr *Manager, logger *slog.Logger) *Handler {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Handler{db: db, client: client, prefs: NewPrefsStore(db), logger: logger}
+	return &Handler{db: db, mgr: mgr, prefs: NewPrefsStore(db), logger: logger}
 }
 
 // RegisterTokenRequest is the POST /api/devices/push-token body.
@@ -76,13 +81,18 @@ func (h *Handler) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Register with the gateway. Failures here are non-fatal: the token is
-	// stored locally and will be retried on the next registration.
-	if h.client != nil {
+	// Register with the gateway. A registration also kicks enrollment when push
+	// is configured but the gateway was unreachable at boot — Ensure resolves
+	// the key, builds the client, and reconciles already-stored tokens on its
+	// first success. Failures here are non-fatal: the token is stored locally
+	// and the gateway picks it up on the next Ensure (reconciliation or retry).
+	if h.mgr != nil {
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
-		if err := h.client.RegisterDevice(ctx, claims.UserID, req.DeviceID, platform, req.APNSToken); err != nil {
-			h.logger.Error("push: register device with gateway", "err", err, "device_id", req.DeviceID)
+		if client := h.mgr.Ensure(ctx); client != nil {
+			if err := client.RegisterDevice(ctx, claims.UserID, req.DeviceID, platform, req.APNSToken); err != nil {
+				h.logger.Error("push: register device with gateway", "err", err, "device_id", req.DeviceID)
+			}
 		}
 	}
 
@@ -119,10 +129,10 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.client != nil {
+	if client := h.client(); client != nil {
 		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
-		if err := h.client.DeleteDevice(ctx, deviceID); err != nil {
+		if err := client.DeleteDevice(ctx, deviceID); err != nil {
 			h.logger.Error("push: delete device from gateway", "err", err, "device_id", deviceID)
 		}
 	}
@@ -168,6 +178,50 @@ func (h *Handler) UpdatePreferences(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, prefs)
+}
+
+// TestPush sends a test notification to the calling user's own devices so the
+// app's "Send test" button can confirm push works end to end. It bypasses the
+// per-category preferences on purpose (the user explicitly asked for it).
+// Returns 503 when push is unconfigured or the gateway is unreachable.
+func (h *Handler) TestPush(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	// Ensure (not just Client) so a first-ever test from a freshly-booted server
+	// that couldn't reach the gateway at startup still kicks enrollment.
+	var client *Client
+	if h.mgr != nil {
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+		defer cancel()
+		client = h.mgr.Ensure(ctx)
+	}
+	if client == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "push not configured"})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	resp, err := client.Send(ctx, []int64{claims.UserID}, "Cantinarr", "Push notifications are working", map[string]any{"type": "test"})
+	if err != nil {
+		h.logger.Error("push: send test notification", "err", err, "user_id", claims.UserID)
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send test notification"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]int{"sent": resp.Sent, "failed": resp.Failed})
+}
+
+// client returns the cached gateway client, or nil when push is unconfigured or
+// the gateway has not yet enrolled. It never triggers enrollment.
+func (h *Handler) client() *Client {
+	if h.mgr == nil {
+		return nil
+	}
+	return h.mgr.Client()
 }
 
 // deviceBelongsToUser reports whether device_id names a (non-revoked) device

--- a/server/internal/push/handler_test.go
+++ b/server/internal/push/handler_test.go
@@ -3,6 +3,7 @@ package push
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -92,6 +93,128 @@ func TestUpdatePreferencesRoundTrip(t *testing.T) {
 	}
 	if stored != want {
 		t.Errorf("stored prefs = %+v, want %+v", stored, want)
+	}
+}
+
+func TestRegisterPushDisabledStoresLocallyAndIsNoop(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// A user owning a device, but push disabled (nil manager).
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (7, 'alice', '', 'user')")
+	mustExec(t, database, "INSERT INTO devices (id, user_id, device_name) VALUES ('dev-1', 7, 'iPhone')")
+	h := NewHandler(database, nil, nil)
+
+	body := `{"device_id":"dev-1","apns_token":"tok-1","platform":"ios"}`
+	rr := httptest.NewRecorder()
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/devices/push-token", strings.NewReader(body)), 7)
+	h.Register(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	// The local row must be stored even with push disabled.
+	var count int
+	if err := database.QueryRow("SELECT COUNT(*) FROM push_tokens WHERE device_id = 'dev-1' AND token = 'tok-1'").Scan(&count); err != nil {
+		t.Fatalf("count tokens: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("stored token rows = %d, want 1", count)
+	}
+}
+
+func TestTestPushSendsToCaller(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (7, 'alice', '', 'user')")
+
+	// Mock gateway that records the send body and reports one delivery.
+	gotBody := make(chan map[string]any, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/notifications" {
+			raw, _ := io.ReadAll(r.Body)
+			body := map[string]any{}
+			_ = json.Unmarshal(raw, &body)
+			gotBody <- body
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"sent":1,"failed":0}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	mgr := NewManager(database, nil, srv.URL, "pgk_test", "", "Cantinarr", nil)
+	h := NewHandler(database, mgr, nil)
+
+	rr := httptest.NewRecorder()
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/notifications/test", nil), 7)
+	h.TestPush(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rr.Code, rr.Body.String())
+	}
+	var counts map[string]int
+	if err := json.Unmarshal(rr.Body.Bytes(), &counts); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if counts["sent"] != 1 || counts["failed"] != 0 {
+		t.Errorf("counts = %v, want sent=1 failed=0", counts)
+	}
+
+	// The push must target the caller's own user id.
+	select {
+	case body := <-gotBody:
+		to, _ := body["to"].(map[string]any)
+		ids, _ := to["user_ids"].([]any)
+		if len(ids) != 1 || ids[0] != "7" {
+			t.Errorf("user_ids = %v, want [\"7\"]", ids)
+		}
+	default:
+		t.Fatal("gateway never received a notification")
+	}
+}
+
+func TestTestPushNotConfigured(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (7, 'alice', '', 'user')")
+	// nil manager => push disabled.
+	h := NewHandler(database, nil, nil)
+
+	rr := httptest.NewRecorder()
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/notifications/test", nil), 7)
+	h.TestPush(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503; body=%s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp["error"] != "push not configured" {
+		t.Errorf("error = %q, want \"push not configured\"", resp["error"])
+	}
+}
+
+func TestTestPushUnauthorized(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	h := NewHandler(database, nil, nil)
+
+	rr := httptest.NewRecorder()
+	// No claims in context.
+	req := httptest.NewRequest(http.MethodPost, "/api/notifications/test", nil)
+	h.TestPush(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
 	}
 }
 

--- a/server/internal/push/manager.go
+++ b/server/internal/push/manager.go
@@ -1,0 +1,225 @@
+package push
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+// defaultRetryInterval is how often StartRetry re-attempts enrollment while the
+// gateway is configured but not yet reachable.
+const defaultRetryInterval = 60 * time.Second
+
+// Manager owns the lazily-built push gateway client and makes the integration
+// self-healing: a gateway that was down at boot, or device tokens registered
+// while push was disabled, reach the gateway WITHOUT a server restart or app
+// re-open. It resolves the per-app API key (explicit env key > a key
+// auto-enrolled on a previous start > a fresh self-enrollment), caches the
+// client behind a mutex, and on its first success reconciles every stored
+// token with the gateway. All failures are non-fatal — push simply stays off
+// until the next Ensure (driven by a registration or the background retry).
+type Manager struct {
+	db          *sql.DB
+	cipher      *secrets.Cipher
+	gatewayURL  string
+	explicitKey string
+	enrollToken string
+	serverName  string
+	logger      *slog.Logger
+	// retryInterval is the StartRetry backoff; overridable in tests.
+	retryInterval time.Duration
+
+	mu       sync.Mutex
+	client   *Client
+	enrolled bool
+}
+
+// NewManager builds a push Manager. gatewayURL is required (callers gate on it
+// being non-empty); explicitKey is an operator-supplied per-app key that wins
+// over any stored/auto-enrolled key; enrollToken is sent as X-Enroll-Token on
+// auto-enroll (needed only for gated gateways); serverName names the tenant on
+// auto-enroll (defaults to "Cantinarr" when empty).
+func NewManager(db *sql.DB, cipher *secrets.Cipher, gatewayURL, explicitKey, enrollToken, serverName string, logger *slog.Logger) *Manager {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if serverName == "" {
+		serverName = "Cantinarr"
+	}
+	return &Manager{
+		db:            db,
+		cipher:        cipher,
+		gatewayURL:    gatewayURL,
+		explicitKey:   explicitKey,
+		enrollToken:   enrollToken,
+		serverName:    serverName,
+		logger:        logger,
+		retryInterval: defaultRetryInterval,
+	}
+}
+
+// Ensure returns a ready gateway client, building it on first use. It is
+// single-flight: a cached client is returned immediately, otherwise the key is
+// resolved (explicit > stored > self-enroll), the client is built and cached,
+// and stored device tokens are reconciled with the gateway exactly once. A
+// resolution failure is logged and reported as a nil client (never fatal); the
+// next call retries.
+func (m *Manager) Ensure(ctx context.Context) *Client {
+	m.mu.Lock()
+	if m.client != nil {
+		client := m.client
+		m.mu.Unlock()
+		return client
+	}
+
+	apiKey, err := m.resolveAPIKey(ctx)
+	if err != nil {
+		m.mu.Unlock()
+		m.logger.Error("push: resolve gateway key", "err", err)
+		return nil
+	}
+
+	client := NewClient(m.gatewayURL, apiKey)
+	m.client = client
+	m.enrolled = true
+	m.mu.Unlock()
+	m.logger.Info("push: gateway client ready", "gateway", m.gatewayURL)
+
+	// First success: reconcile every locally-stored token with the gateway so
+	// tokens registered while push was disabled (or against a gateway that was
+	// down) are now known to it. Done after releasing the lock — it makes one
+	// network call per token and must not block concurrent Client() readers.
+	// Best-effort; errors are logged inside.
+	m.forwardStoredTokens(ctx, client)
+
+	return client
+}
+
+// Client returns the cached gateway client without attempting to enroll. It is
+// nil until a successful Ensure, so send paths can be wired unconditionally and
+// no-op while push is unconfigured or the gateway is unreachable.
+func (m *Manager) Client() *Client {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.client
+}
+
+// StartRetry runs a background goroutine that retries Ensure every
+// retryInterval until enrollment succeeds, then exits. It returns immediately;
+// pass the server context so the loop stops on shutdown. Safe to call once at
+// startup — if the first Ensure (run elsewhere) already succeeded, the loop
+// exits on its first check.
+func (m *Manager) StartRetry(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(m.retryInterval)
+		defer ticker.Stop()
+		for {
+			m.mu.Lock()
+			done := m.enrolled
+			m.mu.Unlock()
+			if done {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if m.Ensure(ctx) != nil {
+					return
+				}
+			}
+		}
+	}()
+}
+
+// ForwardStoredTokens reconciles every locally-stored token with the gateway by
+// re-registering each one. Used on first enrollment; exported so it can be
+// driven on demand. A nil cached client makes it a no-op.
+func (m *Manager) ForwardStoredTokens(ctx context.Context) {
+	client := m.Client()
+	if client == nil {
+		return
+	}
+	m.forwardStoredTokens(ctx, client)
+}
+
+// forwardStoredTokens reads every push_tokens row and re-registers it with the
+// given client. Best-effort: a failure on one token is logged and the rest
+// continue. The client is passed in (rather than read from m.client) so the
+// caller controls locking — it runs without the manager mutex held.
+func (m *Manager) forwardStoredTokens(ctx context.Context, client *Client) {
+	rows, err := m.db.Query(`SELECT device_id, user_id, platform, token FROM push_tokens`)
+	if err != nil {
+		m.logger.Error("push: read stored tokens for reconciliation", "err", err)
+		return
+	}
+	defer rows.Close()
+
+	type token struct {
+		deviceID string
+		userID   int64
+		platform string
+		value    string
+	}
+	var tokens []token
+	for rows.Next() {
+		var t token
+		if err := rows.Scan(&t.deviceID, &t.userID, &t.platform, &t.value); err != nil {
+			m.logger.Error("push: scan stored token", "err", err)
+			return
+		}
+		tokens = append(tokens, t)
+	}
+	if err := rows.Err(); err != nil {
+		m.logger.Error("push: iterate stored tokens", "err", err)
+		return
+	}
+
+	forwarded := 0
+	for _, t := range tokens {
+		if err := client.RegisterDevice(ctx, t.userID, t.deviceID, t.platform, t.value); err != nil {
+			m.logger.Error("push: reconcile stored token with gateway", "err", err, "device_id", t.deviceID)
+			continue
+		}
+		forwarded++
+	}
+	m.logger.Info("push: reconciled stored device tokens with gateway", "forwarded", forwarded, "total", len(tokens))
+}
+
+// resolveAPIKey resolves the per-app gateway key: an explicit operator key
+// wins (and is never persisted); otherwise a key auto-enrolled on a previous
+// start is loaded from the settings table and decrypted; otherwise the server
+// self-enrolls with the gateway once and persists the issued key (encrypted at
+// rest, like the JWT secret). This gives self-hosters push with zero manual
+// key handling. To force re-enrollment, delete the 'push_api_key' settings row.
+// Mirrors the former main.ensurePushAPIKey logic.
+func (m *Manager) resolveAPIKey(ctx context.Context) (string, error) {
+	if m.explicitKey != "" {
+		return m.explicitKey, nil // explicit operator override; not persisted
+	}
+
+	var stored string
+	if err := m.db.QueryRow("SELECT value FROM settings WHERE key = 'push_api_key'").Scan(&stored); err == nil {
+		return m.cipher.Decrypt(stored)
+	}
+
+	// No key yet: self-enroll with the gateway and persist the issued key.
+	res, err := Enroll(m.gatewayURL, m.serverName, m.enrollToken)
+	if err != nil {
+		return "", fmt.Errorf("auto-enroll with push gateway: %w", err)
+	}
+	enc, err := m.cipher.Encrypt(res.APIKey)
+	if err != nil {
+		return "", fmt.Errorf("encrypt push key: %w", err)
+	}
+	if _, err := m.db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES ('push_api_key', ?)", enc); err != nil {
+		return "", fmt.Errorf("persist push key: %w", err)
+	}
+	m.logger.Info("push: auto-enrolled with gateway; key persisted", "gateway", m.gatewayURL, "tenant", res.TenantID)
+	return res.APIKey, nil
+}

--- a/server/internal/push/manager_test.go
+++ b/server/internal/push/manager_test.go
@@ -1,0 +1,272 @@
+package push
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+// testCipher builds a deterministic cipher for manager tests that exercise the
+// stored-key and auto-enroll paths.
+func testCipher(t *testing.T) *secrets.Cipher {
+	t.Helper()
+	c, err := secrets.NewCipher(bytes.Repeat([]byte{0x42}, 32))
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	return c
+}
+
+// mockGateway records enroll calls and device registrations. enrollFails, when
+// set, makes /v1/enroll return 503 so the background-retry path can be driven.
+type mockGateway struct {
+	mu          sync.Mutex
+	enrollCalls int
+	registered  []string // device ids seen at /v1/devices
+	enrollFails bool
+}
+
+func (g *mockGateway) setEnrollFails(v bool) {
+	g.mu.Lock()
+	g.enrollFails = v
+	g.mu.Unlock()
+}
+
+func (g *mockGateway) enrollCount() int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.enrollCalls
+}
+
+func (g *mockGateway) registeredIDs() []string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	out := make([]string, len(g.registered))
+	copy(out, g.registered)
+	return out
+}
+
+// newMockGatewayServer stands up the mock and returns it plus its base URL.
+func newMockGatewayServer(t *testing.T) (*mockGateway, string) {
+	t.Helper()
+	g := &mockGateway{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/enroll":
+			g.mu.Lock()
+			g.enrollCalls++
+			fail := g.enrollFails
+			g.mu.Unlock()
+			if fail {
+				http.Error(w, `{"error":"unavailable"}`, http.StatusServiceUnavailable)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"tenant_id":"t-1","api_key":"pgk_enrolled"}`)
+		case "/v1/devices":
+			body := map[string]any{}
+			raw, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(raw, &body)
+			if id, _ := body["device_id"].(string); id != "" {
+				g.mu.Lock()
+				g.registered = append(g.registered, id)
+				g.mu.Unlock()
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"id":"d","created":true}`)
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return g, srv.URL
+}
+
+// storedPushKey reads and decrypts the persisted push_api_key, or "" if absent.
+func storedPushKey(t *testing.T, database *sql.DB, cipher *secrets.Cipher) string {
+	t.Helper()
+	var stored string
+	if err := database.QueryRow("SELECT value FROM settings WHERE key = 'push_api_key'").Scan(&stored); err != nil {
+		return ""
+	}
+	got, err := cipher.Decrypt(stored)
+	if err != nil {
+		t.Fatalf("decrypt stored push key: %v", err)
+	}
+	return got
+}
+
+func TestManagerEnsureExplicitKeyWins(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	g, url := newMockGatewayServer(t)
+	cipher := testCipher(t)
+
+	mgr := NewManager(database, cipher, url, "pgk_explicit", "", "Cantinarr", nil)
+	client := mgr.Ensure(context.Background())
+	if client == nil {
+		t.Fatal("Ensure returned nil for explicit-key manager")
+	}
+	if client.apiKey != "pgk_explicit" {
+		t.Errorf("client key = %q, want pgk_explicit", client.apiKey)
+	}
+	if g.enrollCount() != 0 {
+		t.Errorf("enroll calls = %d, want 0 (explicit key must not enroll)", g.enrollCount())
+	}
+	// An explicit key is never persisted.
+	if k := storedPushKey(t, database, cipher); k != "" {
+		t.Errorf("stored push key = %q, want empty (explicit key not persisted)", k)
+	}
+}
+
+func TestManagerEnsureUsesStoredKey(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	g, url := newMockGatewayServer(t)
+	cipher := testCipher(t)
+
+	// Seed an encrypted, previously-enrolled key.
+	enc, err := cipher.Encrypt("pgk_stored")
+	if err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO settings (key, value) VALUES ('push_api_key', ?)", enc)
+
+	mgr := NewManager(database, cipher, url, "", "", "Cantinarr", nil)
+	client := mgr.Ensure(context.Background())
+	if client == nil {
+		t.Fatal("Ensure returned nil for stored-key manager")
+	}
+	if client.apiKey != "pgk_stored" {
+		t.Errorf("client key = %q, want pgk_stored", client.apiKey)
+	}
+	if g.enrollCount() != 0 {
+		t.Errorf("enroll calls = %d, want 0 (stored key must not enroll)", g.enrollCount())
+	}
+}
+
+func TestManagerEnsureEnrollsAndPersists(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	g, url := newMockGatewayServer(t)
+	cipher := testCipher(t)
+
+	mgr := NewManager(database, cipher, url, "", "", "Cantinarr", nil)
+	client := mgr.Ensure(context.Background())
+	if client == nil {
+		t.Fatal("Ensure returned nil; expected auto-enroll to succeed")
+	}
+	if client.apiKey != "pgk_enrolled" {
+		t.Errorf("client key = %q, want pgk_enrolled", client.apiKey)
+	}
+	if g.enrollCount() != 1 {
+		t.Errorf("enroll calls = %d, want 1", g.enrollCount())
+	}
+	// The issued key must be persisted (encrypted) for the next start.
+	if k := storedPushKey(t, database, cipher); k != "pgk_enrolled" {
+		t.Errorf("stored push key = %q, want pgk_enrolled", k)
+	}
+
+	// A second Ensure is single-flight: same client, no second enroll.
+	if mgr.Ensure(context.Background()) != client {
+		t.Error("second Ensure returned a different client")
+	}
+	if g.enrollCount() != 1 {
+		t.Errorf("enroll calls after second Ensure = %d, want 1", g.enrollCount())
+	}
+}
+
+func TestManagerEnsureReconcilesStoredTokens(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	g, url := newMockGatewayServer(t)
+	cipher := testCipher(t)
+
+	// Two device tokens registered while push was disabled (no gateway client).
+	seedDeviceToken(t, database, 1, "dev-a", "tok-a")
+	seedDeviceToken(t, database, 2, "dev-b", "tok-b")
+
+	mgr := NewManager(database, cipher, url, "pgk_explicit", "", "Cantinarr", nil)
+	if mgr.Ensure(context.Background()) == nil {
+		t.Fatal("Ensure returned nil")
+	}
+
+	got := map[string]bool{}
+	for _, id := range g.registeredIDs() {
+		got[id] = true
+	}
+	if len(got) != 2 || !got["dev-a"] || !got["dev-b"] {
+		t.Errorf("reconciled device ids = %v, want dev-a and dev-b", g.registeredIDs())
+	}
+}
+
+func TestManagerStartRetrySucceedsWhenGatewayComesUp(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	g, url := newMockGatewayServer(t)
+	cipher := testCipher(t)
+
+	// Gateway starts down: the initial Ensure fails and the client stays nil.
+	g.setEnrollFails(true)
+
+	mgr := NewManager(database, cipher, url, "", "", "Cantinarr", nil)
+	mgr.retryInterval = 10 * time.Millisecond // fast retry for the test
+	if mgr.Ensure(context.Background()) != nil {
+		t.Fatal("Ensure should return nil while the gateway is down")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	mgr.StartRetry(ctx)
+
+	// Bring the gateway up; the retry loop should enroll and cache a client.
+	g.setEnrollFails(false)
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if mgr.Client() != nil {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("background retry did not enroll after the gateway came up")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// seedDeviceToken inserts the user, device, and push_tokens rows needed for a
+// stored token, satisfying the push_tokens -> devices -> users foreign keys.
+// Used by the reconciliation and prune tests.
+func seedDeviceToken(t *testing.T, database *sql.DB, userID int64, deviceID, token string) {
+	t.Helper()
+	mustExec(t, database,
+		"INSERT OR IGNORE INTO users (id, username, password_hash, role) VALUES (?, ?, '', 'user')",
+		userID, "user-"+deviceID)
+	mustExec(t, database,
+		"INSERT INTO devices (id, user_id, device_name) VALUES (?, ?, ?)",
+		deviceID, userID, "device-"+deviceID)
+	mustExec(t, database,
+		"INSERT INTO push_tokens (id, device_id, user_id, platform, token) VALUES (?, ?, ?, 'ios', ?)",
+		"pt-"+deviceID, deviceID, userID, token)
+}

--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -8,30 +8,49 @@ import (
 	"time"
 )
 
-// Notifier turns request events into push notifications via the gateway. It
-// implements request.Notifier. Sends are fire-and-forget so a slow or failing
-// gateway never blocks an approval/denial. Every notification is filtered by
-// the recipient's per-category preferences before dispatch.
+// Notifier turns request and content events into push notifications via the
+// gateway. It implements request.Notifier. Sends are fire-and-forget so a slow
+// or failing gateway never blocks an approval/denial. Every notification is
+// filtered by the recipient's per-category preferences before dispatch.
+//
+// The Notifier holds the push Manager rather than a static client, so it picks
+// up a gateway that enrolled after boot and no-ops cleanly while push is
+// unconfigured or the gateway is unreachable (Manager.Client() == nil). After
+// each send it inspects the gateway's per-device results and drops any local
+// token the gateway pruned (token rejected by APNs), keeping push_tokens from
+// accumulating dead rows.
 type Notifier struct {
-	client *Client
+	mgr    *Manager
+	db     *sql.DB
 	prefs  *PrefsStore
 	logger *slog.Logger
 }
 
-// NewNotifier builds a push notifier. A nil client makes every method a no-op,
-// so callers can wire it unconditionally and gate on configuration elsewhere.
-func NewNotifier(db *sql.DB, client *Client, logger *slog.Logger) *Notifier {
+// NewNotifier builds a push notifier over the push Manager. A nil manager (or
+// one whose client has not enrolled) makes every method a no-op, so callers can
+// wire it unconditionally and let the manager gate on configuration.
+func NewNotifier(db *sql.DB, mgr *Manager, logger *slog.Logger) *Notifier {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Notifier{client: client, prefs: NewPrefsStore(db), logger: logger}
+	return &Notifier{mgr: mgr, db: db, prefs: NewPrefsStore(db), logger: logger}
+}
+
+// client returns the currently-enrolled gateway client, or nil when push is
+// unconfigured or the gateway has not yet come up. nil-receiver safe.
+func (n *Notifier) client() *Client {
+	if n == nil || n.mgr == nil {
+		return nil
+	}
+	return n.mgr.Client()
 }
 
 // NotifyUser pushes the outcome of a request decision to the requesting user.
 // Only "request_decision" events produce a notification, and only when the
 // requester has opted into that category (off by default).
 func (n *Notifier) NotifyUser(userID int64, eventType string, data map[string]interface{}) {
-	if n == nil || n.client == nil || eventType != CategoryRequestDecision {
+	client := n.client()
+	if client == nil || eventType != CategoryRequestDecision {
 		return
 	}
 	if !n.prefs.optedIn(userID, CategoryRequestDecision) {
@@ -43,14 +62,15 @@ func (n *Notifier) NotifyUser(userID int64, eventType string, data map[string]in
 		return
 	}
 
-	n.send([]int64{userID}, title, body, passthrough(CategoryRequestDecision, data))
+	n.send(client, []int64{userID}, title, body, passthrough(CategoryRequestDecision, data))
 }
 
 // NotifyAdmins pushes a new pending request to every admin who has opted into
 // the request_pending category (on by default). Only "request_pending" events
 // produce a notification.
 func (n *Notifier) NotifyAdmins(eventType string, data map[string]interface{}) {
-	if n == nil || n.client == nil || eventType != CategoryRequestPending {
+	client := n.client()
+	if client == nil || eventType != CategoryRequestPending {
 		return
 	}
 
@@ -68,7 +88,7 @@ func (n *Notifier) NotifyAdmins(eventType string, data map[string]interface{}) {
 		return
 	}
 
-	n.send(recipients, "New request", title, passthrough(CategoryRequestPending, data))
+	n.send(client, recipients, "New request", title, passthrough(CategoryRequestPending, data))
 }
 
 // NotifyNewMovie pushes a "movie became available" alert to every user opted
@@ -88,7 +108,8 @@ func (n *Notifier) NotifyNewEpisode(seriesTitle string, tmdbID int) {
 // resolves the opted-in audience for the category and dispatches one collapsed
 // push carrying the media identity for tap routing.
 func (n *Notifier) notifyNewContent(category, mediaType, title, body, mediaTitle string, tmdbID int) {
-	if n == nil || n.client == nil || mediaTitle == "" {
+	client := n.client()
+	if client == nil || mediaTitle == "" {
 		return
 	}
 	recipients, err := n.prefs.usersOptedInto(category)
@@ -104,19 +125,21 @@ func (n *Notifier) notifyNewContent(category, mediaType, title, body, mediaTitle
 		"tmdb_id":    tmdbID,
 		"media_type": mediaType,
 	}
-	n.sendWithOptions(recipients, title, body, data, SendOptions{
+	n.sendWithOptions(client, recipients, title, body, data, SendOptions{
 		CollapseID: fmt.Sprintf("%s:%d", category, tmdbID),
 	})
 }
 
 // send dispatches a notification in the background with panic recovery, so a
 // failed delivery (or a marshalling bug) can never take down the caller.
-func (n *Notifier) send(userIDs []int64, title, body string, data map[string]any) {
-	n.sendWithOptions(userIDs, title, body, data, SendOptions{})
+func (n *Notifier) send(client *Client, userIDs []int64, title, body string, data map[string]any) {
+	n.sendWithOptions(client, userIDs, title, body, data, SendOptions{})
 }
 
 // sendWithOptions is send with explicit gateway options (e.g. a collapse id).
-func (n *Notifier) sendWithOptions(userIDs []int64, title, body string, data map[string]any, opts SendOptions) {
+// After the gateway replies it prunes any local token the gateway reported
+// dead, so push_tokens self-cleans without a separate sweep.
+func (n *Notifier) sendWithOptions(client *Client, userIDs []int64, title, body string, data map[string]any, opts SendOptions) {
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
@@ -125,10 +148,37 @@ func (n *Notifier) sendWithOptions(userIDs []int64, title, body string, data map
 		}()
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		if err := n.client.SendWithOptions(ctx, userIDs, title, body, data, opts); err != nil {
+		resp, err := client.SendWithOptions(ctx, userIDs, title, body, data, opts)
+		if err != nil {
 			n.logger.Error("push: send notification", "err", err, "title", title)
+			return
 		}
+		n.pruneDeadTokens(resp)
 	}()
+}
+
+// pruneDeadTokens deletes the local push_tokens row for every result the
+// gateway flagged as pruned (token rejected by APNs as unregistered). Matching
+// on token keeps it precise even if a device re-registered with a new token in
+// the meantime. Best-effort: delete failures are logged, not surfaced.
+func (n *Notifier) pruneDeadTokens(resp *SendResponse) {
+	if resp == nil {
+		return
+	}
+	pruned := 0
+	for _, r := range resp.Results {
+		if !r.Pruned || r.Token == "" {
+			continue
+		}
+		if _, err := n.db.Exec("DELETE FROM push_tokens WHERE token = ?", r.Token); err != nil {
+			n.logger.Error("push: prune dead token", "err", err, "device_id", r.DeviceID)
+			continue
+		}
+		pruned++
+	}
+	if pruned > 0 {
+		n.logger.Info("push: pruned dead device tokens", "count", pruned)
+	}
 }
 
 // decisionMessage derives the alert title/body from a request_decision payload.

--- a/server/internal/push/notifier_test.go
+++ b/server/internal/push/notifier_test.go
@@ -1,6 +1,7 @@
 package push
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"io"
@@ -38,7 +39,12 @@ type notificationCapture struct {
 	ch chan map[string]any
 }
 
-func newNotifierTestGateway(t *testing.T) (*Client, *notificationCapture) {
+// newNotifierTestGateway stands up a mock gateway and returns an already-
+// enrolled push.Manager wired to it (explicit key, so resolveAPIKey never
+// touches the cipher or settings) plus a capture of POST /v1/notifications
+// bodies. The manager shares the test's database so the notifier's token
+// pruning hits the same rows.
+func newNotifierTestGateway(t *testing.T, database *sql.DB) (*Manager, *notificationCapture) {
 	t.Helper()
 	cap := &notificationCapture{ch: make(chan map[string]any, 4)}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -52,7 +58,11 @@ func newNotifierTestGateway(t *testing.T) (*Client, *notificationCapture) {
 		_, _ = io.WriteString(w, `{"sent":1,"failed":0}`)
 	}))
 	t.Cleanup(srv.Close)
-	return NewClient(srv.URL, "pgk_test"), cap
+	mgr := NewManager(database, nil, srv.URL, "pgk_test", "", "Cantinarr", nil)
+	if mgr.Ensure(context.Background()) == nil {
+		t.Fatal("Ensure returned nil client for an explicit-key manager")
+	}
+	return mgr, cap
 }
 
 // waitForNotification returns the next captured notification body, failing if
@@ -90,8 +100,8 @@ func TestNotifyUserRequestDecision(t *testing.T) {
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (42, 'req', '', 'user')")
 	mustExec(t, database, "INSERT INTO notification_prefs (user_id, request_decision) VALUES (42, 1)")
 
-	client, cap := newNotifierTestGateway(t)
-	n := NewNotifier(database, client, nil)
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
 
 	n.NotifyUser(42, "request_decision", map[string]interface{}{
 		"decision":   "approved",
@@ -125,8 +135,8 @@ func TestNotifyUserRequestDecisionSuppressedByDefault(t *testing.T) {
 	// No prefs row: request_decision defaults to off, so nothing is sent.
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (42, 'req', '', 'user')")
 
-	client, cap := newNotifierTestGateway(t)
-	n := NewNotifier(database, client, nil)
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
 
 	n.NotifyUser(42, "request_decision", map[string]interface{}{
 		"decision": "approved",
@@ -150,8 +160,8 @@ func TestNotifyUserRequestDecisionSuppressedWhenOff(t *testing.T) {
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (42, 'req', '', 'user')")
 	mustExec(t, database, "INSERT INTO notification_prefs (user_id, request_decision) VALUES (42, 0)")
 
-	client, cap := newNotifierTestGateway(t)
-	n := NewNotifier(database, client, nil)
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
 
 	n.NotifyUser(42, "request_decision", map[string]interface{}{
 		"decision": "approved",
@@ -171,8 +181,8 @@ func TestNotifyUserIgnoresOtherEvents(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open db: %v", err)
 	}
-	client, cap := newNotifierTestGateway(t)
-	n := NewNotifier(database, client, nil)
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
 
 	n.NotifyUser(42, "request_status_changed", map[string]interface{}{"title": "X"})
 
@@ -195,8 +205,8 @@ func TestNotifyAdminsResolvesAdminIDs(t *testing.T) {
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (2, 'admin2', '', 'admin')")
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (3, 'bob', '', 'user')")
 
-	client, cap := newNotifierTestGateway(t)
-	n := NewNotifier(database, client, nil)
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
 
 	n.NotifyAdmins("request_pending", map[string]interface{}{
 		"tmdb_id":    603,
@@ -231,8 +241,8 @@ func TestNotifyAdminsHonorsOptOutAndRole(t *testing.T) {
 	mustExec(t, database, "INSERT INTO notification_prefs (user_id, request_pending) VALUES (1, 0)")
 	mustExec(t, database, "INSERT INTO notification_prefs (user_id, request_pending) VALUES (3, 1)")
 
-	client, cap := newNotifierTestGateway(t)
-	n := NewNotifier(database, client, nil)
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
 
 	n.NotifyAdmins("request_pending", map[string]interface{}{"title": "The Matrix"})
 
@@ -268,8 +278,8 @@ func TestNotifyNewMovieReachesOptedInUsers(t *testing.T) {
 	mustExec(t, database, "INSERT INTO notification_prefs (user_id, new_movie) VALUES (2, 0)")
 	mustExec(t, database, "INSERT INTO notification_prefs (user_id, new_movie) VALUES (3, 1)")
 
-	client, cap := newNotifierTestGateway(t)
-	n := NewNotifier(database, client, nil)
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
 
 	n.NotifyNewMovie("The Matrix", 603)
 
@@ -313,8 +323,8 @@ func TestNotifyNewEpisodeReachesOptedInUsers(t *testing.T) {
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (2, 'bob', '', 'user')")
 	mustExec(t, database, "INSERT INTO notification_prefs (user_id, new_episode) VALUES (2, 0)")
 
-	client, cap := newNotifierTestGateway(t)
-	n := NewNotifier(database, client, nil)
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
 
 	n.NotifyNewEpisode("Severance", 95396)
 
@@ -340,6 +350,48 @@ func TestNotifyNewEpisodeReachesOptedInUsers(t *testing.T) {
 	}
 }
 
+func TestNotifierPrunesDeadTokenOnPrunedResult(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	// One opted-in user with a stored token the gateway will report as pruned.
+	seedDeviceToken(t, database, 1, "dev-dead", "tok-dead")
+
+	// A mock gateway that reports the token as pruned on send.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"sent":0,"failed":1,"results":[{"device_id":"dev-dead","token":"tok-dead","platform":"ios","ok":false,"pruned":true,"error":"unregistered"}]}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	mgr := NewManager(database, nil, srv.URL, "pgk_test", "", "Cantinarr", nil)
+	if mgr.Ensure(context.Background()) == nil {
+		t.Fatal("Ensure returned nil")
+	}
+	n := NewNotifier(database, mgr, nil)
+
+	// new_movie is on by default, so user 1 is targeted and a send happens.
+	n.NotifyNewMovie("The Matrix", 603)
+
+	// The pruned token's local row must be deleted (fire-and-forget, so poll).
+	deadline := time.After(2 * time.Second)
+	for {
+		var count int
+		if err := database.QueryRow("SELECT COUNT(*) FROM push_tokens WHERE token = 'tok-dead'").Scan(&count); err != nil {
+			t.Fatalf("count tokens: %v", err)
+		}
+		if count == 0 {
+			return // pruned as expected
+		}
+		select {
+		case <-deadline:
+			t.Fatal("dead token was not pruned from push_tokens")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
 func TestNotifyNewContentNoRecipientsIsNoop(t *testing.T) {
 	database, err := dbOpen(t)
 	if err != nil {
@@ -349,8 +401,8 @@ func TestNotifyNewContentNoRecipientsIsNoop(t *testing.T) {
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'alice', '', 'user')")
 	mustExec(t, database, "INSERT INTO notification_prefs (user_id, new_movie) VALUES (1, 0)")
 
-	client, cap := newNotifierTestGateway(t)
-	n := NewNotifier(database, client, nil)
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
 
 	n.NotifyNewMovie("The Matrix", 603)
 


### PR DESCRIPTION
Hardens push per the robustness review.

**Server**
- `push.Manager`: lazy, self-healing gateway client. Resolves key (explicit env > stored > self-enroll), **single-flight** `Ensure`, **background retry** until the gateway is reachable, and **reconciliation** (`ForwardStoredTokens`) on first success — so a gateway down at boot, or tokens registered while push was off, recover with **no restart or app re-open**.
- **Prune-learning**: the notifier reads the gateway send response and deletes local `push_tokens` it reports dead.
- **`POST /api/notifications/test`** (authed): test push to the caller — `200 {sent,failed}` / `503` unconfigured / `502` gateway error.

**Flutter**
- Notification Preferences **Status** section: permission state, *Open iOS Settings* (denied), *Enable notifications* (undetermined), and a **Send test notification** button.

Verified: `go build/vet/test` + `-race` + gofmt clean; `flutter analyze` clean. (`AppDelegate.swift` 'No such module Flutter' in editor diagnostics is the usual generated-at-build-time false positive.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)