### PR TITLE
feat(remediation): Wave 1 app — report a problem + admin issues + settings

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -9,6 +9,7 @@ import 'core/providers/realtime_provider.dart';
 import 'core/storage/preferences.dart';
 import 'core/theme/app_theme.dart';
 import 'features/auth/logic/auth_provider.dart';
+import 'features/issues/logic/issues_provider.dart';
 import 'features/notifications/push_service.dart';
 import 'features/request/logic/pending_approvals_provider.dart';
 import 'navigation/app_router.dart';
@@ -48,6 +49,8 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
       // Re-sync the approvals badges in case the queue changed (or another
       // admin acted) while we were backgrounded. No-op for non-admins.
       ref.read(pendingApprovalsProvider.notifier).refresh();
+      // Same for the open-issues badge.
+      ref.read(openIssuesProvider.notifier).refresh();
     }
   }
 

--- a/app/lib/core/models/backend_connection.dart
+++ b/app/lib/core/models/backend_connection.dart
@@ -37,6 +37,12 @@ class BackendConnection {
   final AvailableServices services;
   final List<ServiceInstance> instances;
 
+  /// Whether the AI-remediation feature is enabled server-side.
+  final bool issuesEnabled;
+
+  /// Whether the user-facing "Report a problem" affordance should be shown.
+  final bool allowReporting;
+
   const BackendConnection({
     required this.serverUrl,
     required this.accessToken,
@@ -44,6 +50,8 @@ class BackendConnection {
     this.serverName,
     this.services = const AvailableServices(),
     this.instances = const [],
+    this.issuesEnabled = false,
+    this.allowReporting = false,
   });
 
   BackendConnection copyWith({
@@ -53,6 +61,8 @@ class BackendConnection {
     String? serverName,
     AvailableServices? services,
     List<ServiceInstance>? instances,
+    bool? issuesEnabled,
+    bool? allowReporting,
   }) =>
       BackendConnection(
         serverUrl: serverUrl ?? this.serverUrl,
@@ -61,6 +71,8 @@ class BackendConnection {
         serverName: serverName ?? this.serverName,
         services: services ?? this.services,
         instances: instances ?? this.instances,
+        issuesEnabled: issuesEnabled ?? this.issuesEnabled,
+        allowReporting: allowReporting ?? this.allowReporting,
       );
 
   /// Get all Radarr instances.

--- a/app/lib/core/providers/realtime_provider.dart
+++ b/app/lib/core/providers/realtime_provider.dart
@@ -54,3 +54,24 @@ final requestDecisionEventsProvider = StreamProvider.autoDispose<WsEvent>((ref) 
   final events = ref.watch(realtimeEventsProvider);
   return events.where((e) => e.type == 'request_decision');
 });
+
+/// Per-issue update pings (`issue_updated` events) for one issue id. On a
+/// ping the thread screen refetches that issue over REST (the server emits a
+/// thin ping per persisted agent step, not full bodies). Mirrors
+/// [arrQueueChangedProvider].
+final issueEventsProvider =
+    StreamProvider.autoDispose.family<WsEvent, int>((ref, issueId) {
+  final events = ref.watch(realtimeEventsProvider);
+  return events.where((e) =>
+      e.type == 'issue_updated' &&
+      (e.data['issue_id'] as num?)?.toInt() == issueId);
+});
+
+/// New-issue / pending-approval pings (`issue_created`,
+/// `agent_action_pending`). The admin issues list refreshes its contents on
+/// any of these.
+final issuesChangedProvider = StreamProvider.autoDispose<WsEvent>((ref) {
+  final events = ref.watch(realtimeEventsProvider);
+  return events.where(
+      (e) => e.type == 'issue_created' || e.type == 'agent_action_pending');
+});

--- a/app/lib/features/auth/data/auth_service.dart
+++ b/app/lib/features/auth/data/auth_service.dart
@@ -459,10 +459,18 @@ class ServerConfig {
   final AvailableServices services;
   final List<ServiceInstance> instances;
 
+  /// Whether the AI-remediation feature is enabled server-side.
+  final bool issuesEnabled;
+
+  /// Whether users may see the "Report a problem" affordance.
+  final bool allowReporting;
+
   const ServerConfig({
     required this.serverName,
     required this.services,
     this.instances = const [],
+    this.issuesEnabled = false,
+    this.allowReporting = false,
   });
 
   factory ServerConfig.fromJson(Map<String, dynamic> json) {
@@ -476,6 +484,8 @@ class ServerConfig {
       services: AvailableServices.fromJson(
           json['services'] as Map<String, dynamic>? ?? {}),
       instances: instancesList,
+      issuesEnabled: json['issues_enabled'] as bool? ?? false,
+      allowReporting: json['allow_reporting'] as bool? ?? false,
     );
   }
 }

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -135,6 +135,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
                     ServiceInstance.fromJson(e as Map<String, dynamic>))
                 .toList() ??
             const [],
+        issuesEnabled: meta['issues_enabled'] as bool? ?? false,
+        allowReporting: meta['allow_reporting'] as bool? ?? false,
       );
       return AuthState(
           connection: connection, user: user, isReconnecting: true);
@@ -170,6 +172,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         serverName: config.serverName,
         services: config.services,
         instances: config.instances,
+        issuesEnabled: config.issuesEnabled,
+        allowReporting: config.allowReporting,
       );
       await _persistSession(connection, authResp.user);
       _stopReconnect();
@@ -216,6 +220,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         serverName: config.serverName,
         services: config.services,
         instances: config.instances,
+        issuesEnabled: config.issuesEnabled,
+        allowReporting: config.allowReporting,
       );
       await _persistSession(connection, authResp.user);
       _registerForPush();
@@ -303,6 +309,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         serverName: config.serverName,
         services: config.services,
         instances: config.instances,
+        issuesEnabled: config.issuesEnabled,
+        allowReporting: config.allowReporting,
       );
 
       await _persistSession(connection, authResp.user);
@@ -351,6 +359,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         serverName: config.serverName,
         services: config.services,
         instances: config.instances,
+        issuesEnabled: config.issuesEnabled,
+        allowReporting: config.allowReporting,
       );
 
       final offerPasskey =
@@ -394,6 +404,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         serverName: config.serverName,
         services: config.services,
         instances: config.instances,
+        issuesEnabled: config.issuesEnabled,
+        allowReporting: config.allowReporting,
       );
 
       await _persistSession(connection, authResp.user);
@@ -431,6 +443,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       serverName: config.serverName,
       services: config.services,
       instances: config.instances,
+      issuesEnabled: config.issuesEnabled,
+      allowReporting: config.allowReporting,
     );
     final user = current.user;
     if (user != null) await _persistSession(updatedConn, user);
@@ -611,6 +625,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         serverName: config.serverName,
         services: config.services,
         instances: config.instances,
+        issuesEnabled: config.issuesEnabled,
+        allowReporting: config.allowReporting,
       );
 
       await _persistSession(connection, authResp.user);
@@ -729,6 +745,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         'server_name': conn.serverName,
         'services': conn.services.toJson(),
         'instances': conn.instances.map((i) => i.toJson()).toList(),
+        'issues_enabled': conn.issuesEnabled,
+        'allow_reporting': conn.allowReporting,
       }),
     );
   }

