### PR TITLE
feat(sonarr): Import Doctor — one-click fixes for stuck downloads

### DIFF
--- a/app/lib/features/sonarr/data/sonarr_api_service.dart
+++ b/app/lib/features/sonarr/data/sonarr_api_service.dart
@@ -141,14 +141,21 @@ class SonarrApiService {
   }
 
   /// Removes a queue item, optionally from the download client / blocklist.
+  /// [changeCategory] hands the download to the post-import category instead of
+  /// deleting it (e.g. for Unpackerr); [skipRedownload] suppresses the
+  /// automatic re-grab on a blocklist removal.
   Future<void> deleteQueueItem(
     int id, {
     bool removeFromClient = true,
     bool blocklist = false,
+    bool skipRedownload = false,
+    bool changeCategory = false,
   }) async {
     await _dio.delete('$_basePath/queue/$id', queryParameters: {
       'removeFromClient': removeFromClient,
       'blocklist': blocklist,
+      'skipRedownload': skipRedownload,
+      'changeCategory': changeCategory,
     });
   }
 
@@ -279,5 +286,53 @@ class SonarrApiService {
       }
     }
     await _dio.put('$_basePath/series/$seriesId', data: series);
+  }
+
+  // --- Import Doctor (admin; proxy requires instances:manage) ---
+
+  /// Lists the importable files Sonarr found for a finished download, with any
+  /// rejection reasons. Backs the manual-import recovery flow.
+  Future<List<SonarrManualImportCandidate>> getManualImportCandidates(
+    String downloadId,
+  ) async {
+    final resp = await _dio.get(
+      '$_basePath/manualimport',
+      queryParameters: {
+        'downloadId': downloadId,
+        'filterExistingFiles': false,
+      },
+      options: Options(receiveTimeout: const Duration(seconds: 60)),
+    );
+    return (resp.data as List<dynamic>)
+        .map((c) =>
+            SonarrManualImportCandidate.fromJson(c as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Imports the given candidate files. [importMode] must be lowercase
+  /// (`move`/`copy`/`auto`); `copy` preserves seeding for torrents.
+  Future<void> executeManualImport(
+    List<Map<String, dynamic>> files, {
+    String importMode = 'move',
+  }) async {
+    await _dio.post('$_basePath/command', data: {
+      'name': 'ManualImport',
+      'importMode': importMode,
+      'files': files,
+    });
+  }
+
+  /// Nudges Sonarr to run its completed-download import pass now (clears items
+  /// stuck "waiting to import").
+  Future<void> processMonitoredDownloads() async {
+    await _dio.post('$_basePath/command',
+        data: {'name': 'ProcessMonitoredDownloads'});
+  }
+
+  /// Rescans a series' files on disk (retries imports blocked by a transient
+  /// path/permissions problem).
+  Future<void> rescanSeries(int seriesId) async {
+    await _dio.post('$_basePath/command',
+        data: {'name': 'RescanSeries', 'seriesId': seriesId});
   }
 }

--- a/app/lib/features/sonarr/data/sonarr_models.dart
+++ b/app/lib/features/sonarr/data/sonarr_models.dart
@@ -654,3 +654,119 @@ class SonarrRelease {
     return '<1h';
   }
 }
+
+/// Why a manual-import candidate was rejected. `type` is "permanent" or
+/// "temporary"; permanent rejections only import with force.
+class SonarrImportRejection {
+  final String reason;
+  final String type;
+
+  const SonarrImportRejection({this.reason = '', this.type = ''});
+
+  factory SonarrImportRejection.fromJson(Map<String, dynamic> json) =>
+      SonarrImportRejection(
+        reason: json['reason'] as String? ?? '',
+        type: json['type'] as String? ?? '',
+      );
+
+  bool get isPermanent => type.toLowerCase() == 'permanent';
+}
+
+/// One importable file returned by GET /manualimport. The `quality` and
+/// `languages` blobs are kept VERBATIM and round-tripped back into the
+/// ManualImport command unchanged (re-modelling them loses fields Sonarr needs).
+class SonarrManualImportCandidate {
+  final int id;
+  final String path;
+  final String? folderName;
+  final String name;
+  final int size;
+  final int? seriesId;
+  final int? seasonNumber;
+  final List<int> episodeIds;
+  final List<String> episodeLabels;
+  final Map<String, dynamic>? quality;
+  final List<dynamic> languages;
+  final String? releaseGroup;
+  final String? downloadId;
+  final int? indexerFlags;
+  final String? releaseType;
+  final List<SonarrImportRejection> rejections;
+
+  const SonarrManualImportCandidate({
+    required this.id,
+    required this.path,
+    this.folderName,
+    this.name = '',
+    this.size = 0,
+    this.seriesId,
+    this.seasonNumber,
+    this.episodeIds = const [],
+    this.episodeLabels = const [],
+    this.quality,
+    this.languages = const [],
+    this.releaseGroup,
+    this.downloadId,
+    this.indexerFlags,
+    this.releaseType,
+    this.rejections = const [],
+  });
+
+  factory SonarrManualImportCandidate.fromJson(Map<String, dynamic> json) {
+    final episodes = (json['episodes'] as List<dynamic>?) ?? [];
+    final ids = <int>[];
+    final labels = <String>[];
+    for (final e in episodes) {
+      final map = e as Map<String, dynamic>;
+      final id = map['id'] as int?;
+      if (id != null) ids.add(id);
+      final s = map['seasonNumber'] as int?;
+      final n = map['episodeNumber'] as int?;
+      if (s != null && n != null) {
+        labels.add('S${s.toString().padLeft(2, '0')}'
+            'E${n.toString().padLeft(2, '0')}');
+      }
+    }
+    return SonarrManualImportCandidate(
+      id: json['id'] as int? ?? 0,
+      path: json['path'] as String? ?? '',
+      folderName: json['folderName'] as String?,
+      name: json['name'] as String? ??
+          (json['relativePath'] as String?) ??
+          (json['path'] as String? ?? ''),
+      size: (json['size'] as num?)?.toInt() ?? 0,
+      seriesId: (json['series'] as Map<String, dynamic>?)?['id'] as int?,
+      seasonNumber: json['seasonNumber'] as int?,
+      episodeIds: ids,
+      episodeLabels: labels,
+      quality: json['quality'] as Map<String, dynamic>?,
+      languages: (json['languages'] as List<dynamic>?) ?? const [],
+      releaseGroup: json['releaseGroup'] as String?,
+      downloadId: json['downloadId'] as String?,
+      indexerFlags: json['indexerFlags'] as int?,
+      releaseType: json['releaseType'] as String?,
+      rejections: ((json['rejections'] as List<dynamic>?) ?? [])
+          .map((r) => SonarrImportRejection.fromJson(r as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  bool get hasPermanentRejection => rejections.any((r) => r.isPermanent);
+  bool get isMapped => episodeIds.isNotEmpty;
+  String get sizeFormatted => _formatBytes(size);
+
+  /// The file entry for the ManualImport command, with quality/languages sent
+  /// back exactly as received.
+  Map<String, dynamic> toImportFile() => {
+        'path': path,
+        if (folderName != null) 'folderName': folderName,
+        if (seriesId != null) 'seriesId': seriesId,
+        'episodeIds': episodeIds,
+        if (quality != null) 'quality': quality,
+        'languages': languages,
+        if (releaseGroup != null) 'releaseGroup': releaseGroup,
+        if (downloadId != null) 'downloadId': downloadId,
+        if (indexerFlags != null) 'indexerFlags': indexerFlags,
+        if (releaseType != null) 'releaseType': releaseType,
+      };
+}

--- a/app/lib/features/sonarr/logic/import_doctor.dart
+++ b/app/lib/features/sonarr/logic/import_doctor.dart
@@ -1,0 +1,248 @@
+import '../data/sonarr_models.dart';
+
+/// One-click remediation a diagnosis can suggest. Mirrors the action verbs in
+/// the server-side classifier (server/internal/arr/doctor.go) so the app and
+/// the MCP tools agree on fixes.
+enum DoctorAction {
+  process,
+  manualImport,
+  forceImport,
+  remove,
+  blocklistSearch,
+  changeCategory,
+  rescan,
+}
+
+enum DoctorSeverity { ok, info, warning, error }
+
+/// The classifier's verdict for one queue item.
+class SonarrDiagnosis {
+  final DoctorSeverity severity;
+  final String problem;
+  final String transparency;
+  final List<DoctorAction> actions;
+
+  const SonarrDiagnosis({
+    required this.severity,
+    this.problem = '',
+    this.transparency = '',
+    this.actions = const [],
+  });
+
+  bool get isHealthy => severity == DoctorSeverity.ok;
+}
+
+class _Rule {
+  final String prefix; // stable English fragment, lower-cased
+  final String problem;
+  final String transparency;
+  final DoctorSeverity severity;
+  final List<DoctorAction> actions;
+  const _Rule(
+      this.prefix, this.problem, this.transparency, this.severity, this.actions);
+}
+
+/// Verbatim-prefix catalog for statusMessages, first-match-wins. More specific /
+/// more dangerous reasons come first. Kept in sync with doctor.go.
+const List<_Rule> _messageRules = [
+  _Rule(
+    'caution: found',
+    'Dangerous file in release',
+    'This release contains an executable or otherwise dangerous file — possible malware. Do not import it.',
+    DoctorSeverity.error,
+    [DoctorAction.blocklistSearch],
+  ),
+  _Rule(
+    'individual episode mappings',
+    'TheXEM mapping needs confirmation',
+    "This show has individual episode mappings on TheXEM, so the download wasn't imported automatically. Confirm the episode and we'll force the import.",
+    DoctorSeverity.warning,
+    [DoctorAction.manualImport, DoctorAction.forceImport],
+  ),
+  _Rule(
+    'found archive file',
+    'Release is an unextracted archive',
+    'This release is packed in an archive (RAR) and must be unpacked before it can be imported.',
+    DoctorSeverity.warning,
+    [DoctorAction.changeCategory, DoctorAction.manualImport],
+  ),
+  _Rule(
+    'no files found are eligible for import',
+    'Nothing importable in the folder',
+    'The download folder had nothing importable — likely all samples, an unextracted archive, or a path/permissions issue.',
+    DoctorSeverity.warning,
+    [DoctorAction.manualImport, DoctorAction.blocklistSearch],
+  ),
+  _Rule(
+    'unable to determine if file is a sample',
+    'Could not verify sample',
+    "The file's runtime couldn't be verified, so it might be a sample clip. Force the import if you know it's the full file.",
+    DoctorSeverity.warning,
+    [DoctorAction.forceImport, DoctorAction.blocklistSearch],
+  ),
+  _Rule(
+    'sample',
+    'File looks like a sample',
+    'The file looks like a sample clip rather than the full release.',
+    DoctorSeverity.warning,
+    [DoctorAction.forceImport, DoctorAction.blocklistSearch],
+  ),
+  _Rule(
+    'not an upgrade for existing',
+    'Not an upgrade',
+    "This release isn't better than the file you already have, so it wasn't imported.",
+    DoctorSeverity.info,
+    [DoctorAction.remove, DoctorAction.forceImport],
+  ),
+  _Rule(
+    'already imported',
+    'Already imported',
+    "This exact download was already imported, so there's nothing to do but clear it.",
+    DoctorSeverity.info,
+    [DoctorAction.remove],
+  ),
+  _Rule(
+    'not enough free space',
+    'Not enough free space',
+    'The library drive is below its free-space floor. Free up space, then rescan to retry.',
+    DoctorSeverity.error,
+    [DoctorAction.rescan],
+  ),
+  _Rule(
+    'permission',
+    'Path or permissions error',
+    'A permissions problem or wrong remote-path mapping blocked the import. Fix access to the path, then rescan to retry.',
+    DoctorSeverity.error,
+    [DoctorAction.rescan],
+  ),
+  _Rule(
+    'does not exist',
+    'Path not accessible',
+    "The download path doesn't exist or isn't accessible to Sonarr — usually a remote-path mapping issue. Fix the path, then rescan to retry.",
+    DoctorSeverity.error,
+    [DoctorAction.rescan],
+  ),
+];
+
+const List<_Rule> _errorRules = [
+  _Rule(
+    'stalled',
+    'Download stalled',
+    'This torrent has no seeders and will never finish on its own.',
+    DoctorSeverity.error,
+    [DoctorAction.blocklistSearch],
+  ),
+  _Rule(
+    'no connections',
+    'Download stalled',
+    'This torrent has no connections and will never finish on its own.',
+    DoctorSeverity.error,
+    [DoctorAction.blocklistSearch],
+  ),
+  _Rule(
+    'is reporting an error',
+    'Download client error',
+    "Your download client errored on this download. It won't recover on its own.",
+    DoctorSeverity.error,
+    [DoctorAction.blocklistSearch],
+  ),
+];
+
+SonarrDiagnosis? _matchRule(String line, List<_Rule> rules) {
+  final lower = line.toLowerCase().trim();
+  if (lower.isEmpty) return null;
+  for (final r in rules) {
+    if (lower.contains(r.prefix)) {
+      return SonarrDiagnosis(
+        severity: r.severity,
+        problem: r.problem,
+        transparency: r.transparency,
+        actions: r.actions,
+      );
+    }
+  }
+  return null;
+}
+
+bool _looksHealthy(SonarrQueueItem item) {
+  final tds = (item.trackedDownloadStatus ?? '').toLowerCase();
+  if (tds.isNotEmpty && tds != 'ok') return false;
+  if ((item.errorMessage ?? '').isNotEmpty) return false;
+  for (final g in item.statusMessageGroups) {
+    for (final line in g.messages) {
+      if (line.trim().isNotEmpty) return false;
+    }
+  }
+  return true;
+}
+
+/// Classifies a queue item with first-match-wins rules. Mirrors the Go
+/// classifier's order: client/stalled error → import rejections → stuck
+/// pending → failed → healthy → unknown-blocked fallback.
+SonarrDiagnosis diagnoseSonarrQueueItem(SonarrQueueItem item) {
+  final status = (item.trackedDownloadStatus ?? '').toLowerCase();
+  final state = (item.trackedDownloadState ?? '').toLowerCase();
+
+  // 1. Hard download-client / stalled errors.
+  if (status == 'error') {
+    final matched = _matchRule(item.errorMessage ?? '', _errorRules);
+    if (matched != null) return matched;
+    final msg = item.errorMessage ?? '';
+    return SonarrDiagnosis(
+      severity: DoctorSeverity.error,
+      problem: 'Download error',
+      transparency: msg.isNotEmpty
+          ? 'This download errored ($msg) and won\'t recover on its own.'
+          : 'This download errored and won\'t recover on its own.',
+      actions: const [DoctorAction.blocklistSearch],
+    );
+  }
+
+  // 2. Import rejections surfaced as statusMessages.
+  for (final g in item.statusMessageGroups) {
+    final candidates = <String>[
+      if (g.title.isNotEmpty) g.title,
+      ...g.messages,
+    ];
+    for (final line in candidates) {
+      final matched = _matchRule(line, _messageRules);
+      if (matched != null) return matched;
+    }
+  }
+
+  // 3. Stuck waiting on the import pass.
+  if (state == 'importpending') {
+    return const SonarrDiagnosis(
+      severity: DoctorSeverity.warning,
+      problem: 'Waiting to import',
+      transparency:
+          "The download finished but hasn't been imported yet — Sonarr hasn't run its import pass. Process it now to import it.",
+      actions: [DoctorAction.process, DoctorAction.manualImport],
+    );
+  }
+
+  // 4. Failed download.
+  if (state == 'failed' || state == 'failedpending') {
+    return const SonarrDiagnosis(
+      severity: DoctorSeverity.error,
+      problem: 'Download failed',
+      transparency:
+          'This download failed. Remove and blocklist it so a fresh search grabs a different release.',
+      actions: [DoctorAction.blocklistSearch],
+    );
+  }
+
+  // 5. Healthy.
+  if (_looksHealthy(item)) {
+    return const SonarrDiagnosis(severity: DoctorSeverity.ok);
+  }
+
+  // 6. Unknown blocked state.
+  return const SonarrDiagnosis(
+    severity: DoctorSeverity.warning,
+    problem: 'Import blocked',
+    transparency:
+        "Sonarr couldn't import this automatically. Review the candidate files and import manually, or remove and re-search.",
+    actions: [DoctorAction.manualImport, DoctorAction.blocklistSearch],
+  );
+}

--- a/app/lib/features/sonarr/ui/episode_detail_sheet.dart
+++ b/app/lib/features/sonarr/ui/episode_detail_sheet.dart
@@ -6,6 +6,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/status_pill.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
+import 'import_doctor_sheet.dart';
 import 'widgets/queue_item_card.dart';
 
 /// Bottom sheet for a single episode: status, overview, the active download (if
@@ -63,6 +64,23 @@ class _EpisodeDetailSheetState extends ConsumerState<EpisodeDetailSheet> {
       if (!mounted) return;
       setState(() => _loadingHistory = false);
     }
+  }
+
+  void _openDoctor() {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => ImportDoctorSheet(
+        instanceId: widget.instanceId,
+        item: widget.queueItem!,
+        // The Doctor closes itself; close this episode sheet too (returning
+        // true) so the season list refreshes with the result.
+        onChanged: () {
+          if (mounted) Navigator.of(context).pop(true);
+        },
+      ),
+    );
   }
 
   ({String label, Color color}) get _shortStatus {
@@ -146,6 +164,8 @@ class _EpisodeDetailSheetState extends ConsumerState<EpisodeDetailSheet> {
                   child: QueueItemCard(
                     item: widget.queueItem!,
                     primaryTitle: widget.queueItem!.title,
+                    onShowIssues:
+                        widget.queueItem!.hasIssues ? _openDoctor : null,
                   ),
                 ),
               ],

--- a/app/lib/features/sonarr/ui/import_doctor_sheet.dart
+++ b/app/lib/features/sonarr/ui/import_doctor_sheet.dart
@@ -1,0 +1,502 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/sonarr_api_service.dart';
+import '../data/sonarr_models.dart';
+import '../logic/import_doctor.dart';
+
+/// The "Import Doctor": explains why a download is stuck (full transparency,
+/// including the raw Sonarr messages) and offers one-click fixes. Destructive
+/// actions (remove / blocklist / hand-off) ask for confirmation first.
+class ImportDoctorSheet extends ConsumerStatefulWidget {
+  final String instanceId;
+  final SonarrQueueItem item;
+
+  /// Called after a fix is applied so the caller can refresh.
+  final VoidCallback onChanged;
+
+  const ImportDoctorSheet({
+    super.key,
+    required this.instanceId,
+    required this.item,
+    required this.onChanged,
+  });
+
+  @override
+  ConsumerState<ImportDoctorSheet> createState() => _ImportDoctorSheetState();
+}
+
+class _ImportDoctorSheetState extends ConsumerState<ImportDoctorSheet> {
+  late final SonarrApiService _service;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = SonarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: widget.instanceId,
+    );
+  }
+
+  void _toast(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<bool> _confirm(String title, String message, String confirmLabel) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppTheme.surface,
+        title: Text(title),
+        content: Text(message,
+            style: const TextStyle(color: AppTheme.textSecondary)),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+            child: Text(confirmLabel),
+          ),
+        ],
+      ),
+    );
+    return ok ?? false;
+  }
+
+  /// Runs a fix and, on success, refreshes the caller and closes the sheet.
+  Future<void> _run(Future<void> Function() action, String successMessage) async {
+    setState(() => _busy = true);
+    try {
+      await action();
+      if (!mounted) return;
+      _toast(successMessage);
+      Navigator.of(context).pop(); // close the Doctor sheet first…
+      widget.onChanged(); // …then let the caller refresh / close itself
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _busy = false);
+      _toast('Failed: $e');
+    }
+  }
+
+  Future<void> _onAction(DoctorAction action) async {
+    final item = widget.item;
+    switch (action) {
+      case DoctorAction.process:
+        await _run(_service.processMonitoredDownloads,
+            'Running the import pass…');
+      case DoctorAction.rescan:
+        if (item.seriesId == null) {
+          _toast('No series to rescan.');
+          return;
+        }
+        await _run(() => _service.rescanSeries(item.seriesId!),
+            'Rescanning the series…');
+      case DoctorAction.manualImport:
+        await _runManualImport(force: false);
+      case DoctorAction.forceImport:
+        await _runManualImport(force: true);
+      case DoctorAction.remove:
+        if (!await _confirm('Remove download',
+            'This deletes the download from the client. The release is not blocklisted, so it could be grabbed again.',
+            'Remove')) {
+          return;
+        }
+        await _run(() => _service.deleteQueueItem(item.id),
+            'Removed from the queue.');
+      case DoctorAction.blocklistSearch:
+        if (!await _confirm('Remove, blocklist & search',
+            'This deletes the download, blocklists the release so it is not grabbed again, and starts a fresh search for a different one.',
+            'Do it')) {
+          return;
+        }
+        await _run(() async {
+          await _service.deleteQueueItem(item.id, blocklist: true);
+          if (item.episodeId != null) {
+            await _service.searchEpisodes([item.episodeId!]);
+          }
+        }, 'Blocklisted and searching for a replacement…');
+      case DoctorAction.changeCategory:
+        if (!await _confirm('Hand off to download client',
+            'This stops Sonarr managing the download and moves it to the post-import category (for tools like Unpackerr). It stays in your client.',
+            'Hand off')) {
+          return;
+        }
+        await _run(
+            () => _service.deleteQueueItem(item.id,
+                removeFromClient: false, changeCategory: true),
+            'Handed off to the download client.');
+    }
+  }
+
+  Future<void> _runManualImport({required bool force}) async {
+    final downloadId = widget.item.downloadId;
+    if (downloadId == null || downloadId.isEmpty) {
+      _toast('This download has no client id yet — nothing to import.');
+      return;
+    }
+    setState(() => _busy = true);
+    List<SonarrManualImportCandidate> candidates;
+    try {
+      candidates = await _service.getManualImportCandidates(downloadId);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _busy = false);
+      _toast('Could not fetch files: $e');
+      return;
+    }
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (candidates.isEmpty) {
+      _toast('No importable files found in the download folder.');
+      return;
+    }
+
+    final importable = candidates
+        .where((c) => c.isMapped && (force || !c.hasPermanentRejection))
+        .toList();
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => _CandidatesDialog(
+        candidates: candidates,
+        importableCount: importable.length,
+        force: force,
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    if (importable.isEmpty) {
+      _toast(force
+          ? 'None of the files are matched to an episode, so they cannot be imported.'
+          : 'No files qualify — use Force import to import despite the warnings.');
+      return;
+    }
+
+    final files = importable.map((c) => c.toImportFile()).toList();
+    final mode = widget.item.protocol == 'torrent' ? 'copy' : 'move';
+    await _run(() => _service.executeManualImport(files, importMode: mode),
+        'Importing ${files.length} file(s)…');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final diagnosis = diagnoseSonarrQueueItem(item);
+    final (icon, color) = _severityVisual(diagnosis.severity);
+
+    final rawMessages = <String>[
+      if (item.errorMessage != null && item.errorMessage!.isNotEmpty)
+        item.errorMessage!,
+      for (final g in item.statusMessageGroups) ...[
+        if (g.messages.isEmpty && g.title.isNotEmpty) g.title,
+        ...g.messages,
+      ],
+    ];
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: Container(
+        constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(context).size.height * 0.85),
+        decoration: const BoxDecoration(
+          color: AppTheme.surface,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: AppTheme.textSecondary,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(icon, color: color, size: 26),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      diagnosis.problem.isNotEmpty
+                          ? diagnosis.problem
+                          : 'Download status',
+                      style: const TextStyle(
+                          color: AppTheme.textPrimary,
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(item.title,
+                  style: const TextStyle(
+                      color: AppTheme.textSecondary, fontSize: 12),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis),
+              if (diagnosis.transparency.isNotEmpty) ...[
+                const SizedBox(height: 14),
+                Text(diagnosis.transparency,
+                    style: const TextStyle(
+                        color: AppTheme.textPrimary, fontSize: 14, height: 1.4)),
+              ],
+              if (rawMessages.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                const Text('Messages',
+                    style: TextStyle(
+                        color: AppTheme.textSecondary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600)),
+                const SizedBox(height: 6),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppTheme.requested.withValues(alpha: 0.08),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      for (final m in rawMessages)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 2),
+                          child: Text('• $m',
+                              style: const TextStyle(
+                                  color: AppTheme.textSecondary,
+                                  fontSize: 12,
+                                  height: 1.35)),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+              const SizedBox(height: 18),
+              if (_busy)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 12),
+                  child: Center(
+                      child: CircularProgressIndicator(color: AppTheme.accent)),
+                )
+              else if (diagnosis.actions.isEmpty)
+                const Text('No automatic fix is needed.',
+                    style: TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 13))
+              else
+                ...diagnosis.actions.asMap().entries.map((e) => Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: _ActionButton(
+                        meta: _actionMeta(e.value),
+                        primary: e.key == 0,
+                        onTap: () => _onAction(e.value),
+                      ),
+                    )),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+(IconData, Color) _severityVisual(DoctorSeverity s) => switch (s) {
+      DoctorSeverity.error => (Icons.error_outline, AppTheme.error),
+      DoctorSeverity.warning => (Icons.warning_amber_rounded, AppTheme.requested),
+      DoctorSeverity.info => (Icons.info_outline, AppTheme.downloading),
+      DoctorSeverity.ok => (Icons.check_circle_outline, AppTheme.available),
+    };
+
+class _ActionMeta {
+  final String label;
+  final IconData icon;
+  final bool destructive;
+  const _ActionMeta(this.label, this.icon, {this.destructive = false});
+}
+
+_ActionMeta _actionMeta(DoctorAction action) => switch (action) {
+      DoctorAction.process =>
+        const _ActionMeta('Process now', Icons.play_arrow_rounded),
+      DoctorAction.manualImport =>
+        const _ActionMeta('Manual import', Icons.download_done),
+      DoctorAction.forceImport =>
+        const _ActionMeta('Force import', Icons.bolt),
+      DoctorAction.rescan =>
+        const _ActionMeta('Rescan files', Icons.refresh),
+      DoctorAction.remove =>
+        const _ActionMeta('Remove', Icons.delete_outline, destructive: true),
+      DoctorAction.blocklistSearch => const _ActionMeta(
+          'Remove, block & search', Icons.block, destructive: true),
+      DoctorAction.changeCategory =>
+        const _ActionMeta('Hand off to client', Icons.outbox, destructive: true),
+    };
+
+class _ActionButton extends StatelessWidget {
+  final _ActionMeta meta;
+  final bool primary;
+  final VoidCallback onTap;
+
+  const _ActionButton(
+      {required this.meta, required this.primary, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = meta.destructive ? AppTheme.error : AppTheme.accent;
+    if (primary && !meta.destructive) {
+      return SizedBox(
+        width: double.infinity,
+        child: ElevatedButton.icon(
+          onPressed: onTap,
+          icon: Icon(meta.icon, size: 18),
+          label: Text(meta.label),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppTheme.accent,
+            foregroundColor: AppTheme.background,
+            padding: const EdgeInsets.symmetric(vertical: 13),
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10)),
+          ),
+        ),
+      );
+    }
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: onTap,
+        icon: Icon(meta.icon, size: 18, color: color),
+        label: Text(meta.label, style: TextStyle(color: color)),
+        style: OutlinedButton.styleFrom(
+          side: BorderSide(color: color.withValues(alpha: 0.5)),
+          padding: const EdgeInsets.symmetric(vertical: 13),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows the importable files (with mappings + rejections) before importing —
+/// full transparency about exactly what will land.
+class _CandidatesDialog extends StatelessWidget {
+  final List<SonarrManualImportCandidate> candidates;
+  final int importableCount;
+  final bool force;
+
+  const _CandidatesDialog({
+    required this.candidates,
+    required this.importableCount,
+    required this.force,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: AppTheme.surface,
+      title: Text(force ? 'Force import' : 'Manual import'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              importableCount == 0
+                  ? 'None of these files can be imported as-is:'
+                  : 'Will import $importableCount of ${candidates.length} file(s):',
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
+            const SizedBox(height: 10),
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: candidates.map((c) {
+                  final willImport =
+                      c.isMapped && (force || !c.hasPermanentRejection);
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              willImport
+                                  ? Icons.check_circle
+                                  : Icons.remove_circle_outline,
+                              size: 15,
+                              color: willImport
+                                  ? AppTheme.available
+                                  : AppTheme.textSecondary,
+                            ),
+                            const SizedBox(width: 6),
+                            Expanded(
+                              child: Text(c.name,
+                                  style: const TextStyle(
+                                      color: AppTheme.textPrimary, fontSize: 12),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis),
+                            ),
+                          ],
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(left: 21, top: 2),
+                          child: Text(
+                            [
+                              c.sizeFormatted,
+                              if (c.episodeLabels.isNotEmpty)
+                                c.episodeLabels.join(', ')
+                              else
+                                'no episode match',
+                            ].join(' • '),
+                            style: const TextStyle(
+                                color: AppTheme.textSecondary, fontSize: 11),
+                          ),
+                        ),
+                        if (c.rejections.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(left: 21, top: 2),
+                            child: Text(
+                              c.rejections.map((r) => r.reason).join('; '),
+                              style: const TextStyle(
+                                  color: AppTheme.requested, fontSize: 11),
+                            ),
+                          ),
+                      ],
+                    ),
+                  );
+                }).toList(),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel')),
+        TextButton(
+          onPressed:
+              importableCount == 0 ? null : () => Navigator.pop(context, true),
+          child: Text(force ? 'Force import' : 'Import'),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/sonarr/ui/sonarr_queue_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_queue_screen.dart
@@ -8,6 +8,7 @@ import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
+import 'import_doctor_sheet.dart';
 import 'widgets/queue_item_card.dart';
 
 /// Shows the current Sonarr download queue with per-item actions.
@@ -96,6 +97,21 @@ class _SonarrQueueScreenState extends ConsumerState<SonarrQueueScreen> {
         _error = 'Failed to load queue: $e';
       });
     }
