### PR TITLE
feat(approvals): surface approvals + badges, and deep-link push taps

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -13,6 +13,15 @@ import UserNotifications
   /// ready when the token first arrived from APNs.
   private var apnsToken: String?
 
+  /// Routing payload from a notification tap that arrived before Dart was ready
+  /// to handle it (i.e. a cold start launched by the tap). Held until Dart pulls
+  /// it via `getInitialNotification`.
+  private var pendingTapPayload: [String: Any]?
+
+  /// True once Dart has called `getInitialNotification`, meaning its tap handler
+  /// is wired and subsequent (warm) taps can be delivered live.
+  private var dartTapReady = false
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -57,6 +66,19 @@ import UserNotifications
       fetchAuthorizationStatus { status in result(status) }
     case "openNotificationSettings":
       openNotificationSettings { opened in result(opened) }
+    case "setBadgeCount":
+      let count = (call.arguments as? [String: Any])?["count"] as? Int ?? 0
+      DispatchQueue.main.async {
+        UNUserNotificationCenter.current().setBadgeCount(count)
+      }
+      result(nil)
+    case "getInitialNotification":
+      // Dart pulls the cold-start tap (if any) and signals it's ready for live
+      // taps from here on.
+      dartTapReady = true
+      let payload = pendingTapPayload
+      pendingTapPayload = nil
+      result(payload)
     default:
       result(FlutterMethodNotImplemented)
     }
@@ -153,5 +175,32 @@ import UserNotifications
   ) {
     // Present notifications while the app is in the foreground.
     completionHandler([.banner, .sound, .badge])
+  }
+
+  /// Handles a notification tap. Routes live when Dart's handler is ready
+  /// (warm/background launch); otherwise caches the payload for Dart to pull on
+  /// startup (cold launch).
+  override func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse,
+    withCompletionHandler completionHandler: @escaping () -> Void
+  ) {
+    let payload = routingPayload(from: response.notification.request.content.userInfo)
+    if dartTapReady, let channel = pushChannel {
+      channel.invokeMethod("onNotificationTap", arguments: payload)
+    } else {
+      pendingTapPayload = payload
+    }
+    completionHandler()
+  }
+
+  /// Extracts the tap-routing fields the Dart side understands from an APNs
+  /// `userInfo` dict. Custom keys are delivered as siblings of `aps`.
+  private func routingPayload(from userInfo: [AnyHashable: Any]) -> [String: Any] {
+    var payload: [String: Any] = [:]
+    if let type = userInfo["type"] as? String { payload["type"] = type }
+    if let mediaType = userInfo["media_type"] as? String { payload["media_type"] = mediaType }
+    if let tmdbID = userInfo["tmdb_id"] { payload["tmdb_id"] = tmdbID }
+    return payload
   }
 }

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -9,6 +9,8 @@ import 'core/providers/realtime_provider.dart';
 import 'core/storage/preferences.dart';
 import 'core/theme/app_theme.dart';
 import 'features/auth/logic/auth_provider.dart';
+import 'features/notifications/push_service.dart';
+import 'features/request/logic/pending_approvals_provider.dart';
 import 'navigation/app_router.dart';
 
 class CantinarrApp extends ConsumerStatefulWidget {
@@ -30,6 +32,11 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
     WidgetsBinding.instance.addObserver(this);
     _appLinks = AppLinks();
     _initDeepLinks();
+    // Reading the push service wires its native tap handler (for warm taps);
+    // once the first frame is up (router exists) route any cold-start tap.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(pushServiceProvider).handleInitialNotification();
+    });
   }
 
   @override
@@ -38,6 +45,9 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
     // session immediately instead of waiting for the periodic retry.
     if (state == AppLifecycleState.resumed) {
       ref.read(authProvider.notifier).reconnectNow();
+      // Re-sync the approvals badges in case the queue changed (or another
+      // admin acted) while we were backgrounded. No-op for non-admins.
+      ref.read(pendingApprovalsProvider.notifier).refresh();
     }
   }
 

--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/network/backend_client.dart';
 import '../../core/storage/secure_storage.dart';
+import '../../navigation/app_router.dart';
 
 /// Bridges native APNs registration to the Cantinarr backend.
 ///
