### PR TITLE
feat(request): surface the season picker from 'Request More' + tidy admin season lists + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ Cantinarr makes it dead simple for your family and friends to discover and reque
 - **Zero-config requesting** -- Your users never see API keys, TVDB IDs, or quality profiles. They browse, they tap, it works.
 - **TMDB + Trakt for discovery** -- The best metadata, images, and trending data. Sonarr's TVDB dependency is invisible.
 - **Automatic ID bridging** -- TMDB-to-TVDB translation with Trakt fallback. The #1 source of failed Sonarr adds, solved.
-- **AI assistant** -- "What should I watch tonight?" Bring Anthropic, OpenAI, or Gemini; the assistant searches your library, checks availability, and can request for you. Admins can also manage the server conversationally: check the queue, kick off searches, grab a specific release from the indexers, or clean up failed downloads.
-- **MCP server** -- The same 19 AI tools are exposed as a [Model Context Protocol](https://modelcontextprotocol.io/) endpoint at `/mcp`, with MCP OAuth discovery, browser login, dynamic client registration, and persistent rotating refresh tokens. Every tool can be toggled on/off per server from Settings > AI Tools.
-- **Download clients** -- SABnzbd, qBittorrent, NZBGet, and Transmission modules with live queue management (pause, resume, remove, speeds, real-time push updates) alongside full Radarr/Sonarr control: queue actions, history, wanted/missing, calendar, and interactive release search.
+- **AI assistant** -- "What should I watch tonight?" Bring Anthropic, OpenAI, or Gemini; the assistant searches your library, checks availability, and can request for you. Admins can also manage the server conversationally: check the queue, kick off searches, grab a specific release from the indexers, or diagnose and fix stuck imports.
+- **MCP server** -- The same 25 AI tools are exposed as a [Model Context Protocol](https://modelcontextprotocol.io/) endpoint at `/mcp`, with MCP OAuth discovery, browser login, dynamic client registration, and persistent rotating refresh tokens. Every tool can be toggled on/off per server from Settings > AI Tools.
+- **Deep *arr control** -- SABnzbd, qBittorrent, NZBGet, and Transmission modules with live queue management (pause, resume, remove, speeds, real-time push updates), plus drill-down Radarr/Sonarr control: open a series into its **seasons and individual episodes** (or a movie's detail) for per-item download progress, quality/size, history, and messages, with per-episode/-movie **interactive release search** -- alongside the queue, history, wanted/missing, and calendar.
+- **Import Doctor** -- when a download is stuck, Cantinarr explains *why* in plain English (sample file, un-extracted archive, unconfirmed TheXEM mapping, "not an upgrade", stalled torrent, permissions...) and offers **one-click fixes** with full transparency: manual/force import (with the candidate files shown), remove + blocklist + re-search, hand-off to a tool like Unpackerr, or rescan. The same diagnosis backs the AI assistant and an MCP tool.
+- **Flexible requests** -- request a whole title in one tap, or pick exactly which **seasons** you want; partially-available shows surface per-season availability and a one-tap path to request the rest.
 - **Tautulli** -- watch what's playing on Plex right now: active streams with quality/transcode badges, watch history, and top movies/shows/users stats.
 - **Secrets encrypted at rest** -- arr API keys, download-client passwords, and external credentials are AES-256-GCM encrypted in the database.
 - **Household-friendly** -- Connect links, role-based access. Admins manage arr services, users just browse and request.
@@ -87,7 +89,7 @@ cantinarr/
 │   │   ├── config/         # Server configuration (port, name)
 │   │   ├── credentials/   # API credential management + client registry
 │   │   ├── db/             # SQLite with WAL mode
-│   │   ├── mcp/            # 19 AI tools + per-tool toggles
+│   │   ├── mcp/            # 25 AI tools + per-tool toggles
 │   │   ├── downloads/      # Unified SABnzbd/qBittorrent queue API
 │   │   ├── mcpserver/      # MCP Streamable HTTP endpoint
 │   │   ├── proxy/          # Arr admin reverse proxy

--- a/app/README.md
+++ b/app/README.md
@@ -47,8 +47,14 @@ Dark-first UI with warm gold accents, designed for couch browsing.
 
 ### Requests
 - **One-tap requesting** -- tap a button, the server handles everything
+- **Season-level choice** -- request a whole show or pick exactly which seasons; partially-available shows show per-season availability and a one-tap path to request the rest
 - **No TVDB headaches** -- the backend's ID bridge translates TMDB IDs to TVDB IDs transparently
 - **Real-time status** -- WebSocket-powered download progress, live status updates
+
+### Radarr / Sonarr management
+- **Drill-down** -- open the library into a movie's detail, or a series → season → episode, with per-item download progress, quality/size, history, and messages
+- **Interactive search** -- per-episode and per-movie release search and grab
+- **Import Doctor** -- diagnose why a download is stuck and apply one-click fixes (manual/force import, remove + blocklist + re-search, hand-off, rescan)
 - **Status indicators** -- available (green), requested (orange), downloading (blue), unavailable (grey)
 
 ### AI Assistant
@@ -171,7 +177,7 @@ app/
 │   │   │   ├── logic/media_detail_provider.dart
 │   │   │   └── ui/
 │   │   │       ├── media_detail_screen.dart   # Full detail with backdrop
-│   │   │       ├── season_grid.dart           # Season/episode grid
+│   │   │       ├── season_table.dart          # Per-season availability + request
 │   │   │       └── trailer_player.dart        # YouTube trailer embed
 │   │   │
 │   │   ├── request/                           # Media requesting
@@ -239,8 +245,8 @@ Four-tab bottom navigation with GoRouter:
 | Tab | Path | Screen | Data Source |
 |---|---|---|---|
 | Discover | `/discover` | Browse & search | TMDB + Trakt |
-| Movies | `/radarr` | Radarr library | Backend proxy |
-| TV Shows | `/sonarr` | Sonarr library | Backend proxy |
+| Movies | `/radarr` | Radarr library + movie detail | Backend proxy |
+| TV Shows | `/sonarr` | Sonarr library + season/episode drill-down | Backend proxy |
 | Assistant | `/assistant` | AI chat | Backend SSE |
 
 Full-screen routes: `/detail/:type/:id`, `/settings`, `/login`

--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -37,6 +37,10 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
   late final MediaDetailNotifier _detailNotifier;
   late final RequestNotifier _requestNotifier;
 
+  /// Anchors the "Seasons" section so "Request More" can scroll the user to the
+  /// per-season picker.
+  final GlobalKey _seasonsKey = GlobalKey();
+
   @override
   void initState() {
     super.initState();
@@ -260,9 +264,10 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                     // fed by live availability from the request notifier.
                     if (state.seasons.isNotEmpty) ...[
                       const SizedBox(height: 24),
-                      const Padding(
-                        padding: EdgeInsets.symmetric(horizontal: 16),
-                        child: Text('Seasons',
+                      Padding(
+                        key: _seasonsKey,
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: const Text('Seasons',
                             style: TextStyle(
                                 fontSize: 20,
                                 fontWeight: FontWeight.bold,
@@ -306,6 +311,17 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
     );
   }
 
+  void _scrollToSeasons() {
+    final ctx = _seasonsKey.currentContext;
+    if (ctx == null) return;
+    Scrollable.ensureVisible(
+      ctx,
+      duration: const Duration(milliseconds: 400),
+      curve: Curves.easeInOut,
+      alignment: 0.05,
+    );
+  }
+
   void _openTrailer(String key) {
     final url = Uri.parse('https://www.youtube.com/watch?v=$key');
     launchUrl(url, mode: LaunchMode.externalApplication);
@@ -316,6 +332,17 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
   /// the one-tap experience.
   Future<void> _onRequest() async {
     final s = _detailNotifier.state;
+
+    // A partially-available show: "Request More" drops the user into the
+    // per-season picker below rather than the coarse season-scope sheet, so
+    // they can choose exactly which missing seasons to add.
+    if (widget.mediaType == MediaType.tv &&
+        _requestNotifier.state.status == RequestStatus.partial &&
+        s.seasons.isNotEmpty) {
+      _scrollToSeasons();
+      return;
+    }
+
     final title = s.title;
     final tvdbId = s.tvDetail?.externalIds?.tvdbId;
 

--- a/app/lib/features/request/data/request_service.dart
+++ b/app/lib/features/request/data/request_service.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import '../../discover/data/tmdb_models.dart';
 
@@ -47,6 +49,28 @@ class SeasonScope {
 
   static String labelFor(String value) =>
       choices.firstWhere((c) => c.value == value, orElse: () => choices.last).label;
+
+  /// True when [value] holds an explicit JSON season list (e.g. "[3,5]")
+  /// rather than a coarse scope keyword. The backend stores per-season requests
+  /// this way in the season_scope column.
+  static bool isExplicitList(String value) => value.startsWith('[');
+
+  /// A human label for any stored season_scope value: coarse scopes map to
+  /// their choice label; an explicit list renders as "Season 3" / "Seasons 3, 5".
+  static String describe(String value) {
+    if (isExplicitList(value)) {
+      try {
+        final list = (jsonDecode(value) as List).map((e) => e as int).toList()
+          ..sort();
+        if (list.isEmpty) return labelFor(value);
+        if (list.length == 1) return 'Season ${list.first}';
+        return 'Seasons ${list.join(', ')}';
+      } catch (_) {
+        return value;
+      }
+    }
+    return labelFor(value);
+  }
 }
 
 /// One season's availability, mirroring the backend `SeasonStatus` payload

--- a/app/lib/features/settings/ui/pending_requests_screen.dart
+++ b/app/lib/features/settings/ui/pending_requests_screen.dart
@@ -6,6 +6,10 @@ import '../data/request_settings_service.dart';
 import '../../request/data/request_service.dart';
 import '../../request/logic/pending_approvals_provider.dart';
 
+/// Sentinel season-scope value used in the approve dialog meaning "keep the
+/// exact seasons the user requested" (no coarse-scope override).
+const _keepRequestedScope = '__keep_requested__';
+
 /// Admin approval queue: approve (optionally modifying options) or deny
 /// pending media requests.
 class PendingRequestsScreen extends ConsumerStatefulWidget {
@@ -71,8 +75,14 @@ class _PendingRequestsScreenState
     if (admin == null) return;
     final profiles = item.isTv ? admin.sonarrProfiles : admin.radarrProfiles;
 
-    String chosenScope =
-        item.seasonScope.isNotEmpty ? item.seasonScope : SeasonScope.all;
+    // An explicit per-season request stores a JSON list in seasonScope, which
+    // isn't one of the coarse dropdown values — represent it as a "keep
+    // requested" option so the dropdown doesn't break and the admin can leave
+    // the chosen seasons untouched.
+    final isExplicit = SeasonScope.isExplicitList(item.seasonScope);
+    String chosenScope = isExplicit
+        ? _keepRequestedScope
+        : (item.seasonScope.isNotEmpty ? item.seasonScope : SeasonScope.all);
     int? chosenProfile;
 
     final confirmed = await showDialog<bool>(
@@ -105,12 +115,17 @@ class _PendingRequestsScreenState
                         border: OutlineInputBorder(),
                         isDense: true,
                       ),
-                      items: SeasonScope.choices
-                          .map((c) => DropdownMenuItem<String>(
-                                value: c.value,
-                                child: Text(c.label),
-                              ))
-                          .toList(),
+                      items: [
+                        if (isExplicit)
+                          DropdownMenuItem<String>(
+                            value: _keepRequestedScope,
+                            child: Text(
+                                'Keep requested (${SeasonScope.describe(item.seasonScope)})'),
+                          ),
+                        ...SeasonScope.choices.map((c) =>
+                            DropdownMenuItem<String>(
+                                value: c.value, child: Text(c.label))),
+                      ],
                       onChanged: (v) {
                         if (v != null) {
                           setDialogState(() => chosenScope = v);
@@ -172,7 +187,11 @@ class _PendingRequestsScreenState
     try {
       await _service.approve(
         item.id,
-        seasonScope: item.isTv ? chosenScope : null,
+        // The "keep requested" sentinel sends no override, so the server keeps
+        // the explicit season list the user picked.
+        seasonScope: item.isTv
+            ? (chosenScope == _keepRequestedScope ? null : chosenScope)
+            : null,
         qualityProfileId: chosenProfile,
       );
       if (!mounted) return;
@@ -347,7 +366,7 @@ class _PendingTile extends StatelessWidget {
             runSpacing: 6,
             children: [
               _chip(item.isTv ? 'TV' : 'Movie'),
-              if (showScope) _chip(SeasonScope.labelFor(item.seasonScope)),
+              if (showScope) _chip(SeasonScope.describe(item.seasonScope)),
             ],
           ),
         ],

--- a/app/test/request/season_scope_test.dart
+++ b/app/test/request/season_scope_test.dart
@@ -1,0 +1,39 @@
+import 'package:cantinarr/features/request/data/request_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SeasonScope.isExplicitList', () {
+    test('coarse scopes are not explicit lists', () {
+      expect(SeasonScope.isExplicitList('all'), isFalse);
+      expect(SeasonScope.isExplicitList('first'), isFalse);
+      expect(SeasonScope.isExplicitList(''), isFalse);
+    });
+
+    test('a JSON array is an explicit list', () {
+      expect(SeasonScope.isExplicitList('[3,5]'), isTrue);
+      expect(SeasonScope.isExplicitList('[4]'), isTrue);
+    });
+  });
+
+  group('SeasonScope.describe', () {
+    test('coarse scopes map to their choice label', () {
+      expect(SeasonScope.describe('all'), 'Entire series');
+      expect(SeasonScope.describe('first'), 'First season');
+      expect(SeasonScope.describe('latest'), 'Most recent season');
+      expect(SeasonScope.describe('pilot'), 'Pilot only');
+    });
+
+    test('a single-season list reads "Season N"', () {
+      expect(SeasonScope.describe('[4]'), 'Season 4');
+    });
+
+    test('a multi-season list reads "Seasons a, b" sorted', () {
+      expect(SeasonScope.describe('[3,5]'), 'Seasons 3, 5');
+      expect(SeasonScope.describe('[5,3]'), 'Seasons 3, 5');
+    });
+
+    test('malformed JSON falls back to the raw value', () {
+      expect(SeasonScope.describe('[not json'), '[not json');
+    });
+  });
+}


### PR DESCRIPTION
Follow-ups to the *arr drill-down / Import Doctor / season-request work.

## 1. "Request More" now takes you to the season picker (the reported UX gap)
A partially-available show's **Request More** button opened the *coarse* season-scope sheet (Pilot/First/Latest/Entire), while the actual per-season picker (`SeasonTable`) sat far down the detail page with no signpost. Now, for a partially-available TV title, **Request More scrolls straight to the Seasons table** — the per-season checkboxes + "Request N seasons" action — so picking exactly which missing seasons to add is discoverable.

## 2. Admin approvals handle explicit season lists
An explicit per-season request is stored as a JSON list in the `season_scope` column (e.g. `[3,5]`). In the admin queue this:
- rendered as a misleading **"Entire series"** chip (`labelFor` fell through to its default), and
- would **assert-crash the approve dialog's scope dropdown** (the `[3,5]` value isn't one of the coarse items).

Now it shows **"Seasons 3, 5"** and the dropdown offers a **"Keep requested (…)"** option that approves the chosen seasons unchanged (sends no coarse override, so the server keeps the explicit list). New `SeasonScope.isExplicitList` / `describe` helpers, with unit tests.

## 3. Docs
README + app/README now describe the Sonarr/Radarr **drill-down**, the **Import Doctor**, and **season-level requests**; fixed the stale **19 → 25** tool count and the removed `season_grid.dart` reference.

## Verification
- `flutter analyze` — clean (no new issues; the remaining infos are pre-existing in untouched files)
- `flutter test` — **71 pass** (6 new `SeasonScope.describe` cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)