### PR TITLE
fix(discover): keep Popular Movies / discover rows across session revalidation

### DIFF
--- a/app/lib/core/network/backend_client.dart
+++ b/app/lib/core/network/backend_client.dart
@@ -6,17 +6,27 @@ import '../config/app_config.dart';
 import 'backend_auth_interceptor.dart';
 
 /// Provides an authenticated Dio instance configured for the backend.
+///
+/// Keyed only on the connection's [serverUrl] (via `select`) so the Dio is
+/// rebuilt only when the target server actually changes — not on every
+/// [authProvider] emission. The access/refresh tokens are read dynamically by
+/// the interceptor below, so token refreshes and the optimistic→validated
+/// session handoff on launch reuse the same Dio instead of replacing it. That
+/// keeps downstream providers which `watch` this one (discovery rows, search,
+/// etc.) from being torn down and silently losing their already-fetched state
+/// mid-session.
 final backendClientProvider = Provider<Dio>((ref) {
-  final authState = ref.watch(authProvider);
-  final connection = authState.valueOrNull?.connection;
+  final serverUrl = ref.watch(
+    authProvider.select((s) => s.valueOrNull?.connection?.serverUrl),
+  );
 
-  if (connection == null) {
+  if (serverUrl == null) {
     // Return a no-op Dio that will fail gracefully
     return Dio(BaseOptions(baseUrl: 'http://localhost'));
   }
 
   final dio = Dio(BaseOptions(
-    baseUrl: connection.serverUrl,
+    baseUrl: serverUrl,
     connectTimeout: AppConfig.requestTimeout,
     receiveTimeout: AppConfig.requestTimeout,
     headers: {'Content-Type': 'application/json'},


### PR DESCRIPTION
## Symptom

On a cold launch, the **Popular Movies** row on the Movies tab is consistently empty. Pulling to refresh loads it. Other rows on the same tab ("Downloading Soon", "Recently Downloaded") and the TV tab look fine.

## Root cause

A provider-rebuild race driven by the optimistic→validated auth handoff — **not** an auth-not-ready timing issue.

`backendClientProvider` did `ref.watch(authProvider)` and constructed a **new `Dio` on every auth emission**. The discover service → `movieDiscoverProvider`/`tvDiscoverProvider` all `watch` down that chain, so a new `Dio` identity disposes and recreates the discover `StateNotifier`, **resetting its fetched rows to empty**.

On launch `authProvider` emits `loading → optimistic cached session → validated session` (`auth_provider.dart`). The dashboard mounts under the *optimistic* session, `bootstrap()` fetches Popular Movies fine — then the *validated* emission rebuilds the chain and discards them. The library rows survive because they live in widget `setState`, not a provider. The TV tab looked fine only because it's opened *after* auth settles. Pull-to-refresh re-runs `bootstrap()` on the now-stable notifier, hence the workaround.

## Fix

Key `backendClientProvider` on the connection's `serverUrl` alone (via `select`) instead of the whole auth state. `serverUrl` doesn't change across the optimistic→validated handoff or token refreshes, and the access/refresh tokens are already read dynamically by the interceptor — so the Dio is now built once per server and reused. Downstream discover state is no longer torn down mid-session.

This also stabilizes the main discover screen, shell search, AI chat, and notification-prefs providers, which watch the same client and were silently re-fetching on every token refresh.

## Testing

- `flutter analyze lib/core/network/backend_client.dart` → No issues found.
- Needs an on-device cold-launch check: Movies tab → Popular Movies should populate without a pull-to-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7ahSy76F6R8pytTw7h4Ja