### PR TITLE
feat(remediation): Wave 1 — issue reporting (server)

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/mcp"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/push"
+	"github.com/windoze95/cantinarr-server/internal/remediation"
 	"github.com/windoze95/cantinarr-server/internal/request"
 	"github.com/windoze95/cantinarr-server/internal/secrets"
 	"github.com/windoze95/cantinarr-server/internal/tautulli"
@@ -152,10 +153,12 @@ func main() {
 	wsHub := ws.NewHub(authService, registry, instanceStore, contentNotifier)
 	go wsHub.Run(ctx)
 
-	// Request service. Request decisions fan out to both the WebSocket hub
-	// (live clients) and the push gateway (offline devices). The push notifier
-	// is only added to the fan-out when push is configured.
-	var notifier request.Notifier
+	// Notifier composite. Request decisions and issue events fan out to both the
+	// WebSocket hub (live clients) and the push gateway (offline devices). The
+	// push notifier is only added to the fan-out when push is configured. The
+	// concrete *push.Composite satisfies both request.Notifier and
+	// remediation.Notifier, so the same fan-out drives both.
+	var notifier *push.Composite
 	if pushNotifier != nil {
 		notifier = push.NewComposite(wsHub, pushNotifier)
 	} else {
@@ -163,6 +166,11 @@ func main() {
 	}
 	requestService := request.NewService(database, registry, bridge, notifier)
 	requestHandler := request.NewHandler(requestService)
+
+	// Remediation (issue reporting) service + handler. Wave 1 records and threads
+	// issues only; no AI agent is wired yet.
+	remediationService := remediation.NewService(database, registry, bridge, notifier)
+	remediationHandler := remediation.NewHandler(remediationService)
 
 	// Proxy handler
 	proxyHandler := proxy.NewHandler(instanceStore)
@@ -177,7 +185,7 @@ func main() {
 	discoverHandler := discover.NewHandler(creds, apiCache)
 
 	// Router
-	router := api.NewRouter(cfg, authHandler, authService, requestHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler)
+	router := api.NewRouter(cfg, authHandler, authService, requestHandler, remediationService, remediationHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler)
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	log.Printf("Cantinarr server starting on %s", addr)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -19,6 +19,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/mcpserver"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/push"
+	"github.com/windoze95/cantinarr-server/internal/remediation"
 	"github.com/windoze95/cantinarr-server/internal/request"
 	"github.com/windoze95/cantinarr-server/internal/tautulli"
 	"github.com/windoze95/cantinarr-server/internal/web"
@@ -30,6 +31,8 @@ func NewRouter(
 	authHandler *auth.Handler,
 	authService *auth.Service,
 	requestHandler *request.Handler,
+	remediationService *remediation.Service,
+	remediationHandler *remediation.Handler,
 	proxyHandler *proxy.Handler,
 	wsHub *ws.Hub,
 	aiHandler *ai.Handler,
@@ -154,12 +157,19 @@ func NewRouter(
 			r.With(auth.RequirePermission(auth.PermissionRequestsManage)).Put("/request-settings", requestHandler.UpdateSettings)
 			r.With(auth.RequirePermission(auth.PermissionRequestsManage)).Get("/users/{userID}/request-settings", requestHandler.GetUserSettings)
 			r.With(auth.RequirePermission(auth.PermissionRequestsManage)).Put("/users/{userID}/request-settings", requestHandler.UpdateUserSettings)
+
+			// AI remediation: issue queue + dismissal + global settings (Wave 1;
+			// the agent itself lands in later waves).
+			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/issues", remediationHandler.ListAdmin)
+			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Post("/issues/{id}/dismiss", remediationHandler.Dismiss)
+			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/remediation-settings", remediationHandler.GetSettings)
+			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Put("/remediation-settings", remediationHandler.UpdateSettings)
 		})
 
 		// Config route (authenticated)
 		r.Group(func(r chi.Router) {
 			r.Use(authService.AuthMiddleware)
-			r.Get("/config", configHandler(cfg, instanceStore, creds))
+			r.Get("/config", configHandler(cfg, instanceStore, creds, remediationService))
 		})
 
 		// Device push-token + notification preference routes (authenticated).
@@ -183,6 +193,16 @@ func NewRouter(
 			r.Get("/requests", requestHandler.List)
 			r.Get("/requests/options", requestHandler.Options)
 			r.Get("/requests/{tmdb_id}/status", requestHandler.GetStatus)
+		})
+
+		// Issue reporting (authenticated). Filing an issue needs the same
+		// permission as requesting media; viewing/replying to a single issue is
+		// gated in-handler to the issue's reporter or an admin.
+		r.Group(func(r chi.Router) {
+			r.Use(authService.AuthMiddleware)
+			r.With(auth.RequirePermission(auth.PermissionMediaRequest)).Post("/issues", remediationHandler.Create)
+			r.Get("/issues/{id}", remediationHandler.Get)
+			r.Post("/issues/{id}/reply", remediationHandler.Reply)
 		})
 
 		// Discover / media routes (authenticated)
@@ -341,7 +361,7 @@ func androidAssetLinksHandler(cfg *config.Config) http.HandlerFunc {
 	}
 }
 
-func configHandler(cfg *config.Config, store *instance.Store, creds *credentials.Registry) http.HandlerFunc {
+func configHandler(cfg *config.Config, store *instance.Store, creds *credentials.Registry, remediationService *remediation.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Build instances list
 		type instanceInfo struct {
@@ -379,6 +399,11 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 			}
 		}
 
+		// Remediation toggles so non-admin clients know whether to surface the
+		// "Report a problem" affordance: issues_enabled is the master switch,
+		// allow_reporting the user-facing affordance toggle.
+		remSettings := remediationService.Settings()
+
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"server_name": cfg.ServerName,
@@ -389,7 +414,9 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 				"tmdb":   creds.IsConfigured(credentials.KeyTMDBAccessToken),
 				"trakt":  creds.IsConfigured(credentials.KeyTraktClientID),
 			},
-			"instances": instances,
+			"instances":       instances,
+			"issues_enabled":  remSettings.Enabled,
+			"allow_reporting": remSettings.AllowReporting,
 		})
 	}
 }

