### PR TITLE
fix(auth/push): survive offline cold-launch; honest push tests; per-user device links

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -18,7 +18,8 @@ class CantinarrApp extends ConsumerStatefulWidget {
   ConsumerState<CantinarrApp> createState() => _CantinarrAppState();
 }
 
-class _CantinarrAppState extends ConsumerState<CantinarrApp> {
+class _CantinarrAppState extends ConsumerState<CantinarrApp>
+    with WidgetsBindingObserver {
   late final AppLinks _appLinks;
   StreamSubscription<Uri>? _linkSubscription;
   final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
@@ -26,8 +27,18 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp> {
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _appLinks = AppLinks();
     _initDeepLinks();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Returning to the foreground is a good moment to retry a reconnecting
+    // session immediately instead of waiting for the periodic retry.
+    if (state == AppLifecycleState.resumed) {
+      ref.read(authProvider.notifier).reconnectNow();
+    }
   }
 
   Future<void> _initDeepLinks() async {
@@ -98,6 +109,7 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp> {
 
   @override
   void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
     _linkSubscription?.cancel();
     super.dispose();
   }
@@ -156,6 +168,111 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp> {
       debugShowCheckedModeBanner: false,
       scaffoldMessengerKey: _scaffoldMessengerKey,
       routerConfig: router,
+      builder: (context, child) =>
+          _ReconnectingBanner(child: child ?? const SizedBox.shrink()),
+    );
+  }
+}
+
+/// A thin, non-interactive "Reconnecting…" bar shown at the top of the app
+/// while a session is held optimistically and the server is unreachable. It
+/// waits briefly before appearing so a normal (fast) reconnect never flashes
+/// it, keeping launches seamless.
+class _ReconnectingBanner extends ConsumerStatefulWidget {
+  const _ReconnectingBanner({required this.child});
+
+  final Widget child;
+
+  @override
+  ConsumerState<_ReconnectingBanner> createState() =>
+      _ReconnectingBannerState();
+}
+
+class _ReconnectingBannerState extends ConsumerState<_ReconnectingBanner> {
+  Timer? _delay;
+  bool _visible = false;
+  bool? _lastReconnecting;
+
+  @override
+  void dispose() {
+    _delay?.cancel();
+    super.dispose();
+  }
+
+  void _onChanged(bool reconnecting) {
+    if (reconnecting) {
+      // Defer showing so quick reconnects don't flash the bar.
+      _delay ??= Timer(const Duration(milliseconds: 1200), () {
+        if (mounted) setState(() => _visible = true);
+      });
+    } else {
+      _delay?.cancel();
+      _delay = null;
+      if (_visible && mounted) setState(() => _visible = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final reconnecting = ref.watch(
+      authProvider.select((s) => s.valueOrNull?.isReconnecting ?? false),
+    );
+    // React to transitions after the frame so we never call setState mid-build.
+    if (reconnecting != _lastReconnecting) {
+      _lastReconnecting = reconnecting;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _onChanged(reconnecting);
+      });
+    }
+
+    return Stack(
+      textDirection: TextDirection.ltr,
+      fit: StackFit.expand,
+      children: [
+        widget.child,
+        if (_visible)
+          const Positioned(
+            top: 0,
+            left: 0,
+            right: 0,
+            child: IgnorePointer(
+              child: SafeArea(
+                bottom: false,
+                child: _ReconnectingBar(),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+/// The bar's visual content, factored out so the whole overlay can be const.
+class _ReconnectingBar extends StatelessWidget {
+  const _ReconnectingBar();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 26,
+      color: AppTheme.surfaceVariant,
+      alignment: Alignment.center,
+      child: const Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 12,
+            height: 12,
+            child: CircularProgressIndicator(
+                strokeWidth: 2, color: AppTheme.accent),
+          ),
+          SizedBox(width: 8),
+          Text(
+            'Reconnecting…',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/app/lib/core/network/backend_auth_interceptor.dart
+++ b/app/lib/core/network/backend_auth_interceptor.dart
@@ -6,7 +6,10 @@ import 'package:flutter/foundation.dart';
 ///
 /// On 401 responses, attempts a token refresh via POST /api/auth/refresh.
 /// If refresh succeeds, retries the original request with the new token.
-/// If refresh fails, calls [onAuthExpired] to clear auth state.
+/// Only a genuine rejection (the server answers the refresh with a 401) calls
+/// [onAuthExpired] to clear auth state. A transport failure (VPN down, server
+/// unreachable, timeout) leaves the session intact — the token just couldn't be
+/// refreshed right now.
 class BackendAuthInterceptor extends Interceptor {
   final String Function() getAccessToken;
   final String Function() getRefreshToken;
@@ -75,7 +78,7 @@ class BackendAuthInterceptor extends Interceptor {
       return _refreshCompleter!.future;
     }
 
-    _refreshCompleter = Completer<bool>();
+    final completer = _refreshCompleter = Completer<bool>();
 
     try {
       final dio = Dio();
@@ -93,16 +96,33 @@ class BackendAuthInterceptor extends Interceptor {
         final newAccess = data['access_token'] as String;
         final newRefresh = data['refresh_token'] as String? ?? refreshToken;
         await onTokenRefreshed(newAccess, newRefresh);
-        _refreshCompleter!.complete(true);
-        return true;
+        return _settle(completer, true);
       }
+      // A non-200 without an exception: don't retry, but don't tear the session
+      // down either.
+      return _settle(completer, false);
+    } on DioException catch (e) {
+      // Only a genuine rejection (server reached us and refused the refresh
+      // token — a 401) ends the session. Transport failures (VPN down, server
+      // unreachable, timeout) must NOT log the user out: the long-lived refresh
+      // token is still valid and the next request will retry.
+      if (e.response?.statusCode == 401) {
+        onAuthExpired();
+      } else {
+        debugPrint('Token refresh deferred (server unreachable): $e');
+      }
+      return _settle(completer, false);
     } catch (e) {
-      debugPrint('Token refresh failed: $e');
+      debugPrint('Token refresh failed (session kept): $e');
+      return _settle(completer, false);
     }
+  }
 
-    onAuthExpired();
-    _refreshCompleter!.complete(false);
+  /// Completes the in-flight refresh guard with [result] and clears it, so a
+  /// later 401 starts a fresh refresh instead of reusing this completed future.
+  bool _settle(Completer<bool> completer, bool result) {
+    if (!completer.isCompleted) completer.complete(result);
     _refreshCompleter = null;
-    return false;
+    return result;
   }
 }

--- a/app/lib/core/storage/secure_storage.dart
+++ b/app/lib/core/storage/secure_storage.dart
@@ -70,4 +70,10 @@ class StorageKeys {
   static const String refreshToken = 'jwt_refresh_token';
   static const String serverUrl = 'server_url';
   static const String deviceId = 'device_id';
+
+  // Cached session snapshot (user profile + server config, no secrets) so a
+  // cold launch can restore an optimistic, usable session and validate it in
+  // the background instead of flashing the login screen while offline.
+  static const String sessionUser = 'session_user';
+  static const String sessionConnection = 'session_connection';
 }

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -71,7 +71,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
 
   @override
   Future<AuthState> build() async {
-    _authService = AuthService();
+    _authService = ref.read(authServiceProvider);
     _storage = ref.read(storageServiceProvider);
 
     ref.onDispose(() {
@@ -880,6 +880,10 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     return 'Connection failed. The link may be invalid or expired.';
   }
 }
+
+/// The auth service used by [AuthNotifier]. Exposed as a provider so tests can
+/// inject a fake (subclass [AuthService]) without hitting the network.
+final authServiceProvider = Provider<AuthService>((ref) => AuthService());
 
 /// The main auth state provider used throughout the app.
 final authProvider =

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dio/dio.dart';
@@ -19,12 +21,18 @@ class AuthState {
   final String? error;
   final bool pendingPasskeyOffer;
 
+  /// True when the session was restored optimistically from cache and has not
+  /// yet been (re)validated with the server — i.e. we're "reconnecting". The
+  /// user stays in the app; the UI shows a subtle reconnecting indicator.
+  final bool isReconnecting;
+
   const AuthState({
     this.connection,
     this.user,
     this.isLoading = false,
     this.error,
     this.pendingPasskeyOffer = false,
+    this.isReconnecting = false,
   });
 
   bool get isAuthenticated => connection != null && user != null;
@@ -35,6 +43,7 @@ class AuthState {
     bool? isLoading,
     String? error,
     bool? pendingPasskeyOffer,
+    bool? isReconnecting,
     bool clearConnection = false,
     bool clearUser = false,
     bool clearError = false,
@@ -45,6 +54,7 @@ class AuthState {
         isLoading: isLoading ?? this.isLoading,
         error: clearError ? null : (error ?? this.error),
         pendingPasskeyOffer: pendingPasskeyOffer ?? this.pendingPasskeyOffer,
+        isReconnecting: isReconnecting ?? this.isReconnecting,
       );
 }
 
@@ -53,10 +63,21 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   late final AuthService _authService;
   late final StorageService _storage;
 
+  /// Periodic retry while holding an optimistic (reconnecting) session.
+  Timer? _reconnectTimer;
+
+  /// Guards against overlapping background validations.
+  bool _validating = false;
+
   @override
   Future<AuthState> build() async {
     _authService = AuthService();
     _storage = ref.read(storageServiceProvider);
+
+    ref.onDispose(() {
+      _reconnectTimer?.cancel();
+      _reconnectTimer = null;
+    });
 
     // Try to restore session from secure storage
     return _tryRestoreSession();
@@ -66,27 +87,82 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     final serverUrl = await _storage.read(key: StorageKeys.serverUrl);
     final accessToken = await _storage.read(key: StorageKeys.jwt);
     final refreshToken = await _storage.read(key: StorageKeys.refreshToken);
-    final deviceId = await _storage.read(key: StorageKeys.deviceId);
 
     if (serverUrl == null || accessToken == null || refreshToken == null) {
       return const AuthState();
     }
 
-    try {
-      // Refresh first, then persist the rotated tokens immediately. The refresh
-      // token is single-use, so saving before the config fetch ensures a later
-      // failure can't strand the session on an already-spent token.
-      final authResp = await _authService.refreshToken(serverUrl, refreshToken);
-      await _saveTokens(
-        serverUrl,
-        authResp.accessToken,
-        authResp.refreshToken,
-        authResp.deviceId ?? deviceId,
-      );
+    // If a session snapshot is cached, open straight into an optimistic,
+    // authenticated session and validate it in the background — the app never
+    // flashes the login screen on a slow or offline launch. The seamless path.
+    final cached = await _cachedSession(serverUrl, accessToken, refreshToken);
+    if (cached != null) {
+      unawaited(_validateSession());
+      return cached;
+    }
 
+    // No snapshot yet (first launch after install, or a pre-feature session):
+    // validate inline, which also writes the snapshot for next time.
+    return _restoreInline(serverUrl, accessToken, refreshToken);
+  }
+
+  /// Builds an optimistic [AuthState] from the cached session snapshot plus the
+  /// stored tokens, or null when no snapshot is cached. The access token may be
+  /// stale; [_validateSession] refreshes it. Marked reconnecting until then.
+  Future<AuthState?> _cachedSession(
+    String serverUrl,
+    String accessToken,
+    String refreshToken,
+  ) async {
+    final userJson = await _storage.read(key: StorageKeys.sessionUser);
+    final connJson = await _storage.read(key: StorageKeys.sessionConnection);
+    if (userJson == null || connJson == null) return null;
+    try {
+      final user =
+          UserProfile.fromJson(jsonDecode(userJson) as Map<String, dynamic>);
+      final meta = jsonDecode(connJson) as Map<String, dynamic>;
+      final services = meta['services'];
+      final connection = BackendConnection(
+        serverUrl: serverUrl,
+        accessToken: accessToken,
+        refreshToken: refreshToken,
+        serverName: meta['server_name'] as String?,
+        services: services is Map<String, dynamic>
+            ? AvailableServices.fromJson(services)
+            : const AvailableServices(),
+        instances: (meta['instances'] as List<dynamic>?)
+                ?.map((e) =>
+                    ServiceInstance.fromJson(e as Map<String, dynamic>))
+                .toList() ??
+            const [],
+      );
+      return AuthState(
+          connection: connection, user: user, isReconnecting: true);
+    } catch (e) {
+      debugPrint('Cached session decode failed: $e');
+      return null;
+    }
+  }
+
+  /// Validates the restored session against the server and reconciles state:
+  /// fresh data on success, login on a genuine 401, or a "reconnecting" hold
+  /// (with a retry scheduled) on a transport failure. Safe to call repeatedly.
+  Future<void> _validateSession() async {
+    if (_validating) return;
+    _validating = true;
+    try {
+      final serverUrl = await _storage.read(key: StorageKeys.serverUrl);
+      final refreshToken = await _storage.read(key: StorageKeys.refreshToken);
+      final deviceId = await _storage.read(key: StorageKeys.deviceId);
+      if (serverUrl == null || refreshToken == null) return;
+
+      // Refresh first, persist immediately (the refresh token is single-use),
+      // then fetch config.
+      final authResp = await _authService.refreshToken(serverUrl, refreshToken);
+      await _saveTokens(serverUrl, authResp.accessToken, authResp.refreshToken,
+          authResp.deviceId ?? deviceId);
       final config =
           await _authService.fetchConfig(serverUrl, authResp.accessToken);
-
       final connection = BackendConnection(
         serverUrl: serverUrl,
         accessToken: authResp.accessToken,
@@ -95,16 +171,60 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         services: config.services,
         instances: config.instances,
       );
+      await _persistSession(connection, authResp.user);
+      _stopReconnect();
+      state = AsyncData(AuthState(connection: connection, user: authResp.user));
+      _registerForPush();
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 401) {
+        // The server rejected the refresh token: the session is truly dead.
+        _stopReconnect();
+        await _clearStorage();
+        state = const AsyncData(AuthState());
+      } else {
+        // Server unreachable: keep the user in the app and keep retrying.
+        debugPrint('Session validation deferred (server unreachable): $e');
+        _markReconnecting();
+      }
+    } catch (e) {
+      debugPrint('Session validation error (staying optimistic): $e');
+      _markReconnecting();
+    } finally {
+      _validating = false;
+    }
+  }
 
+  /// No-snapshot fallback: validate the stored tokens inline and return the
+  /// resulting state. Keeps tokens on a transport failure (only a real 401
+  /// clears them) and writes a session snapshot on success.
+  Future<AuthState> _restoreInline(
+    String serverUrl,
+    String accessToken,
+    String refreshToken,
+  ) async {
+    final deviceId = await _storage.read(key: StorageKeys.deviceId);
+    try {
+      final authResp = await _authService.refreshToken(serverUrl, refreshToken);
+      await _saveTokens(serverUrl, authResp.accessToken, authResp.refreshToken,
+          authResp.deviceId ?? deviceId);
+      final config =
+          await _authService.fetchConfig(serverUrl, authResp.accessToken);
+      final connection = BackendConnection(
+        serverUrl: serverUrl,
+        accessToken: authResp.accessToken,
+        refreshToken: authResp.refreshToken,
+        serverName: config.serverName,
+        services: config.services,
+        instances: config.instances,
+      );
+      await _persistSession(connection, authResp.user);
       _registerForPush();
       return AuthState(connection: connection, user: authResp.user);
     } on DioException catch (e) {
-      // Only clear the stored session when the server actually rejected the
-      // credential (a 401 — refresh token invalid/expired/replaced). A transport
-      // failure (VPN down, server unreachable, timeout) must NOT delete the
-      // tokens: keeping them lets the session restore automatically on the next
-      // launch once connectivity returns. Wiping them here is exactly what made
-      // an offline cold-launch a permanent, new-link-only logout.
+      // Only a genuine 401 clears the session; a transport failure keeps the
+      // tokens so the next launch can restore. (Without a snapshot we can't show
+      // an optimistic session yet, so this lands on login until connectivity
+      // returns — the snapshot written on the first success fixes that.)
       if (e.response?.statusCode == 401) {
         debugPrint('Session restore rejected by server (401); clearing.');
         await _clearStorage();
@@ -113,10 +233,41 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       }
       return const AuthState();
     } catch (e) {
-      // Unexpected non-network error: keep the tokens (fail safe — never log the
-      // user out over an unexpected client-side error) and retry next launch.
       debugPrint('Session restore error (tokens kept): $e');
       return const AuthState();
+    }
+  }
+
+  /// Flags the current (optimistic) session as reconnecting and starts the
+  /// retry loop. No-op once the session is gone.
+  void _markReconnecting() {
+    final current = state.valueOrNull;
+    if (current == null || !current.isAuthenticated) return;
+    if (!current.isReconnecting) {
+      state = AsyncData(current.copyWith(isReconnecting: true));
+    }
+    _scheduleReconnect();
+  }
+
+  void _scheduleReconnect() {
+    if (_reconnectTimer != null) return;
+    _reconnectTimer = Timer.periodic(const Duration(seconds: 8), (_) {
+      unawaited(_validateSession());
+    });
+  }
+
+  void _stopReconnect() {
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
+  }
+
+  /// Retry validation now (e.g. when the app returns to the foreground) instead
+  /// of waiting for the periodic timer. No-op unless we're holding a
+  /// reconnecting session.
+  void reconnectNow() {
+    final current = state.valueOrNull;
+    if (current != null && current.isAuthenticated && current.isReconnecting) {
+      unawaited(_validateSession());
     }
   }
 
@@ -153,6 +304,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         instances: config.instances,
       );
 
+      await _persistSession(connection, authResp.user);
       state = AsyncData(AuthState(
         connection: connection,
         user: authResp.user,
@@ -202,6 +354,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       final offerPasskey =
           authResp.user.isAdmin && await _shouldOfferPasskey(normalizedUrl);
 
+      await _persistSession(connection, authResp.user);
       state = AsyncData(AuthState(
         connection: connection,
         user: authResp.user,
@@ -241,6 +394,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         instances: config.instances,
       );
 
+      await _persistSession(connection, authResp.user);
       state = AsyncData(AuthState(connection: connection, user: authResp.user));
       _registerForPush();
     } catch (e) {
@@ -271,13 +425,14 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     final conn = current!.connection!;
     final config =
         await _authService.fetchConfig(conn.serverUrl, conn.accessToken);
-    state = AsyncData(current.copyWith(
-      connection: conn.copyWith(
-        serverName: config.serverName,
-        services: config.services,
-        instances: config.instances,
-      ),
-    ));
+    final updatedConn = conn.copyWith(
+      serverName: config.serverName,
+      services: config.services,
+      instances: config.instances,
+    );
+    final user = current.user;
+    if (user != null) await _persistSession(updatedConn, user);
+    state = AsyncData(current.copyWith(connection: updatedConn));
   }
 
   /// Re-fetch the current user's profile (e.g. to learn whether a password is
@@ -288,6 +443,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     if (current == null || conn == null) return;
     try {
       final user = await _authService.fetchMe(conn.serverUrl, conn.accessToken);
+      await _persistSession(conn, user);
       state = AsyncData(current.copyWith(user: user));
     } catch (e) {
       debugPrint('refreshUser failed: $e');
@@ -452,6 +608,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         instances: config.instances,
       );
 
+      await _persistSession(connection, authResp.user);
       state = AsyncData(AuthState(connection: connection, user: authResp.user));
       _registerForPush();
     } catch (e) {
@@ -487,7 +644,11 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     await _storage.write(key: StorageKeys.jwt, value: accessToken);
     await _storage.write(key: StorageKeys.refreshToken, value: refreshToken);
 
-    state = AsyncData(current.copyWith(connection: updated));
+    // A successful refresh means we reached the server — clear any reconnecting
+    // hold and stop the retry loop.
+    _stopReconnect();
+    state = AsyncData(
+        current.copyWith(connection: updated, isReconnecting: false));
   }
 
   /// Called when the server has *rejected* our refresh token (a genuine 401):
@@ -541,10 +702,30 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   }
 
   Future<void> _clearStorage() async {
+    _stopReconnect();
     await _storage.delete(key: StorageKeys.serverUrl);
     await _storage.delete(key: StorageKeys.jwt);
     await _storage.delete(key: StorageKeys.refreshToken);
     await _storage.delete(key: StorageKeys.deviceId);
+    await _storage.delete(key: StorageKeys.sessionUser);
+    await _storage.delete(key: StorageKeys.sessionConnection);
+  }
+
+  /// Cache the non-secret parts of an authenticated session (user profile +
+  /// server config) so a later cold start can restore an optimistic, usable
+  /// session before the server is reachable. Tokens are stored separately.
+  Future<void> _persistSession(
+      BackendConnection conn, UserProfile user) async {
+    await _storage.write(
+        key: StorageKeys.sessionUser, value: jsonEncode(user.toJson()));
+    await _storage.write(
+      key: StorageKeys.sessionConnection,
+      value: jsonEncode({
+        'server_name': conn.serverName,
+        'services': conn.services.toJson(),
+        'instances': conn.instances.map((i) => i.toJson()).toList(),
+      }),
+    );
   }
 
   /// Fire-and-forget push registration. Must never block or throw into the

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -73,18 +73,19 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     }
 
     try {
-      // Try refreshing the token
+      // Refresh first, then persist the rotated tokens immediately. The refresh
+      // token is single-use, so saving before the config fetch ensures a later
+      // failure can't strand the session on an already-spent token.
       final authResp = await _authService.refreshToken(serverUrl, refreshToken);
-      final config =
-          await _authService.fetchConfig(serverUrl, authResp.accessToken);
-
-      // Persist new tokens
       await _saveTokens(
         serverUrl,
         authResp.accessToken,
         authResp.refreshToken,
         authResp.deviceId ?? deviceId,
       );
+
+      final config =
+          await _authService.fetchConfig(serverUrl, authResp.accessToken);
 
       final connection = BackendConnection(
         serverUrl: serverUrl,
@@ -97,9 +98,24 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
 
       _registerForPush();
       return AuthState(connection: connection, user: authResp.user);
+    } on DioException catch (e) {
+      // Only clear the stored session when the server actually rejected the
+      // credential (a 401 — refresh token invalid/expired/replaced). A transport
+      // failure (VPN down, server unreachable, timeout) must NOT delete the
+      // tokens: keeping them lets the session restore automatically on the next
+      // launch once connectivity returns. Wiping them here is exactly what made
+      // an offline cold-launch a permanent, new-link-only logout.
+      if (e.response?.statusCode == 401) {
+        debugPrint('Session restore rejected by server (401); clearing.');
+        await _clearStorage();
+      } else {
+        debugPrint('Session restore deferred (server unreachable): $e');
+      }
+      return const AuthState();
     } catch (e) {
-      debugPrint('Session restore failed: $e');
-      await _clearStorage();
+      // Unexpected non-network error: keep the tokens (fail safe — never log the
+      // user out over an unexpected client-side error) and retry next launch.
+      debugPrint('Session restore error (tokens kept): $e');
       return const AuthState();
     }
   }
@@ -474,11 +490,17 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     state = AsyncData(current.copyWith(connection: updated));
   }
 
-  /// Called when auth has expired (refresh rejected) or on logout. Clears
-  /// state. Best-effort unregisters push first, while the device id and tokens
-  /// are still available.
+  /// Called when the server has *rejected* our refresh token (a genuine 401):
+  /// the session is truly dead, so clear stored credentials and reset state.
+  ///
+  /// We deliberately do not unregister the push token here. By this point the
+  /// access token is already invalid, so the server-side delete couldn't
+  /// authenticate anyway; and transport failures never reach this path (the
+  /// interceptor only expires on a real 401), so a dropped VPN can't wipe the
+  /// device's push registration. A stale gateway token is pruned server-side the
+  /// next time APNs reports it unregistered. Push deregistration belongs to an
+  /// explicit, deliberate logout (token still valid) — not to session expiry.
   Future<void> onAuthExpired() async {
-    await ref.read(pushServiceProvider).unregister();
     await _clearStorage();
     state = const AsyncData(AuthState());
   }

--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -92,17 +92,26 @@ class PushService {
     }
   }
 
-  /// Asks the backend to send a test push notification to this account's
-  /// registered devices. Returns how many were delivered or failed. Throws on
-  /// any error (including a 503 when push isn't configured) so the caller can
-  /// surface the failure.
-  Future<({int sent, int failed})> sendTest() async {
+  /// Asks the backend to send a test push to this account's own devices and
+  /// returns the diagnostic outcome (tokens registered + per-device results).
+  /// Throws on transport/HTTP errors (including a 503 when push isn't
+  /// configured) so the caller can surface the failure.
+  Future<PushTestResult> sendTest() async {
     final dio = _ref.read(backendClientProvider);
     final resp = await dio.post('/api/notifications/test');
-    final data = resp.data as Map<String, dynamic>? ?? const {};
-    final sent = (data['sent'] as num?)?.toInt() ?? 0;
-    final failed = (data['failed'] as num?)?.toInt() ?? 0;
-    return (sent: sent, failed: failed);
+    return PushTestResult.fromJson(
+        resp.data as Map<String, dynamic>? ?? const {});
+  }
+
+  /// Admin-only: send a test push to another user's devices. Mirrors [sendTest]
+  /// but targets [userId] via the admin endpoint, so an admin can verify a
+  /// specific account's delivery (the self-test can't reach another account).
+  /// Throws on error.
+  Future<PushTestResult> sendTestToUser(int userId) async {
+    final dio = _ref.read(backendClientProvider);
+    final resp = await dio.post('/api/admin/users/$userId/test-push');
+    return PushTestResult.fromJson(
+        resp.data as Map<String, dynamic>? ?? const {});
   }
 
   /// Removes this device's push token from the backend. Best-effort; call
@@ -147,3 +156,105 @@ class PushService {
 
 /// Provides the app-wide [PushService].
 final pushServiceProvider = Provider<PushService>(PushService.new);
+
+/// The outcome of a test-push request: how many tokens the target has
+/// registered, plus the gateway's per-device delivery results.
+class PushTestResult {
+  const PushTestResult({
+    required this.tokens,
+    required this.sent,
+    required this.failed,
+    required this.results,
+  });
+
+  /// Number of push tokens registered for the target user. Zero is the headline
+  /// diagnostic — the device never registered, so nothing could be delivered.
+  final int tokens;
+  final int sent;
+  final int failed;
+  final List<PushTestDeviceResult> results;
+
+  factory PushTestResult.fromJson(Map<String, dynamic> json) => PushTestResult(
+        tokens: (json['tokens'] as num?)?.toInt() ?? 0,
+        sent: (json['sent'] as num?)?.toInt() ?? 0,
+        failed: (json['failed'] as num?)?.toInt() ?? 0,
+        results: (json['results'] as List<dynamic>?)
+                ?.map((e) =>
+                    PushTestDeviceResult.fromJson(e as Map<String, dynamic>))
+                .toList() ??
+            const [],
+      );
+
+  /// The first non-empty per-device error reason, if any (e.g. a rejected
+  /// token's `BadDeviceToken`).
+  String? get firstError {
+    for (final r in results) {
+      if (r.error.isNotEmpty) return r.error;
+    }
+    return null;
+  }
+}
+
+/// One device's delivery outcome within a [PushTestResult].
+class PushTestDeviceResult {
+  const PushTestDeviceResult({
+    required this.ok,
+    required this.pruned,
+    required this.error,
+  });
+
+  final bool ok;
+  final bool pruned;
+  final String error;
+
+  factory PushTestDeviceResult.fromJson(Map<String, dynamic> json) =>
+      PushTestDeviceResult(
+        ok: json['ok'] as bool? ?? false,
+        pruned: json['pruned'] as bool? ?? false,
+        error: json['error'] as String? ?? '',
+      );
+}
+
+/// Builds a human-readable summary of a [PushTestResult] for a snackbar. Pass
+/// [username] for an admin test of another account; omit it for the caller's
+/// own self-test.
+String describePushTest(PushTestResult r, {String? username}) {
+  if (r.tokens == 0) {
+    final subject = username == null ? 'You have' : '$username has';
+    return '$subject no registered push devices yet. Open the app on the '
+        'device (while connected) and allow notifications so it can register.';
+  }
+  if (r.sent > 0 && r.failed == 0) {
+    final n = r.sent == 1 ? '1 device' : '${r.sent} devices';
+    return username == null ? 'Test sent to $n.' : 'Test sent to $username ($n).';
+  }
+  if (r.sent == 0 && r.failed == 0) {
+    // Tokens exist locally but the gateway accepted none — usually a desync
+    // where the gateway already pruned them.
+    return 'No devices were reached — the push gateway has no active token for '
+        '${username ?? 'this account'}. Have them reopen the app to re-register.';
+  }
+  final hint = _apnsHint(r.firstError);
+  if (r.sent > 0) {
+    return 'Sent to ${r.sent}, but ${r.failed} failed$hint.';
+  }
+  final n = r.failed == 1 ? '1 device' : '${r.failed} devices';
+  return username == null
+      ? 'Delivery failed for $n$hint.'
+      : '$username: delivery failed for $n$hint.';
+}
+
+/// Maps the common APNs rejection reasons to a short hint; otherwise echoes the
+/// raw reason in parentheses (or empty when there is none).
+String _apnsHint(String? error) {
+  if (error == null || error.isEmpty) return '';
+  if (error.contains('BadDeviceToken')) {
+    return ' (Apple rejected the token — usually a dev build’s sandbox '
+        'token sent to production APNs, or a stale token)';
+  }
+  if (error.contains('Unregistered')) {
+    return ' (Apple says the token is no longer valid — the app was removed or '
+        'reinstalled; it re-registers on next launch)';
+  }
+  return ' ($error)';
+}

--- a/app/lib/features/notifications/ui/notification_preferences_screen.dart
+++ b/app/lib/features/notifications/ui/notification_preferences_screen.dart
@@ -108,7 +108,7 @@ class _NotificationPreferencesScreenState
       final result = await ref.read(pushServiceProvider).sendTest();
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Test sent (${result.sent} delivered)')),
+        SnackBar(content: Text(describePushTest(result))),
       );
     } catch (e) {
       if (!mounted) return;

--- a/app/lib/features/settings/ui/users_screen.dart
+++ b/app/lib/features/settings/ui/users_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/data/auth_service.dart';
 import '../../auth/logic/auth_provider.dart';
+import '../../notifications/push_service.dart';
 
 /// Admin screen for managing user accounts: change roles, remove users, and
 /// see who still has an outstanding connect-link invite.
@@ -185,6 +186,28 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
     );
   }
 
+  /// Send a test push to a user's devices and report the real outcome — how
+  /// many devices are registered and whether Apple accepted the push. The
+  /// self-only test on the notifications screen can't reach another account, so
+  /// this is how an admin verifies a specific user's delivery.
+  Future<void> _sendTestPush(UserSummary user) async {
+    try {
+      final result =
+          await ref.read(pushServiceProvider).sendTestToUser(user.id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(describePushTest(result, username: user.username)),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_friendlyError(e, 'Failed to send test push'))),
+      );
+    }
+  }
+
   /// Enable or disable a user's password / passkey sign-in. Disabling is a real
   /// revoke (clears the password / deletes passkeys), so confirm it first.
   Future<void> _setAuthMethods(
@@ -304,6 +327,7 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
             onChangeRole: (role) => _changeRole(user, role),
             onDelete: () => _deleteUser(user),
             onResendInvite: () => _resendInvite(user),
+            onSendTestPush: () => _sendTestPush(user),
             onRequestSettings: () => context.push(
               '/settings/users/${user.id}/request-settings',
               extra: user.username,
@@ -328,6 +352,7 @@ class _UserTile extends StatelessWidget {
     required this.onChangeRole,
     required this.onDelete,
     required this.onResendInvite,
+    required this.onSendTestPush,
     required this.onSetAuthMethods,
     required this.onRequestSettings,
   });
@@ -337,6 +362,7 @@ class _UserTile extends StatelessWidget {
   final ValueChanged<String> onChangeRole;
   final VoidCallback onDelete;
   final VoidCallback onResendInvite;
+  final VoidCallback onSendTestPush;
   final void Function({bool? passwordEnabled, bool? passkeyEnabled})
       onSetAuthMethods;
   final VoidCallback onRequestSettings;
@@ -423,6 +449,9 @@ class _UserTile extends StatelessWidget {
           case 'resend_invite':
             onResendInvite();
             break;
+          case 'test_push':
+            onSendTestPush();
+            break;
           case 'request_settings':
             onRequestSettings();
             break;
@@ -453,14 +482,28 @@ class _UserTile extends StatelessWidget {
               contentPadding: EdgeInsets.zero,
             ),
           ),
-        if (_needsInvite)
+        // A connect link works for any user: re-invite one stuck in invited
+        // limbo, re-auth one who lost their session, or authorize a new device
+        // for one who already has one (find-or-create reuses the account).
+        if (!isSelf)
           PopupMenuItem(
             value: 'resend_invite',
             child: ListTile(
               leading: const Icon(Icons.link),
               title: Text(
-                user.hasPendingInvite ? 'New invite link' : 'Re-invite',
+                user.hasPendingInvite
+                    ? 'New invite link'
+                    : (_needsInvite ? 'Re-invite' : 'Issue device link'),
               ),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+        if (!isSelf)
+          const PopupMenuItem(
+            value: 'test_push',
+            child: ListTile(
+              leading: Icon(Icons.notifications_active_outlined),
+              title: Text('Send test push'),
               contentPadding: EdgeInsets.zero,
             ),
           ),

--- a/app/test/auth/auth_restore_test.dart
+++ b/app/test/auth/auth_restore_test.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/storage/secure_storage.dart';
+import 'package:cantinarr/features/auth/data/auth_service.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Exercises [AuthNotifier] session restore: the seamless optimistic restore,
+/// background validation, and — critically — that a transport failure NEVER
+/// destroys the stored session (only a genuine 401 does). These are the branches
+/// behind the offline-logout bug, so they're worth pinning down.
+void main() {
+  // The real PushService (constructed by _registerForPush on success paths)
+  // sets a MethodChannel handler; it needs the test binding initialised. It
+  // then no-ops off-iOS, so no platform calls actually happen.
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const user = UserProfile(id: 1, username: 'tester', role: 'user');
+  const freshResp = AuthResponse(
+    accessToken: 'new-access',
+    refreshToken: 'new-refresh',
+    user: user,
+    deviceId: 'dev-1',
+  );
+  const config =
+      ServerConfig(serverName: 'Home', services: AvailableServices(radarr: true));
+
+  final connectionError = DioException(
+    requestOptions: RequestOptions(path: '/api/auth/refresh'),
+    type: DioExceptionType.connectionError,
+  );
+  final unauthorized = DioException(
+    requestOptions: RequestOptions(path: '/api/auth/refresh'),
+    type: DioExceptionType.badResponse,
+    response: Response(
+      requestOptions: RequestOptions(path: '/api/auth/refresh'),
+      statusCode: 401,
+    ),
+  );
+
+  Map<String, String?> tokensOnlyStorage() => {
+        StorageKeys.serverUrl: 'http://localhost',
+        StorageKeys.jwt: 'old-access',
+        StorageKeys.refreshToken: 'old-refresh',
+        StorageKeys.deviceId: 'dev-1',
+      };
+
+  Map<String, String?> snapshotStorage() => {
+        ...tokensOnlyStorage(),
+        StorageKeys.sessionUser: jsonEncode(user.toJson()),
+        StorageKeys.sessionConnection: jsonEncode({
+          'server_name': 'Home',
+          'services': const AvailableServices(radarr: true).toJson(),
+          'instances': const <Map<String, dynamic>>[],
+        }),
+      };
+
+  ProviderContainer makeContainer(
+    Map<String, String?> storage,
+    AuthService authService,
+  ) {
+    final container = ProviderContainer(overrides: [
+      storageServiceProvider.overrideWithValue(_FakeStorage(storage)),
+      authServiceProvider.overrideWithValue(authService),
+    ]);
+    addTearDown(container.dispose);
+    return container;
+  }
+
+  group('with a cached snapshot (optimistic restore)', () {
+    test('opens authenticated + reconnecting, then upgrades to fresh on '
+        'successful validation', () async {
+      final storage = snapshotStorage();
+      final container = makeContainer(
+        storage,
+        _FakeAuthService(refreshResult: freshResp, config: config),
+      );
+
+      // Build returns the optimistic session immediately, from the snapshot.
+      final optimistic = await container.read(authProvider.future);
+      expect(optimistic.isAuthenticated, isTrue);
+      expect(optimistic.isReconnecting, isTrue);
+      expect(optimistic.user?.username, 'tester');
+      expect(optimistic.connection?.services.radarr, isTrue);
+
+      // Background validation then refreshes and clears the reconnecting flag.
+      await _pumpUntil(() {
+        final s = container.read(authProvider).valueOrNull;
+        return s != null && !s.isReconnecting;
+      });
+      final settled = container.read(authProvider).valueOrNull!;
+      expect(settled.isAuthenticated, isTrue);
+      expect(settled.isReconnecting, isFalse);
+      expect(storage[StorageKeys.jwt], 'new-access');
+      expect(storage[StorageKeys.refreshToken], 'new-refresh');
+    });
+
+    test('keeps the session (reconnecting) and retains tokens on a transport '
+        'failure', () async {
+      final storage = snapshotStorage();
+      final fake = _FakeAuthService(refreshError: connectionError);
+      final container = makeContainer(storage, fake);
+
+      await container.read(authProvider.future);
+      await _pumpUntil(() => fake.refreshCalls > 0);
+      // Let the (synchronous) catch + reconnecting handling fully settle.
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      final s = container.read(authProvider).valueOrNull!;
+      expect(s.isAuthenticated, isTrue, reason: 'must not log out while offline');
+      expect(s.isReconnecting, isTrue);
+      expect(storage[StorageKeys.refreshToken], 'old-refresh',
+          reason: 'tokens must survive a transport failure');
+      expect(storage[StorageKeys.jwt], 'old-access');
+      expect(storage[StorageKeys.sessionUser], isNotNull);
+    });
+
+    test('clears the session on a genuine 401', () async {
+      final storage = snapshotStorage();
+      final container =
+          makeContainer(storage, _FakeAuthService(refreshError: unauthorized));
+
+      await container.read(authProvider.future);
+      await _pumpUntil(() {
+        final s = container.read(authProvider).valueOrNull;
+        return s != null && !s.isAuthenticated;
+      });
+
+      expect(container.read(authProvider).valueOrNull!.isAuthenticated, isFalse);
+      expect(storage[StorageKeys.refreshToken], isNull);
+      expect(storage[StorageKeys.jwt], isNull);
+      expect(storage[StorageKeys.sessionUser], isNull,
+          reason: 'a real rejection should drop the cached snapshot too');
+    });
+  });
+
+  group('without a snapshot (inline fallback)', () {
+    test('authenticates and writes a snapshot on success', () async {
+      final storage = tokensOnlyStorage();
+      final container = makeContainer(
+        storage,
+        _FakeAuthService(refreshResult: freshResp, config: config),
+      );
+
+      final state = await container.read(authProvider.future);
+      expect(state.isAuthenticated, isTrue);
+      expect(state.isReconnecting, isFalse);
+      expect(storage[StorageKeys.jwt], 'new-access');
+      expect(storage[StorageKeys.sessionUser], isNotNull,
+          reason: 'a snapshot should be written so the next launch is seamless');
+    });
+
+    test('stays unauthenticated but RETAINS tokens on a transport failure',
+        () async {
+      final storage = tokensOnlyStorage();
+      final container =
+          makeContainer(storage, _FakeAuthService(refreshError: connectionError));
+
+      final state = await container.read(authProvider.future);
+      expect(state.isAuthenticated, isFalse);
+      expect(storage[StorageKeys.refreshToken], 'old-refresh',
+          reason: 'offline restore must not wipe the credential');
+    });
+
+    test('clears tokens on a genuine 401', () async {
+      final storage = tokensOnlyStorage();
+      final container =
+          makeContainer(storage, _FakeAuthService(refreshError: unauthorized));
+
+      final state = await container.read(authProvider.future);
+      expect(state.isAuthenticated, isFalse);
+      expect(storage[StorageKeys.refreshToken], isNull);
+    });
+  });
+}
+
+/// Pumps the event loop until [predicate] holds or the timeout elapses.
+Future<void> _pumpUntil(
+  bool Function() predicate, {
+  Duration timeout = const Duration(seconds: 2),
+}) async {
+  final sw = Stopwatch()..start();
+  while (!predicate()) {
+    if (sw.elapsed > timeout) fail('Condition not met within $timeout');
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+  }
+}
+
+/// In-memory [StorageService] backed by a caller-owned map so tests can both
+/// seed it and assert on it after the notifier mutates it.
+class _FakeStorage implements StorageService {
+  _FakeStorage(this._data);
+
+  final Map<String, String?> _data;
+
+  @override
+  Future<String?> read({required String key}) async => _data[key];
+
+  @override
+  Future<void> write({required String key, required String? value}) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({required String key}) async => _data.remove(key);
+}
+
+/// Fake [AuthService] that returns a canned refresh result or throws a chosen
+/// error, so restore can be driven through every branch without the network.
+class _FakeAuthService extends AuthService {
+  _FakeAuthService({this.refreshResult, this.refreshError, this.config});
+
+  final AuthResponse? refreshResult;
+  final Object? refreshError;
+  final ServerConfig? config;
+  int refreshCalls = 0;
+
+  @override
+  Future<AuthResponse> refreshToken(String serverUrl, String refreshToken) async {
+    refreshCalls++;
+    final error = refreshError;
+    if (error != null) throw error;
+    return refreshResult!;
+  }
+
+  @override
+  Future<ServerConfig> fetchConfig(String serverUrl, String accessToken) async {
+    return config ??
+        const ServerConfig(serverName: 'Home', services: AvailableServices());
+  }
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -132,6 +132,8 @@ func NewRouter(
 			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Patch("/users/{userID}", authHandler.HandleUpdateUserRole)
 			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Patch("/users/{userID}/auth-methods", authHandler.HandleUpdateUserAuthMethods)
 			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Delete("/users/{userID}", authHandler.HandleDeleteUser)
+			// Send a test push to a specific user's devices (delivery diagnostics).
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Post("/users/{userID}/test-push", pushHandler.TestPushToUser)
 
 			// Credential management
 			r.With(auth.RequirePermission(auth.PermissionCredentialsManage)).Get("/credentials", credHandler.Get)

--- a/server/internal/push/handler.go
+++ b/server/internal/push/handler.go
@@ -6,13 +6,19 @@ import (
 	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/windoze95/cantinarr-server/internal/auth"
 )
+
+// errPushNotConfigured is returned by the send helpers when push is disabled or
+// the gateway has not (yet) enrolled, so the handlers can map it to a 503.
+var errPushNotConfigured = errors.New("push not configured")
 
 // Handler serves the device push-token endpoints, the per-user notification
 // preferences endpoints, and the test-push endpoint. It holds the push Manager
@@ -183,36 +189,112 @@ func (h *Handler) UpdatePreferences(w http.ResponseWriter, r *http.Request) {
 // TestPush sends a test notification to the calling user's own devices so the
 // app's "Send test" button can confirm push works end to end. It bypasses the
 // per-category preferences on purpose (the user explicitly asked for it).
-// Returns 503 when push is unconfigured or the gateway is unreachable.
 func (h *Handler) TestPush(w http.ResponseWriter, r *http.Request) {
 	claims := auth.GetClaims(r.Context())
 	if claims == nil {
 		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 		return
 	}
+	h.runTestPush(w, r, claims.UserID)
+}
 
-	// Ensure (not just Client) so a first-ever test from a freshly-booted server
-	// that couldn't reach the gateway at startup still kicks enrollment.
-	var client *Client
-	if h.mgr != nil {
-		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-		defer cancel()
-		client = h.mgr.Ensure(ctx)
+// TestPushToUser sends a test notification to a chosen user's devices. It is the
+// admin-facing counterpart to TestPush (gated by users:manage on the router) so
+// an admin can verify push delivery for someone other than themselves — the
+// self-only test can't reach another account's devices.
+func (h *Handler) TestPushToUser(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseInt(chi.URLParam(r, "userID"), 10, 64)
+	if err != nil || userID <= 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid user id"})
+		return
 	}
-	if client == nil {
+	h.runTestPush(w, r, userID)
+}
+
+// testPushResult is one device's delivery outcome, sanitised for the client
+// (the raw APNs token is deliberately never exposed).
+type testPushResult struct {
+	DeviceID string `json:"device_id"`
+	OK       bool   `json:"ok"`
+	Pruned   bool   `json:"pruned"`
+	Error    string `json:"error,omitempty"`
+}
+
+// testPushResponse is the body returned by the test-push endpoints. Tokens is
+// how many push tokens are registered for the target user — 0 is the most
+// common reason a "sent" test is never received (the device never registered),
+// so the client surfaces it directly. Sent/Failed/Results come from the gateway
+// so the UI reports real per-device delivery outcomes instead of a blind
+// "delivered".
+type testPushResponse struct {
+	Tokens  int              `json:"tokens"`
+	Sent    int              `json:"sent"`
+	Failed  int              `json:"failed"`
+	Results []testPushResult `json:"results,omitempty"`
+}
+
+// runTestPush sends the canned test notification to one user's devices and
+// writes a diagnostic result: how many tokens are registered, the gateway's
+// per-device outcomes, and (as a side effect) prunes any token APNs rejected.
+func (h *Handler) runTestPush(w http.ResponseWriter, r *http.Request, userID int64) {
+	tokens, err := h.countPushTokens(userID)
+	if err != nil {
+		h.logger.Error("push: count tokens", "err", err, "user_id", userID)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to read devices"})
+		return
+	}
+
+	resp, err := h.sendTestPush(r.Context(), userID)
+	if errors.Is(err, errPushNotConfigured) {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "push not configured"})
 		return
 	}
-
-	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
-	defer cancel()
-	resp, err := client.Send(ctx, []int64{claims.UserID}, "Cantinarr", "Push notifications are working", map[string]any{"type": "test"})
 	if err != nil {
-		h.logger.Error("push: send test notification", "err", err, "user_id", claims.UserID)
+		h.logger.Error("push: send test notification", "err", err, "user_id", userID)
 		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to send test notification"})
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]int{"sent": resp.Sent, "failed": resp.Failed})
+
+	out := testPushResponse{Tokens: tokens, Sent: resp.Sent, Failed: resp.Failed}
+	for _, dr := range resp.Results {
+		out.Results = append(out.Results, testPushResult{
+			DeviceID: dr.DeviceID,
+			OK:       dr.OK,
+			Pruned:   dr.Pruned,
+			Error:    dr.Error,
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// sendTestPush ensures the gateway client, sends the canned test notification to
+// the user's devices, and prunes any token the gateway reported dead. Returns
+// errPushNotConfigured when push is disabled or the gateway is unreachable.
+func (h *Handler) sendTestPush(ctx context.Context, userID int64) (*SendResponse, error) {
+	if h.mgr == nil {
+		return nil, errPushNotConfigured
+	}
+	// Ensure (not just Client) so a first-ever test from a freshly-booted server
+	// that couldn't reach the gateway at startup still kicks enrollment.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	client := h.mgr.Ensure(ctx)
+	if client == nil {
+		return nil, errPushNotConfigured
+	}
+	resp, err := client.Send(ctx, []int64{userID}, "Cantinarr", "Push notifications are working", map[string]any{"type": "test"})
+	if err != nil {
+		return nil, err
+	}
+	pruneDeadTokens(h.db, h.logger, resp)
+	return resp, nil
+}
+
+// countPushTokens returns how many push tokens are registered for a user.
+func (h *Handler) countPushTokens(userID int64) (int, error) {
+	var n int
+	err := h.db.QueryRow("SELECT COUNT(*) FROM push_tokens WHERE user_id = ?", userID).Scan(&n)
+	return n, err
 }
 
 // client returns the cached gateway client, or nil when push is unconfigured or

--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -153,15 +153,16 @@ func (n *Notifier) sendWithOptions(client *Client, userIDs []int64, title, body 
 			n.logger.Error("push: send notification", "err", err, "title", title)
 			return
 		}
-		n.pruneDeadTokens(resp)
+		pruneDeadTokens(n.db, n.logger, resp)
 	}()
 }
 
 // pruneDeadTokens deletes the local push_tokens row for every result the
 // gateway flagged as pruned (token rejected by APNs as unregistered). Matching
 // on token keeps it precise even if a device re-registered with a new token in
-// the meantime. Best-effort: delete failures are logged, not surfaced.
-func (n *Notifier) pruneDeadTokens(resp *SendResponse) {
+// the meantime. Best-effort: delete failures are logged, not surfaced. Shared
+// by the Notifier (after each send) and the test-push handler.
+func pruneDeadTokens(db *sql.DB, logger *slog.Logger, resp *SendResponse) {
 	if resp == nil {
 		return
 	}
@@ -170,14 +171,14 @@ func (n *Notifier) pruneDeadTokens(resp *SendResponse) {
 		if !r.Pruned || r.Token == "" {
 			continue
 		}
-		if _, err := n.db.Exec("DELETE FROM push_tokens WHERE token = ?", r.Token); err != nil {
-			n.logger.Error("push: prune dead token", "err", err, "device_id", r.DeviceID)
+		if _, err := db.Exec("DELETE FROM push_tokens WHERE token = ?", r.Token); err != nil {
+			logger.Error("push: prune dead token", "err", err, "device_id", r.DeviceID)
 			continue
 		}
 		pruned++
 	}
 	if pruned > 0 {
-		n.logger.Info("push: pruned dead device tokens", "count", pruned)
+		logger.Info("push: pruned dead device tokens", "count", pruned)
 	}
 }
 


### PR DESCRIPTION
Fixes three issues from a testing session: a user went offline (WireGuard down), force-closed the app, and was **permanently logged out** — a "test push" reported success but never arrived, and there was no admin way to re-auth her or check her push state.

## 1. Auth persistence + seamless offline restore (affected *every* user)
`_tryRestoreSession()` cleared the Keychain on **any** error. An offline cold-launch makes the token refresh fail with a *transport* error → tokens deleted → logged out. Reconnecting the VPN couldn't recover because the credential was **gone**, not just unvalidated.

- Session is now cleared **only on a genuine 401** (server reachable, refresh token rejected). Transport failures keep the tokens.
- **Seamless restore:** on launch the app restores an **optimistic session from a cached snapshot** (user profile + server config, persisted on every successful auth/refresh — no secrets) and opens straight into its UI, validating in the background. Result on validation: fresh data on success; login **only** on a real 401; or a **"reconnecting" hold** (subtle top bar, delayed ~1.2s so online launches never flash it) with an 8s retry loop + retry-on-resume on a transport failure. No more login-screen bounce when the VPN is briefly down.
- `BackendAuthInterceptor` had the same flaw — a refresh failing for transport reasons called `onAuthExpired()` and wiped the session (and push token). Now it only expires on a real 401. Also fixes a **latent bug**: `_refreshCompleter` was never reset after a successful refresh, silently breaking every subsequent refresh.
- `onAuthExpired()` no longer tears down the push token (by then the access token is invalid so the delete can't authenticate anyway). Stale gateway tokens are pruned server-side when APNs reports them unregistered.
- Rotated tokens are persisted **before** the config fetch so a single-use refresh token can't be stranded mid-restore.

## 2. Push test was misleading + couldn't target another user
The "send test push" button only ever targeted the **caller's own** devices and echoed the gateway's `sent` count as success — so an admin testing someone else saw "delivered" while that user's device was never in scope, and real APNs rejections (`BadDeviceToken`/`Unregistered`) were thrown away.

- New admin endpoint `POST /api/admin/users/{userID}/test-push` + a **"Send test push"** action on the Users screen, targeting a specific user.
- Both test paths now return **tokens-registered** + **per-device results**, prune dead tokens (shared with the notifier), and the UI reports the real outcome — e.g. *"<user> has no registered push devices yet"* or *"Apple rejected the token…"* instead of a blind "delivered".

## 3. No per-user connect link
The per-user re-invite action was hidden unless `deviceCount == 0`, so a user who lost their session or needs a new device had no link option. Now shown for **every non-self user** (relabeled **"Issue device link"** when they already have a device), reusing the existing find-or-create connect-token flow.

## Immediate recovery (already usable on `main`)
To get a locked-out user back in *today*: **Settings → Generate Connect Link → their exact username** (find-or-create reuses the account), or `POST /api/admin/connect-token`. After this PR, the per-user "Issue device link" action does the same from the Users list.

## Test plan
- Server: `go build ./...`, `go vet ./...`, `go test ./...` — all pass (incl. `internal/push`).
- App: `flutter analyze` — clean (pre-existing info lints only); `flutter test` — 36/36 pass.
- Manual on-device:
  - [ ] Authenticate, disconnect WireGuard, force-close, reopen → **opens into the app** with a "Reconnecting…" bar (no login bounce); reconnect VPN → bar clears, data loads. Reopen offline again → still in.
  - [ ] Drop VPN while foregrounded → no logout.
  - [ ] Genuinely revoke the device server-side → next refresh 401 → drops to login (correct).
  - [ ] Admin → Users → "Send test push" on a user with no device → "no registered devices"; on a healthy device → arrives with WireGuard **off** (APNs is public).
  - [ ] Users → "Issue device link" on a user who already has a device → redeems to a fresh session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7ahSy76F6R8pytTw7h4Ja