### PR TITLE
feat(mcp): Import Doctor — diagnose & one-click-fix Radarr/Sonarr queue imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Cantinarr makes it dead simple for your family and friends to discover and reque
 │                                                         │
 │  ┌──────────┐  ┌──────────┐  ┌───────────────────────┐  │
 │  │ Auth/JWT │  │ Request  │  │ AI Chat               │  │
-│  │          │  │ Service  │  │ + 19 MCP Tools        │  │
+│  │          │  │ Service  │  │ + 25 MCP Tools        │  │
 │  └──────────┘  └────┬─────┘  └───────────────────────┘  │
 │                     │                                    │
 │  ┌──────────────────┼──────────────────────┐             │

--- a/server/README.md
+++ b/server/README.md
@@ -203,11 +203,12 @@ Movies skip bridging entirely -- Radarr natively supports `term=tmdb:{id}`.
 
 ### MCP Tools
 
-The same 19 tools power both the in-app AI assistant and the external MCP endpoint. Tools marked admin require an admin account; every tool can be disabled from Settings > AI Tools:
+The same 25 tools power both the in-app AI assistant and the external MCP endpoint. Tools marked admin require an admin account; every tool can be disabled from Settings > AI Tools:
 
 | Tool | Description |
 |---|---|
 | `search_movies` | Search TMDB for movies |
+| `search_movie_collections` | Search TMDB for movie franchises/collections |
 | `search_tv_shows` | Search TMDB for TV shows |
 | `get_trending` | Trending movies/shows by day or week |
 | `get_movie_details` | Full movie metadata |
@@ -226,6 +227,11 @@ The same 19 tools power both the in-app AI assistant and the external MCP endpoi
 | `grab_release` | Download a specific release (admin) |
 | `remove_queue_item` | Remove/blocklist a queue item (admin) |
 | `get_disk_space` | Disk space across instances (admin) |
+| `diagnose_queue` | Import Doctor: explain stuck/failed/blocked queue items and the fix to apply (admin) |
+| `get_manual_import_candidates` | List a stuck download's files, mappings, and rejection reasons (admin) |
+| `execute_manual_import` | Force a download's files into the library via manual import (admin) |
+| `remediate_queue_item` | One-click queue fix: remove, blocklist+search, or change category (admin) |
+| `rescan_media` | Rescan a movie/series on disk and run the import pass (admin) |
 
 ### MCP Server Endpoint
 