--- a/server/internal/auth/permissions.go
+++ b/server/internal/auth/permissions.go
@@ -20,6 +20,7 @@ const (
 	PermissionCredentialsManage Permission = "credentials:manage"
 	PermissionAIToolsManage     Permission = "ai_tools:manage"
 	PermissionInstancesManage   Permission = "instances:manage"
+	PermissionRemediationManage Permission = "remediation:manage"
 	PermissionArrRead           Permission = "arr:read"
 	PermissionArrSearch         Permission = "arr:search"
 	PermissionArrBrowse         Permission = "arr:browse"
@@ -91,6 +92,7 @@ func allPermissions() map[Permission]bool {
 		PermissionCredentialsManage: true,
 		PermissionAIToolsManage:     true,
 		PermissionInstancesManage:   true,
+		PermissionRemediationManage: true,
 		PermissionArrRead:           true,
 		PermissionArrSearch:         true,
 		PermissionArrBrowse:         true,

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -100,7 +100,8 @@ CREATE TABLE IF NOT EXISTS notification_prefs (
     request_decision INTEGER NOT NULL DEFAULT 0,
     request_pending  INTEGER NOT NULL DEFAULT 1,
     new_movie        INTEGER NOT NULL DEFAULT 1,
-    new_episode      INTEGER NOT NULL DEFAULT 1
+    new_episode      INTEGER NOT NULL DEFAULT 1,
+    issue_created    INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE TABLE IF NOT EXISTS connect_tokens (
@@ -173,6 +174,123 @@ CREATE TABLE IF NOT EXISTS oauth_refresh_tokens (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     last_used_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
+
+-- AI remediation / issue reporting (Wave 1 ships issues + issue_messages; the
+-- agent_* tables are created now so later waves need no migration). One row per
+-- problem to work (auto-detected or user-reported). Media-scoped like
+-- request_log (tmdb_id + media_type), optionally narrowed to a season/episode
+-- for TV (0 = whole series/season, Overseerr's sentinel convention). The detail
+-- column and any user reason are UNTRUSTED free text: stored verbatim, never
+-- interpreted.
+CREATE TABLE IF NOT EXISTS issues (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,                       -- 'auto' | 'user'
+    status TEXT NOT NULL DEFAULT 'open',        -- open|investigating|awaiting_user|awaiting_approval|resolved|wont_fix|failed|dismissed
+    category TEXT,                              -- user pick: wrong_content|bad_copy|wrong_audio|other ; NULL for auto
+    reporter_id INTEGER REFERENCES users(id),  -- NULL for auto-detected
+    tmdb_id INTEGER NOT NULL,
+    tvdb_id INTEGER,
+    media_type TEXT NOT NULL,                   -- 'movie' | 'tv'
+    title TEXT NOT NULL DEFAULT '',
+    season_number INTEGER NOT NULL DEFAULT 0,   -- TV scope (0 = whole series / movie)
+    episode_number INTEGER NOT NULL DEFAULT 0,  -- TV scope (0 = whole season / movie)
+    instance_id TEXT,                          -- arr instance the fault came from (auto)
+    download_id TEXT,                          -- stable download-client hash (auto); keys dedupe + doctor tools
+    detail TEXT NOT NULL DEFAULT '',            -- user free-text reason OR doctor diagnosis summary (UNTRUSTED)
+    dedupe_key TEXT,                           -- stable idempotency key (auto); NULL allowed (user reports)
+    occurrences INTEGER NOT NULL DEFAULT 1,     -- bumped when a duplicate signal/report attaches
+    active_run_id INTEGER,                      -- CAS claim: at most one running run per issue
+    resolution TEXT,                           -- short closing note on a terminal state
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    closed_at DATETIME
+);
+-- At most one OPEN issue per dedupe_key, so the poller can INSERT ... WHERE NOT
+-- EXISTS exactly like createPending. This partial unique index is the SOLE
+-- idempotency guarantee for auto-dispatch.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_issues_open_dedupe
+    ON issues(dedupe_key) WHERE dedupe_key IS NOT NULL AND closed_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_issues_status ON issues(status);
+
+-- The user <-> agent <-> admin thread. Append-only. author_kind tags provenance
+-- so agent code NEVER treats a 'user'/'system' message as an instruction. body
+-- is UNTRUSTED when author_kind='user'.
+CREATE TABLE IF NOT EXISTS issue_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id INTEGER NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    author_kind TEXT NOT NULL,                  -- 'user' | 'agent' | 'admin' | 'system'
+    author_id INTEGER REFERENCES users(id),     -- set for user/admin; NULL for agent/system
+    body TEXT NOT NULL DEFAULT '',              -- UNTRUSTED when author_kind='user'
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_issue_messages_issue ON issue_messages(issue_id, id);
+
+-- One bounded investigation of one issue (later waves). Bounds + disposition +
+-- the resumable transcript live here.
+CREATE TABLE IF NOT EXISTS agent_runs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id INTEGER NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    trigger TEXT NOT NULL,                       -- 'auto'|'user_report'|'user_reply'|'approval_granted'|'approval_denied'
+    status TEXT NOT NULL DEFAULT 'running',      -- running|waiting_user|waiting_approval|succeeded|gave_up|failed|aborted
+    model TEXT NOT NULL DEFAULT '',
+    proc_generation TEXT NOT NULL DEFAULT '',    -- process-start token; watchdog uses it to tell crashed-mid-run from parked
+    step_count INTEGER NOT NULL DEFAULT 0,
+    input_tokens INTEGER NOT NULL DEFAULT 0,
+    output_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+    cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_micros INTEGER NOT NULL DEFAULT 0,      -- accumulated cost in millionths of a USD
+    active_seconds INTEGER NOT NULL DEFAULT 0,   -- wall-clock excluding paused waits
+    deadline_at DATETIME,                        -- active-work deadline; NULL while parked
+    stop_reason TEXT,                            -- resolved|max_steps|max_cost|timeout|repeated_failure|awaiting_approval|awaiting_user|tool_error
+    transcript_json TEXT NOT NULL DEFAULT '',    -- UNTRUNCATED provider-neutral transcript for resume (NOT the audit ledger)
+    started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    finished_at DATETIME
+);
+CREATE INDEX IF NOT EXISTS idx_agent_runs_issue ON agent_runs(issue_id);
+
+-- Per-step audit ledger (human-readable; truncated) for later waves. One row per
+-- model turn and per tool call. NOT used to rehydrate the transcript.
+CREATE TABLE IF NOT EXISTS agent_steps (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id INTEGER NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+    issue_id INTEGER NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    seq INTEGER NOT NULL,
+    kind TEXT NOT NULL,                          -- 'assistant'|'tool_call'|'tool_result'|'system'|'giveup'
+    tool_name TEXT,
+    tool_use_id TEXT,                           -- links a tool_result row to its originating tool_use
+    tool_input TEXT,                            -- JSON verbatim, truncated for display (UNTRUSTED if it echoes arr data)
+    tool_output TEXT,                           -- JSON/text verbatim, truncated
+    text TEXT,
+    is_error BOOLEAN NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_agent_steps_run ON agent_steps(run_id, seq);
+
+-- Admin-approvable proposed mutations (later waves; the heart of
+-- propose->approve->execute). Idempotency: UNIQUE(fingerprint) + a CAS UPDATE
+-- guarantee an action runs at most once.
+CREATE TABLE IF NOT EXISTS agent_actions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    issue_id INTEGER NOT NULL REFERENCES issues(id) ON DELETE CASCADE,
+    run_id INTEGER REFERENCES agent_runs(id),
+    tool_use_id TEXT,                           -- the propose_action tool_use.id, so the resume tool_result pairs correctly
+    kind TEXT NOT NULL,                          -- grab_release|remediate_queue|manual_import|trigger_search|rescan
+    params TEXT NOT NULL DEFAULT '{}',           -- JSON: the exact typed args to replay on approval
+    rationale TEXT NOT NULL DEFAULT '',          -- agent's plain-language justification (UNTRUSTED — render as text)
+    risk TEXT NOT NULL DEFAULT 'mutating',       -- 'mutating' (always gated) | 'safe' (auto-exec only if opted in)
+    status TEXT NOT NULL DEFAULT 'proposed',     -- proposed|approved|executing|executed|denied|failed|superseded
+    fingerprint TEXT NOT NULL,                   -- sha256(issue_id|kind|canonical(params)) — UNIQUE
+    decided_by INTEGER REFERENCES users(id),
+    decided_at DATETIME,
+    deny_reason TEXT,
+    executed_at DATETIME,
+    result_text TEXT,                            -- execution outcome, mirrored back into agent_steps + transcript
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_actions_fingerprint ON agent_actions(fingerprint);
+CREATE INDEX IF NOT EXISTS idx_agent_actions_status ON agent_actions(status);
+CREATE INDEX IF NOT EXISTS idx_agent_actions_issue ON agent_actions(issue_id);
 `
 
 func Open(dbPath string) (*sql.DB, error) {
@@ -234,6 +352,9 @@ func Open(dbPath string) (*sql.DB, error) {
 		// instead of creating a duplicate. Empty for rows created before this
 		// column or by clients that can't provide one (e.g. web).
 		{alter: "ALTER TABLE devices ADD COLUMN hardware_id TEXT NOT NULL DEFAULT ''"},
+		// AI remediation: admins are notified of new issues by default (on),
+		// matching request_pending. New on existing databases.
+		{alter: "ALTER TABLE notification_prefs ADD COLUMN issue_created INTEGER NOT NULL DEFAULT 1"},
 	}
 	for _, m := range migrations {
 		if _, err := db.Exec(m.alter); err != nil {

--- a/server/internal/push/handler_test.go
+++ b/server/internal/push/handler_test.go
@@ -36,7 +36,7 @@ func TestGetPreferencesDefaults(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true}
+	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true, IssueCreated: true}
 	if got != want {
 		t.Errorf("prefs = %+v, want %+v", got, want)
 	}

--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -65,20 +65,35 @@ func (n *Notifier) NotifyUser(userID int64, eventType string, data map[string]in
 	n.send(client, []int64{userID}, title, body, passthrough(CategoryRequestDecision, data))
 }
 
-// NotifyAdmins pushes a new pending request to every admin who has opted into
-// the request_pending category (on by default). Only "request_pending" events
-// produce a notification.
+// NotifyAdmins pushes an admin-scoped event to every admin opted into the
+// matching category. Two events produce a notification today: "request_pending"
+// (a new media request) and "issue_created" (a new AI-remediation issue, on by
+// default). Any other event type is a no-op here (WS-only).
+//
+// Untrusted-text invariant (M5): the alert body is a FIXED server-authored
+// template, never an interpolated title/reason; the media title travels only as
+// a structured passthrough field (and as the request alert's body, which is
+// arr/user-sourced and unchanged from existing behavior).
 func (n *Notifier) NotifyAdmins(eventType string, data map[string]interface{}) {
 	client := n.client()
-	if client == nil || eventType != CategoryRequestPending {
+	if client == nil {
 		return
 	}
+	switch eventType {
+	case CategoryRequestPending:
+		n.notifyRequestPending(client, data)
+	case CategoryIssueCreated:
+		n.notifyIssueCreated(client, data)
+	}
+}
 
+// notifyRequestPending pushes a new pending request to opted-in admins, badging
+// the home-screen icon with the live queue depth.
+func (n *Notifier) notifyRequestPending(client *Client, data map[string]interface{}) {
 	title := str(data["title"])
 	if title == "" {
 		title = "a title"
 	}
-
 	recipients, err := n.prefs.usersOptedInto(CategoryRequestPending)
 	if err != nil {
 		n.logger.Error("push: resolve request_pending recipients", "err", err)
@@ -87,7 +102,6 @@ func (n *Notifier) NotifyAdmins(eventType string, data map[string]interface{}) {
 	if len(recipients) == 0 {
 		return
 	}
-
 	// Set the home-screen icon badge to the live queue depth so admins see the
 	// count even while the app is closed (the gateway maps this to aps.badge).
 	var opts SendOptions
@@ -95,6 +109,30 @@ func (n *Notifier) NotifyAdmins(eventType string, data map[string]interface{}) {
 		opts.Badge = &count
 	}
 	n.sendWithOptions(client, recipients, "New request", title, passthrough(CategoryRequestPending, data), opts)
+}
+
+// notifyIssueCreated pushes a new AI-remediation issue to opted-in admins. The
+// body is a fixed template (the untrusted issue title is NOT placed on the
+// lock screen); issue_id rides along for tap deep-linking and open_count badges
+// the icon.
+func (n *Notifier) notifyIssueCreated(client *Client, data map[string]interface{}) {
+	recipients, err := n.prefs.usersOptedInto(CategoryIssueCreated)
+	if err != nil {
+		n.logger.Error("push: resolve issue_created recipients", "err", err)
+		return
+	}
+	if len(recipients) == 0 {
+		return
+	}
+	out := map[string]any{"type": CategoryIssueCreated}
+	if v, ok := data["issue_id"]; ok {
+		out["issue_id"] = v
+	}
+	var opts SendOptions
+	if count, ok := intval(data["open_count"]); ok {
+		opts.Badge = &count
+	}
+	n.sendWithOptions(client, recipients, "New problem reported", "Someone reported a problem with their media", out, opts)
 }
 
 // NotifyNewMovie pushes a "movie became available" alert to every user opted

--- a/server/internal/push/prefs.go
+++ b/server/internal/push/prefs.go
@@ -12,6 +12,7 @@ type Prefs struct {
 	RequestPending  bool `json:"request_pending"`
 	NewMovie        bool `json:"new_movie"`
 	NewEpisode      bool `json:"new_episode"`
+	IssueCreated    bool `json:"issue_created"`
 }
 
 // Notification categories. These are the wire values used by the preferences
@@ -21,6 +22,9 @@ const (
 	CategoryRequestPending  = "request_pending"
 	CategoryNewMovie        = "new_movie"
 	CategoryNewEpisode      = "new_episode"
+	// CategoryIssueCreated notifies admins of a new AI-remediation issue
+	// (user-reported or auto-detected). Admin-scoped, on by default.
+	CategoryIssueCreated = "issue_created"
 )
 
 // defaultPrefs is the preference set applied when a user has no row. It must
@@ -31,6 +35,7 @@ var defaultPrefs = Prefs{
 	RequestPending:  true,
 	NewMovie:        true,
 	NewEpisode:      true,
+	IssueCreated:    true,
 }
 
 // categoryColumn maps a category to its notification_prefs column and the
@@ -44,6 +49,7 @@ var categoryColumn = map[string]struct {
 	CategoryRequestPending:  {"request_pending", defaultPrefs.RequestPending},
 	CategoryNewMovie:        {"new_movie", defaultPrefs.NewMovie},
 	CategoryNewEpisode:      {"new_episode", defaultPrefs.NewEpisode},
+	CategoryIssueCreated:    {"issue_created", defaultPrefs.IssueCreated},
 }
 
 // PrefsStore reads and writes per-user notification preferences. It is safe to
@@ -62,10 +68,10 @@ func NewPrefsStore(db *sql.DB) *PrefsStore {
 func (s *PrefsStore) Get(userID int64) (Prefs, error) {
 	p := defaultPrefs
 	err := s.db.QueryRow(
-		`SELECT request_decision, request_pending, new_movie, new_episode
+		`SELECT request_decision, request_pending, new_movie, new_episode, issue_created
 		 FROM notification_prefs WHERE user_id = ?`,
 		userID,
-	).Scan(&p.RequestDecision, &p.RequestPending, &p.NewMovie, &p.NewEpisode)
+	).Scan(&p.RequestDecision, &p.RequestPending, &p.NewMovie, &p.NewEpisode, &p.IssueCreated)
 	if err == sql.ErrNoRows {
 		return defaultPrefs, nil
 	}
@@ -79,14 +85,15 @@ func (s *PrefsStore) Get(userID int64) (Prefs, error) {
 func (s *PrefsStore) Set(userID int64, p Prefs) error {
 	_, err := s.db.Exec(
 		`INSERT INTO notification_prefs
-		   (user_id, request_decision, request_pending, new_movie, new_episode)
-		 VALUES (?, ?, ?, ?, ?)
+		   (user_id, request_decision, request_pending, new_movie, new_episode, issue_created)
+		 VALUES (?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(user_id) DO UPDATE SET
 		   request_decision = excluded.request_decision,
 		   request_pending  = excluded.request_pending,
 		   new_movie        = excluded.new_movie,
-		   new_episode      = excluded.new_episode`,
-		userID, p.RequestDecision, p.RequestPending, p.NewMovie, p.NewEpisode,
+		   new_episode      = excluded.new_episode,
+		   issue_created    = excluded.issue_created`,
+		userID, p.RequestDecision, p.RequestPending, p.NewMovie, p.NewEpisode, p.IssueCreated,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert notification prefs: %w", err)
@@ -114,7 +121,8 @@ func (s *PrefsStore) usersOptedInto(category string) ([]int64, error) {
 		 WHERE COALESCE(p.%s, %d) = 1`,
 		col.column, def,
 	)
-	if category == CategoryRequestPending {
+	// Admin-scoped categories: only admins act on pending requests or issues.
+	if category == CategoryRequestPending || category == CategoryIssueCreated {
 		query += " AND u.role = 'admin'"
 	}
 

--- a/server/internal/push/prefs_test.go
+++ b/server/internal/push/prefs_test.go
@@ -18,7 +18,7 @@ func TestPrefsGetDefaultsForMissingRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true}
+	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true, IssueCreated: true}
 	if got != want {
 		t.Errorf("default prefs = %+v, want %+v", got, want)
 	}

--- a/server/internal/remediation/handler.go
+++ b/server/internal/remediation/handler.go
@@ -1,0 +1,200 @@
+package remediation
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/auth"
+)
+
+// Handler exposes the Wave-1 issue-reporting REST surface. It clones the shape
+// of request.Handler (claims gate, JSON helpers, decodeOptional).
+type Handler struct {
+	service *Service
+}
+
+func NewHandler(service *Service) *Handler {
+	return &Handler{service: service}
+}
+
+// Create handles POST /api/issues (PermissionMediaRequest). The reporter is the
+// authenticated user; reason/title are UNTRUSTED.
+func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	var req CreateIssueRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if req.MediaType == "" || req.Category == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "media_type and category required"})
+		return
+	}
+	if req.TmdbID == 0 && req.TvdbID == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "tmdb_id or tvdb_id required"})
+		return
+	}
+
+	resp, err := h.service.CreateUserIssue(claims.UserID, &req)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// Get handles GET /api/issues/{id} (the issue's reporter or an admin). Returns
+// the issue plus its thread.
+func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid issue id"})
+		return
+	}
+
+	issue, err := h.service.GetIssue(id)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+	if !canAccessIssue(claims, issue) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+
+	thread, err := h.service.IssueThread(id)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, IssueDetail{Issue: *issue, Thread: thread})
+}
+
+// Reply handles POST /api/issues/{id}/reply (the issue's reporter or an admin).
+// authorKind is derived from the caller's role; body is UNTRUSTED.
+func (h *Handler) Reply(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid issue id"})
+		return
+	}
+
+	issue, err := h.service.GetIssue(id)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+		return
+	}
+	if !canAccessIssue(claims, issue) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "forbidden"})
+		return
+	}
+
+	var body struct {
+		Body string `json:"body"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if body.Body == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "body required"})
+		return
+	}
+
+	authorKind := AuthorUser
+	if auth.HasPermission(claims.Role, auth.PermissionAdmin) {
+		authorKind = AuthorAdmin
+	}
+	if err := h.service.PostReply(id, authorKind, claims.UserID, body.Body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+// ListAdmin handles GET /api/admin/issues?status= (PermissionRemediationManage).
+func (h *Handler) ListAdmin(w http.ResponseWriter, r *http.Request) {
+	status := r.URL.Query().Get("status")
+	issues, err := h.service.ListIssues(status)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, ListIssuesResponse{Issues: issues})
+}
+
+// Dismiss handles POST /api/admin/issues/{id}/dismiss (PermissionRemediationManage).
+func (h *Handler) Dismiss(w http.ResponseWriter, r *http.Request) {
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid issue id"})
+		return
+	}
+	if err := h.service.DismissIssue(id); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
+}
+
+// GetSettings handles GET /api/admin/remediation-settings (PermissionRemediationManage).
+func (h *Handler) GetSettings(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, h.service.Settings())
+}
+
+// UpdateSettings handles PUT /api/admin/remediation-settings (PermissionRemediationManage).
+// Returns the normalized stored settings.
+func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
+	var settings Settings
+	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	saved, err := h.service.SetSettings(settings)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, saved)
+}
+
+// canAccessIssue allows an admin, or the issue's own reporter, to view/reply.
+func canAccessIssue(claims *auth.Claims, issue *Issue) bool {
+	if auth.HasPermission(claims.Role, auth.PermissionAdmin) {
+		return true
+	}
+	return issue.ReporterID != nil && *issue.ReporterID == claims.UserID
+}
+
+// decodeOptional decodes a JSON body, tolerating an empty body.
+func decodeOptional(r *http.Request, v interface{}) error {
+	if err := json.NewDecoder(r.Body).Decode(v); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}

--- a/server/internal/remediation/models.go
+++ b/server/internal/remediation/models.go
@@ -1,0 +1,132 @@
+// Package remediation implements Cantinarr's issue-reporting data model, the
+// service that records and threads issues, and the admin REST surface. Wave 1
+// ships issue reporting only: there is no AI agent here yet (the agent loop,
+// Runner, Executor, agent-only tools, and auto-dispatch arrive in later waves).
+//
+// All user-supplied text (an issue's detail/reason and any message body) is
+// UNTRUSTED: it is stored verbatim and never interpreted as an instruction.
+package remediation
+
+import "time"
+
+// Issue status values stored in issues.status and returned to clients. The
+// state machine spans the whole feature; Wave 1 only ever sets IssueOpen (on
+// create) and IssueDismissed (admin dismiss). The rest are defined now so the
+// API contract and later waves agree.
+const (
+	IssueOpen             = "open"
+	IssueInvestigating    = "investigating"
+	IssueAwaitingUser     = "awaiting_user"
+	IssueAwaitingApproval = "awaiting_approval"
+	IssueResolved         = "resolved"
+	IssueWontFix          = "wont_fix"
+	IssueFailed           = "failed"
+	IssueDismissed        = "dismissed"
+)
+
+// Issue source values.
+const (
+	SourceUser = "user"
+	SourceAuto = "auto"
+)
+
+// User-selectable issue categories (NULL/"" for auto-detected issues).
+const (
+	CategoryWrongContent = "wrong_content"
+	CategoryBadCopy      = "bad_copy"
+	CategoryWrongAudio   = "wrong_audio"
+	CategoryOther        = "other"
+)
+
+// Message author kinds. Provenance tag so agent code never treats a user/system
+// message as an instruction.
+const (
+	AuthorUser   = "user"
+	AuthorAgent  = "agent"
+	AuthorAdmin  = "admin"
+	AuthorSystem = "system"
+)
+
+// Action lifecycle status values (agent_actions.status). Used by later waves;
+// defined now so the table vocabulary is stable.
+const (
+	ActionProposed   = "proposed"
+	ActionApproved   = "approved"
+	ActionExecuting  = "executing"
+	ActionExecuted   = "executed"
+	ActionDenied     = "denied"
+	ActionFailed     = "failed"
+	ActionSuperseded = "superseded"
+)
+
+// ActionKind enumerates the proposable arr mutations (later waves).
+type ActionKind string
+
+const (
+	ActionGrabRelease    ActionKind = "grab_release"
+	ActionRemediateQueue ActionKind = "remediate_queue" // remove | blocklist_search | change_category
+	ActionManualImport   ActionKind = "manual_import"   // force bool
+	ActionTriggerSearch  ActionKind = "trigger_search"
+	ActionRescan         ActionKind = "rescan"
+)
+
+// Issue is one row of the issues table as returned to clients. Nullable columns
+// (category, reporter) are exposed as pointers so the JSON carries null, matching
+// the Wave-1 API contract exactly.
+type Issue struct {
+	ID            int64     `json:"id"`
+	Source        string    `json:"source"`        // "user" | "auto"
+	Status        string    `json:"status"`        // see Issue* consts
+	Category      *string   `json:"category"`      // null for auto
+	ReporterID    *int64    `json:"reporter_id"`   // null for auto
+	ReporterName  *string   `json:"reporter_name"` // null for auto / unknown
+	TmdbID        int       `json:"tmdb_id"`
+	MediaType     string    `json:"media_type"` // "movie" | "tv"
+	Title         string    `json:"title"`
+	SeasonNumber  int       `json:"season_number"`  // 0 = whole series / movie
+	EpisodeNumber int       `json:"episode_number"` // 0 = whole season / movie
+	Detail        string    `json:"detail"`         // UNTRUSTED free text
+	Occurrences   int       `json:"occurrences"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// IssueMessage is one row of an issue's append-only thread.
+type IssueMessage struct {
+	ID         int64     `json:"id"`
+	AuthorKind string    `json:"author_kind"` // "user" | "agent" | "admin" | "system"
+	AuthorName *string   `json:"author_name"` // null for agent/system / unknown
+	Body       string    `json:"body"`        // UNTRUSTED when author_kind="user"
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// IssueDetail is the GET /api/issues/{id} payload: the issue plus its thread.
+type IssueDetail struct {
+	Issue  Issue          `json:"issue"`
+	Thread []IssueMessage `json:"thread"`
+}
+
+// CreateIssueRequest is the POST /api/issues body (snake_case wire contract).
+// Reason/Title are UNTRUSTED. SeasonNumber 0 = whole series; EpisodeNumber 0 =
+// whole season.
+type CreateIssueRequest struct {
+	MediaType     string `json:"media_type"` // "movie" | "tv"
+	TmdbID        int    `json:"tmdb_id"`
+	TvdbID        int    `json:"tvdb_id"`
+	SeasonNumber  int    `json:"season_number"`
+	EpisodeNumber int    `json:"episode_number"`
+	Category      string `json:"category"` // wrong_content|bad_copy|wrong_audio|other
+	Reason        string `json:"reason"`   // UNTRUSTED free text
+	Title         string `json:"title"`    // UNTRUSTED display hint
+}
+
+// CreateIssueResponse is the POST /api/issues result.
+type CreateIssueResponse struct {
+	IssueID int64  `json:"issue_id"`
+	Status  string `json:"status"`
+}
+
+// ListIssuesResponse is the GET /api/admin/issues result.
+type ListIssuesResponse struct {
+	Issues []Issue `json:"issues"`
+}

--- a/server/internal/remediation/service.go
+++ b/server/internal/remediation/service.go
@@ -1,0 +1,416 @@
+package remediation
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/windoze95/cantinarr-server/internal/arr"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+	"github.com/windoze95/cantinarr-server/internal/tmdb"
+)
+
+// Notifier delivers realtime events about issues. The websocket hub (and the
+// push composite) satisfy this; it is optional and may be nil. Same shape as
+// request.Notifier so the existing fan-out is reused verbatim.
+type Notifier interface {
+	NotifyUser(userID int64, eventType string, data map[string]interface{})
+	NotifyAdmins(eventType string, data map[string]interface{})
+}
+
+// Service records, threads, lists, and dismisses issues, and owns the global
+// remediation settings. It mirrors request.Service (db + registry + bridge +
+// notifier). No AI agent is wired in Wave 1: OpenAutoIssue exists and dedupes
+// correctly, but nothing calls it until auto-dispatch lands.
+type Service struct {
+	db       *sql.DB
+	registry *instance.Registry
+	bridge   *tmdb.Bridge
+	notifier Notifier
+}
+
+// NewService constructs the remediation service, mirroring request.NewService.
+func NewService(db *sql.DB, registry *instance.Registry, bridge *tmdb.Bridge, notifier Notifier) *Service {
+	return &Service{
+		db:       db,
+		registry: registry,
+		bridge:   bridge,
+		notifier: notifier,
+	}
+}
+
+// validCategory reports whether a user-selected category is one of the known
+// values.
+func validCategory(c string) bool {
+	switch c {
+	case CategoryWrongContent, CategoryBadCopy, CategoryWrongAudio, CategoryOther:
+		return true
+	}
+	return false
+}
+
+// CreateUserIssue records a user-reported problem. It validates the media type
+// and category, dedupes a duplicate open report from the same reporter+scope+
+// category (bumping occurrences rather than inserting a second row), inserts
+// otherwise, notifies admins, and returns the issue id + status.
+//
+// All free text (Reason, Title) is UNTRUSTED and stored verbatim. When tmdb_id
+// is 0 but tvdb_id is set, a best-effort reverse lookup of the cached
+// tmdb<->tvdb mapping is attempted; otherwise the ids are stored as given.
+func (s *Service) CreateUserIssue(reporterID int64, req *CreateIssueRequest) (*CreateIssueResponse, error) {
+	if req.MediaType != "movie" && req.MediaType != "tv" {
+		return nil, fmt.Errorf("unsupported media type: %s", req.MediaType)
+	}
+	if !validCategory(req.Category) {
+		return nil, fmt.Errorf("invalid category: %s", req.Category)
+	}
+
+	tmdbID := req.TmdbID
+	tvdbID := req.TvdbID
+	// Resolve a missing tmdb_id from a known tvdb_id via the cached mapping the
+	// ID bridge maintains (request flows populate tmdb_tvdb_cache). There is no
+	// live reverse resolver, so this is best-effort: on a miss the ids are stored
+	// as given, which the contract permits.
+	if tmdbID == 0 && tvdbID != 0 {
+		var cached int
+		if err := s.db.QueryRow("SELECT tmdb_id FROM tmdb_tvdb_cache WHERE tvdb_id = ?", tvdbID).Scan(&cached); err == nil && cached != 0 {
+			tmdbID = cached
+		}
+	}
+
+	season := req.SeasonNumber
+	episode := req.EpisodeNumber
+	if req.MediaType == "movie" {
+		// Movies have no season/episode scope; keep the stored row clean.
+		season = 0
+		episode = 0
+	}
+
+	// Dedupe a duplicate open report: the same reporter re-reporting the same
+	// scope (tmdb + media_type + season + episode) with the same category bumps
+	// occurrences instead of opening a second issue. The check + insert is one
+	// statement under the single-writer DB, mirroring createPending.
+	res, err := s.db.Exec(
+		`INSERT INTO issues
+			(source, status, category, reporter_id, tmdb_id, tvdb_id, media_type, title, season_number, episode_number, detail)
+		 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+		 WHERE NOT EXISTS (
+			SELECT 1 FROM issues
+			WHERE source = ? AND reporter_id = ? AND tmdb_id = ? AND media_type = ?
+			  AND season_number = ? AND episode_number = ? AND category = ? AND closed_at IS NULL
+		 )`,
+		SourceUser, IssueOpen, req.Category, reporterID, tmdbID, sqlNullInt(tvdbID), req.MediaType, req.Title, season, episode, req.Reason,
+		SourceUser, reporterID, tmdbID, req.MediaType, season, episode, req.Category,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create issue: %w", err)
+	}
+
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		// Duplicate open report: bump occurrences + refresh updated_at on the
+		// existing open issue, and return it.
+		id, derr := s.bumpDuplicateUserIssue(reporterID, req, tmdbID, season, episode)
+		if derr != nil {
+			return nil, derr
+		}
+		return &CreateIssueResponse{IssueID: id, Status: IssueOpen}, nil
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return nil, fmt.Errorf("create issue: %w", err)
+	}
+
+	s.notifyIssueCreated(id, req.Title)
+	return &CreateIssueResponse{IssueID: id, Status: IssueOpen}, nil
+}
+
+// bumpDuplicateUserIssue increments occurrences on the existing open issue that
+// matched the dedupe predicate and returns its id.
+func (s *Service) bumpDuplicateUserIssue(reporterID int64, req *CreateIssueRequest, tmdbID, season, episode int) (int64, error) {
+	var id int64
+	err := s.db.QueryRow(
+		`SELECT id FROM issues
+		 WHERE source = ? AND reporter_id = ? AND tmdb_id = ? AND media_type = ?
+		   AND season_number = ? AND episode_number = ? AND category = ? AND closed_at IS NULL
+		 ORDER BY id DESC LIMIT 1`,
+		SourceUser, reporterID, tmdbID, req.MediaType, season, episode, req.Category,
+	).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("find duplicate issue: %w", err)
+	}
+	if _, err := s.db.Exec(
+		"UPDATE issues SET occurrences = occurrences + 1, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+		id,
+	); err != nil {
+		return 0, fmt.Errorf("bump duplicate issue: %w", err)
+	}
+	return id, nil
+}
+
+// OpenAutoIssue is the poller hook for auto-detected problems (later waves; no
+// caller in Wave 1). It conditionally inserts an issue keyed by a stable
+// dedupe_key so the same stuck download opens at most one open issue across many
+// polls, mirroring createPending. On a duplicate it bumps occurrences and
+// returns created=false. A terminal (closed) issue does not block a genuinely
+// new recurrence: once closed_at is set the partial unique index no longer
+// guards that key, so the same download re-failing later opens a fresh issue.
+func (s *Service) OpenAutoIssue(scope, instanceID, downloadID string, d arr.Diagnosis) (created bool, id int64) {
+	sum := sha256.Sum256([]byte(instanceID + "|" + downloadID + "|" + d.Problem))
+	dedupeKey := hex.EncodeToString(sum[:])
+
+	res, err := s.db.Exec(
+		`INSERT INTO issues
+			(source, status, media_type, tmdb_id, title, instance_id, download_id, detail, dedupe_key)
+		 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?
+		 WHERE NOT EXISTS (
+			SELECT 1 FROM issues WHERE dedupe_key = ? AND closed_at IS NULL
+		 )`,
+		SourceAuto, IssueOpen, scope, 0, d.Problem, sqlNullStr(instanceID), sqlNullStr(downloadID), d.Transparency, dedupeKey,
+		dedupeKey,
+	)
+	if err != nil {
+		return false, 0
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		// Existing open issue for this key: bump occurrences, no new issue.
+		s.db.Exec(
+			"UPDATE issues SET occurrences = occurrences + 1, updated_at = CURRENT_TIMESTAMP WHERE dedupe_key = ? AND closed_at IS NULL",
+			dedupeKey,
+		)
+		return false, 0
+	}
+	newID, err := res.LastInsertId()
+	if err != nil {
+		return false, 0
+	}
+	s.notifyIssueCreated(newID, d.Problem)
+	return true, newID
+}
+
+// notifyIssueCreated fires the issue_created admin notification carrying the
+// live open-issue count for badging. The title is passed as a structured field
+// (arr/user-sourced) — the push layer builds the human-readable body from fixed
+// templates, never by interpolating it.
+func (s *Service) notifyIssueCreated(issueID int64, title string) {
+	if s.notifier == nil {
+		return
+	}
+	data := map[string]interface{}{
+		"issue_id": issueID,
+		"title":    title,
+	}
+	if count, err := s.OpenIssueCount(); err == nil {
+		data["open_count"] = count
+	}
+	s.notifier.NotifyAdmins("issue_created", data)
+}
+
+// GetIssue loads one issue row (without its thread).
+func (s *Service) GetIssue(issueID int64) (*Issue, error) {
+	row := s.db.QueryRow(
+		`SELECT i.id, i.source, i.status, i.category, i.reporter_id, u.username,
+		        i.tmdb_id, i.media_type, i.title, i.season_number, i.episode_number,
+		        i.detail, i.occurrences, i.created_at, i.updated_at
+		 FROM issues i LEFT JOIN users u ON u.id = i.reporter_id
+		 WHERE i.id = ?`,
+		issueID,
+	)
+	iss, err := scanIssue(row)
+	if err == sql.ErrNoRows {
+		return nil, fmt.Errorf("issue not found")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load issue: %w", err)
+	}
+	return iss, nil
+}
+
+// IssueThread returns an issue's append-only message thread, oldest first.
+func (s *Service) IssueThread(issueID int64) ([]IssueMessage, error) {
+	rows, err := s.db.Query(
+		`SELECT m.id, m.author_kind, u.username, m.body, m.created_at
+		 FROM issue_messages m LEFT JOIN users u ON u.id = m.author_id
+		 WHERE m.issue_id = ? ORDER BY m.id ASC`,
+		issueID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query thread: %w", err)
+	}
+	defer rows.Close()
+
+	out := []IssueMessage{}
+	for rows.Next() {
+		var m IssueMessage
+		var name sql.NullString
+		if err := rows.Scan(&m.ID, &m.AuthorKind, &name, &m.Body, &m.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan message: %w", err)
+		}
+		if name.Valid {
+			v := name.String
+			m.AuthorName = &v
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
+// PostReply appends a message to an issue's thread. The caller's role decides
+// authorKind (the handler passes "admin" or "user"); body is UNTRUSTED and
+// stored verbatim. Touching updated_at keeps the issue sorted as recently
+// active. On a reporter/admin reply the other party is notified via the WS hub.
+func (s *Service) PostReply(issueID int64, authorKind string, authorID int64, body string) error {
+	// Confirm the issue exists (and read its reporter for notification routing).
+	var reporterID sql.NullInt64
+	err := s.db.QueryRow("SELECT reporter_id FROM issues WHERE id = ?", issueID).Scan(&reporterID)
+	if err == sql.ErrNoRows {
+		return fmt.Errorf("issue not found")
+	}
+	if err != nil {
+		return fmt.Errorf("load issue: %w", err)
+	}
+
+	if _, err := s.db.Exec(
+		"INSERT INTO issue_messages (issue_id, author_kind, author_id, body) VALUES (?, ?, ?, ?)",
+		issueID, authorKind, sqlNullInt64(authorID), body,
+	); err != nil {
+		return fmt.Errorf("post reply: %w", err)
+	}
+	s.db.Exec("UPDATE issues SET updated_at = CURRENT_TIMESTAMP WHERE id = ?", issueID)
+
+	// Ping the counterpart so a live thread refreshes. Body text is never put on
+	// the notification; only the issue id + a fixed event string travel.
+	if s.notifier != nil {
+		if authorKind == AuthorAdmin && reporterID.Valid {
+			s.notifier.NotifyUser(reporterID.Int64, "issue_updated", map[string]interface{}{"issue_id": issueID})
+		} else if authorKind == AuthorUser {
+			s.notifier.NotifyAdmins("issue_updated", map[string]interface{}{"issue_id": issueID})
+		}
+	}
+	return nil
+}
+
+// ListIssues returns issues for the admin queue (newest first), optionally
+// filtered by status. An empty/blank status returns all issues.
+func (s *Service) ListIssues(status string) ([]Issue, error) {
+	query := `SELECT i.id, i.source, i.status, i.category, i.reporter_id, u.username,
+	                 i.tmdb_id, i.media_type, i.title, i.season_number, i.episode_number,
+	                 i.detail, i.occurrences, i.created_at, i.updated_at
+	          FROM issues i LEFT JOIN users u ON u.id = i.reporter_id`
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if status != "" {
+		rows, err = s.db.Query(query+" WHERE i.status = ? ORDER BY i.updated_at DESC, i.id DESC", status)
+	} else {
+		rows, err = s.db.Query(query + " ORDER BY i.updated_at DESC, i.id DESC")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query issues: %w", err)
+	}
+	defer rows.Close()
+
+	out := []Issue{}
+	for rows.Next() {
+		iss, err := scanIssue(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan issue: %w", err)
+		}
+		out = append(out, *iss)
+	}
+	return out, rows.Err()
+}
+
+// DismissIssue marks an open (non-terminal) issue dismissed and closes it. The
+// CAS on closed_at IS NULL makes a double-dismiss a no-op.
+func (s *Service) DismissIssue(issueID int64) error {
+	res, err := s.db.Exec(
+		"UPDATE issues SET status = ?, closed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND closed_at IS NULL",
+		IssueDismissed, issueID,
+	)
+	if err != nil {
+		return fmt.Errorf("dismiss issue: %w", err)
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		// Either no such issue or already closed; treat as idempotent success
+		// only when the issue exists.
+		var exists int
+		if qerr := s.db.QueryRow("SELECT 1 FROM issues WHERE id = ?", issueID).Scan(&exists); qerr == sql.ErrNoRows {
+			return fmt.Errorf("issue not found")
+		}
+	}
+	return nil
+}
+
+// OpenIssueCount counts issues that are not in a terminal/closed state. It backs
+// the admin badge, mirroring request.PendingCount.
+func (s *Service) OpenIssueCount() (int, error) {
+	var n int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM issues WHERE closed_at IS NULL").Scan(&n); err != nil {
+		return 0, fmt.Errorf("count open issues: %w", err)
+	}
+	return n, nil
+}
+
+// rowScanner abstracts *sql.Row and *sql.Rows so scanIssue serves GetIssue and
+// ListIssues alike.
+type rowScanner interface {
+	Scan(dest ...interface{}) error
+}
+
+// scanIssue reads one issue row (joined to its reporter's username) into an
+// Issue, mapping NULL category/reporter to nil pointers for the JSON contract.
+func scanIssue(row rowScanner) (*Issue, error) {
+	var (
+		iss        Issue
+		category   sql.NullString
+		reporterID sql.NullInt64
+		reporter   sql.NullString
+	)
+	if err := row.Scan(
+		&iss.ID, &iss.Source, &iss.Status, &category, &reporterID, &reporter,
+		&iss.TmdbID, &iss.MediaType, &iss.Title, &iss.SeasonNumber, &iss.EpisodeNumber,
+		&iss.Detail, &iss.Occurrences, &iss.CreatedAt, &iss.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if category.Valid && category.String != "" {
+		v := category.String
+		iss.Category = &v
+	}
+	if reporterID.Valid {
+		v := reporterID.Int64
+		iss.ReporterID = &v
+	}
+	if reporter.Valid && reporter.String != "" {
+		v := reporter.String
+		iss.ReporterName = &v
+	}
+	return &iss, nil
+}
+
+// sqlNullInt / sqlNullInt64 / sqlNullStr map zero values to NULL for nullable
+// columns, mirroring the request package's helpers.
+func sqlNullInt(v int) interface{} {
+	if v == 0 {
+		return nil
+	}
+	return v
+}
+
+func sqlNullInt64(v int64) interface{} {
+	if v == 0 {
+		return nil
+	}
+	return v
+}
+
+func sqlNullStr(v string) interface{} {
+	if v == "" {
+		return nil
+	}
+	return v
+}

--- a/server/internal/remediation/service_test.go
+++ b/server/internal/remediation/service_test.go
@@ -1,0 +1,292 @@
+package remediation
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/db"
+)
+
+// fakeNotifier records the events fired so a test can assert that creating an
+// issue notifies admins. It satisfies the Notifier interface.
+type fakeNotifier struct {
+	adminEvents []string
+	userEvents  []string
+}
+
+func (f *fakeNotifier) NotifyUser(userID int64, eventType string, data map[string]interface{}) {
+	f.userEvents = append(f.userEvents, eventType)
+}
+
+func (f *fakeNotifier) NotifyAdmins(eventType string, data map[string]interface{}) {
+	f.adminEvents = append(f.adminEvents, eventType)
+}
+
+// setupTestService builds a remediation service over an in-memory DB (which runs
+// the real initSQL, so the issues/issue_messages tables exist) plus a seeded
+// reporter user. registry/bridge are nil: no Wave-1 issue method dereferences
+// them.
+func setupTestService(t *testing.T) (*Service, *fakeNotifier, int64) {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	reporterID := seedUser(t, database, "reporter")
+	notif := &fakeNotifier{}
+	return NewService(database, nil, nil, notif), notif, reporterID
+}
+
+func seedUser(t *testing.T, database *sql.DB, username string) int64 {
+	t.Helper()
+	res, err := database.Exec("INSERT INTO users (username, password_hash, role) VALUES (?, '', 'user')", username)
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("seed user id: %v", err)
+	}
+	return id
+}
+
+// TestUserIssueLifecycle walks the Wave-1 contract end to end: create a user
+// issue (admins notified), dedupe a duplicate report (occurrences bumps, no
+// second row), thread a reply, then list + dismiss.
+func TestUserIssueLifecycle(t *testing.T) {
+	svc, notif, reporterID := setupTestService(t)
+
+	req := &CreateIssueRequest{
+		MediaType:     "tv",
+		TmdbID:        42,
+		SeasonNumber:  2,
+		EpisodeNumber: 4,
+		Category:      CategoryWrongAudio,
+		Reason:        "Default audio track is Russian, I want English.",
+		Title:         "Some Show",
+	}
+
+	resp, err := svc.CreateUserIssue(reporterID, req)
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+	if resp.IssueID == 0 || resp.Status != IssueOpen {
+		t.Fatalf("CreateUserIssue resp = %+v, want non-zero id + open", resp)
+	}
+	if len(notif.adminEvents) != 1 || notif.adminEvents[0] != "issue_created" {
+		t.Fatalf("admin events = %v, want one issue_created", notif.adminEvents)
+	}
+
+	// Duplicate report (same reporter, scope, category): bumps occurrences and
+	// returns the SAME issue, without notifying again.
+	dup, err := svc.CreateUserIssue(reporterID, req)
+	if err != nil {
+		t.Fatalf("CreateUserIssue duplicate: %v", err)
+	}
+	if dup.IssueID != resp.IssueID {
+		t.Fatalf("duplicate issue id = %d, want same as original %d", dup.IssueID, resp.IssueID)
+	}
+	if len(notif.adminEvents) != 1 {
+		t.Fatalf("admin events after duplicate = %v, want still just one", notif.adminEvents)
+	}
+
+	issue, err := svc.GetIssue(resp.IssueID)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issue.Occurrences != 2 {
+		t.Fatalf("occurrences = %d, want 2 after a duplicate report", issue.Occurrences)
+	}
+	if issue.Category == nil || *issue.Category != CategoryWrongAudio {
+		t.Fatalf("category = %v, want wrong_audio", issue.Category)
+	}
+	if issue.ReporterName == nil || *issue.ReporterName != "reporter" {
+		t.Fatalf("reporter_name = %v, want reporter", issue.ReporterName)
+	}
+	if issue.Detail != req.Reason {
+		t.Fatalf("detail = %q, want the verbatim reason", issue.Detail)
+	}
+
+	// A distinct category opens a NEW issue (dedupe is per scope+category).
+	other, err := svc.CreateUserIssue(reporterID, &CreateIssueRequest{
+		MediaType: "tv", TmdbID: 42, SeasonNumber: 2, EpisodeNumber: 4,
+		Category: CategoryBadCopy,
+	})
+	if err != nil {
+		t.Fatalf("CreateUserIssue other category: %v", err)
+	}
+	if other.IssueID == resp.IssueID {
+		t.Fatalf("different-category report reused issue %d, want a new one", resp.IssueID)
+	}
+
+	// Thread: admin reply then reporter reply, oldest-first ordering preserved.
+	if err := svc.PostReply(resp.IssueID, AuthorAdmin, 0, "Looking into it."); err != nil {
+		t.Fatalf("PostReply admin: %v", err)
+	}
+	if err := svc.PostReply(resp.IssueID, AuthorUser, reporterID, "Thanks!"); err != nil {
+		t.Fatalf("PostReply user: %v", err)
+	}
+	thread, err := svc.IssueThread(resp.IssueID)
+	if err != nil {
+		t.Fatalf("IssueThread: %v", err)
+	}
+	if len(thread) != 2 {
+		t.Fatalf("thread length = %d, want 2", len(thread))
+	}
+	if thread[0].AuthorKind != AuthorAdmin || thread[1].AuthorKind != AuthorUser {
+		t.Fatalf("thread author kinds = %q,%q, want admin,user", thread[0].AuthorKind, thread[1].AuthorKind)
+	}
+	if thread[1].Body != "Thanks!" {
+		t.Fatalf("reporter message body = %q, want verbatim", thread[1].Body)
+	}
+
+	// List (all + filtered) and open count.
+	all, err := svc.ListIssues("")
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("ListIssues all = %d, want 2 open issues", len(all))
+	}
+	openOnly, err := svc.ListIssues(IssueOpen)
+	if err != nil {
+		t.Fatalf("ListIssues(open): %v", err)
+	}
+	if len(openOnly) != 2 {
+		t.Fatalf("ListIssues(open) = %d, want 2", len(openOnly))
+	}
+	if n, err := svc.OpenIssueCount(); err != nil || n != 2 {
+		t.Fatalf("OpenIssueCount = %d (err %v), want 2", n, err)
+	}
+
+	// Dismiss closes the issue: it leaves the open set and is idempotent.
+	if err := svc.DismissIssue(resp.IssueID); err != nil {
+		t.Fatalf("DismissIssue: %v", err)
+	}
+	if err := svc.DismissIssue(resp.IssueID); err != nil {
+		t.Fatalf("DismissIssue (second, idempotent): %v", err)
+	}
+	dismissed, err := svc.GetIssue(resp.IssueID)
+	if err != nil {
+		t.Fatalf("GetIssue after dismiss: %v", err)
+	}
+	if dismissed.Status != IssueDismissed {
+		t.Fatalf("status after dismiss = %q, want dismissed", dismissed.Status)
+	}
+	if n, err := svc.OpenIssueCount(); err != nil || n != 1 {
+		t.Fatalf("OpenIssueCount after dismiss = %d (err %v), want 1", n, err)
+	}
+
+	// A dismissed issue may be re-reported, opening a fresh row (closed rows no
+	// longer dedupe).
+	reopened, err := svc.CreateUserIssue(reporterID, req)
+	if err != nil {
+		t.Fatalf("CreateUserIssue after dismiss: %v", err)
+	}
+	if reopened.IssueID == resp.IssueID {
+		t.Fatalf("re-report reused dismissed issue %d, want a new row", resp.IssueID)
+	}
+}
+
+// TestMovieIssueScopeNormalized confirms a movie report stores season/episode 0
+// regardless of what the client sent (movies have no season scope).
+func TestMovieIssueScopeNormalized(t *testing.T) {
+	svc, _, reporterID := setupTestService(t)
+
+	resp, err := svc.CreateUserIssue(reporterID, &CreateIssueRequest{
+		MediaType: "movie", TmdbID: 7, SeasonNumber: 3, EpisodeNumber: 9,
+		Category: CategoryWrongContent,
+	})
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+	issue, err := svc.GetIssue(resp.IssueID)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issue.SeasonNumber != 0 || issue.EpisodeNumber != 0 {
+		t.Fatalf("movie scope = S%d E%d, want 0/0", issue.SeasonNumber, issue.EpisodeNumber)
+	}
+}
+
+// TestCreateUserIssueValidation rejects an unsupported media type and an unknown
+// category before any row is written.
+func TestCreateUserIssueValidation(t *testing.T) {
+	svc, _, reporterID := setupTestService(t)
+
+	if _, err := svc.CreateUserIssue(reporterID, &CreateIssueRequest{MediaType: "music", TmdbID: 1, Category: CategoryOther}); err == nil {
+		t.Fatal("expected error for unsupported media type")
+	}
+	if _, err := svc.CreateUserIssue(reporterID, &CreateIssueRequest{MediaType: "movie", TmdbID: 1, Category: "nonsense"}); err == nil {
+		t.Fatal("expected error for invalid category")
+	}
+}
+
+// TestSettingsRoundTrip proves the remediation settings persist and reload
+// (mirroring request_settings), defaults apply for an unset blob, and out-of-
+// range bound fields normalize while empty provider/model stay empty (inherit).
+func TestSettingsRoundTrip(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+
+	// Defaults before anything is stored.
+	d := svc.Settings()
+	if d.Enabled || d.AutoDispatch || !d.AllowReporting {
+		t.Fatalf("default switches = %+v, want enabled=false auto_dispatch=false allow_reporting=true", d)
+	}
+	if d.Autonomy != AutonomyPropose {
+		t.Fatalf("default autonomy = %q, want propose", d.Autonomy)
+	}
+	if d.Provider != "" || d.Model != "" {
+		t.Fatalf("default provider/model = %q/%q, want empty (inherit)", d.Provider, d.Model)
+	}
+	if d.MaxCostMicros != 500000 || d.DailyCostCeilingMicros != 5000000 {
+		t.Fatalf("default cost ceilings = %d/%d, want 500000/5000000", d.MaxCostMicros, d.DailyCostCeilingMicros)
+	}
+
+	// Round-trip a populated settings value.
+	in := Settings{
+		Enabled:                true,
+		AutoDispatch:           true,
+		AllowReporting:         false,
+		Autonomy:               AutonomyInvestigateOnly,
+		Provider:               "openai",
+		Model:                  "gpt-x",
+		MaxSteps:               20,
+		MaxTurnTokens:          8000,
+		MaxWallClockSecs:       600,
+		MaxCostMicros:          123456,
+		DailyRunCap:            10,
+		DailyCostCeilingMicros: 999999,
+		CircuitBreakerGiveups:  3,
+	}
+	saved, err := svc.SetSettings(in)
+	if err != nil {
+		t.Fatalf("SetSettings: %v", err)
+	}
+	if saved != in {
+		t.Fatalf("SetSettings returned %+v, want the input echoed", saved)
+	}
+	got := svc.Settings()
+	if got != in {
+		t.Fatalf("reloaded settings = %+v, want %+v", got, in)
+	}
+
+	// Out-of-range bounds normalize back to defaults; an unknown autonomy too;
+	// empty provider/model are left empty (inherit), not defaulted.
+	norm, err := svc.SetSettings(Settings{Autonomy: "bogus", MaxSteps: 0, MaxCostMicros: -5})
+	if err != nil {
+		t.Fatalf("SetSettings normalize: %v", err)
+	}
+	def := Defaults()
+	if norm.Autonomy != def.Autonomy {
+		t.Fatalf("normalized autonomy = %q, want %q", norm.Autonomy, def.Autonomy)
+	}
+	if norm.MaxSteps != def.MaxSteps || norm.MaxCostMicros != def.MaxCostMicros {
+		t.Fatalf("normalized bounds = steps %d cost %d, want %d/%d", norm.MaxSteps, norm.MaxCostMicros, def.MaxSteps, def.MaxCostMicros)
+	}
+	if norm.Provider != "" || norm.Model != "" {
+		t.Fatalf("normalized provider/model = %q/%q, want empty (inherit)", norm.Provider, norm.Model)
+	}
+}