@@ -35,11 +36,14 @@ class PushService {
   bool get _isSupported => !kIsWeb && Platform.isIOS;
 
   Future<dynamic> _handleNativeCall(MethodCall call) async {
-    if (call.method == 'onApnsToken') {
-      final token = call.arguments as String?;
-      if (token != null && token.isNotEmpty && token != _registeredToken) {
-        await _sendToken(token);
-      }
+    switch (call.method) {
+      case 'onApnsToken':
+        final token = call.arguments as String?;
+        if (token != null && token.isNotEmpty && token != _registeredToken) {
+          await _sendToken(token);
+        }
+      case 'onNotificationTap':
+        _routeNotification(call.arguments);
     }
     return null;
   }
@@ -90,6 +94,61 @@ class PushService {
     } catch (e) {
       debugPrint('Push: openSystemSettings failed: $e');
     }
+  }
+
+  /// Sets the home-screen app-icon badge to [count] (0 clears it), mirroring
+  /// the in-app approvals count. Best-effort; a no-op on unsupported platforms.
+  Future<void> setBadgeCount(int count) async {
+    if (!_isSupported) return;
+    try {
+      await _channel.invokeMethod('setBadgeCount', {'count': count});
+    } catch (e) {
+      debugPrint('Push: setBadgeCount failed: $e');
+    }
+  }
+
+  /// Pulls the notification (if any) that cold-started the app and routes to it,
+  /// and signals the native side that subsequent (warm) taps can be delivered
+  /// live. Call once at startup, after the router exists. No-op off iOS.
+  Future<void> handleInitialNotification() async {
+    if (!_isSupported) return;
+    try {
+      final args = await _channel.invokeMethod('getInitialNotification');
+      if (args != null) _routeNotification(args);
+    } catch (e) {
+      debugPrint('Push: getInitialNotification failed: $e');
+    }
+  }
+
+  /// Routes a tapped notification to the right screen from its custom payload:
+  /// the approvals queue for `request_pending`; the media detail page for an
+  /// approval decision or a new-content alert.
+  void _routeNotification(Object? arguments) {
+    final data = _asStringMap(arguments);
+    final type = data['type'] as String?;
+    if (type == null) return;
+    final router = _ref.read(appRouterProvider);
+    switch (type) {
+      case 'request_pending':
+        router.push('/approvals');
+      case 'request_decision':
+      case 'new_movie':
+      case 'new_episode':
+        final tmdbId = _asInt(data['tmdb_id']);
+        if (tmdbId == null || tmdbId <= 0) return;
+        final mediaType = data['media_type'] == 'tv' ? 'tv' : 'movie';
+        router.push('/detail/$mediaType/$tmdbId');
+    }
+  }
+
+  Map<String, dynamic> _asStringMap(Object? value) =>
+      value is Map ? value.map((k, v) => MapEntry(k.toString(), v)) : const {};
+
+  int? _asInt(Object? value) {
+    if (value is int) return value;
+    if (value is num) return value.toInt();
+    if (value is String) return int.tryParse(value);
+    return null;
   }
 
   /// Asks the backend to send a test push to this account's own devices and

--- a/app/lib/features/request/logic/pending_approvals_provider.dart
+++ b/app/lib/features/request/logic/pending_approvals_provider.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/backend_client.dart';
+import '../../../core/network/websocket_client.dart';
+import '../../../core/providers/realtime_provider.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../../notifications/push_service.dart';
+import '../../settings/data/request_settings_service.dart';
+
+/// Tracks the number of media requests awaiting admin approval, for admins only.
+///
+/// The count drives the in-app approvals badge (drawer entry + hamburger dot)
+/// and the home-screen app-icon badge. It is seeded from REST, kept live by
+/// `request_pending` websocket events (which carry the authoritative
+/// `pending_count`), and refreshed after an approve/deny. Non-admin accounts
+/// always report 0 and never call the admin-only endpoint.
+class PendingApprovalsNotifier extends StateNotifier<int> {
+  PendingApprovalsNotifier(this._ref) : super(0) {
+    _service =
+        RequestSettingsService(backendDio: _ref.read(backendClientProvider));
+    _bind();
+    // Re-bind on login/logout/role change without rebuilding the provider.
+    _ref.listen(authProvider, (_, __) => _bind());
+  }
+
+  final Ref _ref;
+  late final RequestSettingsService _service;
+  StreamSubscription<WsEvent>? _sub;
+  bool _isAdmin = false;
+
+  /// (Re)attaches to the live event stream when the admin status changes.
+  void _bind() {
+    final admin =
+        _ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    if (admin == _isAdmin) return; // no change
+    _isAdmin = admin;
+    _sub?.cancel();
+    _sub = null;
+    if (!admin) {
+      _set(0);
+      return;
+    }
+    refresh();
+    _sub = _ref
+        .read(realtimeEventsProvider)
+        .where((e) => e.type == 'request_pending')
+        .listen(_onPending);
+  }
+
+  /// Applies the authoritative count carried by a `request_pending` event,
+  /// falling back to an optimistic +1 if the server didn't include it.
+  void _onPending(WsEvent event) {
+    final raw = event.data['pending_count'];
+    if (raw is num) {
+      _set(raw.toInt());
+    } else {
+      _set(state + 1);
+    }
+  }
+
+  /// Re-reads the queue depth from the backend. Call after an approve/deny so
+  /// the badges reflect the resolved queue immediately.
+  Future<void> refresh() async {
+    if (!_isAdmin) return;
+    try {
+      final pending = await _service.listPending();
+      _set(pending.length);
+    } catch (_) {
+      // Best-effort: keep the last known count on a transient failure.
+    }
+  }
+
+  /// Sets the count directly from a caller that already holds the authoritative
+  /// queue (the approvals screen), avoiding a redundant fetch.
+  void setCount(int value) => _set(value);
+
+  void _set(int value) {
+    final next = value < 0 ? 0 : value;
+    state = next;
+    // Mirror to the home-screen app icon so it matches the in-app badge.
+    _ref.read(pushServiceProvider).setBadgeCount(next);
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}
+
+/// Pending-approval count for the signed-in admin (0 for non-admins).
+final pendingApprovalsProvider =
+    StateNotifierProvider<PendingApprovalsNotifier, int>(
+  PendingApprovalsNotifier.new,
+);

--- a/app/lib/features/settings/ui/pending_requests_screen.dart
+++ b/app/lib/features/settings/ui/pending_requests_screen.dart
@@ -4,6 +4,7 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/request_settings_service.dart';
 import '../../request/data/request_service.dart';
+import '../../request/logic/pending_approvals_provider.dart';
 
 /// Admin approval queue: approve (optionally modifying options) or deny
 /// pending media requests.
@@ -53,6 +54,9 @@ class _PendingRequestsScreenState
         _admin = admin;
         _isLoading = false;
       });