--- a/server/internal/arr/doctor.go
+++ b/server/internal/arr/doctor.go
@@ -1,0 +1,335 @@
+// Package arr holds Radarr/Sonarr logic shared across the typed clients and the
+// MCP tools. The Import Doctor classifier lives here so the same rules diagnose
+// queue problems regardless of which service surfaced them.
+package arr
+
+import "strings"
+
+// StatusMessage mirrors a Radarr/Sonarr queue item's statusMessages entry: a
+// title plus one or more human-readable lines.
+type StatusMessage struct {
+	Title    string
+	Messages []string
+}
+
+// ManualImportRejectionView is a service-neutral rejection reason, used when
+// rendering manual-import candidates from either service.
+type ManualImportRejectionView struct {
+	Reason string
+	Type   string
+}
+
+// QueueSignal is the service-neutral projection of a queue item that the
+// classifier reasons over. Both sonarr.DetailedQueueItem and
+// radarr.DetailedQueueItem map into it.
+type QueueSignal struct {
+	Status                string
+	TrackedDownloadStatus string
+	TrackedDownloadState  string
+	ErrorMessage          string
+	StatusMessages        []StatusMessage
+	Protocol              string
+}
+
+// Diagnosis is the classifier's verdict for one queue item.
+type Diagnosis struct {
+	// Severity is one of: ok, info, warning, error.
+	Severity string
+	// Problem is a short label for the detected condition.
+	Problem string
+	// Transparency is a user-facing sentence explaining what happened.
+	Transparency string
+	// SuggestedActions are stable verb strings the caller can map to fix
+	// tools: process, manual_import, force_import, remove, blocklist_search,
+	// change_category, rescan, or none.
+	SuggestedActions []string
+}
+
+// Severity levels.
+const (
+	SeverityOK      = "ok"
+	SeverityInfo    = "info"
+	SeverityWarning = "warning"
+	SeverityError   = "error"
+)
+
+// Action verbs. These are stable across localizations and are what the fix
+// tools key off of.
+const (
+	ActionNone            = "none"
+	ActionProcess         = "process"
+	ActionManualImport    = "manual_import"
+	ActionForceImport     = "force_import"
+	ActionRemove          = "remove"
+	ActionBlocklistSearch = "blocklist_search"
+	ActionChangeCategory  = "change_category"
+	ActionRescan          = "rescan"
+)
+
+// messageRule matches a single statusMessages line by its stable English
+// prefix (case-insensitive substring; the localized tail after {...}
+// substitutions drifts and is ignored). The first rule that matches wins.
+type messageRule struct {
+	// prefix is the stable English fragment to look for, lower-cased.
+	prefix       string
+	problem      string
+	transparency string
+	severity     string
+	actions      []string
+}
+
+// messageRules is the verbatim-prefix catalog, in first-match-wins order. More
+// specific / more dangerous reasons come first so they are not shadowed by a
+// broader rule.
+var messageRules = []messageRule{
+	{
+		prefix:       "caution: found",
+		problem:      "Dangerous file in release",
+		transparency: "This release contains an executable or otherwise dangerous file — possible malware. Do not import it.",
+		severity:     SeverityError,
+		actions:      []string{ActionBlocklistSearch},
+	},
+	{
+		prefix:       "individual episode mappings",
+		problem:      "TheXEM mapping needs confirmation",
+		transparency: "This show has individual episode mappings on TheXEM, so the download wasn't imported automatically. Confirm the episode and we'll force the import.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionManualImport, ActionForceImport},
+	},
+	{
+		prefix:       "found archive file",
+		problem:      "Release is an unextracted archive",
+		transparency: "This release is packed in an archive (RAR) and must be unpacked before it can be imported.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionChangeCategory, ActionManualImport},
+	},
+	{
+		prefix:       "no files found are eligible for import",
+		problem:      "Nothing importable in the folder",
+		transparency: "The download folder had nothing importable — likely all samples, an unextracted archive, or a path/permissions issue.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionManualImport, ActionBlocklistSearch},
+	},
+	{
+		prefix:       "unable to determine if file is a sample",
+		problem:      "Could not verify sample",
+		transparency: "The file's runtime couldn't be verified, so it might be a sample clip. Force the import if you know it's the full file.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionForceImport, ActionBlocklistSearch},
+	},
+	{
+		prefix:       "sample",
+		problem:      "File looks like a sample",
+		transparency: "The file looks like a sample clip rather than the full release.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionForceImport, ActionBlocklistSearch},
+	},
+	{
+		prefix:       "not an upgrade for existing",
+		problem:      "Not an upgrade",
+		transparency: "This release isn't better than the file you already have, so it wasn't imported.",
+		severity:     SeverityInfo,
+		actions:      []string{ActionRemove, ActionForceImport},
+	},
+	{
+		prefix:       "already imported",
+		problem:      "Already imported",
+		transparency: "This exact download was already imported, so there's nothing to do but clear it.",
+		severity:     SeverityInfo,
+		actions:      []string{ActionRemove},
+	},
+	{
+		prefix:       "not enough free space",
+		problem:      "Not enough free space",
+		transparency: "The library drive is below its free-space floor. Free up space, then rescan to retry.",
+		severity:     SeverityError,
+		actions:      []string{ActionRescan},
+	},
+	{
+		prefix:       "permission",
+		problem:      "Path or permissions error",
+		transparency: "A permissions problem or wrong remote-path mapping blocked the import. Fix access to the path, then rescan to retry.",
+		severity:     SeverityError,
+		actions:      []string{ActionRescan},
+	},
+	{
+		prefix:       "does not exist",
+		problem:      "Path not accessible",
+		transparency: "The download path doesn't exist or isn't accessible to the service — usually a remote-path mapping issue. Fix the path, then rescan to retry.",
+		severity:     SeverityError,
+		actions:      []string{ActionRescan},
+	},
+}
+
+// errorRules matches the queue item's errorMessage (used when
+// trackedDownloadStatus is error). First match wins.
+var errorRules = []messageRule{
+	{
+		prefix:       "stalled",
+		problem:      "Download stalled",
+		transparency: "This torrent has no seeders and will never finish on its own.",
+		severity:     SeverityError,
+		actions:      []string{ActionBlocklistSearch},
+	},
+	{
+		prefix:       "no connections",
+		problem:      "Download stalled",
+		transparency: "This torrent has no connections and will never finish on its own.",
+		severity:     SeverityError,
+		actions:      []string{ActionBlocklistSearch},
+	},
+	{
+		prefix:       "qbittorrent is reporting an error",
+		problem:      "Download client error",
+		transparency: "Your torrent client errored on this download. It won't recover on its own.",
+		severity:     SeverityError,
+		actions:      []string{ActionBlocklistSearch},
+	},
+	{
+		prefix:       "is reporting an error",
+		problem:      "Download client error",
+		transparency: "Your download client errored on this download. It won't recover on its own.",
+		severity:     SeverityError,
+		actions:      []string{ActionBlocklistSearch},
+	},
+}
+
+// healthy reports whether the signal looks like a download progressing or
+// completing normally, with no surfaced problem.
+func (s QueueSignal) healthy() bool {
+	tds := strings.ToLower(s.TrackedDownloadStatus)
+	if tds != "" && tds != "ok" {
+		return false
+	}
+	if s.ErrorMessage != "" {
+		return false
+	}
+	for _, m := range s.StatusMessages {
+		for _, line := range m.Messages {
+			if strings.TrimSpace(line) != "" {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Diagnose classifies a single queue signal using first-match-wins rules.
+//
+// Order:
+//  1. trackedDownloadStatus == error -> inspect errorMessage (client/stalled).
+//  2. a warning/blocked/failed-pending item with statusMessages -> match each
+//     line against the verbatim rejection table.
+//  3. trackedDownloadState == importPending with no messages -> stuck pending.
+//  4. trackedDownloadState == failed -> remove + blocklist + re-search.
+//  5. otherwise healthy.
+func Diagnose(sig QueueSignal) Diagnosis {
+	state := strings.ToLower(sig.TrackedDownloadState)
+	status := strings.ToLower(sig.TrackedDownloadStatus)
+
+	// 1. Hard download-client / stalled errors.
+	if status == "error" {
+		if d, ok := matchError(sig.ErrorMessage); ok {
+			return d
+		}
+		// An error status without a recognized message still warrants a remove.
+		msg := sig.ErrorMessage
+		transparency := "This download errored and won't recover on its own."
+		if msg != "" {
+			transparency = "This download errored (" + msg + ") and won't recover on its own."
+		}
+		return Diagnosis{
+			Severity:         SeverityError,
+			Problem:          "Download error",
+			Transparency:     transparency,
+			SuggestedActions: []string{ActionBlocklistSearch},
+		}
+	}
+
+	// 2. Import rejections surfaced as statusMessages.
+	if d, ok := matchMessages(sig.StatusMessages); ok {
+		return d
+	}
+
+	// 3. Stuck waiting on the import pass.
+	if state == "importpending" {
+		return Diagnosis{
+			Severity:         SeverityWarning,
+			Problem:          "Waiting to import",
+			Transparency:     "The download finished but hasn't been imported yet — the service hasn't run its import pass. Process it now to import it.",
+			SuggestedActions: []string{ActionProcess, ActionManualImport},
+		}
+	}
+
+	// 4. Failed download.
+	if state == "failed" || state == "failedpending" {
+		return Diagnosis{
+			Severity:         SeverityError,
+			Problem:          "Download failed",
+			Transparency:     "This download failed. Remove and blocklist it so a fresh search grabs a different release.",
+			SuggestedActions: []string{ActionBlocklistSearch},
+		}
+	}
+
+	// 5. Anything else with no surfaced problem is healthy.
+	if sig.healthy() {
+		return Diagnosis{
+			Severity:         SeverityOK,
+			Problem:          "",
+			Transparency:     "",
+			SuggestedActions: []string{ActionNone},
+		}
+	}
+
+	// Fallback: a warning with messages we don't recognize.
+	return Diagnosis{
+		Severity:         SeverityWarning,
+		Problem:          "Import blocked",
+		Transparency:     "The service couldn't import this automatically. Review the candidates and import manually, or remove and re-search.",
+		SuggestedActions: []string{ActionManualImport, ActionBlocklistSearch},
+	}
+}
+
+// matchMessages returns the first message rule that matches any status line.
+func matchMessages(messages []StatusMessage) (Diagnosis, bool) {
+	for _, group := range messages {
+		// The group title is itself a status line in many *arr responses
+		// (e.g. it carries the source title or the reason), so test it too.
+		candidates := make([]string, 0, len(group.Messages)+1)
+		if group.Title != "" {
+			candidates = append(candidates, group.Title)
+		}
+		candidates = append(candidates, group.Messages...)
+		for _, line := range candidates {
+			if d, ok := matchRule(line, messageRules); ok {
+				return d, true
+			}
+		}
+	}
+	return Diagnosis{}, false
+}
+
+// matchError returns the first error rule that matches the error message.
+func matchError(errorMessage string) (Diagnosis, bool) {
+	return matchRule(errorMessage, errorRules)
+}
+
+// matchRule scans rules in order and returns the first whose prefix is a
+// case-insensitive substring of line.
+func matchRule(line string, rules []messageRule) (Diagnosis, bool) {
+	lower := strings.ToLower(line)
+	if strings.TrimSpace(lower) == "" {
+		return Diagnosis{}, false
+	}
+	for _, r := range rules {
+		if strings.Contains(lower, r.prefix) {
+			return Diagnosis{
+				Severity:         r.severity,
+				Problem:          r.problem,
+				Transparency:     r.transparency,
+				SuggestedActions: r.actions,
+			}, true
+		}
+	}
+	return Diagnosis{}, false
+}

--- a/server/internal/arr/doctor_test.go
+++ b/server/internal/arr/doctor_test.go
@@ -1,0 +1,218 @@
+package arr
+
+import (
+	"slices"
+	"testing"
+)
+
+// msg is a shorthand for building a single-line status message group.
+func msg(lines ...string) []StatusMessage {
+	return []StatusMessage{{Title: "", Messages: lines}}
+}
+
+func TestDiagnose(t *testing.T) {
+	cases := []struct {
+		name        string
+		sig         QueueSignal
+		wantProblem string
+		wantSev     string
+		wantActions []string
+	}{
+		{
+			name: "thexem unconfirmed mapping needs manual input",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages: msg("This show has individual episode mappings on TheXEM and " +
+					"requires manual input to determine the correct episodes."),
+			},
+			wantProblem: "TheXEM mapping needs confirmation",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport, ActionForceImport},
+		},
+		{
+			name: "no files eligible for import",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("No files found are eligible for import in /downloads/Some.Release"),
+			},
+			wantProblem: "Nothing importable in the folder",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport, ActionBlocklistSearch},
+		},
+		{
+			name: "found archive must be extracted",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Found archive file, might need to be extracted"),
+			},
+			wantProblem: "Release is an unextracted archive",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionChangeCategory, ActionManualImport},
+		},
+		{
+			name: "sample file",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Sample"),
+			},
+			wantProblem: "File looks like a sample",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionForceImport, ActionBlocklistSearch},
+		},
+		{
+			name: "unable to determine sample beats generic sample rule",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Unable to determine if file is a sample"),
+			},
+			wantProblem: "Could not verify sample",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionForceImport, ActionBlocklistSearch},
+		},
+		{
+			name: "not an upgrade for existing",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages: msg("Not an upgrade for existing episode file(s). " +
+					"Existing: WEBDL-1080p. New: HDTV-720p."),
+			},
+			wantProblem: "Not an upgrade",
+			wantSev:     SeverityInfo,
+			wantActions: []string{ActionRemove, ActionForceImport},
+		},
+		{
+			name: "dangerous executable wins over everything",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages: []StatusMessage{{
+					Title:    "Some.Release",
+					Messages: []string{"Caution: Found executable file", "Sample"},
+				}},
+			},
+			wantProblem: "Dangerous file in release",
+			wantSev:     SeverityError,
+			wantActions: []string{ActionBlocklistSearch},
+		},
+		{
+			name: "stalled with no connections",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "error",
+				TrackedDownloadState:  "downloading",
+				ErrorMessage:          "The download is stalled with no connections",
+				Protocol:              "torrent",
+			},
+			wantProblem: "Download stalled",
+			wantSev:     SeverityError,
+			wantActions: []string{ActionBlocklistSearch},
+		},
+		{
+			name: "qbittorrent reporting an error",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "error",
+				TrackedDownloadState:  "downloading",
+				ErrorMessage:          "qBittorrent is reporting an error",
+				Protocol:              "torrent",
+			},
+			wantProblem: "Download client error",
+			wantSev:     SeverityError,
+			wantActions: []string{ActionBlocklistSearch},
+		},
+		{
+			name: "import pending stuck with no messages",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "ok",
+				TrackedDownloadState:  "importPending",
+			},
+			wantProblem: "Waiting to import",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionProcess, ActionManualImport},
+		},
+		{
+			name: "failed download",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "ok",
+				TrackedDownloadState:  "failed",
+			},
+			wantProblem: "Download failed",
+			wantSev:     SeverityError,
+			wantActions: []string{ActionBlocklistSearch},
+		},
+		{
+			name: "healthy downloading item",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "ok",
+				TrackedDownloadState:  "downloading",
+				Protocol:              "usenet",
+			},
+			wantProblem: "",
+			wantSev:     SeverityOK,
+			wantActions: []string{ActionNone},
+		},
+		{
+			name: "healthy importing item with empty status status",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "",
+				TrackedDownloadState:  "importing",
+			},
+			wantProblem: "",
+			wantSev:     SeverityOK,
+			wantActions: []string{ActionNone},
+		},
+		{
+			name: "warning with unrecognized message falls back",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Some brand new reason Sonarr invented last week"),
+			},
+			wantProblem: "Import blocked",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport, ActionBlocklistSearch},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Diagnose(tc.sig)
+			if got.Problem != tc.wantProblem {
+				t.Errorf("Problem = %q, want %q", got.Problem, tc.wantProblem)
+			}
+			if got.Severity != tc.wantSev {
+				t.Errorf("Severity = %q, want %q", got.Severity, tc.wantSev)
+			}
+			if !slices.Equal(got.SuggestedActions, tc.wantActions) {
+				t.Errorf("SuggestedActions = %v, want %v", got.SuggestedActions, tc.wantActions)
+			}
+			if tc.wantSev != SeverityOK && got.Transparency == "" {
+				t.Errorf("expected a transparency sentence for a non-ok diagnosis")
+			}
+		})
+	}
+}
+
+func TestDiagnoseFirstMatchWins(t *testing.T) {
+	// "No files found are eligible" should not be shadowed by the broader
+	// "sample" rule even though both could plausibly co-occur; the eligible
+	// rule is earlier and more specific.
+	sig := QueueSignal{
+		TrackedDownloadStatus: "warning",
+		TrackedDownloadState:  "importBlocked",
+		StatusMessages: []StatusMessage{{
+			Messages: []string{
+				"No files found are eligible for import in /downloads/X",
+				"Sample",
+			},
+		}},
+	}
+	got := Diagnose(sig)
+	if got.Problem != "Nothing importable in the folder" {
+		t.Fatalf("first-match-wins broken: got %q", got.Problem)
+	}
+}