--- a/server/internal/remediation/settings.go
+++ b/server/internal/remediation/settings.go
@@ -1,0 +1,140 @@
+package remediation
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// remediationSettingsKey is the settings-table key holding the global AI
+// remediation configuration (JSON blob), mirroring the request_settings storage
+// pattern (request/service.go GetGlobalSettings/SetGlobalSettings).
+const remediationSettingsKey = "remediation_settings"
+
+// Autonomy tiers controlling the mutation policy (enforced in later waves).
+const (
+	AutonomyInvestigateOnly = "investigate_only"
+	AutonomyPropose         = "propose"
+	AutonomyAutoSafe        = "auto_safe"
+)
+
+// Settings is the global AI remediation configuration. It is stored as the
+// remediation_settings JSON blob and unmarshalled over Defaults(), so adding a
+// field later is migration-free (older blobs simply keep the default for it).
+//
+// The remediation agent (later waves) is provider-agnostic: it reuses
+// Cantinarr's existing multi-provider AI layer. Provider/Model are plain
+// configurable overrides — empty means "inherit the server's globally-configured
+// AI provider/model" (the same one the AI assistant uses), so no provider is
+// ever hardcoded here.
+//
+// Wave 1 only stores and serves these values; no agent run consumes the bound
+// fields yet. The two switches that matter in Wave 1 are Enabled (master) and
+// AllowReporting (the user-visible "Report a problem" affordance, surfaced to
+// non-admin clients via /api/config).
+type Settings struct {
+	Enabled                bool   `json:"enabled"`                   // master switch — ships OFF
+	AutoDispatch           bool   `json:"auto_dispatch"`             // poller may open auto issues — ships OFF
+	AllowReporting         bool   `json:"allow_reporting"`           // user-visible "Report a problem" affordance
+	Autonomy               string `json:"autonomy"`                  // investigate_only | propose | auto_safe
+	Provider               string `json:"provider"`                  // "" = inherit the configured AI provider
+	Model                  string `json:"model"`                     // "" = inherit the configured AI model
+	MaxSteps               int    `json:"max_steps"`                 // total tool calls per investigation
+	MaxTurnTokens          int    `json:"max_turn_tokens"`           // per-turn output cap
+	MaxWallClockSecs       int    `json:"max_wall_clock_secs"`       // active wall-clock budget
+	MaxCostMicros          int    `json:"max_cost_micros"`           // per-run cost ceiling (millionths USD)
+	DailyRunCap            int    `json:"daily_run_cap"`             // max runs/day
+	DailyCostCeilingMicros int    `json:"daily_cost_ceiling_micros"` // global cost ceiling/day (millionths USD)
+	CircuitBreakerGiveups  int    `json:"circuit_breaker_giveups"`   // consecutive auto give-ups -> auto-dispatch off
+}
+
+// Defaults returns the built-in remediation settings. Provider and Model are
+// empty so the agent inherits the configured AI provider/model unless an admin
+// overrides them; every mutation is admin-approved (autonomy "propose"); the
+// feature ships OFF. The cost ceilings are best-effort guardrails.
+func Defaults() Settings {
+	return Settings{
+		Enabled:                false,
+		AutoDispatch:           false,
+		AllowReporting:         true,
+		Autonomy:               AutonomyPropose,
+		Provider:               "",
+		Model:                  "",
+		MaxSteps:               12,
+		MaxTurnTokens:          4096,
+		MaxWallClockSecs:       300,
+		MaxCostMicros:          500000, // ~$0.50/run
+		DailyRunCap:            50,
+		DailyCostCeilingMicros: 5000000, // ~$5/day, global
+		CircuitBreakerGiveups:  5,
+	}
+}
+
+// validAutonomy reports whether a stored/submitted autonomy value is one of the
+// known tiers.
+func validAutonomy(a string) bool {
+	switch a {
+	case AutonomyInvestigateOnly, AutonomyPropose, AutonomyAutoSafe:
+		return true
+	}
+	return false
+}
+
+// normalize coerces any out-of-range or unknown field back to a safe default so
+// a hand-edited or partial blob can never disable the bounds. Mirrors the
+// request settings' defensive validSeasonScope fallback.
+func (g *Settings) normalize() {
+	d := Defaults()
+	if !validAutonomy(g.Autonomy) {
+		g.Autonomy = d.Autonomy
+	}
+	// Provider/Model are intentionally not defaulted: empty means "inherit the
+	// configured AI provider/model", which is the shipped default.
+	if g.MaxSteps <= 0 {
+		g.MaxSteps = d.MaxSteps
+	}
+	if g.MaxTurnTokens <= 0 {
+		g.MaxTurnTokens = d.MaxTurnTokens
+	}
+	if g.MaxWallClockSecs <= 0 {
+		g.MaxWallClockSecs = d.MaxWallClockSecs
+	}
+	if g.MaxCostMicros <= 0 {
+		g.MaxCostMicros = d.MaxCostMicros
+	}
+	if g.DailyRunCap <= 0 {
+		g.DailyRunCap = d.DailyRunCap
+	}
+	if g.DailyCostCeilingMicros <= 0 {
+		g.DailyCostCeilingMicros = d.DailyCostCeilingMicros
+	}
+	if g.CircuitBreakerGiveups <= 0 {
+		g.CircuitBreakerGiveups = d.CircuitBreakerGiveups
+	}
+}
+
+// Settings returns the stored global remediation settings, falling back to the
+// built-in defaults for any missing field (read exactly like
+// request.GetGlobalSettings).
+func (s *Service) Settings() Settings {
+	g := Defaults()
+	var v string
+	if err := s.db.QueryRow("SELECT value FROM settings WHERE key = ?", remediationSettingsKey).Scan(&v); err == nil && v != "" {
+		_ = json.Unmarshal([]byte(v), &g)
+	}
+	g.normalize()
+	return g
+}
+
+// SetSettings persists the global remediation settings (written exactly like
+// request.SetGlobalSettings) and returns the normalized value that was stored.
+func (s *Service) SetSettings(g Settings) (Settings, error) {
+	g.normalize()
+	data, err := json.Marshal(g)
+	if err != nil {
+		return Settings{}, fmt.Errorf("encode remediation settings: %w", err)
+	}
+	if _, err := s.db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", remediationSettingsKey, string(data)); err != nil {
+		return Settings{}, fmt.Errorf("save remediation settings: %w", err)
+	}
+	return g, nil
+}


