### PR TITLE
Import Doctor v2: get_arr_health tool, exact next-call output, deeper catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Cantinarr makes it dead simple for your family and friends to discover and reque
 │                                                         │
 │  ┌──────────┐  ┌──────────┐  ┌───────────────────────┐  │
 │  │ Auth/JWT │  │ Request  │  │ AI Chat               │  │
-│  │          │  │ Service  │  │ + 25 MCP Tools        │  │
+│  │          │  │ Service  │  │ + 26 MCP Tools        │  │
 │  └──────────┘  └────┬─────┘  └───────────────────────┘  │
 │                     │                                    │
 │  ┌──────────────────┼──────────────────────┐             │
@@ -44,9 +44,9 @@ Cantinarr makes it dead simple for your family and friends to discover and reque
 - **TMDB + Trakt for discovery** -- The best metadata, images, and trending data. Sonarr's TVDB dependency is invisible.
 - **Automatic ID bridging** -- TMDB-to-TVDB translation with Trakt fallback. The #1 source of failed Sonarr adds, solved.
 - **AI assistant** -- "What should I watch tonight?" Bring Anthropic, OpenAI, or Gemini; the assistant searches your library, checks availability, and can request for you. Admins can also manage the server conversationally: check the queue, kick off searches, grab a specific release from the indexers, or diagnose and fix stuck imports.