--- a/app/lib/features/issues/data/issue_models.dart
+++ b/app/lib/features/issues/data/issue_models.dart
@@ -1,0 +1,330 @@
+// Data models for the AI-remediation issue-reporting feature.
+//
+// These mirror the Wave-1 REST contract (snake_case JSON) exactly. All
+// free-text fields the server marks UNTRUSTED (an issue's `detail`, a
+// message `body`) are carried verbatim and rendered as passive text only.
+
+/// A category a reporter may pick for a problem. The string [value] is the
+/// wire value sent to the server; [label] is the user-facing choice text.
+enum IssueCategory {
+  wrongContent('wrong_content', 'Wrong episode/movie'),
+  badCopy('bad_copy', 'Bad / corrupt copy'),
+  wrongAudio('wrong_audio', 'Wrong or missing audio language'),
+  other('other', 'Something else');
+
+  const IssueCategory(this.value, this.label);
+
+  /// The snake_case value sent to / received from the server.
+  final String value;
+
+  /// The user-facing label shown on the report sheet and issue chips.
+  final String label;
+
+  /// True for the catch-all category, which requires a free-text reason.
+  bool get requiresReason => this == IssueCategory.other;
+
+  /// Resolves a wire value back to a category, defaulting to [other] for an
+  /// unknown string so the UI never crashes on a future server category.
+  static IssueCategory fromValue(String? value) => values.firstWhere(
+        (c) => c.value == value,
+        orElse: () => IssueCategory.other,
+      );
+}
+
+/// The lifecycle state of an issue. Terminal states are
+/// resolved/wont_fix/failed/dismissed. The enum is tolerant of unknown
+/// server values (mapped to [unknown]) so a future status can't break parsing.
+enum IssueStatus {
+  open('open', 'Open'),
+  investigating('investigating', 'Investigating'),
+  awaitingUser('awaiting_user', 'Needs your reply'),
+  awaitingApproval('awaiting_approval', 'Awaiting approval'),
+  resolved('resolved', 'Resolved'),
+  wontFix('wont_fix', "Won't fix"),
+  failed('failed', 'Failed'),
+  dismissed('dismissed', 'Dismissed'),
+  unknown('', 'Unknown');
+
+  const IssueStatus(this.value, this.label);
+
+  final String value;
+  final String label;
+
+  /// True once the issue has reached a state that accepts no further work.
+  bool get isTerminal =>
+      this == resolved ||
+      this == wontFix ||
+      this == failed ||
+      this == dismissed;
+
+  /// True while the issue is actively being worked (drives a typing/poll hint).
+  bool get isActive => this == open || this == investigating;
+
+  static IssueStatus fromValue(String? value) => values.firstWhere(
+        (s) => s.value == value,
+        orElse: () => IssueStatus.unknown,
+      );
+}
+
+/// One reported (or auto-detected) problem. Media-scoped like a media request
+/// (tmdb_id + media_type), optionally narrowed to a TV season/episode (0 means
+/// "whole series" / not applicable).
+class Issue {
+  final int id;
+  final String source; // 'auto' | 'user'
+  final IssueStatus status;
+  final IssueCategory? category; // null for auto-detected
+  final int? reporterId;
+  final String reporterName;
+  final int tmdbId;
+  final String mediaType; // 'movie' | 'tv'
+  final String title;
+  final int seasonNumber; // 0 = whole series / movie
+  final int episodeNumber; // 0 = whole season / movie
+  final String detail; // UNTRUSTED free text — render passively
+  final int occurrences;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+
+  const Issue({
+    required this.id,
+    required this.source,
+    required this.status,
+    required this.category,
+    required this.reporterId,
+    required this.reporterName,
+    required this.tmdbId,
+    required this.mediaType,
+    required this.title,
+    required this.seasonNumber,
+    required this.episodeNumber,
+    required this.detail,
+    required this.occurrences,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  bool get isTv => mediaType == 'tv';
+
+  /// A short scope label for list/thread subtitles:
+  /// "S2·E4" / "Season 2" / "Movie".
+  String get scopeLabel {
+    if (!isTv) return 'Movie';
+    if (seasonNumber <= 0) return 'Series';
+    if (episodeNumber <= 0) return 'Season $seasonNumber';
+    return 'S$seasonNumber·E$episodeNumber';
+  }
+
+  factory Issue.fromJson(Map<String, dynamic> json) => Issue(
+        id: json['id'] as int? ?? 0,
+        source: json['source'] as String? ?? 'user',
+        status: IssueStatus.fromValue(json['status'] as String?),
+        category: json['category'] == null
+            ? null
+            : IssueCategory.fromValue(json['category'] as String?),
+        reporterId: (json['reporter_id'] as num?)?.toInt(),
+        reporterName: json['reporter_name'] as String? ?? '',
+        tmdbId: json['tmdb_id'] as int? ?? 0,
+        mediaType: json['media_type'] as String? ?? 'movie',
+        title: json['title'] as String? ?? '',
+        seasonNumber: json['season_number'] as int? ?? 0,
+        episodeNumber: json['episode_number'] as int? ?? 0,
+        detail: json['detail'] as String? ?? '',
+        occurrences: json['occurrences'] as int? ?? 1,
+        createdAt:
+            DateTime.tryParse(json['created_at'] as String? ?? '')?.toLocal(),
+        updatedAt:
+            DateTime.tryParse(json['updated_at'] as String? ?? '')?.toLocal(),
+      );
+}
+
+/// Who authored a thread message. Provenance is load-bearing: the UI renders
+/// a `user`/`admin` report on the right, an `agent`/`system` message on the
+/// left/centered, and never treats any body as a control.
+enum IssueAuthorKind {
+  user('user'),
+  agent('agent'),
+  admin('admin'),
+  system('system'),
+  unknown('');
+
+  const IssueAuthorKind(this.value);
+  final String value;
+
+  static IssueAuthorKind fromValue(String? value) => values.firstWhere(
+        (k) => k.value == value,
+        orElse: () => IssueAuthorKind.unknown,
+      );
+}
+
+/// One append-only message in an issue thread. [body] is UNTRUSTED when
+/// [authorKind] is `user` — it is always rendered as passive text.
+class IssueMessage {
+  final int id;
+  final IssueAuthorKind authorKind;
+  final String authorName;
+  final String body;
+  final DateTime? createdAt;
+
+  const IssueMessage({
+    required this.id,
+    required this.authorKind,
+    required this.authorName,
+    required this.body,
+    required this.createdAt,
+  });
+
+  /// True for messages that originate from the reporter/admin side of the
+  /// conversation (rendered as a right-aligned bubble).
+  bool get isFromHuman =>
+      authorKind == IssueAuthorKind.user ||
+      authorKind == IssueAuthorKind.admin;
+
+  factory IssueMessage.fromJson(Map<String, dynamic> json) => IssueMessage(
+        id: json['id'] as int? ?? 0,
+        authorKind: IssueAuthorKind.fromValue(json['author_kind'] as String?),
+        authorName: json['author_name'] as String? ?? '',
+        body: json['body'] as String? ?? '',
+        createdAt:
+            DateTime.tryParse(json['created_at'] as String? ?? '')?.toLocal(),
+      );
+}
+
+/// An issue plus its full thread, as returned by `GET /api/issues/{id}`.
+class IssueThread {
+  final Issue issue;
+  final List<IssueMessage> messages;
+
+  const IssueThread({required this.issue, required this.messages});
+
+  factory IssueThread.fromJson(Map<String, dynamic> json) => IssueThread(
+        issue:
+            Issue.fromJson(json['issue'] as Map<String, dynamic>? ?? const {}),
+        messages: ((json['thread'] as List?) ?? const [])
+            .map((e) => IssueMessage.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+}
+
+/// The agent's autonomy tier, shown as a dropdown in admin settings.
+enum RemediationAutonomy {
+  investigateOnly('investigate_only', 'Investigate only'),
+  propose('propose', 'Propose fixes'),
+  autoSafe('auto_safe', 'Auto-fix low-risk');
+
+  const RemediationAutonomy(this.value, this.label);
+  final String value;
+  final String label;
+
+  static RemediationAutonomy fromValue(String? value) => values.firstWhere(
+        (a) => a.value == value,
+        orElse: () => RemediationAutonomy.propose,
+      );
+}
+
+/// The admin-tunable remediation settings, GET/PUT
+/// `/api/admin/remediation-settings`. Field names mirror the server's
+/// `Settings` struct exactly.
+class RemediationSettings {
+  final bool enabled;
+  final bool autoDispatch;
+  final bool allowReporting;
+  final RemediationAutonomy autonomy;
+
+  /// AI provider override (e.g. "anthropic", "openai"). Empty means "use the
+  /// server's configured provider". The agent is provider-agnostic, so this is
+  /// a free-text field, never a fixed list.
+  final String provider;
+
+  /// Model override. Empty means "use the server's configured model".
+  final String model;
+  final int maxSteps;
+  final int maxTurnTokens;
+  final int maxWallClockSecs;
+  final int maxCostMicros;
+  final int dailyRunCap;
+  final int dailyCostCeilingMicros;
+  final int circuitBreakerGiveups;
+
+  const RemediationSettings({
+    required this.enabled,
+    required this.autoDispatch,
+    required this.allowReporting,
+    required this.autonomy,
+    required this.provider,
+    required this.model,
+    required this.maxSteps,
+    required this.maxTurnTokens,
+    required this.maxWallClockSecs,
+    required this.maxCostMicros,
+    required this.dailyRunCap,
+    required this.dailyCostCeilingMicros,
+    required this.circuitBreakerGiveups,
+  });
+
+  factory RemediationSettings.fromJson(Map<String, dynamic> json) =>
+      RemediationSettings(
+        enabled: json['enabled'] as bool? ?? false,
+        autoDispatch: json['auto_dispatch'] as bool? ?? false,
+        allowReporting: json['allow_reporting'] as bool? ?? false,
+        autonomy: RemediationAutonomy.fromValue(json['autonomy'] as String?),
+        provider: json['provider'] as String? ?? '',
+        model: json['model'] as String? ?? '',
+        maxSteps: json['max_steps'] as int? ?? 0,
+        maxTurnTokens: json['max_turn_tokens'] as int? ?? 0,
+        maxWallClockSecs: json['max_wall_clock_secs'] as int? ?? 0,
+        maxCostMicros: json['max_cost_micros'] as int? ?? 0,
+        dailyRunCap: json['daily_run_cap'] as int? ?? 0,
+        dailyCostCeilingMicros: json['daily_cost_ceiling_micros'] as int? ?? 0,
+        circuitBreakerGiveups: json['circuit_breaker_giveups'] as int? ?? 0,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'enabled': enabled,
+        'auto_dispatch': autoDispatch,
+        'allow_reporting': allowReporting,
+        'autonomy': autonomy.value,
+        'provider': provider,
+        'model': model,
+        'max_steps': maxSteps,
+        'max_turn_tokens': maxTurnTokens,
+        'max_wall_clock_secs': maxWallClockSecs,
+        'max_cost_micros': maxCostMicros,
+        'daily_run_cap': dailyRunCap,
+        'daily_cost_ceiling_micros': dailyCostCeilingMicros,
+        'circuit_breaker_giveups': circuitBreakerGiveups,
+      };
+
+  RemediationSettings copyWith({
+    bool? enabled,
+    bool? autoDispatch,
+    bool? allowReporting,
+    RemediationAutonomy? autonomy,
+    String? provider,
+    String? model,
+    int? maxSteps,
+    int? maxTurnTokens,
+    int? maxWallClockSecs,
+    int? maxCostMicros,
+    int? dailyRunCap,
+    int? dailyCostCeilingMicros,
+    int? circuitBreakerGiveups,
+  }) =>
+      RemediationSettings(
+        enabled: enabled ?? this.enabled,
+        autoDispatch: autoDispatch ?? this.autoDispatch,
+        allowReporting: allowReporting ?? this.allowReporting,
+        autonomy: autonomy ?? this.autonomy,
+        provider: provider ?? this.provider,
+        model: model ?? this.model,
+        maxSteps: maxSteps ?? this.maxSteps,
+        maxTurnTokens: maxTurnTokens ?? this.maxTurnTokens,
+        maxWallClockSecs: maxWallClockSecs ?? this.maxWallClockSecs,
+        maxCostMicros: maxCostMicros ?? this.maxCostMicros,
+        dailyRunCap: dailyRunCap ?? this.dailyRunCap,
+        dailyCostCeilingMicros:
+            dailyCostCeilingMicros ?? this.dailyCostCeilingMicros,
+        circuitBreakerGiveups:
+            circuitBreakerGiveups ?? this.circuitBreakerGiveups,
+      );
+}

--- a/app/lib/features/issues/data/issues_service.dart
+++ b/app/lib/features/issues/data/issues_service.dart
@@ -1,0 +1,100 @@
+import 'package:dio/dio.dart';
+
+import 'issue_models.dart';
+
+/// REST client for the issue-reporting / AI-remediation feature.
+///
+/// Talks to the Wave-1 contract (snake_case). The server may not be merged
+/// yet: a 404 from any endpoint is expected pre-merge and surfaces as a thrown
+/// [DioException] that callers handle like any other transient failure.
+class IssuesService {
+  final Dio _dio;
+
+  IssuesService({required Dio backendDio}) : _dio = backendDio;
+
+  // ---- Reporter-facing -----------------------------------------------------
+
+  /// Submit a problem report. Returns the new issue id (the server also echoes
+  /// the initial status, which the caller doesn't currently need).
+  Future<int> reportProblem({
+    required String mediaType, // 'movie' | 'tv'
+    required int tmdbId,
+    int? tvdbId,
+    int? seasonNumber,
+    int? episodeNumber,
+    required IssueCategory category,
+    String? reason,
+    String? title,
+  }) async {
+    final body = <String, dynamic>{
+      'media_type': mediaType,
+      'tmdb_id': tmdbId,
+      'category': category.value,
+    };
+    if (tvdbId != null && tvdbId != 0) body['tvdb_id'] = tvdbId;
+    if (seasonNumber != null && seasonNumber > 0) {
+      body['season_number'] = seasonNumber;
+    }
+    if (episodeNumber != null && episodeNumber > 0) {
+      body['episode_number'] = episodeNumber;
+    }
+    final trimmedReason = reason?.trim();
+    if (trimmedReason != null && trimmedReason.isNotEmpty) {
+      body['reason'] = trimmedReason;
+    }
+    if (title != null && title.isNotEmpty) body['title'] = title;
+
+    final resp = await _dio.post('/api/issues', data: body);
+    final data = resp.data as Map<String, dynamic>?;
+    return (data?['issue_id'] as num?)?.toInt() ?? 0;
+  }
+
+  /// Fetch one issue plus its full message thread (reporter or admin).
+  Future<IssueThread> getThread(int id) async {
+    final resp = await _dio.get('/api/issues/$id');
+    return IssueThread.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Append a reply to an issue thread (reporter or admin note).
+  Future<void> reply(int id, String body) async {
+    await _dio.post('/api/issues/$id/reply', data: {'body': body});
+  }
+
+  // ---- Admin ---------------------------------------------------------------
+
+  /// List issues for the admin queue, optionally filtered by [status].
+  Future<List<Issue>> listIssues({String? status}) async {
+    final resp = await _dio.get(
+      '/api/admin/issues',
+      queryParameters: {
+        if (status != null && status.isNotEmpty) 'status': status,
+      },
+    );
+    final data = resp.data as Map<String, dynamic>?;
+    return ((data?['issues'] as List?) ?? const [])
+        .map((e) => Issue.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Dismiss an issue (admin).
+  Future<void> dismiss(int id) async {
+    await _dio.post('/api/admin/issues/$id/dismiss');
+  }
+
+  /// Read the admin-tunable remediation settings.
+  Future<RemediationSettings> getSettings() async {
+    final resp = await _dio.get('/api/admin/remediation-settings');
+    return RemediationSettings.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Persist the admin-tunable remediation settings, returning the stored
+  /// (normalized) values.
+  Future<RemediationSettings> updateSettings(
+      RemediationSettings settings) async {
+    final resp = await _dio.put(
+      '/api/admin/remediation-settings',
+      data: settings.toJson(),
+    );
+    return RemediationSettings.fromJson(resp.data as Map<String, dynamic>);
+  }
+}

--- a/app/lib/features/issues/logic/issues_provider.dart
+++ b/app/lib/features/issues/logic/issues_provider.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/backend_client.dart';
+import '../../../core/network/websocket_client.dart';
+import '../../../core/providers/realtime_provider.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../data/issues_service.dart';
+
+/// Shared [IssuesService] bound to the authenticated backend Dio client.
+final issuesServiceProvider = Provider<IssuesService>((ref) {
+  return IssuesService(backendDio: ref.watch(backendClientProvider));
+});
+
+/// Tracks the number of open issues awaiting an admin, for admins only.
+///
+/// Drives the drawer "Issues" entry badge (and could feed an app-bar dot the
+/// same way the approvals count does). It is seeded from REST, kept live by
+/// `issue_created`/`agent_action_pending` websocket events, and refreshed
+/// after a dismiss. Non-admin accounts always report 0 and never call the
+/// admin-only endpoint. Mirrors `PendingApprovalsNotifier`.
+class OpenIssuesNotifier extends StateNotifier<int> {
+  OpenIssuesNotifier(this._ref) : super(0) {
+    _service = _ref.read(issuesServiceProvider);
+    _bind();
+    // Re-bind on login/logout/role change without rebuilding the provider.
+    _ref.listen(authProvider, (_, __) => _bind());
+  }
+
+  final Ref _ref;
+  late final IssuesService _service;
+  StreamSubscription<WsEvent>? _sub;
+  bool _isAdmin = false;
+
+  /// (Re)attaches to the live event stream when the admin status changes.
+  void _bind() {
+    final admin = _ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    if (admin == _isAdmin) return; // no change
+    _isAdmin = admin;
+    _sub?.cancel();
+    _sub = null;
+    if (!admin) {
+      _set(0);
+      return;
+    }
+    refresh();
+    _sub = _ref
+        .read(realtimeEventsProvider)
+        .where((e) =>
+            e.type == 'issue_created' || e.type == 'agent_action_pending')
+        .listen(_onPing);
+  }
+
+  /// Applies the authoritative count carried by the event when present,
+  /// otherwise refetches (the badge must stay correct, and a ping doesn't
+  /// always carry the queue depth for issues).
+  void _onPing(WsEvent event) {
+    final raw = event.data['open_count'];
+    if (raw is num) {
+      _set(raw.toInt());
+    } else {
+      refresh();
+    }
+  }
+
+  /// Re-reads the open-issue count from the backend. Call after a dismiss so
+  /// the badge reflects the resolved queue immediately.
+  Future<void> refresh() async {
+    if (!_isAdmin) return;
+    try {
+      final issues = await _service.listIssues();
+      final open = issues.where((i) => !i.status.isTerminal).length;
+      _set(open);
+    } catch (_) {
+      // Best-effort: keep the last known count on a transient failure (covers
+      // the pre-merge 404 too).
+    }
+  }
+
+  /// Sets the count directly from a caller that already holds the authoritative
+  /// list (the issues screen), avoiding a redundant fetch.
+  void setCount(int value) => _set(value);
+
+  void _set(int value) {
+    state = value < 0 ? 0 : value;
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}
+
+/// Open-issue count for the signed-in admin (0 for non-admins).
+final openIssuesProvider =
+    StateNotifierProvider<OpenIssuesNotifier, int>(OpenIssuesNotifier.new);

--- a/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
+++ b/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
@@ -1,0 +1,419 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../data/issue_models.dart';
+import '../logic/issues_provider.dart';
+
+/// Admin screen for the AI-remediation settings. Clones
+/// `RequestSettingsScreen`'s load → edit → Save shape: a master Enabled
+/// switch, sub-toggles, an autonomy dropdown, free-text provider/model
+/// overrides, and numeric bound fields.
+class AiRemediationSettingsScreen extends ConsumerStatefulWidget {
+  const AiRemediationSettingsScreen({super.key});
+
+  @override
+  ConsumerState<AiRemediationSettingsScreen> createState() =>
+      _AiRemediationSettingsScreenState();
+}
+
+class _AiRemediationSettingsScreenState
+    extends ConsumerState<AiRemediationSettingsScreen> {
+  RemediationSettings? _edited;
+  bool _isLoading = true;
+  String? _error;
+  bool _saving = false;
+
+  // Free-text controllers for provider/model so a blank means "server
+  // default". The agent is provider-agnostic — no fixed dropdown here.
+  final _providerController = TextEditingController();
+  final _modelController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  @override
+  void dispose() {
+    _providerController.dispose();
+    _modelController.dispose();
+    super.dispose();
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = _edited == null;
+      _error = null;
+    });
+    try {
+      final settings = await ref.read(issuesServiceProvider).getSettings();
+      if (!mounted) return;
+      setState(() {
+        _edited = settings;
+        _providerController.text = settings.provider;
+        _modelController.text = settings.model;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    final edited = _edited;
+    if (edited == null || _saving) return;
+    setState(() => _saving = true);
+    try {
+      final toSave = edited.copyWith(
+        provider: _providerController.text.trim(),
+        model: _modelController.text.trim(),
+      );
+      final saved =
+          await ref.read(issuesServiceProvider).updateSettings(toSave);
+      if (!mounted) return;
+      setState(() {
+        _edited = saved;
+        _providerController.text = saved.provider;
+        _modelController.text = saved.model;
+        _saving = false;
+      });
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Saved')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _saving = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_friendlyError(e))),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('AI Remediation')),
+      body: _isLoading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent))
+          : _edited == null
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(_friendlyError(_error ?? 'Something went wrong'),
+                            style: const TextStyle(color: AppTheme.error),
+                            textAlign: TextAlign.center),
+                        const SizedBox(height: 12),
+                        ElevatedButton(
+                            onPressed: _load, child: const Text('Retry')),
+                      ],
+                    ),
+                  ),
+                )
+              : _buildBody(_edited!),
+    );
+  }
+
+  Widget _buildBody(RemediationSettings s) {
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: [
+        const Padding(
+          padding: EdgeInsets.fromLTRB(16, 8, 16, 4),
+          child: Text(
+            'Let the assistant investigate reported problems and propose fixes '
+            'for your approval. Read-only investigation never changes anything; '
+            'every mutation waits for an admin.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        const _SectionLabel('General'),
+        SwitchListTile(
+          value: s.enabled,
+          activeThumbColor: AppTheme.accent,
+          onChanged: (v) => setState(() => _edited = s.copyWith(enabled: v)),
+          title: const Text(
+            'Enabled',
+            style: TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+          ),
+          subtitle: const Text(
+            'Master switch for the remediation assistant.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        SwitchListTile(
+          value: s.autoDispatch,
+          activeThumbColor: AppTheme.accent,
+          onChanged: (v) =>
+              setState(() => _edited = s.copyWith(autoDispatch: v)),
+          title: const Text(
+            'Auto-dispatch on detected problems',
+            style: TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+          ),
+          subtitle: const Text(
+            'Open and investigate issues automatically for stuck downloads.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        SwitchListTile(
+          value: s.allowReporting,
+          activeThumbColor: AppTheme.accent,
+          onChanged: (v) =>
+              setState(() => _edited = s.copyWith(allowReporting: v)),
+          title: const Text(
+            'Allow problem reporting',
+            style: TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+          ),
+          subtitle: const Text(
+            'Show a "Report a problem" button to users on media screens.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        ListTile(
+          title: const Text(
+            'Autonomy',
+            style: TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+          ),
+          subtitle: const Text(
+            'How far the assistant may go on its own.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+          trailing: DropdownButton<RemediationAutonomy>(
+            value: s.autonomy,
+            dropdownColor: AppTheme.surface,
+            underline: const SizedBox.shrink(),
+            style: const TextStyle(color: AppTheme.textPrimary, fontSize: 14),
+            items: [
+              for (final a in RemediationAutonomy.values)
+                DropdownMenuItem<RemediationAutonomy>(
+                  value: a,
+                  child: Text(a.label),
+                ),
+            ],
+            onChanged: (v) {
+              if (v == null) return;
+              setState(() => _edited = s.copyWith(autonomy: v));
+            },
+          ),
+        ),
+
+        const _SectionLabel('Model'),
+        _TextField(
+          controller: _providerController,
+          label: 'AI provider',
+          help: "Leave blank to use the server's configured AI provider.",
+          hint: 'e.g. anthropic, openai',
+        ),
+        _TextField(
+          controller: _modelController,
+          label: 'Model',
+          help: "Leave blank to use the server's configured model.",
+          hint: 'e.g. a model name',
+        ),
+
+        const _SectionLabel('Limits'),
+        _NumberTile(
+          label: 'Max steps per run',
+          value: s.maxSteps,
+          onChanged: (v) => setState(() => _edited = s.copyWith(maxSteps: v)),
+        ),
+        _NumberTile(
+          label: 'Max wall-clock (seconds)',
+          value: s.maxWallClockSecs,
+          onChanged: (v) =>
+              setState(() => _edited = s.copyWith(maxWallClockSecs: v)),
+        ),
+        _NumberTile(
+          label: 'Max cost per run (micros)',
+          value: s.maxCostMicros,
+          onChanged: (v) =>
+              setState(() => _edited = s.copyWith(maxCostMicros: v)),
+        ),
+        _NumberTile(
+          label: 'Daily run cap',
+          value: s.dailyRunCap,
+          onChanged: (v) =>
+              setState(() => _edited = s.copyWith(dailyRunCap: v)),
+        ),
+        _NumberTile(
+          label: 'Daily cost ceiling (micros)',
+          value: s.dailyCostCeilingMicros,
+          onChanged: (v) =>
+              setState(() => _edited = s.copyWith(dailyCostCeilingMicros: v)),
+        ),
+
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+          child: SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: AppTheme.accent,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(vertical: 14),
+              ),
+              onPressed: _saving ? null : _save,
+              child: _saving
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        color: Colors.white,
+                        strokeWidth: 2,
+                      ),
+                    )
+                  : const Text('Save'),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A labelled free-text field with helper text (used for provider/model).
+class _TextField extends StatelessWidget {
+  final TextEditingController controller;
+  final String label;
+  final String help;
+  final String hint;
+
+  const _TextField({
+    required this.controller,
+    required this.label,
+    required this.help,
+    required this.hint,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+          ),
+          const SizedBox(height: 6),
+          TextField(
+            controller: controller,
+            style: const TextStyle(color: AppTheme.textPrimary),
+            decoration: InputDecoration(
+              isDense: true,
+              hintText: hint,
+              hintStyle: const TextStyle(color: AppTheme.textSecondary),
+              helperText: help,
+              helperStyle:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+              helperMaxLines: 2,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(10),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A labelled integer field. Empty input is treated as 0.
+class _NumberTile extends StatefulWidget {
+  final String label;
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  const _NumberTile({
+    required this.label,
+    required this.value,
+    required this.onChanged,
+  });
+
+  @override
+  State<_NumberTile> createState() => _NumberTileState();
+}
+
+class _NumberTileState extends State<_NumberTile> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.value.toString());
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(
+        widget.label,
+        style: const TextStyle(
+            color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+      ),
+      trailing: SizedBox(
+        width: 120,
+        child: TextField(
+          controller: _controller,
+          textAlign: TextAlign.end,
+          keyboardType: TextInputType.number,
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          style: const TextStyle(color: AppTheme.textPrimary),
+          decoration: const InputDecoration(
+            isDense: true,
+            border: OutlineInputBorder(),
+          ),
+          onChanged: (v) => widget.onChanged(int.tryParse(v) ?? 0),
+        ),
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  const _SectionLabel(this.text);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+      child: Text(
+        text.toUpperCase(),
+        style: const TextStyle(
+          color: AppTheme.accent,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/issues/ui/issue_thread_screen.dart
+++ b/app/lib/features/issues/ui/issue_thread_screen.dart
@@ -1,0 +1,492 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../core/providers/realtime_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/issue_models.dart';
+import '../logic/issues_provider.dart';
+
+/// The issue conversation: a read-mostly transcript rendered with the AI-chat
+/// bubble grammar, plus a reply field.
+///
+/// Provenance drives layout — a reporter/admin message is a right-aligned
+/// bubble; an agent/system message is left/centered. Every message body is
+/// rendered as PASSIVE, selectable text only (never a control or label),
+/// because a `user` body is untrusted. Wave 1 only ever shows user/admin and
+/// agent/system messages; proposed-action/decision arms are stubbed for a
+/// later wave and intentionally render as a plain notice so unused cases can't
+/// fail `flutter analyze`.
+class IssueThreadScreen extends ConsumerStatefulWidget {
+  final int issueId;
+
+  const IssueThreadScreen({super.key, required this.issueId});
+
+  @override
+  ConsumerState<IssueThreadScreen> createState() => _IssueThreadScreenState();
+}
+
+class _IssueThreadScreenState extends ConsumerState<IssueThreadScreen> {
+  IssueThread? _thread;
+  bool _isLoading = true;
+  String? _error;
+
+  final _replyController = TextEditingController();
+  final _scrollController = ScrollController();
+  bool _sending = false;
+
+  /// A short REST re-poll while the issue is still being worked, so steps that
+  /// arrive without a WS ping (socket down) still surface. Best-effort.
+  Timer? _poll;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load(initial: true));
+  }
+
+  @override
+  void dispose() {
+    _poll?.cancel();
+    _replyController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _load({bool initial = false}) async {
+    if (initial) setState(() => _isLoading = _thread == null);
+    try {
+      final thread =
+          await ref.read(issuesServiceProvider).getThread(widget.issueId);
+      if (!mounted) return;
+      setState(() {
+        _thread = thread;
+        _isLoading = false;
+        _error = null;
+      });
+      _syncPolling(thread.issue.status);
+      if (initial) _scrollToBottomSoon();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        if (_thread == null) _error = e.toString();
+      });
+    }
+  }
+
+  /// Keep a low-frequency poll running only while the issue is actively being
+  /// worked; stop it once the issue parks or terminates.
+  void _syncPolling(IssueStatus status) {
+    if (status.isActive) {
+      _poll ??= Timer.periodic(
+        const Duration(seconds: 10),
+        (_) => _load(),
+      );
+    } else {
+      _poll?.cancel();
+      _poll = null;
+    }
+  }
+
+  void _scrollToBottomSoon() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.jumpTo(_scrollController.position.maxScrollExtent);
+      }
+    });
+  }
+
+  Future<void> _sendReply() async {
+    final text = _replyController.text.trim();
+    if (text.isEmpty || _sending) return;
+    setState(() => _sending = true);
+    try {
+      await ref.read(issuesServiceProvider).reply(widget.issueId, text);
+      _replyController.clear();
+      await _load();
+      if (mounted) _scrollToBottomSoon();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_friendlyError(e))),
+      );
+    } finally {
+      if (mounted) setState(() => _sending = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Refetch the thread over REST when this issue pings (the server emits a
+    // thin `issue_updated` per persisted step, not full bodies).
+    ref.listen(issueEventsProvider(widget.issueId), (_, __) => _load());
+
+    final thread = _thread;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(thread?.issue.title.isNotEmpty == true
+            ? thread!.issue.title
+            : 'Issue'),
+      ),
+      body: _isLoading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent))
+          : thread == null
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(_friendlyError(_error ?? 'Could not load issue'),
+                            style: const TextStyle(color: AppTheme.error),
+                            textAlign: TextAlign.center),
+                        const SizedBox(height: 12),
+                        ElevatedButton(
+                          onPressed: () => _load(initial: true),
+                          child: const Text('Retry'),
+                        ),
+                      ],
+                    ),
+                  ),
+                )
+              : _buildBody(thread),
+    );
+  }
+
+  Widget _buildBody(IssueThread thread) {
+    final issue = thread.issue;
+    return Column(
+      children: [
+        Expanded(
+          child: RefreshIndicator(
+            color: AppTheme.accent,
+            onRefresh: _load,
+            child: ListView(
+              controller: _scrollController,
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.all(16),
+              children: [
+                _IssueSummaryCard(issue: issue),
+                const SizedBox(height: 16),
+                for (final msg in thread.messages) _MessageRow(message: msg),
+                if (issue.status.isActive) const _WorkingIndicator(),
+              ],
+            ),
+          ),
+        ),
+        _ReplyBar(
+          controller: _replyController,
+          sending: _sending,
+          enabled: !issue.status.isTerminal,
+          hintText: issue.status == IssueStatus.awaitingUser
+              ? 'Answer the question…'
+              : 'Add a reply…',
+          onSend: _sendReply,
+        ),
+      ],
+    );
+  }
+}
+
+/// A compact header describing the issue scope/category/status, with the
+/// reporter's free-text detail rendered as passive (untrusted) text.
+class _IssueSummaryCard extends StatelessWidget {
+  final Issue issue;
+  const _IssueSummaryCard({required this.issue});
+
+  @override
+  Widget build(BuildContext context) {
+    final bits = <String>[
+      issue.scopeLabel,
+      if (issue.category != null) issue.category!.label,
+    ];
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppTheme.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            bits.join(' · '),
+            style: const TextStyle(
+                color: AppTheme.textSecondary, fontSize: 12),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Status: ${issue.status.label}',
+            style: const TextStyle(
+                color: AppTheme.textPrimary,
+                fontSize: 13,
+                fontWeight: FontWeight.w600),
+          ),
+          if (issue.detail.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            // UNTRUSTED reporter/diagnosis text — passive, selectable only.
+            SelectableText(
+              issue.detail,
+              style: const TextStyle(
+                  color: AppTheme.textPrimary, fontSize: 14, height: 1.4),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// One thread message rendered in the AI-chat grammar. Human (reporter/admin)
+/// messages align right; agent/system align left or centered.
+class _MessageRow extends StatelessWidget {
+  final IssueMessage message;
+  const _MessageRow({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    switch (message.authorKind) {
+      case IssueAuthorKind.user:
+      case IssueAuthorKind.admin:
+        return _Bubble(message: message, isFromHuman: true);
+      case IssueAuthorKind.agent:
+        return _Bubble(message: message, isFromHuman: false);
+      case IssueAuthorKind.system:
+      case IssueAuthorKind.unknown:
+        // Centered, low-emphasis notice. Also the safe fallback for any
+        // not-yet-modeled message kind a later wave introduces.
+        return _SystemNotice(message: message);
+    }
+  }
+}
+
+/// A left/right chat bubble. The body is always passive selectable text.
+class _Bubble extends StatelessWidget {
+  final IssueMessage message;
+  final bool isFromHuman;
+
+  const _Bubble({required this.message, required this.isFromHuman});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        mainAxisAlignment:
+            isFromHuman ? MainAxisAlignment.end : MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (!isFromHuman) ...[
+            Container(
+              width: 32,
+              height: 32,
+              decoration: const BoxDecoration(
+                color: AppTheme.accent,
+                shape: BoxShape.circle,
+              ),
+              child:
+                  const Icon(Icons.smart_toy, size: 18, color: Colors.white),
+            ),
+            const SizedBox(width: 8),
+          ],
+          Flexible(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (message.authorName.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(left: 2, bottom: 4),
+                    child: Text(
+                      message.authorName,
+                      style: const TextStyle(
+                          color: AppTheme.textSecondary, fontSize: 11),
+                    ),
+                  ),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 14, vertical: 10),
+                  decoration: BoxDecoration(
+                    color: isFromHuman
+                        ? AppTheme.accent.withValues(alpha: 0.15)
+                        : AppTheme.surfaceVariant,
+                    borderRadius: BorderRadius.only(
+                      topLeft: const Radius.circular(16),
+                      topRight: const Radius.circular(16),
+                      bottomLeft: Radius.circular(isFromHuman ? 16 : 4),
+                      bottomRight: Radius.circular(isFromHuman ? 4 : 16),
+                    ),
+                    border: Border.all(
+                      color: isFromHuman
+                          ? AppTheme.accent.withValues(alpha: 0.3)
+                          : AppTheme.border,
+                    ),
+                  ),
+                  // Passive, selectable text — never a control/label.
+                  child: SelectableText(
+                    message.body,
+                    style: const TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontSize: 15,
+                      height: 1.4,
+                    ),
+                  ),
+                ),
+                if (message.createdAt != null)
+                  Padding(
+                    padding: const EdgeInsets.only(left: 2, top: 4),
+                    child: Text(
+                      DateFormat('MMM d, h:mm a').format(message.createdAt!),
+                      style: const TextStyle(
+                          color: AppTheme.textSecondary, fontSize: 10),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          if (isFromHuman) const SizedBox(width: 8),
+        ],
+      ),
+    );
+  }
+}
+
+/// A centered system notice (e.g. "Admin denied: …"). Passive text only.
+class _SystemNotice extends StatelessWidget {
+  final IssueMessage message;
+  const _SystemNotice({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    if (message.body.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: AppTheme.surfaceVariant,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: AppTheme.border),
+          ),
+          child: SelectableText(
+            message.body,
+            textAlign: TextAlign.center,
+            style: const TextStyle(
+                color: AppTheme.textSecondary, fontSize: 12),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A small "working" hint shown while the issue is open/investigating.
+class _WorkingIndicator extends StatelessWidget {
+  const _WorkingIndicator();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.only(top: 4, left: 2),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 12,
+            height: 12,
+            child: CircularProgressIndicator(
+                strokeWidth: 1.5, color: AppTheme.accent),
+          ),
+          SizedBox(width: 8),
+          Text(
+            'Working on it…',
+            style: TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 12,
+                fontStyle: FontStyle.italic),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The bottom reply input. Disabled once the issue is terminal.
+class _ReplyBar extends StatelessWidget {
+  final TextEditingController controller;
+  final bool sending;
+  final bool enabled;
+  final String hintText;
+  final VoidCallback onSend;
+
+  const _ReplyBar({
+    required this.controller,
+    required this.sending,
+    required this.enabled,
+    required this.hintText,
+    required this.onSend,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        color: AppTheme.surface,
+        border: Border(top: BorderSide(color: AppTheme.border)),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: SafeArea(
+        top: false,
+        child: enabled
+            ? Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: controller,
+                      keyboardType: TextInputType.multiline,
+                      textInputAction: TextInputAction.send,
+                      onSubmitted: (_) => onSend(),
+                      minLines: 1,
+                      maxLines: 4,
+                      style: const TextStyle(color: AppTheme.textPrimary),
+                      decoration: InputDecoration(
+                        hintText: hintText,
+                        hintStyle:
+                            const TextStyle(color: AppTheme.textSecondary),
+                        border: InputBorder.none,
+                        contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 10),
+                      ),
+                    ),
+                  ),
+                  IconButton(
+                    onPressed: sending ? null : onSend,
+                    icon: Icon(
+                      Icons.send_rounded,
+                      color:
+                          sending ? AppTheme.textSecondary : AppTheme.accent,
+                    ),
+                  ),
+                ],
+              )
+            : const Padding(
+                padding: EdgeInsets.symmetric(vertical: 10, horizontal: 8),
+                child: Text(
+                  'This issue is closed.',
+                  style:
+                      TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+                ),
+              ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/issues/ui/issues_list_screen.dart
+++ b/app/lib/features/issues/ui/issues_list_screen.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/providers/realtime_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/issue_models.dart';
+import '../logic/issues_provider.dart';
+
+/// Admin list of reported / auto-detected problems. Tapping a row opens the
+/// issue thread. Mirrors `PendingRequestsScreen`: a [RefreshIndicator] over a
+/// [ListView.separated] of `_IssueTile`s, kept live by `issue_created`
+/// pings and seeding the drawer badge on load.
+class IssuesListScreen extends ConsumerStatefulWidget {
+  const IssuesListScreen({super.key});
+
+  @override
+  ConsumerState<IssuesListScreen> createState() => _IssuesListScreenState();
+}
+
+class _IssuesListScreenState extends ConsumerState<IssuesListScreen> {
+  List<Issue>? _issues;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = _issues == null;
+      _error = null;
+    });
+    try {
+      final issues = await ref.read(issuesServiceProvider).listIssues();
+      if (!mounted) return;
+      setState(() {
+        _issues = issues;
+        _isLoading = false;
+      });
+      // Keep the drawer badge in sync with the list we just loaded.
+      final open = issues.where((i) => !i.status.isTerminal).length;
+      ref.read(openIssuesProvider.notifier).setCount(open);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Refresh the list whenever a new issue is created (best-effort over WS).
+    ref.listen(issuesChangedProvider, (_, __) => _load());
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Issues')),
+      body: _isLoading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent))
+          : _error != null && _issues == null
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(_friendlyError(_error!),
+                            style: const TextStyle(color: AppTheme.error),
+                            textAlign: TextAlign.center),
+                        const SizedBox(height: 12),
+                        ElevatedButton(
+                            onPressed: _load, child: const Text('Retry')),
+                      ],
+                    ),
+                  ),
+                )
+              : RefreshIndicator(
+                  color: AppTheme.accent,
+                  onRefresh: _load,
+                  child: (_issues?.isEmpty ?? true)
+                      ? ListView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          children: const [
+                            SizedBox(height: 120),
+                            Center(
+                              child: Text(
+                                'No reported problems.',
+                                style:
+                                    TextStyle(color: AppTheme.textSecondary),
+                              ),
+                            ),
+                          ],
+                        )
+                      : ListView.separated(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          padding: const EdgeInsets.symmetric(vertical: 8),
+                          itemCount: _issues!.length,
+                          separatorBuilder: (_, __) =>
+                              const Divider(color: AppTheme.border, height: 1),
+                          itemBuilder: (context, index) {
+                            final issue = _issues![index];
+                            return _IssueTile(
+                              issue: issue,
+                              onTap: () async {
+                                await context.push('/issues/${issue.id}');
+                                // Returning from the thread may have changed
+                                // state (a reply, a dismiss) — refresh.
+                                if (mounted) _load();
+                              },
+                            );
+                          },
+                        ),
+                ),
+    );
+  }
+}
+
+class _IssueTile extends StatelessWidget {
+  final Issue issue;
+  final VoidCallback onTap;
+
+  const _IssueTile({required this.issue, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final category = issue.category;
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      title: Text(
+        issue.title.isEmpty ? 'Issue #${issue.id}' : issue.title,
+        style: const TextStyle(
+          color: AppTheme.textPrimary,
+          fontWeight: FontWeight.bold,
+        ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 2),
+          Text(
+            issue.scopeLabel +
+                (issue.reporterName.isNotEmpty
+                    ? ' · ${issue.reporterName}'
+                    : ''),
+            style: const TextStyle(
+                color: AppTheme.textSecondary, fontSize: 13),
+          ),
+          const SizedBox(height: 6),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              if (category != null) _chip(category.label),
+              _statusChip(issue.status),
+              if (issue.occurrences > 1) _chip('×${issue.occurrences}'),
+            ],
+          ),
+        ],
+      ),
+      trailing: const Icon(Icons.chevron_right, color: AppTheme.textSecondary),
+      onTap: onTap,
+    );
+  }
+
+  Widget _chip(String label) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: AppTheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: AppTheme.border),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: AppTheme.textSecondary,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  Widget _statusChip(IssueStatus status) {
+    final color = _statusColor(status);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: color.withValues(alpha: 0.5)),
+      ),
+      child: Text(
+        status.label,
+        style: TextStyle(
+          color: color,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  Color _statusColor(IssueStatus status) {
+    switch (status) {
+      case IssueStatus.resolved:
+        return AppTheme.available;
+      case IssueStatus.failed:
+        return AppTheme.error;
+      case IssueStatus.wontFix:
+      case IssueStatus.dismissed:
+        return AppTheme.unavailable;
+      case IssueStatus.awaitingApproval:
+      case IssueStatus.awaitingUser:
+        return AppTheme.requested;
+      case IssueStatus.open:
+      case IssueStatus.investigating:
+        return AppTheme.downloading;
+      case IssueStatus.unknown:
+        return AppTheme.textSecondary;
+    }
+  }
+}

--- a/app/lib/features/issues/ui/report_problem_sheet.dart
+++ b/app/lib/features/issues/ui/report_problem_sheet.dart
@@ -1,0 +1,346 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../data/issue_models.dart';
+import '../logic/issues_provider.dart';
+
+/// The media scope a problem report is filed against. Mirrors the request
+/// payload's identifier set: media-scoped (tmdb_id + media_type), optionally
+/// narrowed to a TV season/episode. Stable identifiers only (TVDB + S/E
+/// numbers), never volatile arr ids.
+class ReportScope {
+  final String mediaType; // 'movie' | 'tv'
+  final int tmdbId;
+  final int? tvdbId;
+  final int? seasonNumber;
+  final int? episodeNumber;
+  final String? title;
+
+  const ReportScope({
+    required this.mediaType,
+    required this.tmdbId,
+    this.tvdbId,
+    this.seasonNumber,
+    this.episodeNumber,
+    this.title,
+  });
+
+  const ReportScope.movie({
+    required int tmdbId,
+    String? title,
+  }) : this(mediaType: 'movie', tmdbId: tmdbId, title: title);
+
+  const ReportScope.episode({
+    required int tmdbId,
+    int? tvdbId,
+    required int seasonNumber,
+    required int episodeNumber,
+    String? title,
+  }) : this(
+          mediaType: 'tv',
+          tmdbId: tmdbId,
+          tvdbId: tvdbId,
+          seasonNumber: seasonNumber,
+          episodeNumber: episodeNumber,
+          title: title,
+        );
+
+  const ReportScope.series({
+    required int tmdbId,
+    int? tvdbId,
+    int? seasonNumber,
+    String? title,
+  }) : this(
+          mediaType: 'tv',
+          tmdbId: tmdbId,
+          tvdbId: tvdbId,
+          seasonNumber: seasonNumber,
+          title: title,
+        );
+}
+
+/// A shared "Report a problem" affordance: an outlined button that opens the
+/// [ReportProblemSheet] for [scope]. Place on any media surface where a
+/// reporter might flag a wrong/bad download; gate the caller on
+/// `allow_reporting`.
+///
+/// On a successful submit it shows a confirmation SnackBar and, if
+/// [onSubmitted] is provided (the arr screens), invokes it so the parent can
+/// refresh.
+class ReportProblemButton extends StatelessWidget {
+  final ReportScope scope;
+  final VoidCallback? onSubmitted;
+
+  const ReportProblemButton({
+    super.key,
+    required this.scope,
+    this.onSubmitted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton.icon(
+      onPressed: () => showReportProblemSheet(
+        context,
+        scope: scope,
+        onSubmitted: onSubmitted,
+      ),
+      icon: const Icon(Icons.flag_outlined,
+          size: 18, color: AppTheme.textSecondary),
+      label: const Text('Report a problem',
+          style: TextStyle(color: AppTheme.textPrimary)),
+      style: OutlinedButton.styleFrom(
+        side: const BorderSide(color: AppTheme.border),
+        shape:
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        padding: const EdgeInsets.symmetric(vertical: 12),
+      ),
+    );
+  }
+}
+
+/// Opens the report sheet and submits the result. Shared by the button above
+/// and by callers that present the affordance some other way (e.g. a quiet
+/// inline link).
+Future<void> showReportProblemSheet(
+  BuildContext context, {
+  required ReportScope scope,
+  VoidCallback? onSubmitted,
+}) async {
+  final submitted = await showModalBottomSheet<bool>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    builder: (_) => ReportProblemSheet(scope: scope),
+  );
+  if (submitted == true) {
+    onSubmitted?.call();
+  }
+}
+
+/// Pre-submit sheet that lets a reporter classify a problem with a media item
+/// (and add an optional reason). Modeled on `RequestOptionsSheet`: a [Wrap] of
+/// category [ChoiceChip]s plus a reason [TextField] (required only for
+/// "Something else"), with Cancel/Submit. Pops `true` on a successful submit.
+class ReportProblemSheet extends ConsumerStatefulWidget {
+  final ReportScope scope;
+
+  const ReportProblemSheet({super.key, required this.scope});
+
+  @override
+  ConsumerState<ReportProblemSheet> createState() => _ReportProblemSheetState();
+}
+
+class _ReportProblemSheetState extends ConsumerState<ReportProblemSheet> {
+  IssueCategory _category = IssueCategory.wrongContent;
+  final _reasonController = TextEditingController();
+  bool _submitting = false;
+  String? _error;
+
+  @override
+  void dispose() {
+    _reasonController.dispose();
+    super.dispose();
+  }
+
+  bool get _reasonRequired => _category.requiresReason;
+
+  Future<void> _submit() async {
+    if (_submitting) return;
+    final reason = _reasonController.text.trim();
+    if (_reasonRequired && reason.isEmpty) {
+      setState(() => _error = 'Please describe the problem.');
+      return;
+    }
+    setState(() {
+      _submitting = true;
+      _error = null;
+    });
+    final scope = widget.scope;
+    try {
+      await ref.read(issuesServiceProvider).reportProblem(
+            mediaType: scope.mediaType,
+            tmdbId: scope.tmdbId,
+            tvdbId: scope.tvdbId,
+            seasonNumber: scope.seasonNumber,
+            episodeNumber: scope.episodeNumber,
+            category: _category,
+            reason: reason.isEmpty ? null : reason,
+            title: scope.title,
+          );
+      if (!mounted) return;
+      Navigator.of(context).pop(true);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("Thanks — we're looking into it")),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _submitting = false;
+        _error = _friendlyError(e);
+      });
+    }
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Could not send your report.';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.only(
+        left: 24,
+        right: 24,
+        top: 16,
+        bottom: 24 + MediaQuery.of(context).viewInsets.bottom,
+      ),
+      decoration: const BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppTheme.textSecondary,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          const Text(
+            'Report a problem',
+            style: TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 20,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          const _SectionLabel("What's wrong?"),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: IssueCategory.values
+                .map((c) => ChoiceChip(
+                      label: Text(c.label),
+                      selected: _category == c,
+                      onSelected: (_) => setState(() {
+                        _category = c;
+                        _error = null;
+                      }),
+                      showCheckmark: false,
+                      selectedColor: AppTheme.accent,
+                      backgroundColor: AppTheme.surfaceVariant,
+                      labelStyle: TextStyle(
+                        color: _category == c
+                            ? Colors.white
+                            : AppTheme.textPrimary,
+                        fontSize: 13,
+                      ),
+                      side: const BorderSide(color: AppTheme.border),
+                    ))
+                .toList(),
+          ),
+          const SizedBox(height: 16),
+          _SectionLabel(_reasonRequired ? 'Details' : 'Details (optional)'),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _reasonController,
+            minLines: 2,
+            maxLines: 4,
+            style: const TextStyle(color: AppTheme.textPrimary),
+            onChanged: (_) {
+              if (_error != null) setState(() => _error = null);
+            },
+            decoration: InputDecoration(
+              hintText: _reasonRequired
+                  ? 'Tell us what happened'
+                  : 'Add anything that helps (optional)',
+              hintStyle: const TextStyle(color: AppTheme.textSecondary),
+              contentPadding:
+                  const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+          ),
+          if (_error != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              _error!,
+              style: const TextStyle(color: AppTheme.error, fontSize: 13),
+            ),
+          ],
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: _submitting
+                      ? null
+                      : () => Navigator.of(context).pop(),
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: AppTheme.textPrimary,
+                    side: const BorderSide(color: AppTheme.border),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: const Text('Cancel'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: ElevatedButton(
+                  onPressed: _submitting ? null : _submit,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppTheme.accent,
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                  ),
+                  child: _submitting
+                      ? const SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(
+                            color: Colors.white,
+                            strokeWidth: 2,
+                          ),
+                        )
+                      : const Text('Submit'),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionLabel extends StatelessWidget {
+  final String text;
+  const _SectionLabel(this.text);
+
+  @override
+  Widget build(BuildContext context) => Text(
+        text,
+        style: const TextStyle(
+          color: AppTheme.textSecondary,
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+        ),
+      );
+}