+  }
+
+  void _showDoctor(SonarrQueueItem item) {
+    final instanceId = ref.read(instanceProvider).activeSonarrInstance?.id;
+    if (instanceId == null) return;
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => ImportDoctorSheet(
+        instanceId: instanceId,
+        item: item,
+        onChanged: () => _loadQueue(silent: true),
+      ),
+    );
   }
 
   Future<void> _removeItem(SonarrQueueItem item) async {
@@ -200,6 +216,8 @@ class _SonarrQueueScreenState extends ConsumerState<SonarrQueueScreen> {
             primaryTitle: primaryTitle,
             releaseTitle: item.seriesTitle != null ? item.title : null,
             onRemove: () => _removeItem(item),
+            onShowIssues:
+                item.hasIssues ? () => _showDoctor(item) : null,
           );
         },
       ),

--- a/app/lib/features/sonarr/ui/sonarr_season_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_season_screen.dart
@@ -135,8 +135,8 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
     );
   }
 
-  void _openEpisode(SonarrEpisode episode) {
-    showModalBottomSheet<void>(
+  Future<void> _openEpisode(SonarrEpisode episode) async {
+    final changed = await showModalBottomSheet<bool>(
       context: context,
       backgroundColor: Colors.transparent,
       isScrollControlled: true,
@@ -149,6 +149,8 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
         onInteractiveSearch: () => _interactiveEpisodeSearch(episode),
       ),
     );
+    // The episode sheet returns true after an Import Doctor fix.
+    if (changed == true && mounted) _load();
   }
 
   @override

--- a/app/test/sonarr/import_doctor_test.dart
+++ b/app/test/sonarr/import_doctor_test.dart
@@ -1,0 +1,105 @@
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:cantinarr/features/sonarr/logic/import_doctor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+SonarrQueueItem _item({
+  String status = 'ok',
+  String state = 'downloading',
+  String? error,
+  List<SonarrStatusMessage> messages = const [],
+}) =>
+    SonarrQueueItem(
+      id: 1,
+      title: 'release',
+      status: 'downloading',
+      trackedDownloadStatus: status,
+      trackedDownloadState: state,
+      errorMessage: error,
+      statusMessageGroups: messages,
+    );
+
+SonarrStatusMessage _msg(String text) =>
+    SonarrStatusMessage(title: 'release', messages: [text]);
+
+void main() {
+  test('healthy download is OK with no actions', () {
+    final d = diagnoseSonarrQueueItem(_item());
+    expect(d.severity, DoctorSeverity.ok);
+    expect(d.isHealthy, isTrue);
+  });
+
+  test('TheXEM unconfirmed mapping → manual + force import', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [
+        _msg('This show has individual episode mappings on TheXEM but the '
+            'mapping for this episode has not been confirmed yet by their '
+            'administrators. TheXEM needs manual input.'),
+      ],
+    ));
+    expect(d.severity, DoctorSeverity.warning);
+    expect(d.problem, contains('TheXEM'));
+    expect(d.actions, containsAll([
+      DoctorAction.manualImport,
+      DoctorAction.forceImport,
+    ]));
+  });
+
+  test('no eligible files → manual import / blocklist+search', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('No files found are eligible for import in /downloads/x')],
+    ));
+    expect(d.actions, contains(DoctorAction.manualImport));
+    expect(d.actions, contains(DoctorAction.blocklistSearch));
+  });
+
+  test('unextracted archive → change category', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('Found archive file, might need to be extracted')],
+    ));
+    expect(d.actions.first, DoctorAction.changeCategory);
+  });
+
+  test('stuck importPending with no messages → process', () {
+    final d = diagnoseSonarrQueueItem(_item(state: 'importPending'));
+    expect(d.problem, 'Waiting to import');
+    expect(d.actions.first, DoctorAction.process);
+  });
+
+  test('stalled torrent error → blocklist + search', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'error',
+      state: 'downloading',
+      error: 'The download is stalled with no connections',
+    ));
+    expect(d.severity, DoctorSeverity.error);
+    expect(d.actions, contains(DoctorAction.blocklistSearch));
+  });
+
+  test('not-an-upgrade is info with remove option', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('Not an upgrade for existing episode file(s). Existing: '
+          'WEBDL-1080p. New: HDTV-720p.')],
+    ));
+    expect(d.severity, DoctorSeverity.info);
+    expect(d.actions, contains(DoctorAction.remove));
+  });
+
+  test('unknown blocked state falls back to manual import', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('Some brand new reason Sonarr just invented')],
+    ));
+    expect(d.severity, DoctorSeverity.warning);
+    expect(d.problem, 'Import blocked');
+    expect(d.actions, contains(DoctorAction.manualImport));
+  });
+}