### PR DESCRIPTION
## Wave 1 (SERVER) — AI-remediation initiative: issue-reporting foundation

Server-only. **No AI agent in this wave** — the agent loop, Runner, Executor, agent-only tools, and auto-dispatch land in later waves. This ships the data model, the issue service, the REST API, settings, and the `issue_created` admin notification.

### What's included
- **db**: all five tables appended to `initSQL` (`issues`, `issue_messages`, `agent_runs`, `agent_steps`, `agent_actions`) + indexes — created now so later waves need no migration; only `issues` + `issue_messages` are used this wave. New `notification_prefs.issue_created` column (+ tolerant ALTER).
- **internal/remediation** (new package): `models.go`, `settings.go`, `service.go`, `handler.go`, `service_test.go`. Service methods: `CreateUserIssue` (reporter+scope+category dedupe → bumps `occurrences`), `OpenAutoIssue` (conditional-insert dedupe; **no caller yet**, correct for later waves), `GetIssue`, `IssueThread`, `PostReply`, `ListIssues`, `DismissIssue`, `OpenIssueCount`, `Settings`/`SetSettings`. All user `reason`/`body` stored verbatim, never interpreted.
- **auth**: `PermissionRemediationManage = "remediation:manage"` (+ in `allPermissions()`); admin's `admin:*` wildcard covers it (no `rolePermissions` change).
- **api**: routes beside the existing admin request/approval routes; `/api/config` now returns `issues_enabled` + `allow_reporting`.
- **push**: `issue_created` admin notification (WS + push), **fixed-template body** (untrusted title never on the lock screen), `issue_id` deep-link + `open_count` badge; admin-scoped category, on by default.
- **main**: `remediation.Service` + handler wired (mirrors `request`). The `*push.Composite` fan-out drives both services.