--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -8,8 +8,10 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/horizontal_item_row.dart';
 import '../../../core/widgets/media_card.dart';
 import '../../../core/widgets/media_header.dart';
+import '../../auth/logic/auth_provider.dart';
 import '../../discover/data/tmdb_models.dart';
 import '../../discover/data/discover_api_service.dart';
+import '../../issues/ui/report_problem_sheet.dart';
 import '../../request/data/request_service.dart';
 import '../../request/logic/request_provider.dart';
 import '../../request/ui/request_button.dart';
@@ -157,6 +159,29 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                           ),
                         ),
                       ),
+                    ),
+
+                    // Quiet "Report a problem" affordance — only once the
+                    // title is at least partially in the library and the
+                    // server allows reporting.
+                    ListenableBuilder(
+                      listenable: _requestNotifier,
+                      builder: (_, __) {
+                        if (!_canReport(_requestNotifier.state.status)) {
+                          return const SizedBox.shrink();
+                        }
+                        return Center(
+                          child: TextButton.icon(
+                            onPressed: () => _onReportProblem(state),
+                            icon: const Icon(Icons.flag_outlined, size: 14),
+                            label: const Text('Report a problem'),
+                            style: TextButton.styleFrom(
+                              foregroundColor: AppTheme.textSecondary,
+                              textStyle: const TextStyle(fontSize: 13),
+                            ),
+                          ),
+                        );
+                      },
                     ),
                     const SizedBox(height: 16),
 