### PR DESCRIPTION
Re-targets the Import Doctor onto `main` (was #88, which GitHub auto-closed when its stacked base branch #87 merged). #87 is now on `main`, so this is a clean single-commit diff.

## What

When a download is stuck, the app explains **why** in plain English and offers **one-click fixes** — full transparency about what each does. Tap the **"⚠ Messages — tap to resolve"** affordance on any queue item (queue tab or per-episode sheet) to open the **Import Doctor**:

- **Diagnosis** — e.g. the TheXEM case → *"This show has individual episode mappings on TheXEM… confirm the episode and we'll force the import."*
- **Raw Sonarr "Messages"** — verbatim, nothing hidden.
- **One-click fixes** (only the ones that apply): Process now · Manual / Force import · Remove · Remove+blocklist+search · Hand off (change category) · Rescan.

**Manual/Force import** lists the candidate files with their episode mappings + rejection reasons, then runs `ManualImport` (lowercase mode, `copy` for torrents). Per the agreed UX, **destructive actions confirm first**; safe ones are one-tap.

## How

- `logic/import_doctor.dart` — a Dart classifier that **mirrors the server catalog** (`internal/arr/doctor.go`, shipped in #86) so app + MCP agree. First-match-wins over `statusMessages` + `trackedDownloadStatus/State`.
- `ui/import_doctor_sheet.dart` — the sheet + candidates dialog.
- `SonarrManualImportCandidate` — `quality`/`languages` round-tripped **verbatim**.
- Proxy-backed service methods (`getManualImportCandidates`, `executeManualImport`, `processMonitoredDownloads`, `rescanSeries`, `deleteQueueItem(…changeCategory)`). **No backend changes; admin-gated by the proxy as today.**

## Verification
- `flutter analyze` clean; `flutter test` all pass incl. **8 new classifier cases** mirroring Go `doctor_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)