-- **MCP server** -- The same 25 AI tools are exposed as a [Model Context Protocol](https://modelcontextprotocol.io/) endpoint at `/mcp`, with MCP OAuth discovery, browser login, dynamic client registration, and persistent rotating refresh tokens. Every tool can be toggled on/off per server from Settings > AI Tools.
+- **MCP server** -- The same 26 AI tools are exposed as a [Model Context Protocol](https://modelcontextprotocol.io/) endpoint at `/mcp`, with MCP OAuth discovery, browser login, dynamic client registration, and persistent rotating refresh tokens. Every tool can be toggled on/off per server from Settings > AI Tools.
 - **Deep *arr control** -- SABnzbd, qBittorrent, NZBGet, and Transmission modules with live queue management (pause, resume, remove, speeds, real-time push updates), plus drill-down Radarr/Sonarr control: open a series into its **seasons and individual episodes** (or a movie's detail) for per-item download progress, quality/size, history, and messages, with per-episode/-movie **interactive release search** -- alongside the queue, history, wanted/missing, and calendar.
-- **Import Doctor** -- when a download is stuck, Cantinarr explains *why* in plain English (sample file, un-extracted archive, unconfirmed TheXEM mapping, "not an upgrade", stalled torrent, permissions...) and offers **one-click fixes** with full transparency: manual/force import (with the candidate files shown), remove + blocklist + re-search, hand-off to a tool like Unpackerr, or rescan. The same diagnosis backs the AI assistant and an MCP tool.
+- **Import Doctor** -- when a download is stuck, Cantinarr explains *why* in plain English (sample file, un-extracted archive, unconfirmed TheXEM mapping, "not an upgrade", not a Custom Format upgrade, unparseable/invalid file, remote-path-mapping or download-client problems, stalled torrent, permissions...) and offers **one-click fixes** with full transparency: manual/force import (with the candidate files shown), remove + blocklist + re-search, hand-off to a tool like Unpackerr, or rescan. Over MCP it also prints the exact next tool call per item and exposes a `get_arr_health` tool to confirm config-level root causes. The same diagnosis backs the AI assistant and the MCP tools.
 - **Flexible requests** -- request a whole title in one tap, or pick exactly which **seasons** you want; partially-available shows surface per-season availability and a one-tap path to request the rest.
 - **Tautulli** -- watch what's playing on Plex right now: active streams with quality/transcode badges, watch history, and top movies/shows/users stats.
 - **Secrets encrypted at rest** -- arr API keys, download-client passwords, and external credentials are AES-256-GCM encrypted in the database.
@@ -89,7 +89,7 @@ cantinarr/
 │   │   ├── config/         # Server configuration (port, name)
 │   │   ├── credentials/   # API credential management + client registry
 │   │   ├── db/             # SQLite with WAL mode
-│   │   ├── mcp/            # 25 AI tools + per-tool toggles
+│   │   ├── mcp/            # 26 AI tools + per-tool toggles
 │   │   ├── downloads/      # Unified SABnzbd/qBittorrent queue API
 │   │   ├── mcpserver/      # MCP Streamable HTTP endpoint
 │   │   ├── proxy/          # Arr admin reverse proxy

--- a/app/lib/features/sonarr/logic/import_doctor.dart
+++ b/app/lib/features/sonarr/logic/import_doctor.dart
@@ -93,10 +93,74 @@ const List<_Rule> _messageRules = [
     DoctorSeverity.warning,
     [DoctorAction.forceImport, DoctorAction.blocklistSearch],
   ),
+  // "Invalid video file, unsupported extension: '{extension}'" — more specific
+  // than the filename-prefix invalid-video rule below, so it comes first (both
+  // share the "invalid video file" prefix).
+  _Rule(
+    'invalid video file, unsupported extension',
+    'Unsupported file type',
+    "The file has an extension the service doesn't import as video. It's likely the wrong file (or needs unpacking) — remove and re-search for a proper release.",
+    DoctorSeverity.warning,
+    [DoctorAction.blocklistSearch, DoctorAction.manualImport],
+  ),
+  // "Invalid video file, filename starts with '._'" (macOS AppleDouble).
+  _Rule(
+    'invalid video file',
+    'Invalid video file',
+    'The service flagged this as not a valid video file (for example a macOS resource-fork "._" file). Inspect the candidates and import the real file manually, or remove and re-search.',
+    DoctorSeverity.warning,
+    [DoctorAction.manualImport, DoctorAction.blocklistSearch],
+  ),
+  // "Unable to parse file" (import-time parse failure).
+  _Rule(
+    'unable to parse file',
+    "Couldn't parse the file",
+    "The service couldn't parse the file name to figure out what it is, so it wasn't imported. Map it yourself with a manual import, or remove and re-search for a cleaner release.",
+    DoctorSeverity.warning,
+    [DoctorAction.manualImport, DoctorAction.blocklistSearch],
+  ),
+  // Sonarr: "One or more episodes expected in this release were not imported or
+  // missing from the release". Radarr's analog says "movies". Verified against a
+  // real Sonarr 4.0.16 instance; the "expected in this release were not
+  // imported" substring matches both services.
+  _Rule(
+    'expected in this release were not imported',
+    'Release contents don\'t match',
+    "Sonarr/Radarr expected files this release didn't contain, so it wasn't fully imported. Review the candidate files and import what's there manually, or remove and re-search for a complete release.",
+    DoctorSeverity.warning,
+    [DoctorAction.manualImport, DoctorAction.blocklistSearch],
+  ),
+  // Co-occurs with the above on a real Sonarr instance: a specific episode
+  // "was not found in the grabbed release". Same fix.
+  _Rule(
+    'was not found in the grabbed release',
+    'Release contents don\'t match',
+    "An episode this grab was supposed to include wasn't in the release, so it wasn't fully imported. Review the candidate files and import what's there manually, or remove and re-search for a complete release.",
+    DoctorSeverity.warning,
+    [DoctorAction.manualImport, DoctorAction.blocklistSearch],
+  ),
+  // "Invalid season or episode" — Sonarr couldn't map the file to a
+  // season/episode. Map it yourself via a manual import.
+  _Rule(
+    'invalid season or episode',
+    'Episode mapping problem',
+    "The service couldn't work out which season/episode this file is, so it wasn't imported. Map it yourself with a manual import.",
+    DoctorSeverity.warning,
+    [DoctorAction.manualImport],
+  ),
   _Rule(
     'not an upgrade for existing',
     'Not an upgrade',
     "This release isn't better than the file you already have, so it wasn't imported.",
+    DoctorSeverity.info,
+    [DoctorAction.remove, DoctorAction.forceImport],
+  ),
+  // "Not a Custom Format upgrade for existing {episode,movie} file(s)..." — a
+  // distinct string from the plain "not an upgrade" rule above.
+  _Rule(
+    'not a custom format upgrade for existing',
+    'Not a Custom Format upgrade',
+    "This release doesn't improve on your existing file's Custom Format score, so it wasn't imported. Clear it, or force the import if you want it anyway.",
     DoctorSeverity.info,
     [DoctorAction.remove, DoctorAction.forceImport],
   ),
@@ -107,6 +171,33 @@ const List<_Rule> _messageRules = [
     DoctorSeverity.info,
     [DoctorAction.remove],
   ),
+  // Sonarr: "...release was matched to series by ID. Automatic import is not
+  // possible...". Radarr's analog says "matched to movie by ID". Verified
+  // against a real Sonarr 4.0.16 instance: automatic import is genuinely
+  // blocked, so this is a warning that needs a manual import.
+  _Rule(
+    'matched to series by id',
+    'Matched by ID — needs manual import',
+    "The release was matched to the series by its download-client ID rather than by its name, so the service won't import it automatically. Import it manually.",
+    DoctorSeverity.warning,
+    [DoctorAction.manualImport],
+  ),
+  _Rule(
+    'matched to movie by id',
+    'Matched by ID — needs manual import',
+    "The release was matched to the movie by its download-client ID rather than by its name, so the service won't import it automatically. Import it manually.",
+    DoctorSeverity.warning,
+    [DoctorAction.manualImport],
+  ),
+  // Grab/search-side rejections ("Series/Episode/Movie is not monitored").
+  // Surfaced for transparency; nothing to fix on the item itself.
+  _Rule(
+    'is not monitored',
+    'Unmonitored',
+    "This item is unmonitored, so the service won't grab or import it. Monitor it first if you want it.",
+    DoctorSeverity.info,
+    [],
+  ),
   _Rule(
     'not enough free space',
     'Not enough free space',
@@ -114,17 +205,27 @@ const List<_Rule> _messageRules = [
     DoctorSeverity.error,
     [DoctorAction.rescan],
   ),
+  // "[{path}] is not a valid local path. You may need a Remote Path Mapping..."
+  // — the download client reported a path the service can't reach. Confirm with
+  // get_arr_health (remote path mapping), then rescan.
+  _Rule(
+    'is not a valid local path. you may need a remote path mapping',
+    'Remote path mapping',
+    "The download client reported a path the service can't reach on disk — a remote-path-mapping problem. Run get_arr_health to confirm the mapping, fix it, then rescan to retry.",
+    DoctorSeverity.error,
+    [DoctorAction.rescan],
+  ),
   _Rule(
     'permission',
     'Path or permissions error',
-    'A permissions problem or wrong remote-path mapping blocked the import. Fix access to the path, then rescan to retry.',
+    'A permissions problem or wrong remote-path mapping blocked the import. Run get_arr_health to confirm the config, fix access to the path, then rescan to retry.',
     DoctorSeverity.error,
     [DoctorAction.rescan],
   ),
   _Rule(
     'does not exist',
     'Path not accessible',
-    "The download path doesn't exist or isn't accessible — usually a remote-path mapping issue. Fix the path, then rescan to retry.",
+    "The download path doesn't exist or isn't accessible to the service — usually a remote-path mapping issue. Run get_arr_health to confirm, fix the path, then rescan to retry.",
     DoctorSeverity.error,
     [DoctorAction.rescan],
   ),
@@ -144,6 +245,27 @@ const List<_Rule> _errorRules = [
     'This torrent has no connections and will never finish on its own.',
     DoctorSeverity.error,
     [DoctorAction.blocklistSearch],
+  ),
+  // "qBittorrent cannot resolve magnet link with DHT disabled" — the torrent
+  // client can't fetch the magnet's metadata, so this download will never
+  // start. Blocklist and re-search; a usenet or non-magnet release sidesteps it.
+  _Rule(
+    'cannot resolve magnet',
+    "Download client can't fetch the magnet",
+    "Your torrent client can't resolve this magnet link (often DHT is disabled), so the download will never start. Remove and blocklist it, then re-search — a usenet or non-magnet release avoids this. Run get_arr_health to check the client.",
+    DoctorSeverity.error,
+    [DoctorAction.blocklistSearch],
+  ),
+  // "Unable to communicate with {downloadClient}..." — the service can't reach
+  // the download client at all. A config/connectivity problem, not the
+  // release's fault, so there's nothing to fix per item; get_arr_health
+  // surfaces the root cause.
+  _Rule(
+    'unable to communicate with',
+    'Download client unreachable',
+    "The service can't reach your download client, so nothing in the queue can progress. Run get_arr_health to confirm, then fix the client connection — this isn't a problem with the release itself.",
+    DoctorSeverity.error,
+    [],
   ),
   _Rule(
     'is reporting an error',
@@ -188,9 +310,10 @@ bool _looksHealthy({
 
 /// Service-neutral rule engine. Classifies a queue item from its raw signals
 /// with first-match-wins rules. Mirrors the Go classifier's order:
-/// client/stalled error → import rejections → stuck pending → failed → healthy →
-/// unknown-blocked fallback. Both [diagnoseSonarrQueueItem] and
-/// [diagnoseRadarrQueueItem] funnel through here so the catalog lives once.
+/// error-status → recognized errorMessage (even when status is ok) → import
+/// rejections → stuck pending → failed → healthy → unknown-blocked fallback.
+/// Both [diagnoseSonarrQueueItem] and [diagnoseRadarrQueueItem] funnel through
+/// here so the catalog lives once.
 QueueDiagnosis diagnoseQueueSignal({
   String? trackedDownloadStatus,
   String? trackedDownloadState,
@@ -215,7 +338,16 @@ QueueDiagnosis diagnoseQueueSignal({
     );
   }
 
-  // 2. Import rejections surfaced as statusMessages.
+  // 2. A recognized errorMessage on an otherwise-ok item (the status hasn't
+  // flipped to 'error' yet, e.g. a qBittorrent magnet error on a still-
+  // downloading item). Checked before the healthy short-circuit so these are
+  // not misclassified to the generic 'Import blocked' fallback.
+  if ((errorMessage ?? '').isNotEmpty) {
+    final matched = _matchRule(errorMessage!, _errorRules);
+    if (matched != null) return matched;
+  }
+
+  // 3. Import rejections surfaced as statusMessages.
   for (final g in statusMessageGroups) {
     final candidates = <String>[
       if (g.title.isNotEmpty) g.title,
@@ -227,7 +359,7 @@ QueueDiagnosis diagnoseQueueSignal({
     }
   }
 
-  // 3. Stuck waiting on the import pass.
+  // 4. Stuck waiting on the import pass.
   if (state == 'importpending') {
     return const QueueDiagnosis(
       severity: DoctorSeverity.warning,
@@ -238,7 +370,7 @@ QueueDiagnosis diagnoseQueueSignal({
     );
   }
 
-  // 4. Failed download.
+  // 5. Failed download.
   if (state == 'failed' || state == 'failedpending') {
     return const QueueDiagnosis(
       severity: DoctorSeverity.error,
@@ -249,7 +381,7 @@ QueueDiagnosis diagnoseQueueSignal({
     );
   }
 
-  // 5. Healthy.
+  // 6. Healthy.
   if (_looksHealthy(
     trackedDownloadStatus: trackedDownloadStatus,
     errorMessage: errorMessage,
@@ -258,7 +390,7 @@ QueueDiagnosis diagnoseQueueSignal({
     return const QueueDiagnosis(severity: DoctorSeverity.ok);
   }
 
-  // 6. Unknown blocked state.
+  // 7. Unknown blocked state.
   return const QueueDiagnosis(
     severity: DoctorSeverity.warning,
     problem: 'Import blocked',

--- a/app/test/sonarr/import_doctor_test.dart
+++ b/app/test/sonarr/import_doctor_test.dart
@@ -81,6 +81,20 @@ void main() {
     expect(d.actions, contains(DoctorAction.blocklistSearch));
   });
 
+  test('errorMessage is classified even when status is still ok', () {
+    // Real Sonarr 4.0.16: a qBittorrent magnet error surfaced on an item whose
+    // trackedDownloadStatus was "ok", not "error". It must not fall through to
+    // the generic "Import blocked" fallback.
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'ok',
+      state: 'downloading',
+      error: 'qBittorrent cannot resolve magnet link with DHT disabled',
+    ));
+    expect(d.severity, DoctorSeverity.error);
+    expect(d.problem, "Download client can't fetch the magnet");
+    expect(d.actions, contains(DoctorAction.blocklistSearch));
+  });
+
   test('not-an-upgrade is info with remove option', () {
     final d = diagnoseSonarrQueueItem(_item(
       status: 'warning',
@@ -101,5 +115,147 @@ void main() {
     expect(d.severity, DoctorSeverity.warning);
     expect(d.problem, 'Import blocked');
     expect(d.actions, contains(DoctorAction.manualImport));
+  });
+
+  // --- Import Doctor v2: deepened catalog (verified Servarr strings) ---
+
+  test('not a Custom Format upgrade is info with remove', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [
+        _msg('Not a Custom Format upgrade for existing episode file(s). '
+            'New: [WEB] (0) do not improve on Existing: [WEB] (5)'),
+      ],
+    ));
+    expect(d.severity, DoctorSeverity.info);
+    expect(d.problem, 'Not a Custom Format upgrade');
+    expect(d.actions, contains(DoctorAction.remove));
+  });
+
+  test('unable to parse file → manual import / blocklist', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('Unable to parse file')],
+    ));
+    expect(d.problem, "Couldn't parse the file");
+    expect(d.actions, contains(DoctorAction.manualImport));
+    expect(d.actions, contains(DoctorAction.blocklistSearch));
+  });
+
+  test('invalid video file (AppleDouble) → manual import', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg("Invalid video file, filename starts with '._'")],
+    ));
+    expect(d.problem, 'Invalid video file');
+    expect(d.actions.first, DoctorAction.manualImport);
+  });
+
+  test('unsupported extension beats invalid-video rule', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg("Invalid video file, unsupported extension: '.mkv.exe'")],
+    ));
+    expect(d.problem, 'Unsupported file type');
+    expect(d.actions.first, DoctorAction.blocklistSearch);
+  });
+
+  test('one or more episodes not imported → manual import / blocklist', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [
+        _msg('One or more episodes expected in this release were not '
+            'imported or missing from the release'),
+      ],
+    ));
+    expect(d.problem, "Release contents don't match");
+    expect(d.actions, contains(DoctorAction.manualImport));
+    expect(d.actions, contains(DoctorAction.blocklistSearch));
+  });
+
+  test('episode not found in the grabbed release → manual import', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('Episode 5 was not found in the grabbed release')],
+    ));
+    expect(d.problem, "Release contents don't match");
+    expect(d.actions, contains(DoctorAction.manualImport));
+  });
+
+  test('invalid season or episode → manual import', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('Invalid season or episode')],
+    ));
+    expect(d.problem, 'Episode mapping problem');
+    expect(d.actions, contains(DoctorAction.manualImport));
+  });
+
+  test('episode file already imported is covered by already-imported rule', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('Episode file already imported at 1/2/2024 3:04 PM')],
+    ));
+    expect(d.problem, 'Already imported');
+    expect(d.actions, contains(DoctorAction.remove));
+  });
+
+  test('matched to series by ID is a warning needing manual import', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [
+        _msg('Found matching series via grab history, but release was matched '
+            'to series by ID. Automatic import is not possible. See the FAQ '
+            'for details.'),
+      ],
+    ));
+    expect(d.severity, DoctorSeverity.warning);
+    expect(d.problem, 'Matched by ID — needs manual import');
+    expect(d.actions, contains(DoctorAction.manualImport));
+  });
+
+  test('unmonitored series is info with no fix', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [_msg('Series is not monitored')],
+    ));
+    expect(d.severity, DoctorSeverity.info);
+    expect(d.problem, 'Unmonitored');
+    expect(d.actions, isEmpty);
+  });
+
+  test('remote path mapping beats generic path rules', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'warning',
+      state: 'importBlocked',
+      messages: [
+        _msg('[/data/incomplete/Some.Release] is not a valid local path. '
+            'You may need a Remote Path Mapping.'),
+      ],
+    ));
+    expect(d.severity, DoctorSeverity.error);
+    expect(d.problem, 'Remote path mapping');
+    expect(d.actions, contains(DoctorAction.rescan));
+  });
+
+  test('download client unreachable is a config error with no per-item fix', () {
+    final d = diagnoseSonarrQueueItem(_item(
+      status: 'error',
+      state: 'downloading',
+      error: 'Unable to communicate with qBittorrent.',
+    ));
+    expect(d.severity, DoctorSeverity.error);
+    expect(d.problem, 'Download client unreachable');
+    expect(d.actions, isEmpty);
   });
 }