@@ -367,6 +392,110 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
       tvdbId: tvdbId,
       seasonScope: seasonScope,
       qualityProfileId: qualityProfileId,
+    );
+  }
+
+  /// Reporting is offered only once the title is at least partially in the
+  /// library (so there's a download to complain about) and the server allows
+  /// it.
+  bool _canReport(RequestStatus status) {
+    final allow =
+        ref.watch(authProvider).valueOrNull?.connection?.allowReporting ??
+            false;
+    if (!allow) return false;
+    return status == RequestStatus.available ||
+        status == RequestStatus.partial ||
+        status == RequestStatus.downloading;
+  }
+
+  /// Opens the report flow. For a movie, scopes directly to the movie. For TV,
+  /// lets the reporter narrow to a season/episode (reusing the loaded seasons)
+  /// or report the whole series.
+  Future<void> _onReportProblem(MediaDetailState state) async {
+    final title = state.title;
+    if (widget.mediaType == MediaType.movie) {
+      await showReportProblemSheet(
+        context,
+        scope: ReportScope.movie(tmdbId: widget.id, title: title),
+      );
+      return;
+    }
+
+    final tvdbId = state.tvDetail?.externalIds?.tvdbId;
+    final scope = await _pickTvScope(state, title, tvdbId);
+    if (scope == null) return; // cancelled
+    if (!mounted) return;
+    await showReportProblemSheet(context, scope: scope);
+  }
+
+  /// Presents a small picker for which part of a show the report is about.
+  /// Returns null if cancelled.
+  Future<ReportScope?> _pickTvScope(
+      MediaDetailState state, String title, int? tvdbId) {
+    // Real seasons only (drop a season 0 / specials placeholder when empty).
+    final seasons =
+        state.seasons.where((s) => s.seasonNumber > 0).toList();
+    return showModalBottomSheet<ReportScope>(
+      context: context,
+      backgroundColor: AppTheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Padding(
+                padding: EdgeInsets.fromLTRB(20, 16, 20, 8),
+                child: Text(
+                  "What's the problem with?",
+                  style: TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold),
+                ),
+              ),
+              ListTile(
+                leading:
+                    const Icon(Icons.tv_outlined, color: AppTheme.textSecondary),
+                title: const Text('The whole series',
+                    style: TextStyle(color: AppTheme.textPrimary)),
+                onTap: () => Navigator.of(sheetContext).pop(
+                  ReportScope.series(
+                      tmdbId: widget.id, tvdbId: tvdbId, title: title),
+                ),
+              ),
+              if (seasons.isNotEmpty)
+                Flexible(
+                  child: ListView(
+                    shrinkWrap: true,
+                    children: [
+                      for (final s in seasons)
+                        ListTile(
+                          leading: const Icon(Icons.video_library_outlined,
+                              color: AppTheme.textSecondary),
+                          title: Text('Season ${s.seasonNumber}',
+                              style:
+                                  const TextStyle(color: AppTheme.textPrimary)),
+                          onTap: () => Navigator.of(sheetContext).pop(
+                            ReportScope.series(
+                              tmdbId: widget.id,
+                              tvdbId: tvdbId,
+                              seasonNumber: s.seasonNumber,
+                              title: title,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
     );
   }
 

--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -138,6 +138,13 @@ class PushService {
         if (tmdbId == null || tmdbId <= 0) return;
         final mediaType = data['media_type'] == 'tv' ? 'tv' : 'movie';
         router.push('/detail/$mediaType/$tmdbId');
+      case 'issue_created':
+      case 'issue_updated':
+      case 'issue_resolved':
+      case 'agent_action_pending':
+        final issueId = _asInt(data['issue_id']);
+        if (issueId == null || issueId <= 0) return;
+        router.push('/issues/$issueId');
     }
   }
 

--- a/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
@@ -6,6 +6,8 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../../../core/widgets/status_pill.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../../issues/ui/report_problem_sheet.dart';
 import '../data/radarr_api_service.dart';
 import '../data/radarr_models.dart';
 import 'radarr_import_doctor_sheet.dart';
@@ -183,6 +185,19 @@ class _RadarrMovieDetailScreenState
               onShowIssues: _queueItem!.hasIssues ? _openDoctor : null,
             ),
           ],
+          if (_canReport) ...[
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              child: ReportProblemButton(
+                scope: ReportScope.movie(
+                  tmdbId: _movie.tmdbId ?? 0,
+                  title: _movie.title,
+                ),
+                onSubmitted: _load,
+              ),
+            ),
+          ],
           const SizedBox(height: 16),
           const Text('History',
               style: TextStyle(
@@ -233,6 +248,15 @@ class _RadarrMovieDetailScreenState
     }
     if (!_movie.monitored) return AppTheme.unavailable;
     return _movie.isAvailable ? AppTheme.error : AppTheme.downloading;
+  }
+
+  /// Show "Report a problem" only when the server allows it and we have a
+  /// TMDB id to scope the report to.
+  bool get _canReport {
+    final allow =
+        ref.watch(authProvider).valueOrNull?.connection?.allowReporting ??
+            false;
+    return allow && (_movie.tmdbId ?? 0) > 0;
   }
 }
 

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -184,6 +184,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               onTap: () => context.push('/settings/request-settings'),
             ),
             _SettingsTile(
+              icon: Icons.auto_fix_high_outlined,
+              title: 'AI Remediation',
+              subtitle: 'Problem reporting and auto-fix assistant',
+              onTap: () => context.push('/settings/ai-remediation'),
+            ),
+            _SettingsTile(
               icon: Icons.people_outline,
               title: 'Users',
               subtitle: 'Manage accounts, roles, and invites',

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -14,6 +14,7 @@ import '../../ai_assistant/ui/chat_bubble.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../discover/data/tmdb_models.dart';
 import '../../discover/ui/search_results_view.dart';
+import '../../issues/logic/issues_provider.dart';
 import '../../radarr/data/radarr_api_service.dart';
 import '../../radarr/logic/radarr_movies_provider.dart';
 import '../../request/logic/pending_approvals_provider.dart';
@@ -338,6 +339,11 @@ class _AppShellState extends ConsumerState<AppShell>
     // Admin approval queue depth — drives the hamburger dot (here) and the
     // drawer "Approvals" entry. Always 0 for non-admins.
     final pendingApprovals = ref.watch(pendingApprovalsProvider);
+    // Open-issue count — drives the drawer "Issues" entry and contributes to
+    // the hamburger dot. Always 0 for non-admins. Watched here (not just in
+    // the drawer) so the badge stays live app-wide.
+    final openIssues = ref.watch(openIssuesProvider);
+    final menuBadgeCount = pendingApprovals + openIssues;
     final showSearchResults = searchState.searchMode == SearchMode.search ||
         searchState.searchMode == SearchMode.aiReady;
     final libraryStatus = searchState.isSearching && showSearchResults
@@ -404,7 +410,7 @@ class _AppShellState extends ConsumerState<AppShell>
             padding: const EdgeInsets.only(left: 4, top: 8, bottom: 8),
             child: IconButton(
               icon: Badge(
-                isLabelVisible: pendingApprovals > 0,
+                isLabelVisible: menuBadgeCount > 0,
                 backgroundColor: AppTheme.accent,
                 smallSize: 9,
                 child: const Icon(Icons.menu, color: AppTheme.textPrimary),
@@ -739,6 +745,7 @@ class _AppShellState extends ConsumerState<AppShell>
     final isAdmin =
         ref.watch(authProvider).valueOrNull?.user?.isAdmin ?? false;
     final pendingApprovals = ref.watch(pendingApprovalsProvider);
+    final openIssues = ref.watch(openIssuesProvider);
 
     return SafeArea(
       child: Column(
@@ -787,6 +794,15 @@ class _AppShellState extends ConsumerState<AppShell>
               onTap: () {
                 if (isOverlay) Navigator.pop(context);
                 context.push('/approvals');
+              },
+            ),
+            _DrawerItem(
+              icon: Icons.flag_outlined,
+              title: 'Issues',
+              badgeCount: openIssues,
+              onTap: () {
+                if (isOverlay) Navigator.pop(context);
+                context.push('/issues');
               },
             ),
             const Divider(color: AppTheme.border),

--- a/app/lib/features/sonarr/ui/episode_detail_sheet.dart
+++ b/app/lib/features/sonarr/ui/episode_detail_sheet.dart
@@ -4,6 +4,8 @@ import 'package:intl/intl.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/status_pill.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../../issues/ui/report_problem_sheet.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
 import 'import_doctor_sheet.dart';
@@ -219,11 +221,39 @@ class _EpisodeDetailSheetState extends ConsumerState<EpisodeDetailSheet> {
                   ),
                 ],
               ),
+              if (_canReport) ...[
+                const SizedBox(height: 10),
+                SizedBox(
+                  width: double.infinity,
+                  child: ReportProblemButton(
+                    scope: ReportScope.episode(
+                      tmdbId: widget.series.tmdbId ?? 0,
+                      tvdbId: widget.series.tvdbId,
+                      seasonNumber: e.seasonNumber,
+                      episodeNumber: e.episodeNumber,
+                      title: widget.series.title,
+                    ),
+                    // The sheet refreshes the season list by popping true.
+                    onSubmitted: () {
+                      if (mounted) Navigator.of(context).pop(true);
+                    },
+                  ),
+                ),
+              ],
             ],
           ),
         ),
       ),
     );
