### PR TITLE
feat(radarr): movie detail + Import Doctor parity with Sonarr

### DIFF
--- a/app/lib/features/radarr/data/radarr_api_service.dart
+++ b/app/lib/features/radarr/data/radarr_api_service.dart
@@ -34,6 +34,10 @@ class RadarrApiService {
     return RadarrMovie.fromJson(resp.data as Map<String, dynamic>);
   }
 
+  /// Alias for [getMovie] used by the movie detail screen for naming parity
+  /// with the Sonarr drill-down (getSeriesById).
+  Future<RadarrMovie> getMovieById(int id) => getMovie(id);
+
   Future<List<RadarrMovie>> lookupMovies(String term) async {
     final resp = await _dio
         .get('$_basePath/movie/lookup', queryParameters: {'term': term});
@@ -114,14 +118,21 @@ class RadarrApiService {
   }
 
   /// Removes a queue item, optionally from the download client / blocklist.
+  /// [changeCategory] hands the download to the post-import category instead of
+  /// deleting it (e.g. for Unpackerr); [skipRedownload] suppresses the
+  /// automatic re-grab on a blocklist removal.
   Future<void> deleteQueueItem(
     int id, {
     bool removeFromClient = true,
     bool blocklist = false,
+    bool skipRedownload = false,
+    bool changeCategory = false,
   }) async {
     await _dio.delete('$_basePath/queue/$id', queryParameters: {
       'removeFromClient': removeFromClient,
       'blocklist': blocklist,
+      'skipRedownload': skipRedownload,
+      'changeCategory': changeCategory,
     });
   }
 
@@ -137,6 +148,19 @@ class RadarrApiService {
       'sortDirection': 'descending',
     });
     return RadarrHistoryPage.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// History for a single movie, newest first. Uses the non-paged
+  /// /history/movie endpoint.
+  Future<List<RadarrHistoryRecord>> getMovieHistory(int movieId) async {
+    final resp = await _dio.get('$_basePath/history/movie',
+        queryParameters: {'movieId': movieId});
+    final records = (resp.data as List<dynamic>)
+        .map((r) => RadarrHistoryRecord.fromJson(r as Map<String, dynamic>))
+        .toList();
+    records.sort(
+        (a, b) => (b.date ?? DateTime(0)).compareTo(a.date ?? DateTime(0)));
+    return records;
   }
 
   /// Fetches a page of monitored movies that have no file, newest in
@@ -183,6 +207,10 @@ class RadarrApiService {
         .toList();
   }
 