--- a/server/README.md
+++ b/server/README.md
@@ -203,7 +203,7 @@ Movies skip bridging entirely -- Radarr natively supports `term=tmdb:{id}`.
 
 ### MCP Tools
 
-The same 25 tools power both the in-app AI assistant and the external MCP endpoint. Tools marked admin require an admin account; every tool can be disabled from Settings > AI Tools:
+The same 26 tools power both the in-app AI assistant and the external MCP endpoint. Tools marked admin require an admin account; every tool can be disabled from Settings > AI Tools:
 
 | Tool | Description |
 |---|---|
@@ -227,7 +227,8 @@ The same 25 tools power both the in-app AI assistant and the external MCP endpoi
 | `grab_release` | Download a specific release (admin) |
 | `remove_queue_item` | Remove/blocklist a queue item (admin) |
 | `get_disk_space` | Disk space across instances (admin) |
-| `diagnose_queue` | Import Doctor: explain stuck/failed/blocked queue items and the fix to apply (admin) |
+| `get_arr_health` | Radarr/Sonarr system health: download client, remote path mapping, indexers, disk, root folder (admin) |
+| `diagnose_queue` | Import Doctor: explain stuck/failed/blocked queue items, print the exact next tool call, and the fix to apply (admin) |
 | `get_manual_import_candidates` | List a stuck download's files, mappings, and rejection reasons (admin) |
 | `execute_manual_import` | Force a download's files into the library via manual import (admin) |
 | `remediate_queue_item` | One-click queue fix: remove, blocklist+search, or change category (admin) |

--- a/server/internal/arr/doctor.go
+++ b/server/internal/arr/doctor.go
@@ -125,9 +125,73 @@ var messageRules = []messageRule{
 		actions:      []string{ActionForceImport, ActionBlocklistSearch},
 	},
 	{
+		// "Invalid video file, unsupported extension: '{extension}'" — more
+		// specific than the filename-prefix invalid-video rule below, so it
+		// comes first (both share the "invalid video file" prefix).
+		prefix:       "invalid video file, unsupported extension",
+		problem:      "Unsupported file type",
+		transparency: "The file has an extension the service doesn't import as video. It's likely the wrong file (or needs unpacking) — remove and re-search for a proper release.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionBlocklistSearch, ActionManualImport},
+	},
+	{
+		// "Invalid video file, filename starts with '._'" (macOS AppleDouble).
+		prefix:       "invalid video file",
+		problem:      "Invalid video file",
+		transparency: "The service flagged this as not a valid video file (for example a macOS resource-fork \"._\" file). Inspect the candidates and import the real file manually, or remove and re-search.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionManualImport, ActionBlocklistSearch},
+	},
+	{
+		// "Unable to parse file" (import-time parse failure).
+		prefix:       "unable to parse file",
+		problem:      "Couldn't parse the file",
+		transparency: "The service couldn't parse the file name to figure out what it is, so it wasn't imported. Map it yourself with a manual import, or remove and re-search for a cleaner release.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionManualImport, ActionBlocklistSearch},
+	},
+	{
+		// Sonarr: "One or more episodes expected in this release were not
+		// imported or missing from the release". Radarr's analog says "movies".
+		// Verified against a real Sonarr 4.0.16 instance. The substring
+		// "expected in this release were not imported" matches both services.
+		prefix:       "expected in this release were not imported",
+		problem:      "Release contents don't match",
+		transparency: "Sonarr/Radarr expected files this release didn't contain, so it wasn't fully imported. Review the candidate files and import what's there manually, or remove and re-search for a complete release.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionManualImport, ActionBlocklistSearch},
+	},
+	{
+		// Co-occurs with the above on a real Sonarr instance: a specific
+		// episode "was not found in the grabbed release". Same fix.
+		prefix:       "was not found in the grabbed release",
+		problem:      "Release contents don't match",
+		transparency: "An episode this grab was supposed to include wasn't in the release, so it wasn't fully imported. Review the candidate files and import what's there manually, or remove and re-search for a complete release.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionManualImport, ActionBlocklistSearch},
+	},
+	{
+		// "Invalid season or episode" — Sonarr couldn't map the file to a
+		// season/episode. Map it yourself via a manual import.
+		prefix:       "invalid season or episode",
+		problem:      "Episode mapping problem",
+		transparency: "The service couldn't work out which season/episode this file is, so it wasn't imported. Map it yourself with a manual import.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionManualImport},
+	},
+	{
 		prefix:       "not an upgrade for existing",
 		problem:      "Not an upgrade",
 		transparency: "This release isn't better than the file you already have, so it wasn't imported.",
+		severity:     SeverityInfo,
+		actions:      []string{ActionRemove, ActionForceImport},
+	},
+	{
+		// "Not a Custom Format upgrade for existing {episode,movie} file(s)..."
+		// A distinct string from the plain "not an upgrade" rule above.
+		prefix:       "not a custom format upgrade for existing",
+		problem:      "Not a Custom Format upgrade",
+		transparency: "This release doesn't improve on your existing file's Custom Format score, so it wasn't imported. Clear it, or force the import if you want it anyway.",
 		severity:     SeverityInfo,
 		actions:      []string{ActionRemove, ActionForceImport},
 	},