+  }
+
+  /// Show "Report a problem" only when the server allows it and we have a
+  /// TMDB id to scope the report to.
+  bool get _canReport {
+    final allow = ref.watch(authProvider).valueOrNull?.connection
+            ?.allowReporting ??
+        false;
+    return allow && (widget.series.tmdbId ?? 0) > 0;
   }
 
   Widget _buildHistory() {

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -15,6 +15,9 @@ import '../features/discover/data/tmdb_models.dart';
 import '../features/downloads/ui/downloads_history_screen.dart';
 import '../features/downloads/ui/downloads_module_shell.dart';
 import '../features/downloads/ui/downloads_queue_screen.dart';
+import '../features/issues/ui/ai_remediation_settings_screen.dart';
+import '../features/issues/ui/issue_thread_screen.dart';
+import '../features/issues/ui/issues_list_screen.dart';
 import '../features/media_detail/ui/media_detail_screen.dart';
 import '../features/notifications/ui/notification_preferences_screen.dart';
 import '../features/radarr/ui/radarr_calendar_screen.dart';
@@ -359,6 +362,24 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         path: '/approvals',
         parentNavigatorKey: _rootNavigatorKey,
         builder: (_, __) => const PendingRequestsScreen(),
+      ),
+      GoRoute(
+        path: '/issues',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (_, __) => const IssuesListScreen(),
+      ),
+      GoRoute(
+        path: '/issues/:id',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) {
+          final id = int.tryParse(state.pathParameters['id'] ?? '') ?? 0;
+          return IssueThreadScreen(issueId: id);
+        },
+      ),
+      GoRoute(
+        path: '/settings/ai-remediation',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (_, __) => const AiRemediationSettingsScreen(),
       ),
       GoRoute(
         path: '/settings/request-settings',

--- a/app/test/issues/issue_models_test.dart
+++ b/app/test/issues/issue_models_test.dart
@@ -1,0 +1,96 @@
+import 'package:cantinarr/features/issues/data/issue_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('IssueCategory', () {
+    test('maps wire values and labels', () {
+      expect(IssueCategory.fromValue('wrong_audio'), IssueCategory.wrongAudio);
+      expect(IssueCategory.wrongContent.value, 'wrong_content');
+    });
+    test('unknown value falls back to other (never crashes)', () {
+      expect(IssueCategory.fromValue('something_new'), IssueCategory.other);
+      expect(IssueCategory.fromValue(null), IssueCategory.other);
+    });
+    test('only "other" requires a reason', () {
+      expect(IssueCategory.other.requiresReason, isTrue);
+      expect(IssueCategory.badCopy.requiresReason, isFalse);
+    });
+  });
+
+  group('IssueStatus', () {
+    test('unknown server status is tolerated', () {
+      expect(IssueStatus.fromValue('a_future_status'), IssueStatus.unknown);
+    });
+    test('terminal vs active', () {
+      expect(IssueStatus.resolved.isTerminal, isTrue);
+      expect(IssueStatus.investigating.isActive, isTrue);
+      expect(IssueStatus.investigating.isTerminal, isFalse);
+    });
+  });
+
+  group('Issue.fromJson', () {
+    test('parses fields and derives a scope label', () {
+      final tv = Issue.fromJson({
+        'id': 7,
+        'source': 'user',
+        'status': 'open',
+        'category': 'wrong_audio',
+        'reporter_id': 3,
+        'reporter_name': 'alice',
+        'tmdb_id': 1399,
+        'media_type': 'tv',
+        'title': 'Show',
+        'season_number': 2,
+        'episode_number': 4,
+        'detail': 'wrong language',
+        'occurrences': 1,
+      });
+      expect(tv.id, 7);
+      expect(tv.category, IssueCategory.wrongAudio);
+      expect(tv.scopeLabel, 'S2·E4');
+
+      final movie = Issue.fromJson({
+        'id': 8,
+        'media_type': 'movie',
+        'status': 'resolved',
+        'category': null,
+        'tmdb_id': 27205,
+      });
+      expect(movie.category, isNull); // auto / no category
+      expect(movie.scopeLabel, 'Movie');
+      expect(movie.status, IssueStatus.resolved);
+    });
+  });
+
+  group('RemediationSettings', () {
+    test('round-trips, including the provider/model override fields', () {
+      const s = RemediationSettings(
+        enabled: true,
+        autoDispatch: false,
+        allowReporting: true,
+        autonomy: RemediationAutonomy.propose,
+        provider: 'openai',
+        model: 'gpt-5',
+        maxSteps: 12,
+        maxTurnTokens: 4096,
+        maxWallClockSecs: 300,
+        maxCostMicros: 500000,
+        dailyRunCap: 50,
+        dailyCostCeilingMicros: 5000000,
+        circuitBreakerGiveups: 5,
+      );
+      final back = RemediationSettings.fromJson(s.toJson());
+      expect(back.provider, 'openai');
+      expect(back.model, 'gpt-5');
+      expect(back.autonomy, RemediationAutonomy.propose);
+      expect(back.maxCostMicros, 500000);
+    });
+
+    test('blank provider/model means "inherit server default"', () {
+      final s = RemediationSettings.fromJson({});
+      expect(s.provider, '');
+      expect(s.model, '');
+      expect(s.autonomy, RemediationAutonomy.propose); // tolerant default
+    });
+  });
+}