### FINAL WAVE-1 API CONTRACT (snake_case JSON — app side must match)
- `POST /api/issues` [PermissionMediaRequest] req `{media_type:"movie"|"tv", tmdb_id:int, tvdb_id?:int, season_number?:int(0=whole), episode_number?:int(0), category:"wrong_content"|"bad_copy"|"wrong_audio"|"other", reason?:string, title?:string}` → `{issue_id:int, status:"open"}`
  - Requires `tmdb_id` **or** `tvdb_id` (one must be non-zero) + `media_type` + `category`. If `tmdb_id==0` && `tvdb_id` set, a best-effort reverse lookup of the cached tmdb↔tvdb mapping is attempted; on a miss the ids are stored as given (there is no live reverse resolver). Movies normalize season/episode to 0.
- `GET /api/issues/{id}` [reporter or admin] → `{issue:Issue, thread:[Message]}`
  - `Issue = {id, source:"user"|"auto", status, category|null, reporter_id|null, reporter_name|null, tmdb_id, media_type, title, season_number, episode_number, detail, occurrences, created_at, updated_at}`
  - `Message = {id, author_kind:"user"|"agent"|"admin"|"system", author_name|null, body, created_at}`
- `POST /api/issues/{id}/reply` [reporter or admin] req `{body:string}` → `{ok:true}` (author_kind from caller's role: admin→"admin", else "user")
- `GET /api/admin/issues?status=` [PermissionRemediationManage] → `{issues:[Issue]}`
- `POST /api/admin/issues/{id}/dismiss` [PermissionRemediationManage] → `{ok:true}`
- `GET /api/admin/remediation-settings` [PermissionRemediationManage] → `Settings`
- `PUT /api/admin/remediation-settings` [PermissionRemediationManage] req `Settings` → `Settings` (normalized)
- `GET /api/config` now also returns `issues_enabled` (= Settings.Enabled) and `allow_reporting` (= Settings.AllowReporting).

**`Settings`** = `{enabled, auto_dispatch, allow_reporting, autonomy:"investigate_only"|"propose"|"auto_safe", provider, model, max_steps, max_turn_tokens, max_wall_clock_secs, max_cost_micros, daily_run_cap, daily_cost_ceiling_micros, circuit_breaker_giveups}`.
`Defaults()`: `enabled=false, auto_dispatch=false, allow_reporting=true, autonomy="propose", provider="", model="", max_steps=12, max_turn_tokens=4096, max_wall_clock_secs=300, max_cost_micros=500000, daily_run_cap=50, daily_cost_ceiling_micros=5000000, circuit_breaker_giveups=5`.

### ⚠️ Deviations from the original task contract (app side: match THIS PR)
- **Added `provider` field** to `Settings` (string, default `""`). The remediation agent is **provider-agnostic**: it reuses Cantinarr's existing multi-provider AI layer. `provider`/`model` empty = inherit the server's configured AI provider/model; non-empty = override. **No provider/model is hardcoded anywhere.**
- **`model` default is `""`** (inherit), not `"claude-haiku-4-5"`.
- **`max_cost_micros=500000`** (~\$0.50/run) and **`daily_cost_ceiling_micros=5000000`** (~\$5/day), scaled up from the original 50000/2500000 — these are best-effort guardrails consumed only by later waves.
- All other defaults unchanged.

### Deferred to later waves (NOT in this PR)
- `ai.RunHeadlessTask`, `remediation.Runner`, `remediation.Executor`, the read-tool allow-list enforcement, the four agent-only MCP tools (`propose_action`/`post_issue_message`/`ask_reporter`/`conclude_issue`) + `IssueStore`, bounds/cost/circuit-breaker logic, the watchdog, approve/deny + `agent_actions` lifecycle, and auto-dispatch from the poller. The `agent_*` tables and the `provider`/`model`/bound `Settings` fields exist now but are unused until then.

### Verification
- `gofmt -l` clean, `go vet ./...` clean, `go test ./...` passes (added `remediation` service test: create → dedupe → thread/reply → settings round-trip → list/dismiss; kept the two push pref-default tests aligned with the new on-by-default `issue_created`).
- No `app/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEChSmKSXg8UDF5TY8aWpE