@@ -139,6 +203,33 @@ var messageRules = []messageRule{
 		actions:      []string{ActionRemove},
 	},
 	{
+		// Sonarr: "...release was matched to series by ID. Automatic import is
+		// not possible...". Radarr's analog says "matched to movie by ID".
+		// Verified against a real Sonarr 4.0.16 instance: automatic import is
+		// genuinely blocked, so this is a warning that needs a manual import.
+		prefix:       "matched to series by id",
+		problem:      "Matched by ID — needs manual import",
+		transparency: "The release was matched to the series by its download-client ID rather than by its name, so the service won't import it automatically. Import it manually.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionManualImport},
+	},
+	{
+		prefix:       "matched to movie by id",
+		problem:      "Matched by ID — needs manual import",
+		transparency: "The release was matched to the movie by its download-client ID rather than by its name, so the service won't import it automatically. Import it manually.",
+		severity:     SeverityWarning,
+		actions:      []string{ActionManualImport},
+	},
+	{
+		// Grab/search-side rejections ("Series/Episode/Movie is not monitored").
+		// Surfaced for transparency; nothing to fix on the item itself.
+		prefix:       "is not monitored",
+		problem:      "Unmonitored",
+		transparency: "This item is unmonitored, so the service won't grab or import it. Monitor it first if you want it.",
+		severity:     SeverityInfo,
+		actions:      []string{ActionNone},
+	},
+	{
 		prefix:       "not enough free space",
 		problem:      "Not enough free space",
 		transparency: "The library drive is below its free-space floor. Free up space, then rescan to retry.",
@@ -146,16 +237,26 @@ var messageRules = []messageRule{
 		actions:      []string{ActionRescan},
 	},
 	{
+		// "[{path}] is not a valid local path. You may need a Remote Path
+		// Mapping..." — the download client reported a path the service can't
+		// reach. Confirm with get_arr_health (remote path mapping), then rescan.
+		prefix:       "is not a valid local path. you may need a remote path mapping",
+		problem:      "Remote path mapping",
+		transparency: "The download client reported a path the service can't reach on disk — a remote-path-mapping problem. Run get_arr_health to confirm the mapping, fix it, then rescan to retry.",
+		severity:     SeverityError,
+		actions:      []string{ActionRescan},
+	},
+	{
 		prefix:       "permission",
 		problem:      "Path or permissions error",
-		transparency: "A permissions problem or wrong remote-path mapping blocked the import. Fix access to the path, then rescan to retry.",
+		transparency: "A permissions problem or wrong remote-path mapping blocked the import. Run get_arr_health to confirm the config, fix access to the path, then rescan to retry.",
 		severity:     SeverityError,
 		actions:      []string{ActionRescan},
 	},
 	{
 		prefix:       "does not exist",
 		problem:      "Path not accessible",
-		transparency: "The download path doesn't exist or isn't accessible to the service — usually a remote-path mapping issue. Fix the path, then rescan to retry.",
+		transparency: "The download path doesn't exist or isn't accessible to the service — usually a remote-path mapping issue. Run get_arr_health to confirm, fix the path, then rescan to retry.",
 		severity:     SeverityError,
 		actions:      []string{ActionRescan},
 	},
@@ -177,6 +278,28 @@ var errorRules = []messageRule{
 		transparency: "This torrent has no connections and will never finish on its own.",
 		severity:     SeverityError,
 		actions:      []string{ActionBlocklistSearch},
+	},
+	{
+		// "qBittorrent cannot resolve magnet link with DHT disabled" — the
+		// torrent client can't fetch the magnet's metadata, so this download
+		// will never start. Blocklist and re-search; a usenet or non-magnet
+		// release sidesteps it.
+		prefix:       "cannot resolve magnet",
+		problem:      "Download client can't fetch the magnet",
+		transparency: "Your torrent client can't resolve this magnet link (often DHT is disabled), so the download will never start. Remove and blocklist it, then re-search — a usenet or non-magnet release avoids this. Run get_arr_health to check the client.",
+		severity:     SeverityError,
+		actions:      []string{ActionBlocklistSearch},
+	},
+	{
+		// "Unable to communicate with {downloadClient}..." — the service can't
+		// reach the download client at all. This is a config/connectivity
+		// problem, not the release's fault, so there's nothing to fix per item;
+		// get_arr_health surfaces the root cause.
+		prefix:       "unable to communicate with",
+		problem:      "Download client unreachable",
+		transparency: "The service can't reach your download client, so nothing in the queue can progress. Run get_arr_health to confirm, then fix the client connection — this isn't a problem with the release itself.",
+		severity:     SeverityError,
+		actions:      []string{ActionNone},
 	},
 	{
 		prefix:       "qbittorrent is reporting an error",
@@ -218,11 +341,14 @@ func (s QueueSignal) healthy() bool {
 //
 // Order:
 //  1. trackedDownloadStatus == error -> inspect errorMessage (client/stalled).
-//  2. a warning/blocked/failed-pending item with statusMessages -> match each
+//  2. any non-empty errorMessage matching the error table -> classify it even
+//     when the status is still "ok" (e.g. qBittorrent magnet errors surface on
+//     an otherwise-downloading item).
+//  3. a warning/blocked/failed-pending item with statusMessages -> match each
 //     line against the verbatim rejection table.
-//  3. trackedDownloadState == importPending with no messages -> stuck pending.
-//  4. trackedDownloadState == failed -> remove + blocklist + re-search.
-//  5. otherwise healthy.
+//  4. trackedDownloadState == importPending with no messages -> stuck pending.
+//  5. trackedDownloadState == failed -> remove + blocklist + re-search.
+//  6. otherwise healthy.
 func Diagnose(sig QueueSignal) Diagnosis {
 	state := strings.ToLower(sig.TrackedDownloadState)
 	status := strings.ToLower(sig.TrackedDownloadStatus)
@@ -246,7 +372,16 @@ func Diagnose(sig QueueSignal) Diagnosis {
 		}
 	}
 
-	// 2. Import rejections surfaced as statusMessages.
+	// 2. A recognized errorMessage on an otherwise-ok item (the status hasn't
+	// flipped to "error" yet). Checked before healthy() so these aren't
+	// misclassified into the generic "Import blocked" fallback.
+	if sig.ErrorMessage != "" {
+		if d, ok := matchError(sig.ErrorMessage); ok {
+			return d
+		}
+	}
+
+	// 3. Import rejections surfaced as statusMessages.
 	if d, ok := matchMessages(sig.StatusMessages); ok {
 		return d
 	}

--- a/server/internal/arr/doctor_test.go
+++ b/server/internal/arr/doctor_test.go
@@ -87,6 +87,205 @@ func TestDiagnose(t *testing.T) {
 			wantActions: []string{ActionRemove, ActionForceImport},
 		},
 		{
+			// Verified Sonarr UpgradeSpecification.cs string.
+			name: "not a custom format upgrade",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages: msg("Not a Custom Format upgrade for existing episode file(s). " +
+					"New: [WEB] (0) do not improve on Existing: [WEB] (5)"),
+			},
+			wantProblem: "Not a Custom Format upgrade",
+			wantSev:     SeverityInfo,
+			wantActions: []string{ActionRemove, ActionForceImport},
+		},
+		{
+			// Verified Radarr UpgradeSpecification.cs string (movie variant).
+			name: "not a custom format upgrade (movie)",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages: msg("Not a Custom Format upgrade for existing movie file(s). " +
+					"New: [WEB] (0) do not improve on Existing: [WEB] (5)"),
+			},
+			wantProblem: "Not a Custom Format upgrade",
+			wantSev:     SeverityInfo,
+			wantActions: []string{ActionRemove, ActionForceImport},
+		},
+		{
+			// Verified ImportDecisionMaker.cs string (both services).
+			name: "unable to parse file",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Unable to parse file"),
+			},
+			wantProblem: "Couldn't parse the file",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport, ActionBlocklistSearch},
+		},
+		{
+			// Verified DownloadedEpisodesImportService.cs / DownloadedMovieImportService.cs.
+			name: "invalid video file applefork",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Invalid video file, filename starts with '._'"),
+			},
+			wantProblem: "Invalid video file",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport, ActionBlocklistSearch},
+		},
+		{
+			// Verified unsupported-extension string; must beat the broader
+			// "invalid video file" rule (both share that prefix).
+			name: "unsupported extension beats invalid video file",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Invalid video file, unsupported extension: '.mkv.exe'"),
+			},
+			wantProblem: "Unsupported file type",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionBlocklistSearch, ActionManualImport},
+		},
+		{
+			// Verified against a real Sonarr 4.0.16 instance.
+			name: "one or more episodes not imported",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("One or more episodes expected in this release were not imported or missing from the release"),
+			},
+			wantProblem: "Release contents don't match",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport, ActionBlocklistSearch},
+		},
+		{
+			// Verified Radarr CompletedDownloadService.cs status message; the
+			// "expected in this release were not imported" substring matches it.
+			name: "one or more movies not imported",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("One or more movies expected in this release were not imported or missing"),
+			},
+			wantProblem: "Release contents don't match",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport, ActionBlocklistSearch},
+		},
+		{
+			// Real Sonarr 4.0.16 line that co-occurs with the partial-import
+			// message above.
+			name: "episode was not found in the grabbed release",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Episode 5 was not found in the grabbed release"),
+			},
+			wantProblem: "Release contents don't match",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport, ActionBlocklistSearch},
+		},
+		{
+			name: "invalid season or episode mapping",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Invalid season or episode"),
+			},
+			wantProblem: "Episode mapping problem",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport},
+		},
+		{
+			// Verified AlreadyImportedSpecification.cs (Sonarr) — covered by the
+			// existing "already imported" rule.
+			name: "episode file already imported at",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Episode file already imported at 1/2/2024 3:04 PM"),
+			},
+			wantProblem: "Already imported",
+			wantSev:     SeverityInfo,
+			wantActions: []string{ActionRemove},
+		},
+		{
+			// Verified Radarr AlreadyImportedSpecification.cs.
+			name: "movie file already imported at",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Movie file already imported at 1/2/2024 3:04 PM"),
+			},
+			wantProblem: "Already imported",
+			wantSev:     SeverityInfo,
+			wantActions: []string{ActionRemove},
+		},
+		{
+			// Verified Sonarr CompletedDownloadService.cs warn message.
+			name: "matched to series by id",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Found matching series via grab history, but release was matched to series by ID. Automatic import is not possible. See the FAQ for details."),
+			},
+			wantProblem: "Matched by ID — needs manual import",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport},
+		},
+		{
+			// Verified Radarr CompletedDownloadService.cs warn message.
+			name: "matched to movie by id",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Found matching movie via grab history, but release was matched to movie by ID. Manual Import required."),
+			},
+			wantProblem: "Matched by ID — needs manual import",
+			wantSev:     SeverityWarning,
+			wantActions: []string{ActionManualImport},
+		},
+		{
+			// Verified MonitoredEpisodeSpecification.cs (Sonarr).
+			name: "series is not monitored",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("Series is not monitored"),
+			},
+			wantProblem: "Unmonitored",
+			wantSev:     SeverityInfo,
+			wantActions: []string{ActionNone},
+		},
+		{
+			// Verified CompletedDownloadService.cs remote-path-mapping string.
+			// Must beat the broad "does not exist"/"permission" path rules.
+			name: "remote path mapping not a valid local path",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "warning",
+				TrackedDownloadState:  "importBlocked",
+				StatusMessages:        msg("[/data/incomplete/Some.Release] is not a valid local path. You may need a Remote Path Mapping."),
+			},
+			wantProblem: "Remote path mapping",
+			wantSev:     SeverityError,
+			wantActions: []string{ActionRescan},
+		},
+		{
+			// Verified DownloadClientCheck en.json string. Surfaces on an error
+			// status; nothing to fix per item (config-level).
+			name: "download client unreachable",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "error",
+				TrackedDownloadState:  "downloading",
+				ErrorMessage:          "Unable to communicate with qBittorrent.",
+			},
+			wantProblem: "Download client unreachable",
+			wantSev:     SeverityError,
+			wantActions: []string{ActionNone},
+		},
+		{
 			name: "dangerous executable wins over everything",
 			sig: QueueSignal{
 				TrackedDownloadStatus: "warning",
@@ -121,6 +320,22 @@ func TestDiagnose(t *testing.T) {
 				Protocol:              "torrent",
 			},
 			wantProblem: "Download client error",
+			wantSev:     SeverityError,
+			wantActions: []string{ActionBlocklistSearch},
+		},
+		{
+			// Real Sonarr 4.0.16: the client error surfaced on an item whose
+			// trackedDownloadStatus was still "ok" (not "error"). The classifier
+			// must inspect errorMessage regardless of status so this is not
+			// misclassified to the generic "Import blocked" fallback.
+			name: "magnet cannot resolve with status still ok",
+			sig: QueueSignal{
+				TrackedDownloadStatus: "ok",
+				TrackedDownloadState:  "downloading",
+				ErrorMessage:          "qBittorrent cannot resolve magnet link with DHT disabled",
+				Protocol:              "torrent",
+			},
+			wantProblem: "Download client can't fetch the magnet",
 			wantSev:     SeverityError,
 			wantActions: []string{ActionBlocklistSearch},
 		},

--- a/server/internal/mcp/arr_tools.go
+++ b/server/internal/mcp/arr_tools.go
@@ -206,9 +206,24 @@ var arrToolDefinitions = []Tool{
 		},
 	},
 	{
+		Name:        "get_arr_health",
+		Permission:  auth.PermissionArrRead,
+		Description: "Check Radarr/Sonarr system health for config-level problems (download client unreachable, remote path mapping, indexers down, disk, no root folder). Use this when diagnose_queue shows path/permission/client errors to confirm the root cause that per-item queue diagnosis can only guess at. Admin only",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"media_type": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"movie", "tv", "all"},
+					"description": "Which service's health to fetch (default: all)",
+				},
+			},
+		},
+	},
+	{
 		Name:        "diagnose_queue",
 		Permission:  auth.PermissionArrRead,
-		Description: "Import Doctor: scan the Radarr/Sonarr download queue for items that are stuck, failed, or blocked from importing, and explain each problem in plain language with the queue_id and suggested fix actions (process, manual_import, force_import, remove, blocklist_search, change_category, rescan). Use this before the fix tools. Admin only",
+		Description: "Import Doctor: scan the Radarr/Sonarr download queue for items that are stuck, failed, or blocked from importing, and explain each problem in plain language with the queue_id and suggested fix actions (process, manual_import, force_import, remove, blocklist_search, change_category, rescan). For each problem it also prints the exact next MCP tool call to run. Use this before the fix tools. Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{

--- a/server/internal/mcp/import_doctor.go
+++ b/server/internal/mcp/import_doctor.go
@@ -71,8 +71,12 @@ func radarrQueueTitle(item radarr.DetailedQueueItem) string {
 	return fmt.Sprintf("movie %d", item.MovieID)
 }
 
-// renderDiagnosis appends a problem item's diagnosis to the builder.
-func renderDiagnosis(sb *strings.Builder, mediaType string, queueID int, title string, d arr.Diagnosis) {
+// renderDiagnosis appends a problem item's diagnosis to the builder, including
+// the exact next MCP tool call(s) to run for each suggested action so a weak
+// agent can execute verbatim. tmdbID is the resolved TMDB id of the underlying
+// movie/series (0 when it could not be resolved cheaply, e.g. a Sonarr queue
+// item only carries a TVDB id).
+func renderDiagnosis(sb *strings.Builder, mediaType string, queueID, tmdbID int, title string, d arr.Diagnosis) {
 	fmt.Fprintf(sb, "\n\n- [queue %d] (%s) %s\n  problem: %s [%s]", queueID, mediaType, title, d.Problem, d.Severity)
 	if d.Transparency != "" {
 		fmt.Fprintf(sb, "\n  what happened: %s", d.Transparency)
@@ -86,6 +90,126 @@ func renderDiagnosis(sb *strings.Builder, mediaType string, queueID int, title s
 	if len(actions) > 0 {
 		fmt.Fprintf(sb, "\n  suggested actions: %s", strings.Join(actions, ", "))
 	}
+	if next := nextCalls(mediaType, queueID, tmdbID, d.SuggestedActions); next != "" {
+		fmt.Fprintf(sb, "\n  → next: %s", next)
+	}
+}
+
+// nextCalls maps a diagnosis's suggested action verbs to the precise MCP tool
+// call(s) to run, with JSON args, joined with " then " when an action needs
+// more than one step. It renders only the FIRST actionable verb (the primary
+// fix); the rest stay visible in "suggested actions" as alternatives. Returns
+// "" when there is nothing actionable.
+func nextCalls(mediaType string, queueID, tmdbID int, verbs []string) string {
+	for _, v := range verbs {
+		switch v {
+		case arr.ActionProcess, arr.ActionRescan:
+			// rescan_media runs Rescan{Series,Movie} then the import pass. It
+			// needs a tmdb_id; the Sonarr queue item only carries a TVDB id, so
+			// fall back to naming the tool when we could not resolve one.
+			if tmdbID != 0 {
+				return toolCall("rescan_media", fmt.Sprintf(`{"tmdb_id": %d, "media_type": %q}`, tmdbID, mediaType))
+			}
+			return "rescan_media (resolve this item's tmdb_id first — get_library media_type=" + mediaType + " by title — then call it with that tmdb_id)"
+		case arr.ActionManualImport:
+			return toolCall("get_manual_import_candidates", fmt.Sprintf(`{"queue_id": %d, "media_type": %q}`, queueID, mediaType)) +
+				" then " + toolCall("execute_manual_import", fmt.Sprintf(`{"queue_id": %d, "media_type": %q}`, queueID, mediaType))
+		case arr.ActionForceImport:
+			return toolCall("execute_manual_import", fmt.Sprintf(`{"queue_id": %d, "media_type": %q, "force": true}`, queueID, mediaType))
+		case arr.ActionRemove, arr.ActionBlocklistSearch, arr.ActionChangeCategory:
+			return toolCall("remediate_queue_item", fmt.Sprintf(`{"queue_id": %d, "media_type": %q, "action": %q}`, queueID, mediaType, v))
+		}
+	}
+	return ""
+}
+
+// toolCall renders a "name args" call fragment for the next-step line.
+func toolCall(name, args string) string {
+	return name + " " + args
+}
+
+// --- get_arr_health ---
+
+// renderHealthSection renders a service's non-ok health checks (ok-type checks
+// are skipped so the agent only sees actionable config problems). The generic
+// parameter lets the one renderer serve both sonarr.HealthCheck and
+// radarr.HealthCheck, which are structurally identical but distinct types.
+func renderHealthSection[T sonarr.HealthCheck | radarr.HealthCheck](label string, checks []T) string {
+	var sb strings.Builder
+	shown := 0
+	for _, c := range checks {
+		var source, ctype, message, wiki string
+		switch v := any(c).(type) {
+		case sonarr.HealthCheck:
+			source, ctype, message, wiki = v.Source, v.Type, v.Message, v.WikiURL
+		case radarr.HealthCheck:
+			source, ctype, message, wiki = v.Source, v.Type, v.Message, v.WikiURL
+		}
+		if strings.EqualFold(ctype, "ok") {
+			continue
+		}
+		if shown == 0 {
+			fmt.Fprintf(&sb, "%s health:", label)
+		}
+		shown++
+		fmt.Fprintf(&sb, "\n- [%s] %s", strings.ToLower(ctype), message)
+		if source != "" {
+			fmt.Fprintf(&sb, " (%s)", source)
+		}
+		if wiki != "" {
+			fmt.Fprintf(&sb, "\n  more: %s", wiki)
+		}
+	}
+	if shown == 0 {
+		fmt.Fprintf(&sb, "%s health: no warnings or errors.", label)
+	}
+	return sb.String()
+}
+
+func (s *ToolServer) getArrHealth(input json.RawMessage) (*ToolResult, error) {
+	var params struct {
+		MediaType string `json:"media_type"`
+	}
+	if err := json.Unmarshal(input, &params); err != nil {
+		return nil, fmt.Errorf("parse input: %w", err)
+	}
+	mediaType := normalizeMediaType(params.MediaType)
+
+	var sections []string
+
+	if mediaType == "movie" || mediaType == "all" {
+		client := s.GetRadarr()
+		if client == nil {
+			if mediaType == "movie" {
+				return &ToolResult{Text: "Radarr is not configured."}, nil
+			}
+			sections = append(sections, "Radarr is not configured.")
+		} else {
+			checks, err := client.GetHealth()
+			if err != nil {
+				return nil, err
+			}
+			sections = append(sections, renderHealthSection("Radarr", checks))
+		}
+	}
+
+	if mediaType == "tv" || mediaType == "all" {
+		client := s.GetSonarr()
+		if client == nil {
+			if mediaType == "tv" {
+				return &ToolResult{Text: "Sonarr is not configured."}, nil
+			}
+			sections = append(sections, "Sonarr is not configured.")
+		} else {
+			checks, err := client.GetHealth()
+			if err != nil {
+				return nil, err
+			}
+			sections = append(sections, renderHealthSection("Sonarr", checks))
+		}
+	}
+
+	return &ToolResult{Text: strings.Join(sections, "\n\n")}, nil
 }
 
 // --- diagnose_queue ---
@@ -123,7 +247,13 @@ func (s *ToolServer) diagnoseQueue(input json.RawMessage) (*ToolResult, error) {
 					continue
 				}
 				problems++
-				renderDiagnosis(&sb, "movie", item.ID, radarrQueueTitle(item), d)
+				// Radarr queue items embed the movie's TMDB id, so rescan_media
+				// calls can be rendered fully resolved.
+				tmdbID := 0
+				if item.Movie != nil {
+					tmdbID = item.Movie.TmdbID
+				}
+				renderDiagnosis(&sb, "movie", item.ID, tmdbID, radarrQueueTitle(item), d)
 			}
 		}
 	}
@@ -147,7 +277,10 @@ func (s *ToolServer) diagnoseQueue(input json.RawMessage) (*ToolResult, error) {
 					continue
 				}
 				problems++
-				renderDiagnosis(&sb, "tv", item.ID, sonarrQueueTitle(item), d)
+				// Sonarr queue items carry only a TVDB id (no TMDB), so we
+				// cannot resolve a tmdb_id cheaply here; pass 0 and let
+				// nextCalls name the tool with a resolve hint instead.
+				renderDiagnosis(&sb, "tv", item.ID, 0, sonarrQueueTitle(item), d)
 			}
 		}
 	}