+  /// Alias for [getReleases] (naming parity with the Sonarr drill-down).
+  Future<List<RadarrRelease>> getMovieReleases(int movieId) =>
+      getReleases(movieId);
+
   /// Sends a release from interactive search to the download client.
   Future<void> grabRelease({
     required String guid,
@@ -193,5 +221,55 @@ class RadarrApiService {
       data: {'guid': guid, 'indexerId': indexerId},
       options: Options(receiveTimeout: const Duration(seconds: 60)),
     );
+  }
+
+  // --- Import Doctor (admin; proxy requires instances:manage) ---
+
+  /// Lists the importable files Radarr found for a finished download, with any
+  /// rejection reasons. Backs the manual-import recovery flow.
+  Future<List<RadarrManualImportCandidate>> getManualImportCandidates(
+    String downloadId,
+  ) async {
+    final resp = await _dio.get(
+      '$_basePath/manualimport',
+      queryParameters: {
+        'downloadId': downloadId,
+        'filterExistingFiles': false,
+      },
+      options: Options(receiveTimeout: const Duration(seconds: 60)),
+    );
+    return (resp.data as List<dynamic>)
+        .map((c) =>
+            RadarrManualImportCandidate.fromJson(c as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Imports the given candidate files. [importMode] must be lowercase
+  /// (`move`/`copy`/`auto`); `copy` preserves seeding for torrents.
+  Future<void> executeManualImport(
+    List<Map<String, dynamic>> files, {
+    String importMode = 'move',
+  }) async {
+    await _dio.post('$_basePath/command', data: {
+      'name': 'ManualImport',
+      'importMode': importMode,
+      'files': files,
+    });
+  }
+
+  /// Nudges Radarr to run its completed-download import pass now (clears items
+  /// stuck "waiting to import").
+  Future<void> processMonitoredDownloads() async {
+    await _dio.post('$_basePath/command',
+        data: {'name': 'ProcessMonitoredDownloads'});
+  }
+
+  /// Rescans a movie's files on disk (retries imports blocked by a transient
+  /// path/permissions problem).
+  Future<void> rescanMovie(int movieId) async {
+    await _dio.post('$_basePath/command', data: {
+      'name': 'RescanMovie',
+      'movieIds': [movieId],
+    });
   }
 }

--- a/app/lib/features/radarr/data/radarr_models.dart
+++ b/app/lib/features/radarr/data/radarr_models.dart
@@ -1,3 +1,5 @@
+import '../../sonarr/data/sonarr_models.dart' show SonarrStatusMessage;
+
 /// A movie managed by Radarr.
 class RadarrMovie {
   final int id;
@@ -20,6 +22,11 @@ class RadarrMovie {
   final DateTime? inCinemas;
   final DateTime? physicalRelease;
   final DateTime? digitalRelease;
+  final int sizeOnDisk;
+
+  /// True when the movie has reached its minimum availability (i.e. Radarr will
+  /// actively search for it). Drives the "Available"/"Not yet available" line.
+  final bool isAvailable;
 
   const RadarrMovie({
     required this.id,
@@ -42,6 +49,8 @@ class RadarrMovie {
     this.inCinemas,
     this.physicalRelease,
     this.digitalRelease,
+    this.sizeOnDisk = 0,
+    this.isAvailable = false,
   });
 
   factory RadarrMovie.fromJson(Map<String, dynamic> json) => RadarrMovie(
@@ -77,6 +86,8 @@ class RadarrMovie {
             DateTime.tryParse(json['physicalRelease'] as String? ?? ''),
         digitalRelease:
             DateTime.tryParse(json['digitalRelease'] as String? ?? ''),
+        sizeOnDisk: (json['sizeOnDisk'] as num?)?.toInt() ?? 0,
+        isAvailable: json['isAvailable'] as bool? ?? false,
       );
 
   Map<String, dynamic> toJson() => {
@@ -105,6 +116,11 @@ class RadarrMovie {
     final fanart = images.where((i) => i.coverType == 'fanart');
     return fanart.isNotEmpty ? fanart.first.remoteUrl : null;
   }
+
+  /// Size on disk, preferring the top-level field but falling back to the
+  /// movie file's size (the list endpoint omits one or the other at times).
+  String get sizeOnDiskFormatted =>
+      _formatBytes(sizeOnDisk > 0 ? sizeOnDisk : (movieFile?.size ?? 0));
 }
 
 class RadarrImage {
@@ -136,28 +152,31 @@ class RadarrMovieFile {
   final String? relativePath;
   final int? size;
   final String? quality;
+  final bool qualityCutoffNotMet;
+  final String? releaseGroup;
 
   const RadarrMovieFile({
     required this.id,
     this.relativePath,
     this.size,
     this.quality,
+    this.qualityCutoffNotMet = false,
+    this.releaseGroup,
   });
 
   factory RadarrMovieFile.fromJson(Map<String, dynamic> json) =>
       RadarrMovieFile(
         id: json['id'] as int,
         relativePath: json['relativePath'] as String?,
-        size: json['size'] as int?,
+        size: (json['size'] as num?)?.toInt(),
         quality: (json['quality'] as Map<String, dynamic>?)?['quality']?['name']
             as String?,
+        qualityCutoffNotMet: json['qualityCutoffNotMet'] as bool? ?? false,
+        releaseGroup: json['releaseGroup'] as String?,
       );
 
-  String get sizeFormatted {
-    if (size == null) return 'Unknown';
-    final gb = size! / (1024 * 1024 * 1024);
-    return '${gb.toStringAsFixed(1)} GB';
-  }
+  String get sizeFormatted =>
+      (size == null || size! <= 0) ? 'Unknown' : _formatBytes(size!);
 }
 
 class RadarrQualityProfile {
@@ -246,7 +265,16 @@ class RadarrQueueItem {
   final double sizeleft;
   final String? timeleft;
   final String? errorMessage;
+
+  /// Flat list of message strings — kept for existing consumers (the queue
+  /// card's inline issues box).
   final List<String> statusMessages;
+
+  /// Grouped status messages ({title, messages[]}) — the data the Import Doctor
+  /// classifies, mirroring [SonarrQueueItem.statusMessageGroups].
+  final List<SonarrStatusMessage> statusMessageGroups;
+  final String? outputPath;
+  final String? downloadId;
   final String? quality;
 
   const RadarrQueueItem({
@@ -265,13 +293,18 @@ class RadarrQueueItem {
     this.timeleft,
     this.errorMessage,
     this.statusMessages = const [],
+    this.statusMessageGroups = const [],
+    this.outputPath,
+    this.downloadId,
     this.quality,
   });
 
   factory RadarrQueueItem.fromJson(Map<String, dynamic> json) {
     final messages = <String>[];
+    final groups = <SonarrStatusMessage>[];
     for (final entry in (json['statusMessages'] as List<dynamic>? ?? [])) {
       final map = entry as Map<String, dynamic>;
+      groups.add(SonarrStatusMessage.fromJson(map));
       for (final msg in (map['messages'] as List<dynamic>? ?? [])) {
         final text = msg.toString();
         if (text.isNotEmpty) messages.add(text);
@@ -297,6 +330,9 @@ class RadarrQueueItem {
       timeleft: json['timeleft'] as String?,
       errorMessage: json['errorMessage'] as String?,
       statusMessages: messages,
+      statusMessageGroups: groups,
+      outputPath: json['outputPath'] as String?,
+      downloadId: json['downloadId'] as String?,
       quality: (json['quality'] as Map<String, dynamic>?)?['quality']?['name']
           as String?,
     );
@@ -321,6 +357,8 @@ class RadarrHistoryRecord {
   final DateTime? date;
   final String? quality;
   final int? movieId;
+  final Map<String, String> data;
+  final String? downloadId;
 
   const RadarrHistoryRecord({
     required this.id,
@@ -329,6 +367,8 @@ class RadarrHistoryRecord {
     this.date,
     this.quality,
     this.movieId,
+    this.data = const {},
+    this.downloadId,
   });
 
   factory RadarrHistoryRecord.fromJson(Map<String, dynamic> json) =>
@@ -340,7 +380,16 @@ class RadarrHistoryRecord {
         quality: (json['quality'] as Map<String, dynamic>?)?['quality']?['name']
             as String?,
         movieId: json['movieId'] as int?,
+        data: ((json['data'] as Map<String, dynamic>?) ?? {})
+            .map((k, v) => MapEntry(k, v?.toString() ?? '')),
+        downloadId: json['downloadId'] as String?,
       );
+
+  /// Indexer the release was grabbed from, e.g. "NZBgeek (Prowlarr)".
+  String? get indexer => data['indexer'];
+
+  /// Release group parsed from the grab, when present.
+  String? get releaseGroup => data['releaseGroup'];
 }
 
 /// Paged envelope for Radarr history.
@@ -440,4 +489,95 @@ class RadarrRelease {
     if (ageHours >= 1) return '${ageHours.round()}h';
     return '<1h';
   }
+}
+
+/// Why a manual-import candidate was rejected. `type` is "permanent" or
+/// "temporary"; permanent rejections only import with force.
+class RadarrImportRejection {
+  final String reason;
+  final String type;
+
+  const RadarrImportRejection({this.reason = '', this.type = ''});
+
+  factory RadarrImportRejection.fromJson(Map<String, dynamic> json) =>
+      RadarrImportRejection(
+        reason: json['reason'] as String? ?? '',
+        type: json['type'] as String? ?? '',
+      );
+
+  bool get isPermanent => type.toLowerCase() == 'permanent';
+}
+
+/// One importable file returned by GET /manualimport for a movie. Mirrors
+/// [SonarrManualImportCandidate] but keyed by `movieId` (movies are single
+/// items — no episodes). The `quality` and `languages` blobs are kept VERBATIM
+/// and round-tripped back into the ManualImport command unchanged (re-modelling
+/// them loses fields Radarr needs).
+class RadarrManualImportCandidate {
+  final int id;
+  final String path;
+  final String? folderName;
+  final String name;
+  final int size;
+  final int? movieId;
+  final Map<String, dynamic>? quality;
+  final List<dynamic> languages;
+  final String? releaseGroup;
+  final String? downloadId;
+  final int? indexerFlags;
+  final List<RadarrImportRejection> rejections;
+
+  const RadarrManualImportCandidate({
+    required this.id,
+    required this.path,
+    this.folderName,
+    this.name = '',
+    this.size = 0,
+    this.movieId,
+    this.quality,
+    this.languages = const [],
+    this.releaseGroup,
+    this.downloadId,
+    this.indexerFlags,
+    this.rejections = const [],
+  });
+
+  factory RadarrManualImportCandidate.fromJson(Map<String, dynamic> json) =>
+      RadarrManualImportCandidate(
+        id: json['id'] as int? ?? 0,
+        path: json['path'] as String? ?? '',
+        folderName: json['folderName'] as String?,
+        name: json['name'] as String? ??
+            (json['relativePath'] as String?) ??
+            (json['path'] as String? ?? ''),
+        size: (json['size'] as num?)?.toInt() ?? 0,
+        movieId: (json['movie'] as Map<String, dynamic>?)?['id'] as int?,
+        quality: json['quality'] as Map<String, dynamic>?,
+        languages: (json['languages'] as List<dynamic>?) ?? const [],
+        releaseGroup: json['releaseGroup'] as String?,
+        downloadId: json['downloadId'] as String?,
+        indexerFlags: json['indexerFlags'] as int?,
+        rejections: ((json['rejections'] as List<dynamic>?) ?? [])
+            .map((r) => RadarrImportRejection.fromJson(r as Map<String, dynamic>))
+            .toList(),
+      );
+
+  bool get hasPermanentRejection => rejections.any((r) => r.isPermanent);
+
+  /// A candidate is importable once Radarr has matched it to a movie.
+  bool get isMapped => movieId != null;
+  String get sizeFormatted => _formatBytes(size);
+
+  /// The file entry for the ManualImport command, with quality/languages sent
+  /// back exactly as received.
+  Map<String, dynamic> toImportFile() => {
+        'path': path,
+        if (folderName != null) 'folderName': folderName,
+        if (movieId != null) 'movieId': movieId,
+        if (quality != null) 'quality': quality,
+        'languages': languages,
+        if (releaseGroup != null) 'releaseGroup': releaseGroup,
+        if (downloadId != null) 'downloadId': downloadId,
+        if (indexerFlags != null) 'indexerFlags': indexerFlags,
+      };
 }

--- a/app/lib/features/radarr/ui/radarr_home_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_home_screen.dart
@@ -7,6 +7,7 @@ import '../../../core/widgets/error_banner.dart';
 import '../data/radarr_api_service.dart';
 import '../data/radarr_models.dart';
 import '../logic/radarr_movies_provider.dart';
+import 'radarr_movie_detail_screen.dart';
 import 'radarr_movie_list.dart';
 import 'radarr_releases_screen.dart';
 
@@ -72,6 +73,19 @@ class _RadarrHomeScreenState extends ConsumerState<RadarrHomeScreen> {
           instanceId: instanceId,
           movieId: movie.id,
           movieTitle: movie.title,
+        ),
+      ),
+    );
+  }
+
+  void _openMovie(RadarrMovie movie) {
+    final instanceId = ref.read(instanceProvider).activeRadarrInstance?.id;
+    if (instanceId == null) return;
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute(
+        builder: (_) => RadarrMovieDetailScreen(
+          instanceId: instanceId,
+          movie: movie,
         ),
       ),
     );
@@ -189,6 +203,7 @@ class _RadarrHomeScreenState extends ConsumerState<RadarrHomeScreen> {
                             _notifier!.deleteMovie(id, deleteFiles: false),
                         onSearch: _triggerAutomaticSearch,
                         onInteractiveSearch: _openInteractiveSearch,
+                        onOpen: _openMovie,
                       ),
                     ),
             ),

--- a/app/lib/features/radarr/ui/radarr_import_doctor_sheet.dart
+++ b/app/lib/features/radarr/ui/radarr_import_doctor_sheet.dart
@@ -1,0 +1,505 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../sonarr/logic/import_doctor.dart';
+import '../data/radarr_api_service.dart';
+import '../data/radarr_models.dart';
+
+/// The "Import Doctor" for movies: explains why a download is stuck (full
+/// transparency, including the raw Radarr messages) and offers one-click fixes.
+/// Destructive actions (remove / blocklist / hand-off) ask for confirmation
+/// first. Mirrors the Sonarr ImportDoctorSheet; movies are single items, so the
+/// remediation is keyed by movieId rather than episode.
+class RadarrImportDoctorSheet extends ConsumerStatefulWidget {
+  final String instanceId;
+  final RadarrQueueItem item;
+
+  /// Called after a fix is applied so the caller can refresh.
+  final VoidCallback onChanged;
+
+  const RadarrImportDoctorSheet({
+    super.key,
+    required this.instanceId,
+    required this.item,
+    required this.onChanged,
+  });
+
+  @override
+  ConsumerState<RadarrImportDoctorSheet> createState() =>
+      _RadarrImportDoctorSheetState();
+}
+
+class _RadarrImportDoctorSheetState
+    extends ConsumerState<RadarrImportDoctorSheet> {
+  late final RadarrApiService _service;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = RadarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: widget.instanceId,
+    );
+  }
+
+  void _toast(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<bool> _confirm(
+      String title, String message, String confirmLabel) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppTheme.surface,
+        title: Text(title),
+        content: Text(message,
+            style: const TextStyle(color: AppTheme.textSecondary)),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+            child: Text(confirmLabel),
+          ),
+        ],
+      ),
+    );
+    return ok ?? false;
+  }
+
+  /// Runs a fix and, on success, refreshes the caller and closes the sheet.
+  Future<void> _run(
+      Future<void> Function() action, String successMessage) async {
+    setState(() => _busy = true);
+    try {
+      await action();
+      if (!mounted) return;
+      _toast(successMessage);
+      Navigator.of(context).pop(); // close the Doctor sheet first…
+      widget.onChanged(); // …then let the caller refresh / close itself
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _busy = false);
+      _toast('Failed: $e');
+    }
+  }
+
+  Future<void> _onAction(DoctorAction action) async {
+    final item = widget.item;
+    switch (action) {
+      case DoctorAction.process:
+        await _run(_service.processMonitoredDownloads,
+            'Running the import pass…');
+      case DoctorAction.rescan:
+        if (item.movieId == null) {
+          _toast('No movie to rescan.');
+          return;
+        }
+        await _run(() => _service.rescanMovie(item.movieId!),
+            'Rescanning the movie…');
+      case DoctorAction.manualImport:
+        await _runManualImport(force: false);
+      case DoctorAction.forceImport:
+        await _runManualImport(force: true);
+      case DoctorAction.remove:
+        if (!await _confirm('Remove download',
+            'This deletes the download from the client. The release is not blocklisted, so it could be grabbed again.',
+            'Remove')) {
+          return;
+        }
+        await _run(() => _service.deleteQueueItem(item.id),
+            'Removed from the queue.');
+      case DoctorAction.blocklistSearch:
+        if (!await _confirm('Remove, blocklist & search',
+            'This deletes the download, blocklists the release so it is not grabbed again, and starts a fresh search for a different one.',
+            'Do it')) {
+          return;
+        }
+        await _run(() async {
+          await _service.deleteQueueItem(item.id, blocklist: true);
+          if (item.movieId != null) {
+            await _service.searchMovie(item.movieId!);
+          }
+        }, 'Blocklisted and searching for a replacement…');
+      case DoctorAction.changeCategory:
+        if (!await _confirm('Hand off to download client',
+            'This stops Radarr managing the download and moves it to the post-import category (for tools like Unpackerr). It stays in your client.',
+            'Hand off')) {
+          return;
+        }
+        await _run(
+            () => _service.deleteQueueItem(item.id,
+                removeFromClient: false, changeCategory: true),
+            'Handed off to the download client.');
+    }
+  }
+
+  Future<void> _runManualImport({required bool force}) async {
+    final downloadId = widget.item.downloadId;
+    if (downloadId == null || downloadId.isEmpty) {
+      _toast('This download has no client id yet — nothing to import.');
+      return;
+    }
+    setState(() => _busy = true);
+    List<RadarrManualImportCandidate> candidates;
+    try {
+      candidates = await _service.getManualImportCandidates(downloadId);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _busy = false);
+      _toast('Could not fetch files: $e');
+      return;
+    }
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (candidates.isEmpty) {
+      _toast('No importable files found in the download folder.');
+      return;
+    }
+
+    final importable = candidates
+        .where((c) => c.isMapped && (force || !c.hasPermanentRejection))
+        .toList();
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => _CandidatesDialog(
+        candidates: candidates,
+        importableCount: importable.length,
+        force: force,
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    if (importable.isEmpty) {
+      _toast(force
+          ? 'None of the files are matched to a movie, so they cannot be imported.'
+          : 'No files qualify — use Force import to import despite the warnings.');
+      return;
+    }
+
+    final files = importable.map((c) => c.toImportFile()).toList();
+    final mode = widget.item.protocol == 'torrent' ? 'copy' : 'move';
+    await _run(() => _service.executeManualImport(files, importMode: mode),
+        'Importing ${files.length} file(s)…');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final diagnosis = diagnoseRadarrQueueItem(item);
+    final (icon, color) = _severityVisual(diagnosis.severity);
+
+    final rawMessages = <String>[
+      if (item.errorMessage != null && item.errorMessage!.isNotEmpty)
+        item.errorMessage!,
+      for (final g in item.statusMessageGroups) ...[
+        if (g.messages.isEmpty && g.title.isNotEmpty) g.title,
+        ...g.messages,
+      ],
+    ];
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: Container(
+        constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(context).size.height * 0.85),
+        decoration: const BoxDecoration(
+          color: AppTheme.surface,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: AppTheme.textSecondary,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(icon, color: color, size: 26),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      diagnosis.problem.isNotEmpty
+                          ? diagnosis.problem
+                          : 'Download status',
+                      style: const TextStyle(
+                          color: AppTheme.textPrimary,
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(item.title,
+                  style: const TextStyle(
+                      color: AppTheme.textSecondary, fontSize: 12),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis),
+              if (diagnosis.transparency.isNotEmpty) ...[
+                const SizedBox(height: 14),
+                Text(diagnosis.transparency,
+                    style: const TextStyle(
+                        color: AppTheme.textPrimary, fontSize: 14, height: 1.4)),
+              ],
+              if (rawMessages.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                const Text('Messages',
+                    style: TextStyle(
+                        color: AppTheme.textSecondary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600)),
+                const SizedBox(height: 6),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppTheme.requested.withValues(alpha: 0.08),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      for (final m in rawMessages)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 2),
+                          child: Text('• $m',
+                              style: const TextStyle(
+                                  color: AppTheme.textSecondary,
+                                  fontSize: 12,
+                                  height: 1.35)),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+              const SizedBox(height: 18),
+              if (_busy)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 12),
+                  child: Center(
+                      child: CircularProgressIndicator(color: AppTheme.accent)),
+                )
+              else if (diagnosis.actions.isEmpty)
+                const Text('No automatic fix is needed.',
+                    style: TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 13))
+              else
+                ...diagnosis.actions.asMap().entries.map((e) => Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: _ActionButton(
+                        meta: _actionMeta(e.value),
+                        primary: e.key == 0,
+                        onTap: () => _onAction(e.value),
+                      ),
+                    )),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+(IconData, Color) _severityVisual(DoctorSeverity s) => switch (s) {
+      DoctorSeverity.error => (Icons.error_outline, AppTheme.error),
+      DoctorSeverity.warning => (Icons.warning_amber_rounded, AppTheme.requested),
+      DoctorSeverity.info => (Icons.info_outline, AppTheme.downloading),
+      DoctorSeverity.ok => (Icons.check_circle_outline, AppTheme.available),
+    };
+
+class _ActionMeta {
+  final String label;
+  final IconData icon;
+  final bool destructive;
+  const _ActionMeta(this.label, this.icon, {this.destructive = false});
+}
+
+_ActionMeta _actionMeta(DoctorAction action) => switch (action) {
+      DoctorAction.process =>
+        const _ActionMeta('Process now', Icons.play_arrow_rounded),
+      DoctorAction.manualImport =>
+        const _ActionMeta('Manual import', Icons.download_done),
+      DoctorAction.forceImport =>
+        const _ActionMeta('Force import', Icons.bolt),
+      DoctorAction.rescan =>
+        const _ActionMeta('Rescan files', Icons.refresh),
+      DoctorAction.remove =>
+        const _ActionMeta('Remove', Icons.delete_outline, destructive: true),
+      DoctorAction.blocklistSearch => const _ActionMeta(
+          'Remove, block & search', Icons.block, destructive: true),
+      DoctorAction.changeCategory =>
+        const _ActionMeta('Hand off to client', Icons.outbox, destructive: true),
+    };
+
+class _ActionButton extends StatelessWidget {
+  final _ActionMeta meta;
+  final bool primary;
+  final VoidCallback onTap;
+
+  const _ActionButton(
+      {required this.meta, required this.primary, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = meta.destructive ? AppTheme.error : AppTheme.accent;
+    if (primary && !meta.destructive) {
+      return SizedBox(
+        width: double.infinity,
+        child: ElevatedButton.icon(
+          onPressed: onTap,
+          icon: Icon(meta.icon, size: 18),
+          label: Text(meta.label),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppTheme.accent,
+            foregroundColor: AppTheme.background,
+            padding: const EdgeInsets.symmetric(vertical: 13),
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(10)),
+          ),
+        ),
+      );
+    }
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: onTap,
+        icon: Icon(meta.icon, size: 18, color: color),
+        label: Text(meta.label, style: TextStyle(color: color)),
+        style: OutlinedButton.styleFrom(
+          side: BorderSide(color: color.withValues(alpha: 0.5)),
+          padding: const EdgeInsets.symmetric(vertical: 13),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows the importable files (with mappings + rejections) before importing —
+/// full transparency about exactly what will land.
+class _CandidatesDialog extends StatelessWidget {
+  final List<RadarrManualImportCandidate> candidates;
+  final int importableCount;
+  final bool force;
+
+  const _CandidatesDialog({
+    required this.candidates,
+    required this.importableCount,
+    required this.force,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: AppTheme.surface,
+      title: Text(force ? 'Force import' : 'Manual import'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              importableCount == 0
+                  ? 'None of these files can be imported as-is:'
+                  : 'Will import $importableCount of ${candidates.length} file(s):',
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
+            const SizedBox(height: 10),
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: candidates.map((c) {
+                  final willImport =
+                      c.isMapped && (force || !c.hasPermanentRejection);
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              willImport
+                                  ? Icons.check_circle
+                                  : Icons.remove_circle_outline,
+                              size: 15,
+                              color: willImport
+                                  ? AppTheme.available
+                                  : AppTheme.textSecondary,
+                            ),
+                            const SizedBox(width: 6),
+                            Expanded(
+                              child: Text(c.name,
+                                  style: const TextStyle(
+                                      color: AppTheme.textPrimary, fontSize: 12),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis),
+                            ),
+                          ],
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(left: 21, top: 2),
+                          child: Text(
+                            [
+                              c.sizeFormatted,
+                              if (!c.isMapped) 'no movie match',
+                            ].join(' • '),
+                            style: const TextStyle(
+                                color: AppTheme.textSecondary, fontSize: 11),
+                          ),
+                        ),
+                        if (c.rejections.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(left: 21, top: 2),
+                            child: Text(
+                              c.rejections.map((r) => r.reason).join('; '),
+                              style: const TextStyle(
+                                  color: AppTheme.requested, fontSize: 11),
+                            ),
+                          ),
+                      ],
+                    ),
+                  );
+                }).toList(),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel')),
+        TextButton(
+          onPressed:
+              importableCount == 0 ? null : () => Navigator.pop(context, true),
+          child: Text(force ? 'Force import' : 'Import'),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
@@ -1,0 +1,504 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../../../core/widgets/status_pill.dart';
+import '../data/radarr_api_service.dart';
+import '../data/radarr_models.dart';
+import 'radarr_import_doctor_sheet.dart';
+import 'radarr_releases_screen.dart';
+import 'widgets/radarr_queue_item_card.dart';
+
+/// Movie detail: poster/overview, the downloaded file's quality+size, the
+/// active download (with the Import Doctor affordance) and recent history, plus
+/// an Automatic/Interactive search action bar. The movie-side mirror of the
+/// Sonarr series → season → episode drill-down (movies are single items, so the
+/// whole picture fits on one screen).
+class RadarrMovieDetailScreen extends ConsumerStatefulWidget {
+  final String instanceId;
+  final RadarrMovie movie;
+
+  const RadarrMovieDetailScreen({
+    super.key,
+    required this.instanceId,
+    required this.movie,
+  });
+
+  @override
+  ConsumerState<RadarrMovieDetailScreen> createState() =>
+      _RadarrMovieDetailScreenState();
+}
+
+class _RadarrMovieDetailScreenState
+    extends ConsumerState<RadarrMovieDetailScreen> {
+  late final RadarrApiService _service;
+  late RadarrMovie _movie;
+  RadarrQueueItem? _queueItem;
+  List<RadarrHistoryRecord> _history = [];
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _movie = widget.movie;
+    _service = RadarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: widget.instanceId,
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    setState(() => _isLoading = true);
+    try {
+      // Kick off in parallel, then await — the movie + its queue item + history.
+      final movieFuture = _service.getMovieById(_movie.id);
+      final queueFuture = _service.getQueueDetailed();
+      final historyFuture = _service.getMovieHistory(_movie.id);
+      final movie = await movieFuture;
+      final queue = await queueFuture;
+      final history = await historyFuture;
+      if (!mounted) return;
+      setState(() {
+        _movie = movie;
+        _queueItem = queue.where((q) => q.movieId == _movie.id).isNotEmpty
+            ? queue.firstWhere((q) => q.movieId == _movie.id)
+            : null;
+        _history = history.take(8).toList();
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load movie: $e';
+      });
+    }
+  }
+
+  Future<void> _automaticSearch() async {
+    try {
+      await _service.searchMovie(_movie.id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Searching for ${_movie.title}…')));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Search failed: $e')));
+    }
+  }
+
+  void _interactiveSearch() {
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute(
+        builder: (_) => RadarrReleasesScreen(
+          instanceId: widget.instanceId,
+          movieId: _movie.id,
+          movieTitle: _movie.title,
+        ),
+      ),
+    );
+  }
+
+  void _openDoctor() {
+    final item = _queueItem;
+    if (item == null) return;
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => RadarrImportDoctorSheet(
+        instanceId: widget.instanceId,
+        item: item,
+        onChanged: _load,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      appBar: AppBar(
+        backgroundColor: AppTheme.background,
+        title: Text(_movie.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh, color: AppTheme.textPrimary),
+            tooltip: 'Refresh',
+            onPressed: _isLoading ? null : _load,
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(child: _buildBody()),
+          _ActionBar(
+            onAutomatic: _automaticSearch,
+            onInteractive: _interactiveSearch,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading && _history.isEmpty && _queueItem == null) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null) {
+      return FullScreenError(message: _error!, onRetry: _load);
+    }
+    return RefreshIndicator(
+      onRefresh: _load,
+      color: AppTheme.accent,
+      child: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 16),
+        children: [
+          _Header(movie: _movie),
+          const SizedBox(height: 16),
+          StatusPill(text: _statusLabel, color: _statusColor),
+          if (_movie.overview != null && _movie.overview!.isNotEmpty) ...[
+            const SizedBox(height: 14),
+            Text(_movie.overview!,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary, fontSize: 14, height: 1.4)),
+          ],
+          if (_movie.movieFile != null) ...[
+            const SizedBox(height: 16),
+            _FileCard(file: _movie.movieFile!),
+          ],
+          if (_queueItem != null) ...[
+            const SizedBox(height: 16),
+            RadarrQueueItemCard(
+              item: _queueItem!,
+              primaryTitle: _queueItem!.title,
+              onShowIssues: _queueItem!.hasIssues ? _openDoctor : null,
+            ),
+          ],
+          const SizedBox(height: 16),
+          const Text('History',
+              style: TextStyle(
+                  color: AppTheme.textSecondary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600)),
+          const SizedBox(height: 8),
+          _buildHistory(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHistory() {
+    if (_isLoading && _history.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 12),
+        child: Center(
+            child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                    strokeWidth: 2, color: AppTheme.accent))),
+      );
+    }
+    if (_history.isEmpty) {
+      return const Text('No history yet.',
+          style: TextStyle(color: AppTheme.textSecondary, fontSize: 13));
+    }
+    return Column(
+      children: _history.map((h) => _HistoryTile(record: h)).toList(),
+    );
+  }
+
+  String get _statusLabel {
+    if (_movie.hasFile) {
+      final met = !(_movie.movieFile?.qualityCutoffNotMet ?? false);
+      return met ? 'Downloaded' : 'Upgrade available';
+    }
+    if (!_movie.monitored) return 'Unmonitored';
+    return _movie.isAvailable ? 'Missing' : 'Not yet available';
+  }
+
+  Color get _statusColor {
+    if (_movie.hasFile) {
+      final met = !(_movie.movieFile?.qualityCutoffNotMet ?? false);
+      return met ? AppTheme.available : AppTheme.requested;
+    }
+    if (!_movie.monitored) return AppTheme.unavailable;
+    return _movie.isAvailable ? AppTheme.error : AppTheme.downloading;
+  }
+}
+
+class _Header extends StatelessWidget {
+  final RadarrMovie movie;
+  const _Header({required this.movie});
+
+  @override
+  Widget build(BuildContext context) {
+    final meta = <String>[
+      if (movie.year > 0) '${movie.year}',
+      if (movie.runtime > 0) '${movie.runtime} min',
+      if (movie.sizeOnDisk > 0 || movie.movieFile?.size != null)
+        movie.sizeOnDiskFormatted,
+    ];
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ClipRRect(
+          borderRadius: BorderRadius.circular(8),
+          child: SizedBox(
+            width: 100,
+            height: 150,
+            child: movie.posterUrl != null
+                ? CachedNetworkImage(
+                    imageUrl: movie.posterUrl!,
+                    fit: BoxFit.cover,
+                  )
+                : Container(
+                    color: AppTheme.surfaceVariant,
+                    child: const Icon(Icons.movie,
+                        color: AppTheme.textSecondary, size: 28),
+                  ),
+          ),
+        ),
+        const SizedBox(width: 14),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(movie.title,
+                  style: const TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold)),
+              const SizedBox(height: 6),
+              if (meta.isNotEmpty)
+                Text(meta.join(' • '),
+                    style: const TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 13)),
+              if (movie.ratings != null) ...[
+                const SizedBox(height: 6),
+                Row(
+                  children: [
+                    const Icon(Icons.star, size: 14, color: AppTheme.accent),
+                    const SizedBox(width: 4),
+                    Text(movie.ratings!.toStringAsFixed(1),
+                        style: const TextStyle(
+                            color: AppTheme.textSecondary, fontSize: 13)),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The downloaded file's quality + size line — Radarr's analogue of the Sonarr
+/// per-episode "WEBDL-1080p — 4.3 GB" status.
+class _FileCard extends StatelessWidget {
+  final RadarrMovieFile file;
+  const _FileCard({required this.file});
+
+  @override
+  Widget build(BuildContext context) {
+    final cutoffMet = !file.qualityCutoffNotMet;
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppTheme.border, width: 0.5),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.movie_creation_outlined,
+              color: cutoffMet ? AppTheme.available : AppTheme.requested,
+              size: 22),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    StatusPill(
+                      text: file.quality ?? 'Downloaded',
+                      color: cutoffMet ? AppTheme.available : AppTheme.requested,
+                    ),
+                    if (!cutoffMet) ...[
+                      const SizedBox(width: 6),
+                      const StatusPill(
+                          text: 'Upgrade available', color: AppTheme.requested),
+                    ],
+                  ],
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  [
+                    file.sizeFormatted,
+                    if (file.releaseGroup != null &&
+                        file.releaseGroup!.isNotEmpty)
+                      file.releaseGroup!,
+                  ].join(' • '),
+                  style: const TextStyle(
+                      color: AppTheme.textSecondary, fontSize: 12),
+                ),
+                if (file.relativePath != null &&
+                    file.relativePath!.isNotEmpty) ...[
+                  const SizedBox(height: 2),
+                  Text(file.relativePath!,
+                      style: const TextStyle(
+                          color: AppTheme.textSecondary, fontSize: 11),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+String _historyEventLabel(RadarrHistoryRecord r) {
+  switch (r.eventType) {
+    case 'grabbed':
+      final indexer = r.indexer;
+      return indexer != null && indexer.isNotEmpty
+          ? 'Grabbed from $indexer'
+          : 'Grabbed';
+    case 'downloadFolderImported':
+      return 'Imported';
+    case 'downloadFailed':
+      return 'Download failed';
+    case 'movieFileDeleted':
+      return 'File deleted';
+    case 'movieFileRenamed':
+      return 'File renamed';
+    case 'movieAdded':
+      return 'Added';
+    case 'downloadIgnored':
+      return 'Download ignored';
+    default:
+      return r.eventType.isEmpty ? 'Event' : r.eventType;
+  }
+}
+
+String _historyTime(DateTime? date) {
+  if (date == null) return '';
+  final local = date.toLocal();
+  final diff = DateTime.now().difference(local);
+  final String rel;
+  if (diff.inMinutes < 1) {
+    rel = 'Just now';
+  } else if (diff.inMinutes < 60) {
+    rel = '${diff.inMinutes}m ago';
+  } else if (diff.inHours < 24) {
+    rel = '${diff.inHours}h ago';
+  } else if (diff.inDays < 30) {
+    rel = '${diff.inDays}d ago';
+  } else {
+    rel = DateFormat('MMM d, yyyy').format(local);
+  }
+  return '$rel • ${DateFormat('MMM d, yyyy • h:mm a').format(local)}';
+}
+
+class _HistoryTile extends StatelessWidget {
+  final RadarrHistoryRecord record;
+  const _HistoryTile({required this.record});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            record.sourceTitle.isNotEmpty
+                ? record.sourceTitle
+                : _historyEventLabel(record),
+            style: const TextStyle(
+                color: AppTheme.textPrimary,
+                fontSize: 13,
+                fontWeight: FontWeight.w500),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 2),
+          Text(_historyTime(record.date),
+              style: const TextStyle(
+                  color: AppTheme.textSecondary, fontSize: 11)),
+          const SizedBox(height: 2),
+          Text(_historyEventLabel(record),
+              style: const TextStyle(
+                  color: AppTheme.requested, fontSize: 12)),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActionBar extends StatelessWidget {
+  final VoidCallback onAutomatic;
+  final VoidCallback onInteractive;
+
+  const _ActionBar({required this.onAutomatic, required this.onInteractive});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.fromLTRB(
+          12, 10, 12, 10 + MediaQuery.of(context).padding.bottom),
+      decoration: const BoxDecoration(
+        color: AppTheme.surface,
+        border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton.icon(
+              onPressed: onAutomatic,
+              icon: const Icon(Icons.search, size: 18, color: AppTheme.available),
+              label: const Text('Automatic',
+                  style: TextStyle(color: AppTheme.textPrimary)),
+              style: OutlinedButton.styleFrom(
+                side: const BorderSide(color: AppTheme.border),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10)),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: OutlinedButton.icon(
+              onPressed: onInteractive,
+              icon: const Icon(Icons.person_outline,
+                  size: 18, color: AppTheme.available),
+              label: const Text('Interactive',
+                  style: TextStyle(color: AppTheme.textPrimary)),
+              style: OutlinedButton.styleFrom(
+                side: const BorderSide(color: AppTheme.border),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10)),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/radarr/ui/radarr_movie_list.dart
+++ b/app/lib/features/radarr/ui/radarr_movie_list.dart
@@ -9,6 +9,7 @@ class RadarrMovieList extends StatelessWidget {
   final void Function(int id) onDelete;
   final void Function(int id) onSearch;
   final void Function(RadarrMovie movie)? onInteractiveSearch;
+  final void Function(RadarrMovie movie)? onOpen;
   final bool embedded;
 
   const RadarrMovieList({
@@ -17,6 +18,7 @@ class RadarrMovieList extends StatelessWidget {
     required this.onDelete,
     required this.onSearch,
     this.onInteractiveSearch,
+    this.onOpen,
     this.embedded = false,
   });
 
@@ -54,6 +56,7 @@ class RadarrMovieList extends StatelessWidget {
             onInteractiveSearch: onInteractiveSearch != null
                 ? () => onInteractiveSearch!(movie)
                 : null,
+            onOpen: onOpen != null ? () => onOpen!(movie) : null,
           ),
         );
       },
@@ -86,16 +89,19 @@ class _MovieTile extends StatelessWidget {
   final RadarrMovie movie;
   final VoidCallback onSearch;
   final VoidCallback? onInteractiveSearch;
+  final VoidCallback? onOpen;
 
   const _MovieTile({
     required this.movie,
     required this.onSearch,
     this.onInteractiveSearch,
+    this.onOpen,
   });
 
   @override
   Widget build(BuildContext context) {
     return ListTile(
+      onTap: onOpen,
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       leading: ClipRRect(
         borderRadius: BorderRadius.circular(6),

--- a/app/lib/features/radarr/ui/radarr_queue_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_queue_screen.dart
@@ -8,6 +8,8 @@ import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/radarr_api_service.dart';
 import '../data/radarr_models.dart';
+import 'radarr_import_doctor_sheet.dart';
+import 'widgets/radarr_queue_item_card.dart';
 
 /// Shows the current Radarr download queue with per-item actions.
 class RadarrQueueScreen extends ConsumerStatefulWidget {
@@ -95,6 +97,21 @@ class _RadarrQueueScreenState extends ConsumerState<RadarrQueueScreen> {
         _error = 'Failed to load queue: $e';
       });
     }
+  }
+
+  void _showDoctor(RadarrQueueItem item) {
+    final instanceId = ref.read(instanceProvider).activeRadarrInstance?.id;
+    if (instanceId == null) return;
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => RadarrImportDoctorSheet(
+        instanceId: instanceId,
+        item: item,
+        onChanged: () => _loadQueue(silent: true),
+      ),
+    );
   }
 
   Future<void> _removeItem(RadarrQueueItem item) async {
@@ -188,24 +205,12 @@ class _RadarrQueueScreenState extends ConsumerState<RadarrQueueScreen> {
         itemCount: _queue.length,
         itemBuilder: (context, index) {
           final item = _queue[index];
-          return _QueueItemCard(
+          return RadarrQueueItemCard(
+            item: item,
             primaryTitle: item.movieTitle ?? item.title,
             releaseTitle: item.movieTitle != null ? item.title : null,
-            status: item.status,
-            trackedDownloadState: item.trackedDownloadState,
-            trackedDownloadStatus: item.trackedDownloadStatus,
-            protocol: item.protocol,
-            indexer: item.indexer,
-            downloadClient: item.downloadClient,
-            quality: item.quality,
-            progress: item.progress,
-            downloadedFormatted: item.downloadedFormatted,
-            sizeFormatted: item.sizeFormatted,
-            timeleft: item.timeleft,
-            errorMessage: item.errorMessage,
-            statusMessages: item.statusMessages,
-            hasIssues: item.hasIssues,
             onRemove: () => _removeItem(item),
+            onShowIssues: item.hasIssues ? () => _showDoctor(item) : null,
           );
         },
       ),
@@ -265,299 +270,6 @@ class _RemoveQueueItemDialogState extends State<_RemoveQueueItemDialog> {
           child: const Text('Remove'),
         ),
       ],
-    );
-  }
-}
-
-/// A rich queue item card: status, protocol, indexer, download client,
-/// progress bar, timeleft and any error/status messages.
-class _QueueItemCard extends StatelessWidget {
-  final String primaryTitle;
-  final String? releaseTitle;
-  final String status;
-  final String? trackedDownloadState;
-  final String? trackedDownloadStatus;
-  final String protocol;
-  final String? indexer;
-  final String? downloadClient;
-  final String? quality;
-  final double progress;
-  final String downloadedFormatted;
-  final String sizeFormatted;
-  final String? timeleft;
-  final String? errorMessage;
-  final List<String> statusMessages;
-  final bool hasIssues;
-  final VoidCallback onRemove;
-
-  const _QueueItemCard({
-    required this.primaryTitle,
-    this.releaseTitle,
-    required this.status,
-    this.trackedDownloadState,
-    this.trackedDownloadStatus,
-    required this.protocol,
-    this.indexer,
-    this.downloadClient,
-    this.quality,
-    required this.progress,
-    required this.downloadedFormatted,
-    required this.sizeFormatted,
-    this.timeleft,
-    this.errorMessage,
-    this.statusMessages = const [],
-    this.hasIssues = false,
-    required this.onRemove,
-  });
-
-  String get _statusLabel {
-    if (trackedDownloadStatus == 'error' || status == 'failed') return 'Error';
-    switch (trackedDownloadState) {
-      case 'importPending':
-        return 'Import pending';
-      case 'importing':
-        return 'Importing';
-      case 'imported':
-        return 'Imported';
-      case 'failedPending':
-        return 'Failed';
-    }
-    if (trackedDownloadStatus == 'warning') return 'Warning';
-    switch (status) {
-      case 'downloading':
-        return 'Downloading';
-      case 'paused':
-        return 'Paused';
-      case 'queued':
-        return 'Queued';
-      case 'completed':
-        return 'Completed';
-      case 'delay':
-        return 'Delayed';
-      case 'downloadClientUnavailable':
-        return 'Client unavailable';
-      case 'warning':
-        return 'Warning';
-      default:
-        return status.isEmpty ? 'Unknown' : status;
-    }
-  }
-
-  Color get _statusColor {
-    if (trackedDownloadStatus == 'error' ||
-        status == 'failed' ||
-        trackedDownloadState == 'failedPending') {
-      return AppTheme.error;
-    }
-    if (trackedDownloadStatus == 'warning' || status == 'warning') {
-      return AppTheme.requested;
-    }
-    switch (trackedDownloadState) {
-      case 'importPending':
-      case 'importing':
-        return AppTheme.requested;
-      case 'imported':
-        return AppTheme.available;
-    }
-    switch (status) {
-      case 'downloading':
-        return AppTheme.downloading;
-      case 'completed':
-        return AppTheme.available;
-      case 'paused':
-      case 'queued':
-      case 'delay':
-      case 'downloadClientUnavailable':
-        return AppTheme.unavailable;
-      default:
-        return AppTheme.downloading;
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final statusColor = _statusColor;
-    final issues = <String>[
-      if (errorMessage != null && errorMessage!.isNotEmpty) errorMessage!,
-      ...statusMessages,
-    ];
-
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      padding: const EdgeInsets.fromLTRB(12, 10, 4, 12),
-      decoration: BoxDecoration(
-        color: AppTheme.surface,
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: AppTheme.border, width: 0.5),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      primaryTitle,
-                      style: const TextStyle(
-                          color: AppTheme.textPrimary,
-                          fontWeight: FontWeight.w600,
-                          fontSize: 14),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    if (releaseTitle != null)
-                      Padding(
-                        padding: const EdgeInsets.only(top: 2),
-                        child: Text(
-                          releaseTitle!,
-                          style: const TextStyle(
-                              color: AppTheme.textSecondary, fontSize: 11),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                  ],
-                ),
-              ),
-              PopupMenuButton<String>(
-                icon: const Icon(Icons.more_vert,
-                    color: AppTheme.textSecondary, size: 20),
-                color: AppTheme.surfaceVariant,
-                onSelected: (value) {
-                  if (value == 'remove') onRemove();
-                },
-                itemBuilder: (_) => const [
-                  PopupMenuItem(
-                    value: 'remove',
-                    child: Row(
-                      children: [
-                        Icon(Icons.delete_outline,
-                            size: 18, color: AppTheme.error),
-                        SizedBox(width: 8),
-                        Text('Remove'),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ],
-          ),
-          const SizedBox(height: 6),
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: Wrap(
-              spacing: 6,
-              runSpacing: 4,
-              children: [
-                _QueueBadge(text: _statusLabel, color: statusColor),
-                _QueueBadge(
-                  text: protocol.toUpperCase(),
-                  color: protocol == 'torrent'
-                      ? AppTheme.downloading
-                      : AppTheme.available,
-                ),
-                if (quality != null)
-                  _QueueBadge(text: quality!, color: AppTheme.accent),
-                if (indexer != null && indexer!.isNotEmpty)
-                  _QueueBadge(text: indexer!, color: AppTheme.textSecondary),
-                if (downloadClient != null && downloadClient!.isNotEmpty)
-                  _QueueBadge(
-                      text: downloadClient!, color: AppTheme.textSecondary),
-              ],
-            ),
-          ),
-          const SizedBox(height: 10),
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: ClipRRect(
-              borderRadius: BorderRadius.circular(3),
-              child: LinearProgressIndicator(
-                value: progress,
-                minHeight: 5,
-                backgroundColor: AppTheme.surfaceVariant,
-                valueColor: AlwaysStoppedAnimation(statusColor),
-              ),
-            ),
-          ),
-          const SizedBox(height: 6),
-          Padding(
-            padding: const EdgeInsets.only(right: 8),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    '${(progress * 100).toStringAsFixed(1)}% • '
-                    '$downloadedFormatted of $sizeFormatted',
-                    style: const TextStyle(
-                        color: AppTheme.textSecondary, fontSize: 11),
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ),
-                if (timeleft != null && timeleft!.isNotEmpty)
-                  Text(
-                    timeleft!,
-                    style: const TextStyle(
-                        color: AppTheme.textSecondary, fontSize: 11),
-                  ),
-              ],
-            ),
-          ),
-          if (hasIssues && issues.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.only(top: 8, right: 8),
-              child: Container(
-                width: double.infinity,
-                padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(
-                  color: AppTheme.error.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(6),
-                ),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Icon(Icons.warning_amber_rounded,
-                        size: 16, color: AppTheme.requested),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        issues.join('\n'),
-                        style: const TextStyle(
-                            color: AppTheme.textSecondary, fontSize: 11),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-class _QueueBadge extends StatelessWidget {
-  final String text;
-  final Color color;
-
-  const _QueueBadge({required this.text, required this.color});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-      decoration: BoxDecoration(
-        color: color.withValues(alpha: 0.15),
-        borderRadius: BorderRadius.circular(4),
-      ),
-      child: Text(
-        text,
-        style: TextStyle(
-            color: color, fontSize: 10.5, fontWeight: FontWeight.w500),
-      ),
     );
   }
 }

--- a/app/lib/features/radarr/ui/widgets/radarr_queue_item_card.dart
+++ b/app/lib/features/radarr/ui/widgets/radarr_queue_item_card.dart
@@ -1,0 +1,326 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/status_pill.dart';
+import '../../data/radarr_models.dart';
+
+/// Short status label for a queue item (e.g. "Import pending", "Downloading").
+String radarrQueueStatusLabel(RadarrQueueItem item) {
+  if (item.trackedDownloadStatus == 'error' || item.status == 'failed') {
+    return 'Error';
+  }
+  switch (item.trackedDownloadState) {
+    case 'importPending':
+      return 'Import pending';
+    case 'importing':
+      return 'Importing';
+    case 'imported':
+      return 'Imported';
+    case 'importBlocked':
+      return 'Import blocked';
+    case 'failedPending':
+      return 'Failed';
+  }
+  if (item.trackedDownloadStatus == 'warning') return 'Warning';
+  switch (item.status) {
+    case 'downloading':
+      return 'Downloading';
+    case 'paused':
+      return 'Paused';
+    case 'queued':
+      return 'Queued';
+    case 'completed':
+      return 'Completed';
+    case 'delay':
+      return 'Delayed';
+    case 'downloadClientUnavailable':
+      return 'Client unavailable';
+    case 'warning':
+      return 'Warning';
+    default:
+      return item.status.isEmpty ? 'Unknown' : item.status;
+  }
+}
+
+/// Status colour for a queue item, matched to the design system tokens.
+Color radarrQueueStatusColor(RadarrQueueItem item) {
+  if (item.trackedDownloadStatus == 'error' ||
+      item.status == 'failed' ||
+      item.trackedDownloadState == 'failedPending') {
+    return AppTheme.error;
+  }
+  if (item.trackedDownloadStatus == 'warning' || item.status == 'warning') {
+    return AppTheme.requested;
+  }
+  switch (item.trackedDownloadState) {
+    case 'importPending':
+    case 'importing':
+    case 'importBlocked':
+      return AppTheme.requested;
+    case 'imported':
+      return AppTheme.available;
+  }
+  switch (item.status) {
+    case 'downloading':
+      return AppTheme.downloading;
+    case 'completed':
+      return AppTheme.available;
+    case 'paused':
+    case 'queued':
+    case 'delay':
+    case 'downloadClientUnavailable':
+      return AppTheme.unavailable;
+    default:
+      return AppTheme.downloading;
+  }
+}
+
+/// A rich queue item card: status, protocol, indexer, download client, progress
+/// bar, time left and any error/status messages. Shared by the Radarr queue
+/// screen and the movie detail screen. Mirrors the Sonarr [QueueItemCard].
+class RadarrQueueItemCard extends StatelessWidget {
+  final RadarrQueueItem item;
+  final String primaryTitle;
+  final String? releaseTitle;
+
+  /// When provided, a Remove action is offered in the overflow menu.
+  final VoidCallback? onRemove;
+
+  /// When provided, an "Issues" affordance opens this callback instead of
+  /// showing the inline issues box (used by the Import Doctor).
+  final VoidCallback? onShowIssues;
+
+  const RadarrQueueItemCard({
+    super.key,
+    required this.item,
+    required this.primaryTitle,
+    this.releaseTitle,
+    this.onRemove,
+    this.onShowIssues,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final statusColor = radarrQueueStatusColor(item);
+    final issues = <String>[
+      if (item.errorMessage != null && item.errorMessage!.isNotEmpty)
+        item.errorMessage!,
+      ...item.statusMessages,
+    ];
+    final protocol = item.protocol;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      padding: const EdgeInsets.fromLTRB(12, 10, 4, 12),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppTheme.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      primaryTitle,
+                      style: const TextStyle(
+                          color: AppTheme.textPrimary,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 14),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (releaseTitle != null)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 2),
+                        child: Text(
+                          releaseTitle!,
+                          style: const TextStyle(
+                              color: AppTheme.textSecondary, fontSize: 11),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              if (onRemove != null)
+                PopupMenuButton<String>(
+                  icon: const Icon(Icons.more_vert,
+                      color: AppTheme.textSecondary, size: 20),
+                  color: AppTheme.surfaceVariant,
+                  onSelected: (value) {
+                    if (value == 'remove') onRemove!();
+                  },
+                  itemBuilder: (_) => const [
+                    PopupMenuItem(
+                      value: 'remove',
+                      child: Row(
+                        children: [
+                          Icon(Icons.delete_outline,
+                              size: 18, color: AppTheme.error),
+                          SizedBox(width: 8),
+                          Text('Remove'),
+                        ],
+                      ),
+                    ),
+                  ],
+                )
+              else
+                const SizedBox(width: 8),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: [
+                StatusPill(text: radarrQueueStatusLabel(item), color: statusColor),
+                StatusPill(
+                  text: protocol.toUpperCase(),
+                  color: protocol == 'torrent'
+                      ? AppTheme.downloading
+                      : AppTheme.available,
+                ),
+                if (item.quality != null)
+                  StatusPill(text: item.quality!, color: AppTheme.accent),
+                if (item.indexer != null && item.indexer!.isNotEmpty)
+                  StatusPill(text: item.indexer!, color: AppTheme.textSecondary),
+                if (item.downloadClient != null &&
+                    item.downloadClient!.isNotEmpty)
+                  StatusPill(
+                      text: item.downloadClient!, color: AppTheme.textSecondary),
+              ],
+            ),
+          ),
+          const SizedBox(height: 10),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(3),
+              child: LinearProgressIndicator(
+                value: item.progress,
+                minHeight: 5,
+                backgroundColor: AppTheme.surfaceVariant,
+                valueColor: AlwaysStoppedAnimation(statusColor),
+              ),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    '${(item.progress * 100).toStringAsFixed(1)}% • '
+                    '${item.downloadedFormatted} of ${item.sizeFormatted}',
+                    style: const TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 11),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (item.timeleft != null && item.timeleft!.isNotEmpty)
+                  Text(
+                    item.timeleft!,
+                    style: const TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 11),
+                  ),
+              ],
+            ),
+          ),
+          if (item.hasIssues && issues.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8, right: 8),
+              child: onShowIssues != null
+                  ? _IssuesButton(count: issues.length, onTap: onShowIssues!)
+                  : _IssuesBox(text: issues.join('\n')),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The inline amber issues box (default rendering when no Doctor handler set).
+class _IssuesBox extends StatelessWidget {
+  final String text;
+  const _IssuesBox({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: AppTheme.error.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.warning_amber_rounded,
+              size: 16, color: AppTheme.requested),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              text,
+              style: const TextStyle(
+                  color: AppTheme.textSecondary, fontSize: 11),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A tappable "Messages" affordance that defers to the Import Doctor.
+class _IssuesButton extends StatelessWidget {
+  final int count;
+  final VoidCallback onTap;
+  const _IssuesButton({required this.count, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+        decoration: BoxDecoration(
+          color: AppTheme.requested.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.warning_amber_rounded,
+                size: 16, color: AppTheme.requested),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                count == 1
+                    ? '1 message — tap to resolve'
+                    : '$count messages — tap to resolve',
+                style: const TextStyle(
+                    color: AppTheme.requested,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500),
+              ),
+            ),
+            const Icon(Icons.chevron_right,
+                size: 18, color: AppTheme.requested),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/sonarr/logic/import_doctor.dart
+++ b/app/lib/features/sonarr/logic/import_doctor.dart
@@ -1,3 +1,4 @@
+import '../../radarr/data/radarr_models.dart';
 import '../data/sonarr_models.dart';
 
 /// One-click remediation a diagnosis can suggest. Mirrors the action verbs in
@@ -15,14 +16,16 @@ enum DoctorAction {
 
 enum DoctorSeverity { ok, info, warning, error }
 
-/// The classifier's verdict for one queue item.
-class SonarrDiagnosis {
+/// The classifier's verdict for one queue item. Service-neutral: the same rule
+/// engine drives both Sonarr and Radarr (movies are single items, so the
+/// signals are identical — only the remediation wiring differs).
+class QueueDiagnosis {
   final DoctorSeverity severity;
   final String problem;
   final String transparency;
   final List<DoctorAction> actions;
 
-  const SonarrDiagnosis({
+  const QueueDiagnosis({
     required this.severity,
     this.problem = '',
     this.transparency = '',
@@ -31,6 +34,9 @@ class SonarrDiagnosis {
 
   bool get isHealthy => severity == DoctorSeverity.ok;
 }
+
+/// Back-compat alias for callers that referenced the old Sonarr-specific name.
+typedef SonarrDiagnosis = QueueDiagnosis;
 
 class _Rule {
   final String prefix; // stable English fragment, lower-cased
@@ -118,7 +124,7 @@ const List<_Rule> _messageRules = [
   _Rule(
     'does not exist',
     'Path not accessible',
-    "The download path doesn't exist or isn't accessible to Sonarr — usually a remote-path mapping issue. Fix the path, then rescan to retry.",
+    "The download path doesn't exist or isn't accessible — usually a remote-path mapping issue. Fix the path, then rescan to retry.",
     DoctorSeverity.error,
     [DoctorAction.rescan],
   ),
@@ -148,12 +154,12 @@ const List<_Rule> _errorRules = [
   ),
 ];
 
-SonarrDiagnosis? _matchRule(String line, List<_Rule> rules) {
+QueueDiagnosis? _matchRule(String line, List<_Rule> rules) {
   final lower = line.toLowerCase().trim();
   if (lower.isEmpty) return null;
   for (final r in rules) {
     if (lower.contains(r.prefix)) {
-      return SonarrDiagnosis(
+      return QueueDiagnosis(
         severity: r.severity,
         problem: r.problem,
         transparency: r.transparency,
@@ -164,11 +170,15 @@ SonarrDiagnosis? _matchRule(String line, List<_Rule> rules) {
   return null;
 }
 
-bool _looksHealthy(SonarrQueueItem item) {
-  final tds = (item.trackedDownloadStatus ?? '').toLowerCase();
+bool _looksHealthy({
+  required String? trackedDownloadStatus,
+  required String? errorMessage,
+  required List<SonarrStatusMessage> statusMessageGroups,
+}) {
+  final tds = (trackedDownloadStatus ?? '').toLowerCase();
   if (tds.isNotEmpty && tds != 'ok') return false;
-  if ((item.errorMessage ?? '').isNotEmpty) return false;
-  for (final g in item.statusMessageGroups) {
+  if ((errorMessage ?? '').isNotEmpty) return false;
+  for (final g in statusMessageGroups) {
     for (final line in g.messages) {
       if (line.trim().isNotEmpty) return false;
     }
@@ -176,19 +186,26 @@ bool _looksHealthy(SonarrQueueItem item) {
   return true;
 }
 
-/// Classifies a queue item with first-match-wins rules. Mirrors the Go
-/// classifier's order: client/stalled error → import rejections → stuck
-/// pending → failed → healthy → unknown-blocked fallback.
-SonarrDiagnosis diagnoseSonarrQueueItem(SonarrQueueItem item) {
-  final status = (item.trackedDownloadStatus ?? '').toLowerCase();
-  final state = (item.trackedDownloadState ?? '').toLowerCase();
+/// Service-neutral rule engine. Classifies a queue item from its raw signals
+/// with first-match-wins rules. Mirrors the Go classifier's order:
+/// client/stalled error → import rejections → stuck pending → failed → healthy →
+/// unknown-blocked fallback. Both [diagnoseSonarrQueueItem] and
+/// [diagnoseRadarrQueueItem] funnel through here so the catalog lives once.
+QueueDiagnosis diagnoseQueueSignal({
+  String? trackedDownloadStatus,
+  String? trackedDownloadState,
+  String? errorMessage,
+  required List<SonarrStatusMessage> statusMessageGroups,
+}) {
+  final status = (trackedDownloadStatus ?? '').toLowerCase();
+  final state = (trackedDownloadState ?? '').toLowerCase();
 
   // 1. Hard download-client / stalled errors.
   if (status == 'error') {
-    final matched = _matchRule(item.errorMessage ?? '', _errorRules);
+    final matched = _matchRule(errorMessage ?? '', _errorRules);
     if (matched != null) return matched;
-    final msg = item.errorMessage ?? '';
-    return SonarrDiagnosis(
+    final msg = errorMessage ?? '';
+    return QueueDiagnosis(
       severity: DoctorSeverity.error,
       problem: 'Download error',
       transparency: msg.isNotEmpty
@@ -199,7 +216,7 @@ SonarrDiagnosis diagnoseSonarrQueueItem(SonarrQueueItem item) {
   }
 
   // 2. Import rejections surfaced as statusMessages.
-  for (final g in item.statusMessageGroups) {
+  for (final g in statusMessageGroups) {
     final candidates = <String>[
       if (g.title.isNotEmpty) g.title,
       ...g.messages,
@@ -212,18 +229,18 @@ SonarrDiagnosis diagnoseSonarrQueueItem(SonarrQueueItem item) {
 
   // 3. Stuck waiting on the import pass.
   if (state == 'importpending') {
-    return const SonarrDiagnosis(
+    return const QueueDiagnosis(
       severity: DoctorSeverity.warning,
       problem: 'Waiting to import',
       transparency:
-          "The download finished but hasn't been imported yet — Sonarr hasn't run its import pass. Process it now to import it.",
+          "The download finished but hasn't been imported yet — the import pass hasn't run. Process it now to import it.",
       actions: [DoctorAction.process, DoctorAction.manualImport],
     );
   }
 
   // 4. Failed download.
   if (state == 'failed' || state == 'failedpending') {
-    return const SonarrDiagnosis(
+    return const QueueDiagnosis(
       severity: DoctorSeverity.error,
       problem: 'Download failed',
       transparency:
@@ -233,16 +250,38 @@ SonarrDiagnosis diagnoseSonarrQueueItem(SonarrQueueItem item) {
   }
 
   // 5. Healthy.
-  if (_looksHealthy(item)) {
-    return const SonarrDiagnosis(severity: DoctorSeverity.ok);
+  if (_looksHealthy(
+    trackedDownloadStatus: trackedDownloadStatus,
+    errorMessage: errorMessage,
+    statusMessageGroups: statusMessageGroups,
+  )) {
+    return const QueueDiagnosis(severity: DoctorSeverity.ok);
   }
 
   // 6. Unknown blocked state.
-  return const SonarrDiagnosis(
+  return const QueueDiagnosis(
     severity: DoctorSeverity.warning,
     problem: 'Import blocked',
     transparency:
-        "Sonarr couldn't import this automatically. Review the candidate files and import manually, or remove and re-search.",
+        "This download couldn't be imported automatically. Review the candidate files and import manually, or remove and re-search.",
     actions: [DoctorAction.manualImport, DoctorAction.blocklistSearch],
   );
 }
+
+/// Classifies a Sonarr queue item (thin wrapper over [diagnoseQueueSignal]).
+QueueDiagnosis diagnoseSonarrQueueItem(SonarrQueueItem item) =>
+    diagnoseQueueSignal(
+      trackedDownloadStatus: item.trackedDownloadStatus,
+      trackedDownloadState: item.trackedDownloadState,
+      errorMessage: item.errorMessage,
+      statusMessageGroups: item.statusMessageGroups,
+    );
+
+/// Classifies a Radarr queue item (thin wrapper over [diagnoseQueueSignal]).
+QueueDiagnosis diagnoseRadarrQueueItem(RadarrQueueItem item) =>
+    diagnoseQueueSignal(
+      trackedDownloadStatus: item.trackedDownloadStatus,
+      trackedDownloadState: item.trackedDownloadState,
+      errorMessage: item.errorMessage,
+      statusMessageGroups: item.statusMessageGroups,
+    );

--- a/app/test/radarr/import_doctor_test.dart
+++ b/app/test/radarr/import_doctor_test.dart
@@ -1,0 +1,90 @@
+import 'package:cantinarr/features/radarr/data/radarr_models.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:cantinarr/features/sonarr/logic/import_doctor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+RadarrQueueItem _item({
+  String status = 'ok',
+  String state = 'downloading',
+  String? error,
+  List<SonarrStatusMessage> messages = const [],
+}) =>
+    RadarrQueueItem(
+      id: 1,
+      title: 'release',
+      status: 'downloading',
+      trackedDownloadStatus: status,
+      trackedDownloadState: state,
+      errorMessage: error,
+      statusMessageGroups: messages,
+    );
+
+SonarrStatusMessage _msg(String text) =>
+    SonarrStatusMessage(title: 'release', messages: [text]);
+
+void main() {
+  test('healthy movie download is OK with no actions', () {
+    final d = diagnoseRadarrQueueItem(_item());
+    expect(d.severity, DoctorSeverity.ok);
+    expect(d.isHealthy, isTrue);
+  });
+
+  test('stuck importPending with no messages → process', () {
+    final d = diagnoseRadarrQueueItem(_item(state: 'importPending'));
+    expect(d.problem, 'Waiting to import');
+    expect(d.actions.first, DoctorAction.process);
+  });
+
+  test('unextracted archive → change category', () {
+    final d = diagnoseRadarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('Found archive file, might need to be extracted')],
+    ));
+    expect(d.actions.first, DoctorAction.changeCategory);
+  });
+
+  test('no eligible files → manual import / blocklist+search', () {
+    final d = diagnoseRadarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('No files found are eligible for import in /downloads/x')],
+    ));
+    expect(d.actions, contains(DoctorAction.manualImport));
+    expect(d.actions, contains(DoctorAction.blocklistSearch));
+  });
+
+  test('stalled torrent error → blocklist + search', () {
+    final d = diagnoseRadarrQueueItem(_item(
+      status: 'error',
+      state: 'downloading',
+      error: 'The download is stalled with no connections',
+    ));
+    expect(d.severity, DoctorSeverity.error);
+    expect(d.actions, contains(DoctorAction.blocklistSearch));
+  });
+
+  test('not-an-upgrade is info with remove option', () {
+    final d = diagnoseRadarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [
+        _msg('Not an upgrade for existing movie file(s). Existing: '
+            'WEBDL-1080p. New: HDTV-720p.')
+      ],
+    ));
+    expect(d.severity, DoctorSeverity.info);
+    expect(d.actions, contains(DoctorAction.remove));
+  });
+
+  test('unknown blocked state falls back to manual import', () {
+    final d = diagnoseRadarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('Some brand new reason Radarr just invented')],
+    ));
+    expect(d.severity, DoctorSeverity.warning);
+    expect(d.problem, 'Import blocked');
+    expect(d.actions, contains(DoctorAction.manualImport));
+  });
+}


### PR DESCRIPTION
## What

Brings the **Radarr (movies) module to parity** with the just-merged Sonarr drill-down + Import Doctor (#87, #89). Movies are single items (no seasons/episodes), so the whole picture — file, queue, history, and search — fits on **one movie detail screen** instead of a series → season → episode drill-down. `app/` only; no `server/` changes.

## Screens & flows

- **`RadarrMovieDetailScreen`** (new): poster/overview/rating, the downloaded file's quality + size (with an "Upgrade available" pill when below cutoff), the movie's active queue item, recent history ("Grabbed from <indexer>"), and an Automatic/Interactive action bar. Automatic = `MoviesSearch`; Interactive = the existing `RadarrReleasesScreen`. Pushed from the movie-list tile's `onTap` via `rootNavigator` (no router changes), mirroring Sonarr's `_openSeries`.
- **`RadarrImportDoctorSheet`** (new): the movie-side mirror of the Sonarr Import Doctor — same transparency + raw Messages + one-click fixes, **confirm on destructive** (remove / remove+blocklist+search / hand-off). `blocklist_search` → `deleteQueueItem(blocklist: true)` then `searchMovie(movieId)`.
- **Queue card**: extracted a shared **`RadarrQueueItemCard`** (with the "⚠ messages — tap to resolve" affordance) used by both the queue screen and the detail screen; the old private card in `radarr_queue_screen.dart` is removed. The queue screen now opens the Doctor on tap.

## Classifier sharing (no duplicated rule catalog)

Refactored `sonarr/logic/import_doctor.dart` so the rule engine is **service-neutral**: a `diagnoseQueueSignal({trackedDownloadStatus, trackedDownloadState, errorMessage, statusMessageGroups})` function plus shared `QueueDiagnosis` / `DoctorAction` / `DoctorSeverity`. `diagnoseSonarrQueueItem` stays a thin wrapper and `diagnoseRadarrQueueItem` is added. `SonarrDiagnosis` is kept as a `typedef` alias so existing callers/tests are untouched.

## Models & service

- **Models**: `RadarrMovie` gains `sizeOnDisk` + `isAvailable`; `RadarrMovieFile` gains `qualityCutoffNotMet` + `releaseGroup`. `RadarrQueueItem` gains grouped `statusMessageGroups` (kept the flat `statusMessages` for current consumers) + `downloadId` + `outputPath`. `RadarrHistoryRecord` gains a `data` Map + `downloadId`. New `RadarrManualImportCandidate` / `RadarrImportRejection` mirror the Sonarr ones but keyed by `movieId`; **`quality` and `languages` round-trip verbatim** via `toImportFile()`.
- **Service**: adds `getMovieById`, `getMovieHistory` (`/history/movie`), `getMovieReleases`, `getManualImportCandidates`, `executeManualImport` (importMode lowercase — `copy` for torrents else `move`), `processMonitoredDownloads`, `rescanMovie` (`RescanMovie`), and extends `deleteQueueItem` with `changeCategory` / `skipRedownload`.

All writes (search/import/remove) go through the existing instance proxy and remain admin-gated exactly as the Sonarr Doctor does — no new permissions, no backend changes.

## Acceptance

- `flutter analyze` (from `app/`): **no new issues** in any changed/added file (only pre-existing `info` lints remain, in files this PR doesn't touch).
- `flutter test` (from `app/`): **all 57 pass**, including the existing Sonarr `import_doctor_test.dart` (kept green) plus a new Radarr classifier test (`test/radarr/import_doctor_test.dart`).
- No `server/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEChSmKSXg8UDF5TY8aWpE