### PR TITLE
ci(testflight): serialize runs + skip web/macOS-only changes

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -5,8 +5,21 @@ on:
     branches: [main]
     paths:
       - "app/**"
+      - "!app/web/**"
+      - "!app/macos/**"
+      - "!app/android/**"
+      - "!app/windows/**"
+      - "!app/linux/**"
       - ".github/workflows/testflight.yml"
   workflow_dispatch:
+
+# Serialize TestFlight runs. The build number is latest_testflight_build_number + 1,
+# so two concurrent runs compute the SAME number and the second upload is rejected
+# as a duplicate (ENTITY_ERROR.ATTRIBUTE.INVALID.DUPLICATE). Queue instead of racing,
+# and never cancel an in-flight upload.
+concurrency:
+  group: testflight-deploy
+  cancel-in-progress: false
 
 jobs:
   deploy:


### PR DESCRIPTION
Fixes the build-number race that failed #79's run (two concurrent app/ merges both computed build 93 → duplicate-upload rejection). Adds a `concurrency` group (queue, don't race) and narrows the path filter so web/macOS/other-platform-only changes don't trigger a redundant iOS build. Build-number logic unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)