### PR TITLE
fix(request): resolve TVDB ID for TMDB-only series requests

### DIFF
--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -514,6 +514,16 @@ func (s *Service) addSeries(r *resolvedRequest) (string, string, error) {
 	}
 
 	tvdbID := r.tvdbID
+	// A request that arrives with only a TMDB ID — e.g. the AI assistant's
+	// requestMedia tool, which sends just tmdb_id + media_type — has nothing for
+	// Sonarr's series lookup to match. Resolve the TVDB ID the same way the
+	// status path does (cache -> TMDB external IDs -> Trakt) so a TMDB ID alone
+	// is enough to add a series.
+	if tvdbID == 0 && s.bridge != nil {
+		if res, err := s.bridge.ResolveTVDBID(r.tmdbID); err == nil && res != nil && res.TVDBID != 0 {
+			tvdbID = res.TVDBID
+		}
+	}
 	if tvdbID != 0 {
 		s.db.Exec("INSERT OR REPLACE INTO tmdb_tvdb_cache (tmdb_id, tvdb_id) VALUES (?, ?)", r.tmdbID, tvdbID)
 	}
@@ -538,7 +548,7 @@ func (s *Service) addSeries(r *resolvedRequest) (string, string, error) {
 	}
 	if lookup == nil || err != nil {
 		if r.title == "" {
-			return "", "", fmt.Errorf("series lookup failed: no TVDB ID or title provided")
+			return "", "", fmt.Errorf("series lookup failed: could not resolve a TVDB ID for tmdb %d and no title was provided", r.tmdbID)
 		}
 		lookup, err = sonarrClient.LookupByTitle(r.title)
 		if err != nil {


### PR DESCRIPTION
## Problem

Requesting a TV show through the **AI Assistant** failed with:

> series lookup failed: no TVDB ID or title provided

(observed for *President Curtis*, TMDB 296756 → TVDB 466198). The same show requested via the iOS app's **Request** button worked.

## Root cause

The assistant's `requestMedia` MCP tool (`internal/mcp/tools.go`) sends only `tmdb_id` + `media_type` to `CreateMediaRequest`, dropping `tvdb_id` and `title`. So `addSeries` ran with `tvdbID = 0` and `title = ""`:

- `tvdbID == 0` → `LookupByTVDB` skipped, `lookup` stays `nil`
- falls into the title fallback → `title == ""` → returns the error

The iOS path works because `handler.go` posts the full body (`tvdb_id` + `title`).

The deeper inconsistency: the **status** path (`getTVStatus`) already resolves TMDB→TVDB via `tmdb.Bridge.ResolveTVDBID()`, but the **add** path never did.

## Fix

`addSeries` now resolves the TVDB ID through the existing `tmdb.Bridge` (cache → TMDB external IDs → Trakt) when a request arrives with only a TMDB ID — the same resolver the read path uses.

Why this over a Sonarr title lookup:
- Exact TVDB-ID match, not a fuzzy title match
- Reuses an existing, already-wired primitive
- Fixes **every** caller — direct add *and* pending-approval replay — not just the one tool
- Bonus: enables the existing `GetSeriesByTVDB` dedup for assistant requests

Also clarifies the residual error message, which now fires only when resolution genuinely fails *and* no title was provided.

## Testing

- `go build ./...` — clean
- `go vet ./internal/request/... ./internal/mcp/...` — clean
- `go test ./internal/mcp/... ./internal/tmdb/...` — pass

⚠️ The `request` package has **no test files**, so this change is covered by build/vet + logic review rather than a regression test. Adding a test seam for the request service (mockable Sonarr/Bridge) is a worthwhile follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7ahSy76F6R8pytTw7h4Ja