--- a/server/internal/mcp/arr_tools.go
+++ b/server/internal/mcp/arr_tools.go
@@ -205,6 +205,114 @@ var arrToolDefinitions = []Tool{
 			"properties": map[string]interface{}{},
 		},
 	},
+	{
+		Name:        "diagnose_queue",
+		Permission:  auth.PermissionArrRead,
+		Description: "Import Doctor: scan the Radarr/Sonarr download queue for items that are stuck, failed, or blocked from importing, and explain each problem in plain language with the queue_id and suggested fix actions (process, manual_import, force_import, remove, blocklist_search, change_category, rescan). Use this before the fix tools. Admin only",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"media_type": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"movie", "tv", "all"},
+					"description": "Which queue to diagnose (default: all)",
+				},
+			},
+		},
+	},
+	{
+		Name:        "get_manual_import_candidates",
+		AdminOnly:   true,
+		Permission:  auth.PermissionDownloadsManage,
+		Description: "List the files Radarr/Sonarr found for a stuck download (from its queue_id), including each file's mapped movie/series/episodes and any rejection reasons that blocked an automatic import. Use this to understand why an item won't import before calling execute_manual_import. Admin only",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"queue_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "The queue item id, from get_queue or diagnose_queue",
+				},
+				"media_type": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"movie", "tv"},
+					"description": "Whether the queue item is a movie or TV download",
+				},
+			},
+			"required": []string{"queue_id", "media_type"},
+		},
+	},
+	{
+		Name:        "execute_manual_import",
+		AdminOnly:   true,
+		Permission:  auth.PermissionDownloadsManage,
+		Description: "Force the files of a stuck download (from its queue_id) into the library via a manual import. By default skips candidates with permanent rejections; set force=true to import them anyway. Choose this when an item is blocked but the file is actually correct. Admin only",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"queue_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "The queue item id, from get_queue or diagnose_queue",
+				},
+				"media_type": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"movie", "tv"},
+					"description": "Whether the queue item is a movie or TV download",
+				},
+				"force": map[string]interface{}{
+					"type":        "boolean",
+					"description": "Import even candidates with permanent rejections (default: false)",
+				},
+			},
+			"required": []string{"queue_id", "media_type"},
+		},
+	},
+	{
+		Name:        "remediate_queue_item",
+		AdminOnly:   true,
+		Permission:  auth.PermissionDownloadsManage,
+		Description: "Apply a one-click fix to a stuck queue item: remove (delete it and the download), blocklist_search (remove, blocklist the release, and start a fresh search for a different one), or change_category (hand the download to the client's post-import category for tools like Unpackerr). Admin only",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"queue_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "The queue item id, from get_queue or diagnose_queue",
+				},
+				"media_type": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"movie", "tv"},
+					"description": "Whether the queue item is a movie or TV download",
+				},
+				"action": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"remove", "blocklist_search", "change_category"},
+					"description": "The remediation to apply",
+				},
+			},
+			"required": []string{"queue_id", "media_type", "action"},
+		},
+	},
+	{
+		Name:        "rescan_media",
+		AdminOnly:   true,
+		Permission:  auth.PermissionArrSearch,
+		Description: "Rescan the files on disk for a library movie or series, then run the import pass. Use this after fixing a disk-space, path, or permissions problem so Radarr/Sonarr picks up files that are already there. Admin only",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"tmdb_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "The TMDB ID of the movie or TV show",
+				},
+				"media_type": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"movie", "tv"},
+					"description": "Whether this is a movie or TV show",
+				},
+			},
+			"required": []string{"tmdb_id", "media_type"},
+		},
+	},
 }
 
 func init() {
@@ -990,7 +1098,7 @@ func (s *ToolServer) removeQueueItem(input json.RawMessage) (*ToolResult, error)
 		if radarrClient == nil {
 			return &ToolResult{Text: "Radarr is not configured."}, nil
 		}
-		if err := radarrClient.RemoveQueueItem(params.QueueID, true, params.Blocklist); err != nil {
+		if err := radarrClient.RemoveQueueItem(params.QueueID, true, params.Blocklist, false, false); err != nil {
 			return nil, err
 		}
 	case "tv":
@@ -998,7 +1106,7 @@ func (s *ToolServer) removeQueueItem(input json.RawMessage) (*ToolResult, error)
 		if sonarrClient == nil {
 			return &ToolResult{Text: "Sonarr is not configured."}, nil
 		}
-		if err := sonarrClient.RemoveQueueItem(params.QueueID, true, params.Blocklist); err != nil {
+		if err := sonarrClient.RemoveQueueItem(params.QueueID, true, params.Blocklist, false, false); err != nil {
 			return nil, err
 		}
 	default:

--- a/server/internal/mcp/import_doctor.go
+++ b/server/internal/mcp/import_doctor.go
@@ -1,0 +1,647 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/windoze95/cantinarr-server/internal/arr"
+	"github.com/windoze95/cantinarr-server/internal/radarr"
+	"github.com/windoze95/cantinarr-server/internal/sonarr"
+)
+
+// --- Import Doctor: shared signal mapping ---
+
+// sonarrSignal projects a Sonarr queue item into the neutral classifier input.
+func sonarrSignal(item sonarr.DetailedQueueItem) arr.QueueSignal {
+	messages := make([]arr.StatusMessage, 0, len(item.StatusMessages))
+	for _, m := range item.StatusMessages {
+		messages = append(messages, arr.StatusMessage{Title: m.Title, Messages: m.Messages})
+	}
+	return arr.QueueSignal{
+		Status:                item.Status,
+		TrackedDownloadStatus: item.TrackedDownloadStatus,
+		TrackedDownloadState:  item.TrackedDownloadState,
+		ErrorMessage:          item.ErrorMessage,
+		StatusMessages:        messages,
+		Protocol:              item.Protocol,
+	}
+}
+
+// radarrSignal projects a Radarr queue item into the neutral classifier input.
+func radarrSignal(item radarr.DetailedQueueItem) arr.QueueSignal {
+	messages := make([]arr.StatusMessage, 0, len(item.StatusMessages))
+	for _, m := range item.StatusMessages {
+		messages = append(messages, arr.StatusMessage{Title: m.Title, Messages: m.Messages})
+	}
+	return arr.QueueSignal{
+		Status:                item.Status,
+		TrackedDownloadStatus: item.TrackedDownloadStatus,
+		TrackedDownloadState:  item.TrackedDownloadState,
+		ErrorMessage:          item.ErrorMessage,
+		StatusMessages:        messages,
+		Protocol:              item.Protocol,
+	}
+}
+
+func sonarrQueueTitle(item sonarr.DetailedQueueItem) string {
+	if item.Series != nil {
+		if item.Episode != nil {
+			title := fmt.Sprintf("%s S%02dE%02d", item.Series.Title, item.Episode.SeasonNumber, item.Episode.EpisodeNumber)
+			if item.Episode.Title != "" {
+				title += fmt.Sprintf(" %q", item.Episode.Title)
+			}
+			return title
+		}
+		return item.Series.Title
+	}
+	if item.Title != "" {
+		return item.Title
+	}
+	return fmt.Sprintf("series %d", item.SeriesID)
+}
+
+func radarrQueueTitle(item radarr.DetailedQueueItem) string {
+	if item.Movie != nil {
+		return fmt.Sprintf("%s (%d)", item.Movie.Title, item.Movie.Year)
+	}
+	if item.Title != "" {
+		return item.Title
+	}
+	return fmt.Sprintf("movie %d", item.MovieID)
+}
+
+// renderDiagnosis appends a problem item's diagnosis to the builder.
+func renderDiagnosis(sb *strings.Builder, mediaType string, queueID int, title string, d arr.Diagnosis) {
+	fmt.Fprintf(sb, "\n\n- [queue %d] (%s) %s\n  problem: %s [%s]", queueID, mediaType, title, d.Problem, d.Severity)
+	if d.Transparency != "" {
+		fmt.Fprintf(sb, "\n  what happened: %s", d.Transparency)
+	}
+	actions := make([]string, 0, len(d.SuggestedActions))
+	for _, a := range d.SuggestedActions {
+		if a != arr.ActionNone {
+			actions = append(actions, a)
+		}
+	}
+	if len(actions) > 0 {
+		fmt.Fprintf(sb, "\n  suggested actions: %s", strings.Join(actions, ", "))
+	}
+}
+
+// --- diagnose_queue ---
+
+func (s *ToolServer) diagnoseQueue(input json.RawMessage) (*ToolResult, error) {
+	var params struct {
+		MediaType string `json:"media_type"`
+	}
+	if err := json.Unmarshal(input, &params); err != nil {
+		return nil, fmt.Errorf("parse input: %w", err)
+	}
+	mediaType := normalizeMediaType(params.MediaType)
+
+	var sb strings.Builder
+	var notes []string
+	problems := 0
+	healthy := 0
+
+	if mediaType == "movie" || mediaType == "all" {
+		radarrClient := s.GetRadarr()
+		if radarrClient == nil {
+			if mediaType == "movie" {
+				return &ToolResult{Text: "Radarr is not configured."}, nil
+			}
+			notes = append(notes, "Radarr is not configured.")
+		} else {
+			items, err := radarrClient.GetQueueDetailed()
+			if err != nil {
+				return nil, err
+			}
+			for _, item := range items {
+				d := arr.Diagnose(radarrSignal(item))
+				if d.Severity == arr.SeverityOK {
+					healthy++
+					continue
+				}
+				problems++
+				renderDiagnosis(&sb, "movie", item.ID, radarrQueueTitle(item), d)
+			}
+		}
+	}
+
+	if mediaType == "tv" || mediaType == "all" {
+		sonarrClient := s.GetSonarr()
+		if sonarrClient == nil {
+			if mediaType == "tv" {
+				return &ToolResult{Text: "Sonarr is not configured."}, nil
+			}
+			notes = append(notes, "Sonarr is not configured.")
+		} else {
+			items, err := sonarrClient.GetQueueDetailed()
+			if err != nil {
+				return nil, err
+			}
+			for _, item := range items {
+				d := arr.Diagnose(sonarrSignal(item))
+				if d.Severity == arr.SeverityOK {
+					healthy++
+					continue
+				}
+				problems++
+				renderDiagnosis(&sb, "tv", item.ID, sonarrQueueTitle(item), d)
+			}
+		}
+	}
+
+	var header strings.Builder
+	if problems == 0 {
+		header.WriteString("Import Doctor: no queue problems found.")
+		if healthy > 0 {
+			fmt.Fprintf(&header, " %d item(s) are downloading or importing normally.", healthy)
+		}
+	} else {
+		fmt.Fprintf(&header, "Import Doctor found %d queue item(s) needing attention", problems)
+		if healthy > 0 {
+			fmt.Fprintf(&header, " (%d other item(s) are healthy)", healthy)
+		}
+		header.WriteString(". Use get_manual_import_candidates, execute_manual_import, remediate_queue_item, or rescan_media with the queue_id to fix them:")
+	}
+	if len(notes) > 0 {
+		fmt.Fprintf(&header, " (%s)", strings.Join(notes, " "))
+	}
+
+	return &ToolResult{Text: header.String() + sb.String()}, nil
+}
+
+// --- queue item lookup ---
+
+// findRadarrQueueItem returns the queue item with the given id, or nil.
+func findRadarrQueueItem(client *radarr.Client, queueID int) (*radarr.DetailedQueueItem, error) {
+	items, err := client.GetQueueDetailed()
+	if err != nil {
+		return nil, err
+	}
+	for i := range items {
+		if items[i].ID == queueID {
+			return &items[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// findSonarrQueueItem returns the queue item with the given id, or nil.
+func findSonarrQueueItem(client *sonarr.Client, queueID int) (*sonarr.DetailedQueueItem, error) {
+	items, err := client.GetQueueDetailed()
+	if err != nil {
+		return nil, err
+	}
+	for i := range items {
+		if items[i].ID == queueID {
+			return &items[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// --- get_manual_import_candidates ---
+
+func formatRejections(rejections []arr.ManualImportRejectionView) string {
+	if len(rejections) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(rejections))
+	for _, r := range rejections {
+		if r.Type != "" {
+			parts = append(parts, fmt.Sprintf("%s (%s)", r.Reason, r.Type))
+		} else {
+			parts = append(parts, r.Reason)
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (s *ToolServer) getManualImportCandidates(input json.RawMessage) (*ToolResult, error) {
+	var params struct {
+		QueueID   int    `json:"queue_id"`
+		MediaType string `json:"media_type"`
+	}
+	if err := json.Unmarshal(input, &params); err != nil {
+		return nil, fmt.Errorf("parse input: %w", err)
+	}
+
+	switch params.MediaType {
+	case "movie":
+		client := s.GetRadarr()
+		if client == nil {
+			return &ToolResult{Text: "Radarr is not configured."}, nil
+		}
+		item, err := findRadarrQueueItem(client, params.QueueID)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			return &ToolResult{Text: fmt.Sprintf("No movie queue item with id %d. Run get_queue or diagnose_queue for current ids.", params.QueueID)}, nil
+		}
+		if item.DownloadID == "" {
+			return &ToolResult{Text: fmt.Sprintf("Queue item %d has no download-client id yet, so its files cannot be inspected. Wait until it has been handed to the download client.", params.QueueID)}, nil
+		}
+		candidates, err := client.GetManualImportCandidates(item.DownloadID)
+		if err != nil {
+			return nil, err
+		}
+		if len(candidates) == 0 {
+			return &ToolResult{Text: fmt.Sprintf("No importable files found for %s. The folder may be empty, an unextracted archive, or inaccessible.", radarrQueueTitle(*item))}, nil
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d candidate file(s) for %s:", len(candidates), radarrQueueTitle(*item))
+		for _, c := range candidates {
+			fmt.Fprintf(&sb, "\n- %s (%s)", c.Name, humanBytes(float64(c.Size)))
+			if c.MovieID != 0 {
+				fmt.Fprintf(&sb, "\n  maps to movie id %d", c.MovieID)
+			} else {
+				sb.WriteString("\n  not matched to a movie")
+			}
+			if rej := formatRejections(toRejectionViews(c.Rejections)); rej != "" {
+				fmt.Fprintf(&sb, "\n  rejections: %s", rej)
+			}
+		}
+		sb.WriteString("\n\nUse execute_manual_import to import these (add force=true to import despite permanent rejections).")
+		return &ToolResult{Text: sb.String()}, nil
+
+	case "tv":
+		client := s.GetSonarr()
+		if client == nil {
+			return &ToolResult{Text: "Sonarr is not configured."}, nil
+		}
+		item, err := findSonarrQueueItem(client, params.QueueID)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			return &ToolResult{Text: fmt.Sprintf("No TV queue item with id %d. Run get_queue or diagnose_queue for current ids.", params.QueueID)}, nil
+		}
+		if item.DownloadID == "" {
+			return &ToolResult{Text: fmt.Sprintf("Queue item %d has no download-client id yet, so its files cannot be inspected. Wait until it has been handed to the download client.", params.QueueID)}, nil
+		}
+		candidates, err := client.GetManualImportCandidates(item.DownloadID)
+		if err != nil {
+			return nil, err
+		}
+		if len(candidates) == 0 {
+			return &ToolResult{Text: fmt.Sprintf("No importable files found for %s. The folder may be empty, an unextracted archive, or inaccessible.", sonarrQueueTitle(*item))}, nil
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d candidate file(s) for %s:", len(candidates), sonarrQueueTitle(*item))
+		for _, c := range candidates {
+			fmt.Fprintf(&sb, "\n- %s (%s)", c.Name, humanBytes(float64(c.Size)))
+			if len(c.Episodes) > 0 {
+				eps := make([]string, 0, len(c.Episodes))
+				for _, e := range c.Episodes {
+					eps = append(eps, fmt.Sprintf("S%02dE%02d", e.SeasonNumber, e.EpisodeNumber))
+				}
+				fmt.Fprintf(&sb, "\n  maps to %s", strings.Join(eps, ", "))
+			} else {
+				sb.WriteString("\n  not matched to any episode (cannot be imported without episode mapping)")
+			}
+			if rej := formatRejections(toRejectionViews(c.Rejections)); rej != "" {
+				fmt.Fprintf(&sb, "\n  rejections: %s", rej)
+			}
+		}
+		sb.WriteString("\n\nUse execute_manual_import to import these (add force=true to import despite permanent rejections).")
+		return &ToolResult{Text: sb.String()}, nil
+
+	default:
+		return &ToolResult{Text: "media_type must be \"movie\" or \"tv\"."}, nil
+	}
+}
+
+func toRejectionViews[T sonarr.ManualImportRejection | radarr.ManualImportRejection](rejections []T) []arr.ManualImportRejectionView {
+	out := make([]arr.ManualImportRejectionView, 0, len(rejections))
+	for _, r := range rejections {
+		switch v := any(r).(type) {
+		case sonarr.ManualImportRejection:
+			out = append(out, arr.ManualImportRejectionView{Reason: v.Reason, Type: v.Type})
+		case radarr.ManualImportRejection:
+			out = append(out, arr.ManualImportRejectionView{Reason: v.Reason, Type: v.Type})
+		}
+	}
+	return out
+}
+
+// hasPermanentRejection reports whether any rejection is permanent.
+func hasPermanentRejection(rejections []arr.ManualImportRejectionView) bool {
+	for _, r := range rejections {
+		if strings.EqualFold(r.Type, "permanent") {
+			return true
+		}
+	}
+	return false
+}
+
+// --- execute_manual_import ---
+
+func (s *ToolServer) executeManualImport(input json.RawMessage) (*ToolResult, error) {
+	var params struct {
+		QueueID   int    `json:"queue_id"`
+		MediaType string `json:"media_type"`
+		Force     bool   `json:"force"`
+	}
+	if err := json.Unmarshal(input, &params); err != nil {
+		return nil, fmt.Errorf("parse input: %w", err)
+	}
+
+	switch params.MediaType {
+	case "movie":
+		client := s.GetRadarr()
+		if client == nil {
+			return &ToolResult{Text: "Radarr is not configured."}, nil
+		}
+		item, err := findRadarrQueueItem(client, params.QueueID)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			return &ToolResult{Text: fmt.Sprintf("No movie queue item with id %d.", params.QueueID)}, nil
+		}
+		if item.DownloadID == "" {
+			return &ToolResult{Text: fmt.Sprintf("Queue item %d has no download-client id yet; nothing to import.", params.QueueID)}, nil
+		}
+		candidates, err := client.GetManualImportCandidates(item.DownloadID)
+		if err != nil {
+			return nil, err
+		}
+		var files []radarr.ManualImportFile
+		var skipped []string
+		for _, c := range candidates {
+			rejections := toRejectionViews(c.Rejections)
+			if !params.Force && hasPermanentRejection(rejections) {
+				skipped = append(skipped, fmt.Sprintf("%s (%s)", c.Name, formatRejections(rejections)))
+				continue
+			}
+			if c.MovieID == 0 {
+				skipped = append(skipped, fmt.Sprintf("%s (not matched to a movie)", c.Name))
+				continue
+			}
+			files = append(files, radarr.ManualImportFile{
+				Path:         c.Path,
+				FolderName:   c.FolderName,
+				MovieID:      c.MovieID,
+				Quality:      c.Quality,
+				Languages:    c.Languages,
+				ReleaseGroup: c.ReleaseGroup,
+				DownloadID:   c.DownloadID,
+				IndexerFlags: c.IndexerFlags,
+			})
+		}
+		if len(files) == 0 {
+			return &ToolResult{Text: importSkippedMessage(skipped, params.Force)}, nil
+		}
+		importMode := importModeFor(item.Protocol)
+		if err := client.ExecuteManualImport(files, importMode); err != nil {
+			return nil, err
+		}
+		return &ToolResult{Text: importResultMessage(len(files), importMode, skipped)}, nil
+
+	case "tv":
+		client := s.GetSonarr()
+		if client == nil {
+			return &ToolResult{Text: "Sonarr is not configured."}, nil
+		}
+		item, err := findSonarrQueueItem(client, params.QueueID)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			return &ToolResult{Text: fmt.Sprintf("No TV queue item with id %d.", params.QueueID)}, nil
+		}
+		if item.DownloadID == "" {
+			return &ToolResult{Text: fmt.Sprintf("Queue item %d has no download-client id yet; nothing to import.", params.QueueID)}, nil
+		}
+		candidates, err := client.GetManualImportCandidates(item.DownloadID)
+		if err != nil {
+			return nil, err
+		}
+		var files []sonarr.ManualImportFile
+		var skipped []string
+		for _, c := range candidates {
+			rejections := toRejectionViews(c.Rejections)
+			if !params.Force && hasPermanentRejection(rejections) {
+				skipped = append(skipped, fmt.Sprintf("%s (%s)", c.Name, formatRejections(rejections)))
+				continue
+			}
+			episodeIDs := make([]int, 0, len(c.Episodes))
+			for _, e := range c.Episodes {
+				if e.ID != 0 {
+					episodeIDs = append(episodeIDs, e.ID)
+				}
+			}
+			if len(episodeIDs) == 0 {
+				skipped = append(skipped, fmt.Sprintf("%s (no episode mapping)", c.Name))
+				continue
+			}
+			files = append(files, sonarr.ManualImportFile{
+				Path:         c.Path,
+				FolderName:   c.FolderName,
+				SeriesID:     c.SeriesID,
+				EpisodeIDs:   episodeIDs,
+				Quality:      c.Quality,
+				Languages:    c.Languages,
+				ReleaseGroup: c.ReleaseGroup,
+				DownloadID:   c.DownloadID,
+				IndexerFlags: c.IndexerFlags,
+				ReleaseType:  c.ReleaseType,
+			})
+		}
+		if len(files) == 0 {
+			return &ToolResult{Text: importSkippedMessage(skipped, params.Force)}, nil
+		}
+		importMode := importModeFor(item.Protocol)
+		if err := client.ExecuteManualImport(files, importMode); err != nil {
+			return nil, err
+		}
+		return &ToolResult{Text: importResultMessage(len(files), importMode, skipped)}, nil
+
+	default:
+		return &ToolResult{Text: "media_type must be \"movie\" or \"tv\"."}, nil
+	}
+}
+
+// importModeFor picks the lowercase ManualImport importMode: copy for torrents
+// (preserves seeding/hardlinks), move for usenet and anything else.
+func importModeFor(protocol string) string {
+	if strings.EqualFold(protocol, "torrent") {
+		return "copy"
+	}
+	return "move"
+}
+
+func importResultMessage(count int, importMode string, skipped []string) string {
+	text := fmt.Sprintf("Sent %d file(s) to import (mode: %s). Check get_queue or diagnose_queue shortly to confirm they imported.", count, importMode)
+	if len(skipped) > 0 {
+		text += fmt.Sprintf("\nSkipped %d file(s): %s", len(skipped), strings.Join(skipped, "; "))
+	}
+	return text
+}
+
+func importSkippedMessage(skipped []string, force bool) string {
+	if len(skipped) == 0 {
+		return "Nothing to import: no candidate files were found."
+	}
+	text := fmt.Sprintf("Nothing imported. Skipped %d file(s): %s", len(skipped), strings.Join(skipped, "; "))
+	if !force {
+		text += "\nRetry with force=true to import despite permanent rejections."
+	}
+	return text
+}
+
+// --- remediate_queue_item ---
+
+func (s *ToolServer) remediateQueueItem(input json.RawMessage) (*ToolResult, error) {
+	var params struct {
+		QueueID   int    `json:"queue_id"`
+		MediaType string `json:"media_type"`
+		Action    string `json:"action"`
+	}
+	if err := json.Unmarshal(input, &params); err != nil {
+		return nil, fmt.Errorf("parse input: %w", err)
+	}
+	switch params.Action {
+	case "remove", "blocklist_search", "change_category":
+	default:
+		return &ToolResult{Text: "action must be \"remove\", \"blocklist_search\", or \"change_category\"."}, nil
+	}
+
+	switch params.MediaType {
+	case "movie":
+		client := s.GetRadarr()
+		if client == nil {
+			return &ToolResult{Text: "Radarr is not configured."}, nil
+		}
+		item, err := findRadarrQueueItem(client, params.QueueID)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			return &ToolResult{Text: fmt.Sprintf("No movie queue item with id %d.", params.QueueID)}, nil
+		}
+		switch params.Action {
+		case "remove":
+			if err := client.RemoveQueueItem(params.QueueID, true, false, false, false); err != nil {
+				return nil, err
+			}
+			return &ToolResult{Text: fmt.Sprintf("Removed queue item %d (%s) and deleted the download.", params.QueueID, radarrQueueTitle(*item))}, nil
+		case "blocklist_search":
+			if err := client.RemoveQueueItem(params.QueueID, true, true, false, false); err != nil {
+				return nil, err
+			}
+			if item.MovieID != 0 {
+				if err := client.TriggerMoviesSearch([]int{item.MovieID}); err != nil {
+					return nil, err
+				}
+				return &ToolResult{Text: fmt.Sprintf("Removed and blocklisted queue item %d (%s) and started a fresh search for a different release.", params.QueueID, radarrQueueTitle(*item))}, nil
+			}
+			return &ToolResult{Text: fmt.Sprintf("Removed and blocklisted queue item %d (%s). Could not start a search: no movie id on the item.", params.QueueID, radarrQueueTitle(*item))}, nil
+		case "change_category":
+			if err := client.RemoveQueueItem(params.QueueID, false, false, false, true); err != nil {
+				return nil, err
+			}
+			return &ToolResult{Text: fmt.Sprintf("Handed queue item %d (%s) to the download client's post-import category. It stays in the client for tools like Unpackerr.", params.QueueID, radarrQueueTitle(*item))}, nil
+		}
+
+	case "tv":
+		client := s.GetSonarr()
+		if client == nil {
+			return &ToolResult{Text: "Sonarr is not configured."}, nil
+		}
+		item, err := findSonarrQueueItem(client, params.QueueID)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			return &ToolResult{Text: fmt.Sprintf("No TV queue item with id %d.", params.QueueID)}, nil
+		}
+		switch params.Action {
+		case "remove":
+			if err := client.RemoveQueueItem(params.QueueID, true, false, false, false); err != nil {
+				return nil, err
+			}
+			return &ToolResult{Text: fmt.Sprintf("Removed queue item %d (%s) and deleted the download.", params.QueueID, sonarrQueueTitle(*item))}, nil
+		case "blocklist_search":
+			if err := client.RemoveQueueItem(params.QueueID, true, true, false, false); err != nil {
+				return nil, err
+			}
+			if item.EpisodeID != 0 {
+				if err := client.TriggerEpisodeSearch([]int{item.EpisodeID}); err != nil {
+					return nil, err
+				}
+				return &ToolResult{Text: fmt.Sprintf("Removed and blocklisted queue item %d (%s) and started a fresh search for a different release.", params.QueueID, sonarrQueueTitle(*item))}, nil
+			}
+			return &ToolResult{Text: fmt.Sprintf("Removed and blocklisted queue item %d (%s). Could not start a search: no episode id on the item.", params.QueueID, sonarrQueueTitle(*item))}, nil
+		case "change_category":
+			if err := client.RemoveQueueItem(params.QueueID, false, false, false, true); err != nil {
+				return nil, err
+			}
+			return &ToolResult{Text: fmt.Sprintf("Handed queue item %d (%s) to the download client's post-import category. It stays in the client for tools like Unpackerr.", params.QueueID, sonarrQueueTitle(*item))}, nil
+		}
+
+	default:
+		return &ToolResult{Text: "media_type must be \"movie\" or \"tv\"."}, nil
+	}
+	return &ToolResult{Text: "No remediation was applied."}, nil
+}
+
+// --- rescan_media ---
+
+func (s *ToolServer) rescanMedia(input json.RawMessage) (*ToolResult, error) {
+	var params struct {
+		TmdbID    int    `json:"tmdb_id"`
+		MediaType string `json:"media_type"`
+	}
+	if err := json.Unmarshal(input, &params); err != nil {
+		return nil, fmt.Errorf("parse input: %w", err)
+	}
+
+	switch params.MediaType {
+	case "movie":
+		client := s.GetRadarr()
+		if client == nil {
+			return &ToolResult{Text: "Radarr is not configured."}, nil
+		}
+		movie, err := client.GetMovieByTMDB(params.TmdbID)
+		if err != nil {
+			return nil, err
+		}
+		if movie == nil {
+			return &ToolResult{Text: "This movie is not in the library."}, nil
+		}
+		if err := client.RescanMovie(movie.ID); err != nil {
+			return nil, err
+		}
+		if err := client.ProcessMonitoredDownloads(); err != nil {
+			return nil, err
+		}
+		return &ToolResult{Text: fmt.Sprintf("Rescanning %s (%d) and running the import pass. Check diagnose_queue shortly.", movie.Title, movie.Year)}, nil
+
+	case "tv":
+		client := s.GetSonarr()
+		if client == nil {
+			return &ToolResult{Text: "Sonarr is not configured."}, nil
+		}
+		series, err := s.findSeriesByTMDB(client, params.TmdbID)
+		if err != nil {
+			return nil, err
+		}
+		if series == nil {
+			return &ToolResult{Text: "This show is not in the library."}, nil
+		}
+		if err := client.RescanSeries(series.ID); err != nil {
+			return nil, err
+		}
+		if err := client.ProcessMonitoredDownloads(); err != nil {
+			return nil, err
+		}
+		return &ToolResult{Text: fmt.Sprintf("Rescanning %s and running the import pass. Check diagnose_queue shortly.", series.Title)}, nil
+
+	default:
+		return &ToolResult{Text: "media_type must be \"movie\" or \"tv\"."}, nil
+	}
+}

--- a/server/internal/mcp/server.go
+++ b/server/internal/mcp/server.go
@@ -195,6 +195,16 @@ func (s *ToolServer) ExecuteTool(ctx context.Context, name string, input json.Ra
 		return s.removeQueueItem(input)
 	case "get_disk_space":
 		return s.getDiskSpace()
+	case "diagnose_queue":
+		return s.diagnoseQueue(input)
+	case "get_manual_import_candidates":
+		return s.getManualImportCandidates(input)
+	case "execute_manual_import":
+		return s.executeManualImport(input)
+	case "remediate_queue_item":
+		return s.remediateQueueItem(input)
+	case "rescan_media":
+		return s.rescanMedia(input)
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", name)
 	}

--- a/server/internal/mcpserver/guidance.go
+++ b/server/internal/mcpserver/guidance.go
@@ -113,10 +113,11 @@ Workflow:
 
 Workflow:
 1. Use get_queue for current downloads, get_history for recent activity, get_calendar for upcoming releases, and get_library for library state.
-2. For missing media or failed downloads, trigger_search can start an automatic search.
-3. Use search_releases before grab_release when the user wants a particular quality, release group, or manual selection.
-4. Only call destructive tools such as grab_release or remove_queue_item when the user explicitly asks for that action. Summarize consequences before or after the call.
-5. If a tool says it is disabled or not permitted for this role, say so plainly and do not retry the same action.`, issue)
+2. For stuck, failed, or stuck-importing downloads, run diagnose_queue first (the Import Doctor). It explains each problem and lists the fix to apply by queue_id: get_manual_import_candidates then execute_manual_import (force a correct file in), remediate_queue_item (remove / blocklist_search / change_category), or rescan_media (after fixing disk/path/permissions).
+3. For missing media or failed downloads, trigger_search can start an automatic search.
+4. Use search_releases before grab_release when the user wants a particular quality, release group, or manual selection.
+5. Only call destructive tools such as grab_release, remove_queue_item, execute_manual_import, or remediate_queue_item when the user explicitly asks for that action. Summarize consequences before or after the call.
+6. If a tool says it is disabled or not permitted for this role, say so plainly and do not retry the same action.`, issue)
 			return promptResult("Admin download triage", text), nil
 		},
 	)
@@ -203,7 +204,8 @@ Tools may be hidden or disabled by RBAC and administrator settings. If a tool re
 - Use get_library for library state, missing, or unmonitored items.
 - Use get_history for recent grabs, imports, and failures.
 - If a library item is missing or a download failed, trigger_search can start a new automatic search.
+- For downloads that are stuck, failed, or stuck importing, run diagnose_queue (the Import Doctor) to explain the problem and the right fix, then use get_manual_import_candidates / execute_manual_import to force a correct file in, remediate_queue_item to remove / blocklist+search / change category, or rescan_media after fixing a disk, path, or permissions issue.
 - For manual control, call search_releases before grab_release so the user can choose quality, release group, or a specific release.
-- Only call destructive or state-changing tools such as grab_release and remove_queue_item when the user explicitly asks for that action.
+- Only call destructive or state-changing tools such as grab_release, remove_queue_item, execute_manual_import, and remediate_queue_item when the user explicitly asks for that action.
 `, role, toolList)
 }

--- a/server/internal/radarr/client.go
+++ b/server/internal/radarr/client.go
@@ -265,6 +265,7 @@ type DetailedQueueItem struct {
 	Size                  float64 `json:"size"`
 	Sizeleft              float64 `json:"sizeleft"`
 	DownloadClient        string  `json:"downloadClient"`
+	DownloadID            string  `json:"downloadId"`
 	Indexer               string  `json:"indexer"`
 	Protocol              string  `json:"protocol"`
 	ErrorMessage          string  `json:"errorMessage"`
@@ -306,9 +307,14 @@ func (c *Client) GetQueueDetailed() ([]DetailedQueueItem, error) {
 	return all, nil
 }
 
-// RemoveQueueItem removes an item from the download queue.
-func (c *Client) RemoveQueueItem(id int, removeFromClient, blocklist bool) error {
-	path := fmt.Sprintf("/api/v3/queue/%d?removeFromClient=%t&blocklist=%t", id, removeFromClient, blocklist)
+// RemoveQueueItem removes an item from the download queue. removeFromClient
+// also deletes the download from the client; blocklist prevents the release
+// from being grabbed again; skipRedownload suppresses the automatic re-search
+// that a blocklist would otherwise trigger; changeCategory hands the download
+// to the client's post-import category instead of removing it.
+func (c *Client) RemoveQueueItem(id int, removeFromClient, blocklist, skipRedownload, changeCategory bool) error {
+	path := fmt.Sprintf("/api/v3/queue/%d?removeFromClient=%t&blocklist=%t&skipRedownload=%t&changeCategory=%t",
+		id, removeFromClient, blocklist, skipRedownload, changeCategory)
 	if err := c.do("DELETE", path, nil, nil); err != nil {
 		return fmt.Errorf("radarr remove queue item: %w", err)
 	}
@@ -453,4 +459,97 @@ func (c *Client) GetDiskSpace() ([]DiskSpace, error) {
 		return nil, fmt.Errorf("radarr diskspace: %w", err)
 	}
 	return disks, nil
+}
+
+// ManualImportRejection is a single reason Radarr would not auto-import a file,
+// plus whether the rejection is permanent (a force import will likely still
+// fail) or temporary.
+type ManualImportRejection struct {
+	Reason string `json:"reason"`
+	Type   string `json:"type"`
+}
+
+// ManualImportCandidate is a file Radarr found for a download, as returned by
+// GET /manualimport. Quality and Languages are kept as raw JSON so they can be
+// round-tripped verbatim back into the ManualImport command (modeling and
+// re-serializing them risks losing fields Radarr requires).
+type ManualImportCandidate struct {
+	ID           int                     `json:"id"`
+	Path         string                  `json:"path"`
+	FolderName   string                  `json:"folderName"`
+	Name         string                  `json:"name"`
+	Size         int64                   `json:"size"`
+	MovieID      int                     `json:"-"`
+	Quality      json.RawMessage         `json:"quality"`
+	Languages    json.RawMessage         `json:"languages"`
+	ReleaseGroup string                  `json:"releaseGroup"`
+	DownloadID   string                  `json:"downloadId"`
+	IndexerFlags int                     `json:"indexerFlags"`
+	Rejections   []ManualImportRejection `json:"rejections"`
+}
+
+// UnmarshalJSON decodes a manual-import candidate, lifting the nested movie id
+// (Radarr nests it under "movie": {"id": ...}) into MovieID.
+func (m *ManualImportCandidate) UnmarshalJSON(data []byte) error {
+	type alias ManualImportCandidate
+	aux := struct {
+		*alias
+		Movie *struct {
+			ID int `json:"id"`
+		} `json:"movie"`
+	}{alias: (*alias)(m)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.Movie != nil {
+		m.MovieID = aux.Movie.ID
+	}
+	return nil
+}
+
+// GetManualImportCandidates lists the files Radarr found for a download,
+// including any rejection reasons, without importing existing files.
+func (c *Client) GetManualImportCandidates(downloadID string) ([]ManualImportCandidate, error) {
+	var candidates []ManualImportCandidate
+	path := fmt.Sprintf("/api/v3/manualimport?downloadId=%s&filterExistingFiles=false", url.QueryEscape(downloadID))
+	if err := c.do("GET", path, nil, &candidates); err != nil {
+		return nil, fmt.Errorf("radarr manual import candidates: %w", err)
+	}
+	return candidates, nil
+}
+
+// ManualImportFile is one file to import via the ManualImport command. Quality
+// and Languages are passed back verbatim from the candidate.
+type ManualImportFile struct {
+	Path         string          `json:"path"`
+	FolderName   string          `json:"folderName,omitempty"`
+	MovieID      int             `json:"movieId"`
+	Quality      json.RawMessage `json:"quality,omitempty"`
+	Languages    json.RawMessage `json:"languages,omitempty"`
+	ReleaseGroup string          `json:"releaseGroup,omitempty"`
+	DownloadID   string          `json:"downloadId,omitempty"`
+	IndexerFlags int             `json:"indexerFlags,omitempty"`
+}
+
+// ExecuteManualImport tells Radarr to import the given files. importMode must be
+// lowercase (move/copy/auto); the PascalCase form is silently ignored by the
+// ManualImport command.
+func (c *Client) ExecuteManualImport(files []ManualImportFile, importMode string) error {
+	payload := map[string]any{
+		"name":       "ManualImport",
+		"importMode": importMode,
+		"files":      files,
+	}
+	return c.triggerCommand(payload)
+}
+
+// ProcessMonitoredDownloads asks Radarr to run its import pass over the
+// download client now (the pass that normally runs on a timer).
+func (c *Client) ProcessMonitoredDownloads() error {
+	return c.triggerCommand(map[string]any{"name": "ProcessMonitoredDownloads"})
+}
+
+// RescanMovie rescans the files on disk for a movie.
+func (c *Client) RescanMovie(movieID int) error {
+	return c.triggerCommand(map[string]any{"name": "RescanMovie", "movieIds": []int{movieID}})
 }

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -300,6 +300,7 @@ type DetailedQueueItem struct {
 	Size                  float64 `json:"size"`
 	Sizeleft              float64 `json:"sizeleft"`
 	DownloadClient        string  `json:"downloadClient"`
+	DownloadID            string  `json:"downloadId"`
 	Indexer               string  `json:"indexer"`
 	Protocol              string  `json:"protocol"`
 	ErrorMessage          string  `json:"errorMessage"`
@@ -342,9 +343,14 @@ func (c *Client) GetQueueDetailed() ([]DetailedQueueItem, error) {
 	return all, nil
 }
 
-// RemoveQueueItem removes an item from the download queue.
-func (c *Client) RemoveQueueItem(id int, removeFromClient, blocklist bool) error {
-	path := fmt.Sprintf("/api/v3/queue/%d?removeFromClient=%t&blocklist=%t", id, removeFromClient, blocklist)
+// RemoveQueueItem removes an item from the download queue. removeFromClient
+// also deletes the download from the client; blocklist prevents the release
+// from being grabbed again; skipRedownload suppresses the automatic re-search
+// that a blocklist would otherwise trigger; changeCategory hands the download
+// to the client's post-import category instead of removing it.
+func (c *Client) RemoveQueueItem(id int, removeFromClient, blocklist, skipRedownload, changeCategory bool) error {
+	path := fmt.Sprintf("/api/v3/queue/%d?removeFromClient=%t&blocklist=%t&skipRedownload=%t&changeCategory=%t",
+		id, removeFromClient, blocklist, skipRedownload, changeCategory)
 	if err := c.do("DELETE", path, nil, nil); err != nil {
 		return fmt.Errorf("sonarr remove queue item: %w", err)
 	}
@@ -535,4 +541,103 @@ func (c *Client) GetEpisodes(seriesID, seasonNumber int) ([]Episode, error) {
 		return nil, fmt.Errorf("sonarr episodes: %w", err)
 	}
 	return episodes, nil
+}
+
+// ManualImportRejection is a single reason Sonarr would not auto-import a file,
+// plus whether the rejection is permanent (a force import will likely still
+// fail) or temporary.
+type ManualImportRejection struct {
+	Reason string `json:"reason"`
+	Type   string `json:"type"`
+}
+
+// ManualImportCandidate is a file Sonarr found for a download, as returned by
+// GET /manualimport. Quality and Languages are kept as raw JSON so they can be
+// round-tripped verbatim back into the ManualImport command (modeling and
+// re-serializing them risks losing fields Sonarr requires).
+type ManualImportCandidate struct {
+	ID           int                     `json:"id"`
+	Path         string                  `json:"path"`
+	FolderName   string                  `json:"folderName"`
+	Name         string                  `json:"name"`
+	Size         int64                   `json:"size"`
+	SeriesID     int                     `json:"-"`
+	SeasonNumber int                     `json:"seasonNumber"`
+	Episodes     []EpisodeContext        `json:"episodes"`
+	Quality      json.RawMessage         `json:"quality"`
+	Languages    json.RawMessage         `json:"languages"`
+	ReleaseGroup string                  `json:"releaseGroup"`
+	DownloadID   string                  `json:"downloadId"`
+	IndexerFlags int                     `json:"indexerFlags"`
+	ReleaseType  string                  `json:"releaseType"`
+	Rejections   []ManualImportRejection `json:"rejections"`
+}
+
+// UnmarshalJSON decodes a manual-import candidate, lifting the nested series id
+// (Sonarr nests it under "series": {"id": ...}) into SeriesID.
+func (m *ManualImportCandidate) UnmarshalJSON(data []byte) error {
+	type alias ManualImportCandidate
+	aux := struct {
+		*alias
+		Series *struct {
+			ID int `json:"id"`
+		} `json:"series"`
+	}{alias: (*alias)(m)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.Series != nil {
+		m.SeriesID = aux.Series.ID
+	}
+	return nil
+}
+
+// GetManualImportCandidates lists the files Sonarr found for a download,
+// including any rejection reasons, without importing existing files.
+func (c *Client) GetManualImportCandidates(downloadID string) ([]ManualImportCandidate, error) {
+	var candidates []ManualImportCandidate
+	path := fmt.Sprintf("/api/v3/manualimport?downloadId=%s&filterExistingFiles=false", url.QueryEscape(downloadID))
+	if err := c.do("GET", path, nil, &candidates); err != nil {
+		return nil, fmt.Errorf("sonarr manual import candidates: %w", err)
+	}
+	return candidates, nil
+}
+
+// ManualImportFile is one file to import via the ManualImport command. Quality
+// and Languages are passed back verbatim from the candidate. EpisodeIDs must be
+// non-empty for Sonarr or the file is silently skipped.
+type ManualImportFile struct {
+	Path         string          `json:"path"`
+	FolderName   string          `json:"folderName,omitempty"`
+	SeriesID     int             `json:"seriesId"`
+	EpisodeIDs   []int           `json:"episodeIds"`
+	Quality      json.RawMessage `json:"quality,omitempty"`
+	Languages    json.RawMessage `json:"languages,omitempty"`
+	ReleaseGroup string          `json:"releaseGroup,omitempty"`
+	DownloadID   string          `json:"downloadId,omitempty"`
+	IndexerFlags int             `json:"indexerFlags,omitempty"`
+	ReleaseType  string          `json:"releaseType,omitempty"`
+}
+
+// ExecuteManualImport tells Sonarr to import the given files. importMode must be
+// lowercase (move/copy/auto); the PascalCase form is silently ignored by the
+// ManualImport command.
+func (c *Client) ExecuteManualImport(files []ManualImportFile, importMode string) error {
+	payload := map[string]any{
+		"name":       "ManualImport",
+		"importMode": importMode,
+		"files":      files,
+	}
+	return c.triggerCommand(payload)
+}
+
+// ProcessMonitoredDownloads asks Sonarr to run its import pass over the
+// download client now (the pass that normally runs on a timer).
+func (c *Client) ProcessMonitoredDownloads() error {
+	return c.triggerCommand(map[string]any{"name": "ProcessMonitoredDownloads"})
+}
+
+// RescanSeries rescans the files on disk for a series.
+func (c *Client) RescanSeries(seriesID int) error {
+	return c.triggerCommand(map[string]any{"name": "RescanSeries", "seriesId": seriesID})
 }


### PR DESCRIPTION
## Summary

Adds the **MCP "Import Doctor"** — tools that let the AI assistant (and any MCP client) diagnose Radarr/Sonarr download-queue import problems and apply one-click fixes. This is the server/MCP slice of the larger drill-deeper initiative (the Flutter app is on a separate branch). **Server-only; nothing under `app/` is touched.**

## What's new

### Shared classifier — `server/internal/arr/doctor.go` (new package)
A pure, well-tested `Diagnose(QueueSignal) Diagnosis` classifier with **first-match-wins** rules. Both Sonarr and Radarr queue items map into a service-neutral `QueueSignal`. Rules match on the **stable English message prefix** (case-insensitive substring — the localized tail drifts) plus the `trackedDownloadStatus`/`trackedDownloadState` enums.

Catalog covers: TheXEM unconfirmed mappings, "No files found are eligible for import", unextracted archives, samples, "Not an upgrade for existing", already-imported, free-space / path / permission errors, stalled / no-connections, download-client errors, stuck `importPending`, failed downloads, and healthy items. Each verdict carries a `Severity`, a user-facing `Transparency` sentence, and stable `SuggestedActions` verbs (`process`, `manual_import`, `force_import`, `remove`, `blocklist_search`, `change_category`, `rescan`, `none`). Fixtures-based unit test included.

### Five MCP tools (definitions in `arr_tools.go`, dispatch in `server.go`, handlers in `import_doctor.go`)

| Tool | Permission | What it does |
|---|---|---|
| `diagnose_queue` | `arr:read` | Scans the queue, reports each problem with its `queue_id`, transparency sentence, and suggested fix verbs. Skips healthy items. |
| `get_manual_import_candidates` | admin / `downloads:manage` | Looks up the queue item, lists the download's files with mappings (series/episodes or movie) and rejection reasons. |
| `execute_manual_import` | admin / `downloads:manage` | Builds `ManualImportFile`s from candidates and runs the `ManualImport` command. Skips permanent rejections unless `force=true`; `copy` for torrents, `move` for usenet; Sonarr `episodeIds` derived from candidates (skips unmapped files). |
| `remediate_queue_item` | admin / `downloads:manage` | `remove` / `blocklist_search` (remove+blocklist then a fresh episode/movie search) / `change_category`. |
| `rescan_media` | admin / `arr:search` | `RescanSeries`/`RescanMovie` then `ProcessMonitoredDownloads`. |

### Client support (`sonarr` + `radarr`)
- Add `DownloadID` to `DetailedQueueItem`.
- New `ManualImportCandidate` (with `Quality`/`Languages` kept as `json.RawMessage` and **round-tripped verbatim**) + `ManualImportRejection`.
- `GetManualImportCandidates`, `ExecuteManualImport` (**lowercase** `importMode`), `ProcessMonitoredDownloads`, `RescanSeries`/`RescanMovie`.
- Extend `RemoveQueueItem` to `(id, removeFromClient, blocklist, skipRedownload, changeCategory)` and update both existing callers.

### Docs & guidance
- Diagnose→fix sentence added to the `admin-download-triage` prompt and the agent guide.
- Documented MCP tool count bumped to **25** in `README.md` and `server/README.md` (the docs were already stale at 19 vs. 20 shipped; added the 5 new rows).

## Notes / decisions
- Permissioning is conservative and mirrors existing arr tools: the read-only diagnosis uses `arr:read` (like `get_queue`); all fixes are admin-gated. No new permission constants.
- `mark_failed` was intentionally **not** added — a queue item exposes `downloadId`, not a grabbed-history id, so the remove+blocklist path is the primary remediation (per the plan).
- The MCP tools diagnose/fix the **default** instance (consistent with the existing arr tools' `GetDefault*Client` resolution).

## Testing
- `gofmt` / `go vet` clean.
- `go test ./...` from `server/` passes, including `TestToolDefinitionsDeclarePermissions` and the new `internal/arr/doctor_test.go`.
- Smoke-tested all five tools through `ExecuteTool` with nil clients (no panic; readable "not configured" output) and verified RBAC keeps them out of the non-admin tool list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEChSmKSXg8UDF5TY8aWpE