+      // Keep the drawer + app-icon badges in sync with the queue we just loaded
+      // (covers opening the screen and the reload after an approve/deny).
+      ref.read(pendingApprovalsProvider.notifier).setCount(pending.length);
     } catch (e) {
       if (!mounted) return;
       setState(() {
@@ -247,7 +251,7 @@ class _PendingRequestsScreenState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Pending Requests')),
+      appBar: AppBar(title: const Text('Approvals')),
       body: _isLoading
           ? const Center(
               child: CircularProgressIndicator(color: AppTheme.accent))

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -178,12 +178,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               onTap: () => context.push('/settings/ai-tools'),
             ),
             _SettingsTile(
-              icon: Icons.playlist_add_check_circle_outlined,
-              title: 'Pending Requests',
-              subtitle: 'Approve or deny requests awaiting review',
-              onTap: () => context.push('/settings/requests'),
-            ),
-            _SettingsTile(
               icon: Icons.tune,
               title: 'Request Settings',
               subtitle: 'Approval, season, and quality defaults',

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -16,6 +16,7 @@ import '../../discover/data/tmdb_models.dart';
 import '../../discover/ui/search_results_view.dart';
 import '../../radarr/data/radarr_api_service.dart';
 import '../../radarr/logic/radarr_movies_provider.dart';
+import '../../request/logic/pending_approvals_provider.dart';
 import '../../sonarr/data/sonarr_api_service.dart';
 import '../../sonarr/logic/sonarr_series_provider.dart';
 import '../logic/shell_search_provider.dart';
@@ -334,6 +335,9 @@ class _AppShellState extends ConsumerState<AppShell>
     final searchNotifier = ref.read(shellSearchProvider.notifier);
     final hasAi =
         ref.watch(authProvider).valueOrNull?.connection?.services.ai ?? false;
+    // Admin approval queue depth — drives the hamburger dot (here) and the
+    // drawer "Approvals" entry. Always 0 for non-admins.
+    final pendingApprovals = ref.watch(pendingApprovalsProvider);
     final showSearchResults = searchState.searchMode == SearchMode.search ||
         searchState.searchMode == SearchMode.aiReady;
     final libraryStatus = searchState.isSearching && showSearchResults
@@ -399,7 +403,15 @@ class _AppShellState extends ConsumerState<AppShell>
           Padding(
             padding: const EdgeInsets.only(left: 4, top: 8, bottom: 8),
             child: IconButton(
-              icon: const Icon(Icons.menu, color: AppTheme.textPrimary),
+              icon: Badge(
+                isLabelVisible: pendingApprovals > 0,
+                backgroundColor: AppTheme.accent,
+                smallSize: 9,
+                child: const Icon(Icons.menu, color: AppTheme.textPrimary),
+              ),
+              tooltip: pendingApprovals > 0
+                  ? '$pendingApprovals approval${pendingApprovals == 1 ? '' : 's'} waiting'
+                  : null,
               onPressed: () {
                 _dismissKeyboard();
                 _scaffoldKey.currentState?.openDrawer();
@@ -724,6 +736,9 @@ class _AppShellState extends ConsumerState<AppShell>
 
   Widget _buildDrawerContent(BuildContext context, {required bool isOverlay}) {
     final moduleState = ref.watch(moduleProvider);
+    final isAdmin =
+        ref.watch(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    final pendingApprovals = ref.watch(pendingApprovalsProvider);
 
     return SafeArea(
       child: Column(
@@ -761,6 +776,21 @@ class _AppShellState extends ConsumerState<AppShell>
             ),
           ),
           const Divider(color: AppTheme.border),
+
+          // Admin approval queue — kept above the modules so a waiting count is
+          // the first thing an admin sees when the drawer opens.
+          if (isAdmin) ...[
+            _DrawerItem(
+              icon: Icons.fact_check_outlined,
+              title: 'Approvals',
+              badgeCount: pendingApprovals,
+              onTap: () {
+                if (isOverlay) Navigator.pop(context);
+                context.push('/approvals');
+              },
+            ),
+            const Divider(color: AppTheme.border),
+          ],
 
           // Scrollable module navigation items
           Expanded(
@@ -856,11 +886,15 @@ class _DrawerItem extends StatelessWidget {
   final bool selected;
   final VoidCallback onTap;
 
+  /// When > 0, renders a trailing count pill (e.g. the pending-approvals count).
+  final int badgeCount;
+
   const _DrawerItem({
     required this.icon,
     required this.title,
     this.selected = false,
     required this.onTap,
+    this.badgeCount = 0,
   });
 
   @override
@@ -875,10 +909,38 @@ class _DrawerItem extends StatelessWidget {
           fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
         ),
       ),
+      trailing: badgeCount > 0 ? _CountPill(count: badgeCount) : null,
       selected: selected,
       selectedTileColor: AppTheme.accent.withValues(alpha: 0.08),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
       onTap: onTap,
+    );
+  }
+}
+
+/// A small filled pill showing a count (capped at 99+), used for the drawer
+/// approvals badge.
+class _CountPill extends StatelessWidget {
+  final int count;
+
+  const _CountPill({required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: AppTheme.accent,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        count > 99 ? '99+' : '$count',
+        style: const TextStyle(
+          color: AppTheme.background,
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+        ),
+      ),
     );
   }
 }

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -356,7 +356,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         },
       ),
       GoRoute(
-        path: '/settings/requests',
+        path: '/approvals',
         parentNavigatorKey: _rootNavigatorKey,
         builder: (_, __) => const PendingRequestsScreen(),
       ),

--- a/server/internal/push/client.go
+++ b/server/internal/push/client.go
@@ -106,6 +106,10 @@ type SendOptions struct {
 	// repeat notifications about the same subject coalesce on-device into a
 	// single alert. Empty means no collapsing.
 	CollapseID string
+	// Badge, when non-nil, sets the APNs badge (aps.badge) so the app's
+	// home-screen icon shows the count even while the app is closed. A nil badge
+	// leaves the device's current badge untouched; a pointer to 0 clears it.
+	Badge *int
 }
 
 // SendResponse is the gateway's reply to POST /v1/notifications: per-send
@@ -147,14 +151,18 @@ func (c *Client) SendWithOptions(ctx context.Context, userIDs []int64, title, bo
 	if opts.CollapseID != "" {
 		options["collapse_id"] = opts.CollapseID
 	}
+	notification := map[string]any{
+		"title": title,
+		"body":  body,
+	}
+	if opts.Badge != nil {
+		notification["badge"] = *opts.Badge
+	}
 	payload := map[string]any{
-		"to": map[string]any{"user_ids": ids},
-		"notification": map[string]any{
-			"title": title,
-			"body":  body,
-		},
-		"data":    data,
-		"options": options,
+		"to":           map[string]any{"user_ids": ids},
+		"notification": notification,
+		"data":         data,
+		"options":      options,
 	}
 	var out SendResponse
 	if err := c.do(ctx, http.MethodPost, "/v1/notifications", payload, &out); err != nil {

--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -88,7 +88,13 @@ func (n *Notifier) NotifyAdmins(eventType string, data map[string]interface{}) {
 		return
 	}
 
-	n.send(client, recipients, "New request", title, passthrough(CategoryRequestPending, data))
+	// Set the home-screen icon badge to the live queue depth so admins see the
+	// count even while the app is closed (the gateway maps this to aps.badge).
+	var opts SendOptions
+	if count, ok := intval(data["pending_count"]); ok {
+		opts.Badge = &count
+	}
+	n.sendWithOptions(client, recipients, "New request", title, passthrough(CategoryRequestPending, data), opts)
 }
 
 // NotifyNewMovie pushes a "movie became available" alert to every user opted
@@ -221,4 +227,19 @@ func passthrough(eventType string, data map[string]interface{}) map[string]any {
 func str(v interface{}) string {
 	s, _ := v.(string)
 	return s
+}
+
+// intval reads an int from a map value, tolerating the int/int64/float64 forms a
+// value may take whether it arrived in-process or via a JSON round-trip.
+func intval(v interface{}) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	default:
+		return 0, false
+	}
 }

--- a/server/internal/push/notifier_test.go
+++ b/server/internal/push/notifier_test.go
@@ -227,6 +227,31 @@ func TestNotifyAdminsResolvesAdminIDs(t *testing.T) {
 	}
 }
 
+func TestNotifyAdminsSetsBadgeFromPendingCount(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'admin1', '', 'admin')")
+
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
+
+	n.NotifyAdmins("request_pending", map[string]interface{}{
+		"tmdb_id":       603,
+		"media_type":    "movie",
+		"title":         "The Matrix",
+		"pending_count": 3,
+	})
+
+	body := cap.waitForNotification(t)
+	notif, _ := body["notification"].(map[string]any)
+	// JSON numbers decode as float64.
+	if got, _ := notif["badge"].(float64); got != 3 {
+		t.Errorf("notification.badge = %v, want 3", notif["badge"])
+	}
+}
+
 func TestNotifyAdminsHonorsOptOutAndRole(t *testing.T) {
 	database, err := dbOpen(t)
 	if err != nil {

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -434,11 +434,18 @@ func (s *Service) createPending(r *resolvedRequest) (*CreateResponse, error) {
 
 	// Only notify admins when a new row was actually queued (not a duplicate).
 	if n, _ := res.RowsAffected(); n > 0 && s.notifier != nil {
-		s.notifier.NotifyAdmins("request_pending", map[string]interface{}{
+		data := map[string]interface{}{
 			"tmdb_id":    r.tmdbID,
 			"media_type": r.mediaType,
 			"title":      r.title,
-		})
+		}
+		// Carry the live queue depth so the in-app surface and the home-screen
+		// icon can badge the count (push sets aps.badge, the WS client reads it
+		// directly).
+		if count, err := s.PendingCount(); err == nil {
+			data["pending_count"] = count
+		}
+		s.notifier.NotifyAdmins("request_pending", data)
 	}
 	return &CreateResponse{Success: true, Status: StatusPending, Title: r.title}, nil
 }
@@ -722,6 +729,17 @@ func (s *Service) GetRequests(userID int64) ([]RequestLog, error) {
 }
 
 // ListPending returns the admin approval queue (oldest first).
+// PendingCount returns the number of requests awaiting admin approval. It backs
+// the badge on the admin approval surface (in-app drawer entry + home-screen
+// app icon).
+func (s *Service) PendingCount() (int, error) {
+	var n int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM request_log WHERE status = ?", StatusPending).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count pending requests: %w", err)
+	}
+	return n, nil
+}
+
 func (s *Service) ListPending() ([]PendingRequest, error) {
 	rows, err := s.db.Query(
 		`SELECT r.id, r.user_id, COALESCE(u.username, ''), r.tmdb_id, COALESCE(r.tvdb_id, 0), r.media_type, r.title, COALESCE(r.season_scope, ''), COALESCE(r.quality_profile_id, 0), r.requested_at


### PR DESCRIPTION
Addresses two admin-experience issues.

## Issue 1 — Approvals don't belong in Settings; make a waiting queue visible

**Placement (confirmed with product):** drawer entry + hamburger dot.

- Moved the approval queue out of Settings to a top-level **`/approvals`** route. Settings keeps only *Request Settings* (the policy config); the queue screen is unchanged apart from its title ("Approvals").
- Added an **admin-only "Approvals" entry** near the top of the nav drawer with a live **count pill**, and a **dot on the hamburger icon** so a waiting queue is noticeable without opening the drawer.
- New `pendingApprovalsProvider` tracks queue depth for admins: seeded from REST (`/api/admin/requests`), kept live by `request_pending` WS events (which now carry an authoritative `pending_count`), and refreshed after approve/deny and on app resume. Non-admins always report 0 and never call the admin endpoint.
- **Home-screen app-icon badge (Messenger-style):** the server sets `aps.badge` = pending count on `request_pending` pushes (updates the icon even while the app is closed), and the app mirrors the count to the icon via a native `setBadgeCount` channel (covers approve/deny, foreground re-sync, and clearing to 0 when the queue empties).

## Issue 2 — Push taps should deep-link to the right place

- `AppDelegate` now handles notification taps: routes **live** for warm/background launches, and caches a **cold-start** tap for Dart to pull via `getInitialNotification` (race-safe — no lost taps).
- `PushService` routes by payload `type`:
  - `request_pending` → `/approvals`
  - `request_decision` / `new_movie` / `new_episode` → `/detail/{movie|tv}/{tmdb_id}`
- The backend already includes `type` / `tmdb_id` / `media_type` in the push `data`, so **no payload changes were needed** for routing.

## Server

- `request.Service.PendingCount()`; the `request_pending` event now carries `pending_count`.
- Push `Client`/`Notifier` gain an optional `Badge` → `aps.badge`.

## Push gateway

No change required: the gateway already maps `notification.badge` → `aps.badge` and delivers custom `data` as top-level `userInfo` keys (verified in `internal/api/notifications.go` + `internal/push/apns/apns.go`). So the whole feature works end-to-end from this PR alone.

## Testing

- **Server:** `go build`, `go vet`, full `go test ./...` pass. Added `TestNotifyAdminsSetsBadgeFromPendingCount`.
- **App:** full `flutter test` suite passes (42 tests, incl. the shell/router tests for files I touched); `flutter analyze` clean for changed files.
- **Swift:** `swiftc -parse` clean + manual review. ⚠️ A full iOS Xcode compile could **not** run in my environment (Xcode is missing the iOS 26.5 platform component, so the scheme resolves no build destination) — please confirm on CI.
- The new Dart provider isn't unit-tested (would require heavy mocking of `authProvider` + the WS stream + Dio together); it's covered by analyze + the shell test that instantiates it + review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7ahSy76F6R8pytTw7h4Ja