@@ -163,7 +296,7 @@ func (s *ToolServer) diagnoseQueue(input json.RawMessage) (*ToolResult, error) {
 		if healthy > 0 {
 			fmt.Fprintf(&header, " (%d other item(s) are healthy)", healthy)
 		}
-		header.WriteString(". Use get_manual_import_candidates, execute_manual_import, remediate_queue_item, or rescan_media with the queue_id to fix them:")
+		header.WriteString(". Each item lists the exact next tool call to run on its \"→ next:\" line (get_manual_import_candidates, execute_manual_import, remediate_queue_item, or rescan_media). For path/permission/client errors, get_arr_health confirms the config root cause:")
 	}
 	if len(notes) > 0 {
 		fmt.Fprintf(&header, " (%s)", strings.Join(notes, " "))

--- a/server/internal/mcp/import_doctor_test.go
+++ b/server/internal/mcp/import_doctor_test.go
@@ -1,0 +1,144 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/arr"
+	"github.com/windoze95/cantinarr-server/internal/radarr"
+	"github.com/windoze95/cantinarr-server/internal/sonarr"
+)
+
+// TestNextCalls verifies that each suggested-action verb maps to the exact next
+// MCP tool call a weak agent can run verbatim.
+func TestNextCalls(t *testing.T) {
+	cases := []struct {
+		name      string
+		mediaType string
+		queueID   int
+		tmdbID    int
+		verbs     []string
+		want      string
+	}{
+		{
+			name:      "manual_import renders candidates then execute",
+			mediaType: "tv",
+			queueID:   42,
+			tmdbID:    0,
+			verbs:     []string{arr.ActionManualImport, arr.ActionForceImport},
+			want:      `get_manual_import_candidates {"queue_id": 42, "media_type": "tv"} then execute_manual_import {"queue_id": 42, "media_type": "tv"}`,
+		},
+		{
+			name:      "force_import sets force true",
+			mediaType: "movie",
+			queueID:   7,
+			tmdbID:    603,
+			verbs:     []string{arr.ActionForceImport},
+			want:      `execute_manual_import {"queue_id": 7, "media_type": "movie", "force": true}`,
+		},
+		{
+			name:      "remove maps to remediate",
+			mediaType: "movie",
+			queueID:   9,
+			verbs:     []string{arr.ActionRemove},
+			want:      `remediate_queue_item {"queue_id": 9, "media_type": "movie", "action": "remove"}`,
+		},
+		{
+			name:      "blocklist_search maps to remediate",
+			mediaType: "tv",
+			queueID:   3,
+			verbs:     []string{arr.ActionBlocklistSearch},
+			want:      `remediate_queue_item {"queue_id": 3, "media_type": "tv", "action": "blocklist_search"}`,
+		},
+		{
+			name:      "change_category maps to remediate",
+			mediaType: "movie",
+			queueID:   5,
+			verbs:     []string{arr.ActionChangeCategory},
+			want:      `remediate_queue_item {"queue_id": 5, "media_type": "movie", "action": "change_category"}`,
+		},
+		{
+			name:      "rescan with resolved tmdb renders rescan_media",
+			mediaType: "movie",
+			queueID:   11,
+			tmdbID:    603,
+			verbs:     []string{arr.ActionRescan},
+			want:      `rescan_media {"tmdb_id": 603, "media_type": "movie"}`,
+		},
+		{
+			name:      "process with resolved tmdb renders rescan_media",
+			mediaType: "movie",
+			queueID:   11,
+			tmdbID:    27205,
+			verbs:     []string{arr.ActionProcess, arr.ActionManualImport},
+			want:      `rescan_media {"tmdb_id": 27205, "media_type": "movie"}`,
+		},
+		{
+			name:      "none is not actionable",
+			mediaType: "tv",
+			queueID:   1,
+			verbs:     []string{arr.ActionNone},
+			want:      "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := nextCalls(tc.mediaType, tc.queueID, tc.tmdbID, tc.verbs)
+			if got != tc.want {
+				t.Errorf("nextCalls() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNextCallsRescanWithoutTmdbFallsBack verifies that when a tmdb_id cannot be
+// resolved (Sonarr queue items carry only a TVDB id), the rescan path names the
+// tool with a resolve hint instead of emitting a bogus call.
+func TestNextCallsRescanWithoutTmdbFallsBack(t *testing.T) {
+	got := nextCalls("tv", 8, 0, []string{arr.ActionRescan})
+	if !strings.HasPrefix(got, "rescan_media") {
+		t.Fatalf("expected rescan_media fallback, got %q", got)
+	}
+	if strings.Contains(got, `"tmdb_id": 0`) {
+		t.Fatalf("must not emit a tmdb_id of 0: %q", got)
+	}
+	if !strings.Contains(got, "tmdb_id") {
+		t.Fatalf("fallback should still tell the agent to resolve a tmdb_id: %q", got)
+	}
+}
+
+// TestRenderHealthSectionSkipsOK verifies ok-type checks are hidden and non-ok
+// checks render with type, message, source, and wiki URL.
+func TestRenderHealthSectionSkipsOK(t *testing.T) {
+	radarrChecks := []radarr.HealthCheck{
+		{Source: "IndexerStatusCheck", Type: "ok", Message: "all good"},
+		{Source: "DownloadClientCheck", Type: "error", Message: "Unable to communicate with qBittorrent.", WikiURL: "https://wiki.servarr.com/x"},
+	}
+	out := renderHealthSection("Radarr", radarrChecks)
+	if strings.Contains(out, "all good") {
+		t.Errorf("ok checks should be skipped: %q", out)
+	}
+	if !strings.Contains(out, "Unable to communicate with qBittorrent.") {
+		t.Errorf("error check message missing: %q", out)
+	}
+	if !strings.Contains(out, "[error]") {
+		t.Errorf("type should be rendered: %q", out)
+	}
+	if !strings.Contains(out, "DownloadClientCheck") {
+		t.Errorf("source should be rendered: %q", out)
+	}
+	if !strings.Contains(out, "https://wiki.servarr.com/x") {
+		t.Errorf("wiki url should be rendered: %q", out)
+	}
+}
+
+// TestRenderHealthSectionAllOK verifies a clean service reports no problems.
+func TestRenderHealthSectionAllOK(t *testing.T) {
+	sonarrChecks := []sonarr.HealthCheck{
+		{Source: "RootFolderCheck", Type: "ok", Message: "fine"},
+	}
+	out := renderHealthSection("Sonarr", sonarrChecks)
+	if !strings.Contains(out, "no warnings or errors") {
+		t.Errorf("expected clean health summary, got %q", out)
+	}
+}

--- a/server/internal/mcp/server.go
+++ b/server/internal/mcp/server.go
@@ -195,6 +195,8 @@ func (s *ToolServer) ExecuteTool(ctx context.Context, name string, input json.Ra
 		return s.removeQueueItem(input)
 	case "get_disk_space":
 		return s.getDiskSpace()
+	case "get_arr_health":
+		return s.getArrHealth(input)
 	case "diagnose_queue":
 		return s.diagnoseQueue(input)
 	case "get_manual_import_candidates":

--- a/server/internal/mcpserver/guidance.go
+++ b/server/internal/mcpserver/guidance.go
@@ -113,7 +113,7 @@ Workflow:
 
 Workflow:
 1. Use get_queue for current downloads, get_history for recent activity, get_calendar for upcoming releases, and get_library for library state.
-2. For stuck, failed, or stuck-importing downloads, run diagnose_queue first (the Import Doctor). It explains each problem and lists the fix to apply by queue_id: get_manual_import_candidates then execute_manual_import (force a correct file in), remediate_queue_item (remove / blocklist_search / change_category), or rescan_media (after fixing disk/path/permissions).
+2. For stuck, failed, or stuck-importing downloads, run diagnose_queue first (the Import Doctor). It explains each problem and prints the exact next tool call to run on each item's "→ next:" line: get_manual_import_candidates then execute_manual_import (force a correct file in), remediate_queue_item (remove / blocklist_search / change_category), or rescan_media (after fixing disk/path/permissions). When diagnose_queue shows path, permission, or download-client errors, call get_arr_health to confirm the config-level root cause (download client unreachable, remote path mapping, indexers down).
 3. For missing media or failed downloads, trigger_search can start an automatic search.
 4. Use search_releases before grab_release when the user wants a particular quality, release group, or manual selection.
 5. Only call destructive tools such as grab_release, remove_queue_item, execute_manual_import, or remediate_queue_item when the user explicitly asks for that action. Summarize consequences before or after the call.
@@ -204,7 +204,8 @@ Tools may be hidden or disabled by RBAC and administrator settings. If a tool re
 - Use get_library for library state, missing, or unmonitored items.
 - Use get_history for recent grabs, imports, and failures.
 - If a library item is missing or a download failed, trigger_search can start a new automatic search.
-- For downloads that are stuck, failed, or stuck importing, run diagnose_queue (the Import Doctor) to explain the problem and the right fix, then use get_manual_import_candidates / execute_manual_import to force a correct file in, remediate_queue_item to remove / blocklist+search / change category, or rescan_media after fixing a disk, path, or permissions issue.
+- For downloads that are stuck, failed, or stuck importing, run diagnose_queue (the Import Doctor). It explains each problem and prints the exact next tool call to run on each item's "→ next:" line, then use get_manual_import_candidates / execute_manual_import to force a correct file in, remediate_queue_item to remove / blocklist+search / change category, or rescan_media after fixing a disk, path, or permissions issue.
+- When diagnose_queue reports a path, permission, or download-client problem, call get_arr_health to confirm the config-level root cause (download client unreachable, remote path mapping wrong, indexers down, no root folder) that per-item diagnosis can only guess at.
 - For manual control, call search_releases before grab_release so the user can choose quality, release group, or a specific release.
 - Only call destructive or state-changing tools such as grab_release, remove_queue_item, execute_manual_import, and remediate_queue_item when the user explicitly asks for that action.
 `, role, toolList)

--- a/server/internal/radarr/client.go
+++ b/server/internal/radarr/client.go
@@ -461,6 +461,27 @@ func (c *Client) GetDiskSpace() ([]DiskSpace, error) {
 	return disks, nil
 }
 
+// HealthCheck is one entry from Radarr's system health report: a config-level
+// problem (download client unreachable, remote path mapping, indexers down, no
+// root folder, low disk, etc.). Type is one of ok/notice/warning/error.
+type HealthCheck struct {
+	Source  string `json:"source"`
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	WikiURL string `json:"wikiUrl"`
+}
+
+// GetHealth returns Radarr's current system health checks. These surface
+// config-level root causes (download client down, remote path mapping wrong,
+// indexers unavailable) that per-item queue diagnosis can only guess at.
+func (c *Client) GetHealth() ([]HealthCheck, error) {
+	var checks []HealthCheck
+	if err := c.do("GET", "/api/v3/health", nil, &checks); err != nil {
+		return nil, fmt.Errorf("radarr health: %w", err)
+	}
+	return checks, nil
+}
+
 // ManualImportRejection is a single reason Radarr would not auto-import a file,
 // plus whether the rejection is permanent (a force import will likely still
 // fail) or temporary.

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -571,6 +571,27 @@ func (c *Client) GetDiskSpace() ([]DiskSpace, error) {
 	return disks, nil
 }
 
+// HealthCheck is one entry from Sonarr's system health report: a config-level
+// problem (download client unreachable, remote path mapping, indexers down, no
+// root folder, low disk, etc.). Type is one of ok/notice/warning/error.
+type HealthCheck struct {
+	Source  string `json:"source"`
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	WikiURL string `json:"wikiUrl"`
+}
+
+// GetHealth returns Sonarr's current system health checks. These surface
+// config-level root causes (download client down, remote path mapping wrong,
+// indexers unavailable) that per-item queue diagnosis can only guess at.
+func (c *Client) GetHealth() ([]HealthCheck, error) {
+	var checks []HealthCheck
+	if err := c.do("GET", "/api/v3/health", nil, &checks); err != nil {
+		return nil, fmt.Errorf("sonarr health: %w", err)
+	}
+	return checks, nil
+}
+
 type Episode struct {
 	ID            int        `json:"id"`
 	SeriesID      int        `json:"seriesId"`


### PR DESCRIPTION
Makes Cantinarr's Import Doctor deeper and more agent-actionable. Touches `server/` (Go) and the Dart classifier in `app/`, keeping the Go and Dart catalogs **in sync**.

## 1. New `get_arr_health` MCP tool (25 → 26 tools)
- `GetHealth() ([]HealthCheck, error)` on **both** the `sonarr` and `radarr` clients (`GET /api/v3/health` → `[]HealthCheck{ Source; Type; Message; WikiURL }`).
- Tool `get_arr_health` — definition in `arr_tools.go`, dispatch in `server.go`, handler in `import_doctor.go`. Permission `auth.PermissionArrRead` (admin), mirroring `get_queue`. Input `{media_type?: "movie"|"tv"|"all"}`. Lists each service's non-`ok` health checks (download client unreachable, remote-path-mapping, indexers down, no root folder, disk) so an agent can **confirm CONFIG root causes** that per-item queue diagnosis can only guess at. Clients are nil-checked ("Radarr is not configured.").

## 2. `diagnose_queue` prints the EXACT next tool call per problem item
Each problem item now renders a `→ next:` line with the precise MCP call(s) + JSON args, so a weak agent can execute verbatim. Verb → call mapping (helper `nextCalls`):
- `process` / `rescan` → `rescan_media {"tmdb_id": <id>, "media_type": "..."}`. Radarr items resolve `tmdb_id` from the embedded movie; **Sonarr queue items carry only a TVDB id**, so the rescan path falls back to naming the tool with a resolve hint (as the spec allows).
- `manual_import` → `get_manual_import_candidates {...}` **then** `execute_manual_import {...}`.
- `force_import` → `execute_manual_import {"queue_id": <id>, "media_type": "...", "force": true}`.
- `remove` / `blocklist_search` / `change_category` → `remediate_queue_item {"queue_id": <id>, "media_type": "...", "action": "<verb>"}`.

The existing transparency text is preserved.

## 3. Deepened diagnosis catalog (`doctor.go` AND `import_doctor.dart`, identical)
Catalogs kept identical in prefixes/severity/actions; same canonical messages added to **both** `doctor_test.go` and `import_doctor_test.dart`. First-match-wins ordering preserved (specific/dangerous before broad).

**Classifier bug fix** (found on the user's live Sonarr 4.0.16): a recognized `errorMessage` is now classified even when `trackedDownloadStatus` is still `"ok"` (not just `"error"`), **before** the `healthy()` short-circuit — otherwise a real item (`tds=ok`, `state=downloading`, `errorMessage="qBittorrent cannot resolve magnet link with DHT disabled"`) fell through to the generic "Import blocked" fallback.

New rules added (prefix → problem · severity · actions · source):

| Prefix (lowercased substring) | Problem | Severity | Actions | Source |
|---|---|---|---|---|
| `invalid video file, unsupported extension` | Unsupported file type | warning | blocklist_search, manual_import | Sonarr/Radarr `Downloaded*ImportService` |
| `invalid video file` | Invalid video file | warning | manual_import, blocklist_search | Sonarr/Radarr `Downloaded*ImportService` (AppleDouble `._`) |
| `unable to parse file` | Couldn't parse the file | warning | manual_import, blocklist_search | Sonarr/Radarr `ImportDecisionMaker` |
| `expected in this release were not imported` | Release contents don't match | warning | manual_import, blocklist_search | Sonarr/Radarr `CompletedDownloadService`; **verified live Sonarr 4.0.16** (substring matches both episode & movie variants) |
| `was not found in the grabbed release` | Release contents don't match | warning | manual_import, blocklist_search | **verified live Sonarr 4.0.16** (co-occurs with the above) |
| `invalid season or episode` | Episode mapping problem | warning | manual_import | **verified live Sonarr 4.0.16** |
| `not a custom format upgrade for existing` | Not a Custom Format upgrade | info | remove, force_import | Sonarr/Radarr `UpgradeSpecification` |
| `matched to series by id` / `matched to movie by id` | Matched by ID — needs manual import | warning | manual_import | Sonarr/Radarr `CompletedDownloadService`; **verified live Sonarr 4.0.16** (automatic import genuinely blocked) |
| `is not monitored` | Unmonitored | info | none | Sonarr/Radarr `Monitored*Specification` |
| `is not a valid local path. you may need a remote path mapping` | Remote path mapping | error | rescan (+ suggests get_arr_health) | Sonarr/Radarr `CompletedDownloadService` |
| `cannot resolve magnet` (errorRules) | Download client can't fetch the magnet | error | blocklist_search (+ suggests get_arr_health) | **verified live Sonarr 4.0.16** (qBittorrent + DHT disabled) |
| `unable to communicate with` (errorRules) | Download client unreachable | error | none (+ suggests get_arr_health) | Sonarr/Radarr `DownloadClientCheck` health string |

`already imported` (existing rule) was confirmed to also cover "Episode/Movie file already imported at ..." — test cases added, no new rule.

### Rules skipped for lack of a verified source
None of the proposed strings were dropped — every rule above is backed by either the Servarr GitHub source or the user's live Sonarr 4.0.16 instance.

## Also
- `guidance.go` (agent guide + `admin-download-triage` prompt) now mentions `get_arr_health` for config root causes and that `diagnose_queue` prints the exact next call.
- `README.md` + `server/README.md`: tool count 25 → 26, with the new `get_arr_health` row in the server tool table.

## Verification
- `gofmt`/`go vet` clean; `go test ./...` from `server/` passes (incl. `TestToolDefinitionsDeclarePermissions` + extended `doctor_test.go` + new `import_doctor_test.go` covering `nextCalls`/`renderHealthSection`).
- `flutter analyze` shows no new issues (changed files clean; the 20 remaining info lints are pre-existing in unrelated UI files); `flutter test` of the extended `import_doctor_test.dart` passes (21 cases).
- Go and Dart catalogs verified identical in prefixes/severity/actions (Dart has no `none` enum value, so Go `[ActionNone]` ↔ Dart `[]` per the existing convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEChSmKSXg8UDF5TY8aWpE