### PR DESCRIPTION
The **app** half of the AI-remediation issue-reporting MVP (no agent yet), built against the Wave-1 server contract (#94, merged). Pairs with that PR.

## What
- **Report a problem** — a flag affordance on the **Sonarr episode sheet**, **Radarr movie detail**, and the **TMDB media detail**, shown only when the server reports `allow_reporting`. Opens a sheet with category chips (Wrong episode/movie · Bad/corrupt copy · Wrong/missing audio · Something else) + an optional reason (required for "Something else") → `POST /api/issues`.
- **Admin Issues list** + an **issue thread** (chat-style; user/admin bubbles right, agent/system left — every body rendered as **passive text**, never a control). Drawer item + open-issue badge.
- **AI-remediation settings screen** — Enabled / Auto-dispatch / Allow reporting toggles, an Autonomy dropdown, **`provider` + `model` as free-text** ("leave blank to inherit the server's configured AI"), and the numeric bounds.
- Threads `/api/config`'s `issues_enabled` + `allow_reporting` through `BackendConnection` + auth state; adds `issue_*` realtime providers + push deep-links.

## Notes
- **Provider-agnostic** per the locked decision: nothing pins Anthropic — the model/provider inherit whatever AI provider you've configured (Anthropic / OpenAI / Gemini), overridable per-remediation.
- All enums tolerate unknown server values (future statuses/categories won't crash parsing).
- No agent logic — that's the next waves. Agent/proposed-action bubble types are stubbed for forward-compat.

## Verification
- `flutter analyze` — clean (only pre-existing infos in unrelated files)
- `flutter test` — all pass, incl. **8 new model/contract tests** (category/status tolerance, Issue parse + scope label, settings round-trip incl. provider/model)

🤖 Generated with [Claude Code](https://claude.com/claude-code)