### PR TITLE
feat(remediation): auto-dispatch stuck downloads to the agent (Wave 5)

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -150,8 +150,10 @@ func main() {
 	if pushNotifier != nil {
 		contentNotifier = pushNotifier
 	}
-	wsHub := ws.NewHub(authService, registry, instanceStore, contentNotifier)
-	go wsHub.Run(ctx)
+	// The auto-dispatch opener is wired after the remediation service exists (it
+	// depends on the notifier composite, which depends on this hub). The hub's
+	// poll loop is therefore started LATER, once SetIssueOpener has run.
+	wsHub := ws.NewHub(authService, registry, instanceStore, contentNotifier, nil)
 
 	// Notifier composite. Request decisions and issue events fan out to both the
 	// WebSocket hub (live clients) and the push gateway (offline devices). The
@@ -167,8 +169,9 @@ func main() {
 	requestService := request.NewService(database, registry, bridge, notifier)
 	requestHandler := request.NewHandler(requestService)
 
-	// Remediation (issue reporting) service + handler. Wave 1 records and threads
-	// issues only; no AI agent is wired yet.
+	// Remediation (issue reporting) service + handler. Records/threads issues, runs
+	// the read-only agent, and (Wave 5) accepts auto-dispatched issues from the
+	// poller. AutoDispatch ships OFF; the opener re-checks the live toggle per call.
 	remediationService := remediation.NewService(database, registry, bridge, notifier)
 	remediationHandler := remediation.NewHandler(remediationService)
 
@@ -189,6 +192,16 @@ func main() {
 	remediationProcToken := newProcToken()
 	remediationRunner := remediation.NewRunner(database, remediationService, toolServer, creds, remediationProcToken)
 	remediationService.StartWorkers(ctx, remediationRunner, 2)
+
+	// Auto-dispatch (Wave 5, highest-risk trigger, ships OFF). The hub's poller
+	// hands stuck/blocked downloads to this opener, which re-checks the live
+	// Enabled && AutoDispatch toggles, opens a deduped issue, and enqueues the
+	// Runner off the poll goroutine. Wire it before starting the hub's poll loop
+	// (SetIssueOpener is not safe to call once Run is polling). Passing the opener
+	// only here keeps a server with the feature unwired from ever fetching the
+	// detailed queue.
+	wsHub.SetIssueOpener(remediation.NewAutoDispatcher(remediationService))
+	go wsHub.Run(ctx)
 
 	// Discover handler (always created — checks credentials at request time)
 	apiCache := cache.New()

--- a/server/internal/remediation/autodispatch.go
+++ b/server/internal/remediation/autodispatch.go
@@ -1,0 +1,160 @@
+package remediation
+
+import (
+	"database/sql"
+	"log"
+	"strconv"
+
+	"github.com/windoze95/cantinarr-server/internal/arr"
+)
+
+// autoGiveupStreakKey is the settings-table key holding the consecutive
+// auto-dispatch give-up counter (a plain integer string). It is kept OUT of the
+// remediation_settings JSON blob on purpose: it is operational state, not admin
+// configuration, and keeping it separate avoids a read-modify-write race with
+// the blob and keeps settings.go untouched.
+const autoGiveupStreakKey = "remediation_auto_giveup_streak"
+
+// AutoDispatcher is the IssueOpener the websocket hub calls when its poller finds
+// a stuck/blocked download. It is the gate + glue between the read-only poll path
+// and the remediation Service: it re-checks the live toggles per call (so an
+// admin flipping Enabled/AutoDispatch takes effect without a restart), opens a
+// deduped issue, and — on a genuinely new issue — enqueues the read-only Runner
+// OFF the poll goroutine so the 30s loop never blocks on the agent.
+//
+// It is a thin wrapper around *Service (not the Service itself) so the hub's
+// optional-interface contract is explicit: main.go passes a non-nil
+// *AutoDispatcher only when remediation is wired, and a nil *AutoDispatcher (or
+// leaving the hub's opener unset) cleanly disables the whole path.
+type AutoDispatcher struct {
+	svc *Service
+}
+
+// NewAutoDispatcher wraps a remediation Service as the hub's IssueOpener.
+func NewAutoDispatcher(svc *Service) *AutoDispatcher {
+	return &AutoDispatcher{svc: svc}
+}
+
+// OpenAutoIssue is the poller hook (implements websocket.IssueOpener). It gates
+// on the LIVE settings (read fresh each call), records a deduped auto issue via
+// the Service, and enqueues the Runner when a NEW issue was created. The DB
+// partial-unique index in Service.OpenAutoIssue is the real one-issue-per-stuck-
+// download guarantee; the hub's 2-poll debounce only reduces noise upstream.
+//
+// It never runs the agent inline: Enqueue pushes onto the worker channel and
+// returns immediately, so a slow investigation can't stall the poll goroutine.
+func (a *AutoDispatcher) OpenAutoIssue(serviceType, instanceID, downloadID string, d arr.Diagnosis) {
+	if a == nil || a.svc == nil {
+		return
+	}
+	s := a.svc.Settings()
+	// Gate at CALL time on BOTH switches, read fresh so toggling takes effect
+	// without a restart. AutoDispatch independently gates only this poll path; the
+	// circuit breaker flips AutoDispatch off (not Enabled) when it trips.
+	if !s.Enabled || !s.AutoDispatch {
+		return
+	}
+
+	created, id := a.svc.OpenAutoIssue(serviceType, instanceID, downloadID, d)
+	if !created {
+		return // existing open issue (or a write error): nothing new to run.
+	}
+	// Kick off the read-only investigation off the poll goroutine.
+	a.svc.Enqueue(id)
+}
+
+// --- circuit breaker ---
+//
+// The breaker bounds how many unattended auto-dispatch investigations can fail
+// in a row before auto-dispatch shuts itself off, so a flapping or misconfigured
+// indexer can't fan out into dozens of give-ups. It is driven entirely from the
+// terminal outcomes of AUTO-sourced issues (user-reported issues never touch the
+// streak):
+//
+//   - an auto issue resolves              -> streak reset to 0
+//   - an auto issue terminates non-resolved (wont_fix/failed/dismissed)
+//                                          -> streak++; at the threshold,
+//                                             AutoDispatch is persisted OFF and
+//                                             admins are notified.
+//
+// noteAutoTerminal is invoked from ConcludeIssue (the single chokepoint every
+// terminal transition funnels through) ONLY when the row actually transitioned,
+// so a double-conclude can never double-count. DismissIssue is an admin action,
+// not an agent give-up, and deliberately does not feed the breaker.
+
+// noteAutoTerminal updates the circuit-breaker streak for a terminal issue
+// outcome. It is a no-op for user-reported issues. resolved means the agent
+// closed the issue successfully; anything else counts as a give-up.
+func (s *Service) noteAutoTerminal(issueID int64, status string) {
+	var source string
+	if err := s.db.QueryRow("SELECT source FROM issues WHERE id = ?", issueID).Scan(&source); err != nil || source != SourceAuto {
+		return
+	}
+
+	if status == IssueResolved {
+		s.resetAutoGiveupStreak()
+		return
+	}
+
+	streak := s.bumpAutoGiveupStreak()
+	threshold := s.Settings().CircuitBreakerGiveups
+	if threshold > 0 && streak >= threshold {
+		s.tripCircuitBreaker(streak, threshold)
+	}
+}
+
+// readAutoGiveupStreak returns the persisted consecutive-give-up counter (0 when
+// unset/unparsable).
+func (s *Service) readAutoGiveupStreak() int {
+	var v sql.NullInt64
+	if err := s.db.QueryRow("SELECT CAST(value AS INTEGER) FROM settings WHERE key = ?", autoGiveupStreakKey).Scan(&v); err != nil {
+		return 0
+	}
+	if !v.Valid || v.Int64 < 0 {
+		return 0
+	}
+	return int(v.Int64)
+}
+
+// resetAutoGiveupStreak clears the counter (an auto issue resolved). Best-effort.
+func (s *Service) resetAutoGiveupStreak() {
+	s.db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES (?, '0')", autoGiveupStreakKey)
+}
+
+// bumpAutoGiveupStreak increments and persists the counter, returning the new
+// value. Under the single-writer SQLite DB the read-then-write is atomic enough
+// for this coarse guardrail (the breaker only needs to trip eventually).
+func (s *Service) bumpAutoGiveupStreak() int {
+	n := s.readAutoGiveupStreak() + 1
+	if _, err := s.db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", autoGiveupStreakKey, strconv.Itoa(n)); err != nil {
+		log.Printf("remediation: bump auto give-up streak: %v", err)
+	}
+	return n
+}
+
+// tripCircuitBreaker persists AutoDispatch=off and notifies admins. It then
+// resets the streak so a re-enable starts from a clean slate. Enabled (the
+// master switch) is left untouched: only the poller path is disarmed.
+func (s *Service) tripCircuitBreaker(streak, threshold int) {
+	cur := s.Settings()
+	if !cur.AutoDispatch {
+		// Already off (e.g. a concurrent trip): just clear the streak.
+		s.resetAutoGiveupStreak()
+		return
+	}
+	cur.AutoDispatch = false
+	if _, err := s.SetSettings(cur); err != nil {
+		log.Printf("remediation: circuit breaker could not disable auto-dispatch: %v", err)
+		return
+	}
+	log.Printf("remediation: circuit breaker tripped after %d consecutive auto-dispatch give-ups (threshold %d); auto-dispatch disabled", streak, threshold)
+	if s.notifier != nil {
+		// Fixed-template event: only structured fields travel, no model text.
+		s.notifier.NotifyAdmins("remediation_autodispatch_disabled", map[string]interface{}{
+			"reason":    "circuit_breaker",
+			"giveups":   streak,
+			"threshold": threshold,
+		})
+	}
+	s.resetAutoGiveupStreak()
+}

--- a/server/internal/remediation/autodispatch_test.go
+++ b/server/internal/remediation/autodispatch_test.go
@@ -1,0 +1,287 @@
+package remediation
+
+import (
+	"context"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/arr"
+	"github.com/windoze95/cantinarr-server/internal/db"
+)
+
+// enableAutoDispatch turns on both the master switch and the auto-dispatch
+// sub-toggle with a known circuit-breaker threshold, returning the saved value.
+func enableAutoDispatch(t *testing.T, svc *Service, breakerGiveups int) {
+	t.Helper()
+	s := Defaults()
+	s.Enabled = true
+	s.AutoDispatch = true
+	s.CircuitBreakerGiveups = breakerGiveups
+	if _, err := svc.SetSettings(s); err != nil {
+		t.Fatalf("enable auto-dispatch: %v", err)
+	}
+}
+
+// countOpenAutoIssues returns how many open (closed_at IS NULL) auto-sourced
+// issues exist — the invariant the dedupe must hold to one per stuck download.
+func countOpenAutoIssues(t *testing.T, svc *Service) int {
+	t.Helper()
+	var n int
+	if err := svc.db.QueryRow("SELECT COUNT(*) FROM issues WHERE source = ? AND closed_at IS NULL", SourceAuto).Scan(&n); err != nil {
+		t.Fatalf("count open auto issues: %v", err)
+	}
+	return n
+}
+
+// drainJobs counts how many jobs are currently queued (non-blocking), draining
+// the channel. Used to assert the Runner was enqueued exactly once for a new
+// auto issue and never for a duplicate.
+func drainJobs(svc *Service) int {
+	n := 0
+	for {
+		select {
+		case <-svc.jobs:
+			n++
+		default:
+			return n
+		}
+	}
+}
+
+func stalledDiagnosis() arr.Diagnosis {
+	return arr.Diagnose(arr.QueueSignal{
+		TrackedDownloadStatus: "error",
+		ErrorMessage:          "The download is stalled with no connections",
+	})
+}
+
+// TestAutoDispatcherOpensExactlyOneIssueAcrossPolls is the core dedupe guarantee:
+// the hub may call OpenAutoIssue once per confirming poll, but the DB partial-
+// unique index collapses every repeat for the same stuck download into a SINGLE
+// open issue, and the Runner is enqueued only for the first (genuinely new) one.
+func TestAutoDispatcherOpensExactlyOneIssueAcrossPolls(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	enableAutoDispatch(t, svc, 5)
+	ad := NewAutoDispatcher(svc)
+
+	d := stalledDiagnosis()
+	// Simulate many confirming polls of the SAME stuck download.
+	for i := 0; i < 6; i++ {
+		ad.OpenAutoIssue("radarr", "inst1", "stuckHash", d)
+	}
+
+	if got := countOpenAutoIssues(t, svc); got != 1 {
+		t.Fatalf("open auto issues after repeated polls = %d, want exactly 1", got)
+	}
+	// The occurrences counter on the single issue reflects the repeats (1 insert +
+	// 5 duplicate bumps).
+	var occ int
+	if err := svc.db.QueryRow("SELECT occurrences FROM issues WHERE source = ? AND closed_at IS NULL", SourceAuto).Scan(&occ); err != nil {
+		t.Fatalf("read occurrences: %v", err)
+	}
+	if occ != 6 {
+		t.Fatalf("occurrences = %d, want 6 (1 create + 5 dedupe bumps)", occ)
+	}
+	// The Runner was enqueued exactly once (only the create path enqueues).
+	if jobs := drainJobs(svc); jobs != 1 {
+		t.Fatalf("enqueued jobs = %d, want exactly 1 (only the new issue)", jobs)
+	}
+}
+
+// TestAutoDispatcherGatedOff proves the opener is a no-op unless BOTH the master
+// switch and the auto-dispatch sub-toggle are on — checked at call time so a live
+// toggle takes effect without a restart.
+func TestAutoDispatcherGatedOff(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	ad := NewAutoDispatcher(svc)
+	d := stalledDiagnosis()
+
+	// Default settings: Enabled=false, AutoDispatch=false -> no-op.
+	ad.OpenAutoIssue("radarr", "inst1", "h1", d)
+	if got := countOpenAutoIssues(t, svc); got != 0 {
+		t.Fatalf("with feature off, opened %d issue(s), want 0", got)
+	}
+
+	// Enabled but AutoDispatch off -> still no-op (the sub-toggle independently
+	// gates the poll path).
+	s := Defaults()
+	s.Enabled = true
+	s.AutoDispatch = false
+	if _, err := svc.SetSettings(s); err != nil {
+		t.Fatalf("set settings: %v", err)
+	}
+	ad.OpenAutoIssue("radarr", "inst1", "h1", d)
+	if got := countOpenAutoIssues(t, svc); got != 0 {
+		t.Fatalf("with AutoDispatch off, opened %d issue(s), want 0", got)
+	}
+
+	// Both on -> opens.
+	enableAutoDispatch(t, svc, 5)
+	ad.OpenAutoIssue("radarr", "inst1", "h1", d)
+	if got := countOpenAutoIssues(t, svc); got != 1 {
+		t.Fatalf("with both on, opened %d issue(s), want 1", got)
+	}
+}
+
+// seedAutoIssue inserts an open auto-sourced issue and returns its id, so the
+// circuit-breaker tests can drive terminal outcomes through ConcludeIssue.
+func seedAutoIssue(t *testing.T, svc *Service, downloadID string) int64 {
+	t.Helper()
+	res, err := svc.db.Exec(
+		"INSERT INTO issues (source, status, media_type, tmdb_id, title, instance_id, download_id, dedupe_key) VALUES (?,?,?,?,?,?,?,?)",
+		SourceAuto, IssueOpen, "movie", 0, "Stuck", "inst1", downloadID, downloadID,
+	)
+	if err != nil {
+		t.Fatalf("seed auto issue: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+// TestCircuitBreakerDisablesAutoDispatchAfterNGiveups proves that N consecutive
+// auto-dispatch give-ups (auto issues concluded non-resolved) flip AutoDispatch
+// OFF (persisted) and fire the admin notification, while leaving the master
+// Enabled switch untouched. User-reported give-ups never feed the breaker.
+func TestCircuitBreakerDisablesAutoDispatchAfterNGiveups(t *testing.T) {
+	svc, notif, reporterID := setupTestService(t)
+	const threshold = 3
+	enableAutoDispatch(t, svc, threshold)
+	ctx := context.Background()
+
+	// A user-reported give-up must NOT count toward the breaker.
+	userIssue, err := svc.CreateUserIssue(reporterID, &CreateIssueRequest{
+		MediaType: "movie", TmdbID: 99, Category: CategoryOther,
+	})
+	if err != nil {
+		t.Fatalf("create user issue: %v", err)
+	}
+	if err := svc.ConcludeIssue(ctx, userIssue.IssueID, IssueWontFix, "user give-up"); err != nil {
+		t.Fatalf("conclude user issue: %v", err)
+	}
+	if svc.readAutoGiveupStreak() != 0 {
+		t.Fatalf("user give-up bumped the streak to %d, want 0", svc.readAutoGiveupStreak())
+	}
+
+	// threshold-1 auto give-ups: AutoDispatch stays ON.
+	for i := 0; i < threshold-1; i++ {
+		id := seedAutoIssue(t, svc, "hash"+string(rune('a'+i)))
+		if err := svc.ConcludeIssue(ctx, id, IssueWontFix, "agent gave up"); err != nil {
+			t.Fatalf("conclude auto issue: %v", err)
+		}
+	}
+	if !svc.Settings().AutoDispatch {
+		t.Fatalf("AutoDispatch flipped off too early (after %d give-ups, threshold %d)", threshold-1, threshold)
+	}
+	if svc.readAutoGiveupStreak() != threshold-1 {
+		t.Fatalf("streak = %d, want %d", svc.readAutoGiveupStreak(), threshold-1)
+	}
+
+	// The threshold-th auto give-up trips the breaker.
+	tripID := seedAutoIssue(t, svc, "tripHash")
+	if err := svc.ConcludeIssue(ctx, tripID, IssueWontFix, "agent gave up"); err != nil {
+		t.Fatalf("conclude tripping issue: %v", err)
+	}
+
+	final := svc.Settings()
+	if final.AutoDispatch {
+		t.Fatalf("AutoDispatch still on after %d consecutive give-ups, want off", threshold)
+	}
+	if !final.Enabled {
+		t.Fatalf("circuit breaker disabled the master Enabled switch, want only AutoDispatch off")
+	}
+	// The streak reset to 0 after tripping (a clean slate for a re-enable).
+	if svc.readAutoGiveupStreak() != 0 {
+		t.Fatalf("streak after trip = %d, want 0 (reset)", svc.readAutoGiveupStreak())
+	}
+	// An admin notification fired for the trip.
+	found := false
+	for _, e := range notif.adminEvents {
+		if e == "remediation_autodispatch_disabled" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("admin events = %v, want a remediation_autodispatch_disabled event", notif.adminEvents)
+	}
+}
+
+// TestCircuitBreakerResetOnResolve proves a successful auto resolution clears the
+// give-up streak, so an intermittent problem that the agent sometimes fixes never
+// trips the breaker.
+func TestCircuitBreakerResetOnResolve(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	const threshold = 3
+	enableAutoDispatch(t, svc, threshold)
+	ctx := context.Background()
+
+	// Two give-ups, then a resolve, then two more give-ups: the resolve resets the
+	// streak so the breaker (threshold 3) never trips across this sequence.
+	g1 := seedAutoIssue(t, svc, "g1")
+	g2 := seedAutoIssue(t, svc, "g2")
+	if err := svc.ConcludeIssue(ctx, g1, IssueWontFix, "gave up"); err != nil {
+		t.Fatalf("conclude g1: %v", err)
+	}
+	if err := svc.ConcludeIssue(ctx, g2, IssueWontFix, "gave up"); err != nil {
+		t.Fatalf("conclude g2: %v", err)
+	}
+	if svc.readAutoGiveupStreak() != 2 {
+		t.Fatalf("streak before resolve = %d, want 2", svc.readAutoGiveupStreak())
+	}
+
+	r1 := seedAutoIssue(t, svc, "r1")
+	if err := svc.ConcludeIssue(ctx, r1, IssueResolved, "fixed"); err != nil {
+		t.Fatalf("conclude r1 resolved: %v", err)
+	}
+	if svc.readAutoGiveupStreak() != 0 {
+		t.Fatalf("streak after resolve = %d, want 0", svc.readAutoGiveupStreak())
+	}
+
+	g3 := seedAutoIssue(t, svc, "g3")
+	g4 := seedAutoIssue(t, svc, "g4")
+	if err := svc.ConcludeIssue(ctx, g3, IssueWontFix, "gave up"); err != nil {
+		t.Fatalf("conclude g3: %v", err)
+	}
+	if err := svc.ConcludeIssue(ctx, g4, IssueWontFix, "gave up"); err != nil {
+		t.Fatalf("conclude g4: %v", err)
+	}
+	if !svc.Settings().AutoDispatch {
+		t.Fatalf("AutoDispatch tripped despite a reset (streak should be 2, threshold 3)")
+	}
+	if svc.readAutoGiveupStreak() != 2 {
+		t.Fatalf("final streak = %d, want 2", svc.readAutoGiveupStreak())
+	}
+}
+
+// TestConcludeIdempotentDoesNotDoubleCountBreaker proves a double-conclude of the
+// same auto issue bumps the give-up streak only once (the second conclude is a
+// no-op transition).
+func TestConcludeIdempotentDoesNotDoubleCountBreaker(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	enableAutoDispatch(t, svc, 5)
+	ctx := context.Background()
+
+	id := seedAutoIssue(t, svc, "once")
+	if err := svc.ConcludeIssue(ctx, id, IssueWontFix, "gave up"); err != nil {
+		t.Fatalf("first conclude: %v", err)
+	}
+	if err := svc.ConcludeIssue(ctx, id, IssueWontFix, "gave up again"); err != nil {
+		t.Fatalf("second conclude (idempotent): %v", err)
+	}
+	if svc.readAutoGiveupStreak() != 1 {
+		t.Fatalf("streak after double-conclude = %d, want 1 (no double count)", svc.readAutoGiveupStreak())
+	}
+}
+
+// Ensure the in-memory DB schema actually has the columns the seed uses (guards
+// against an initSQL drift breaking these tests silently).
+func TestAutoIssueSchemaSanity(t *testing.T) {
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	if _, err := database.Exec(
+		"INSERT INTO issues (source, status, media_type, tmdb_id, title, instance_id, download_id, dedupe_key) VALUES ('auto','open','movie',0,'x','i','d','k')",
+	); err != nil {
+		t.Fatalf("insert auto issue with dedupe_key: %v", err)
+	}
+}

--- a/server/internal/remediation/issuestore.go
+++ b/server/internal/remediation/issuestore.go
@@ -54,7 +54,9 @@ func (s *Service) ConcludeIssue(ctx context.Context, issueID int64, status, reso
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
 		// Already closed (or no such issue): treat as idempotent success when the
-		// row exists, so a resumed/duplicated conclude does not error.
+		// row exists, so a resumed/duplicated conclude does not error. No circuit-
+		// breaker update here: the row did not transition, so this is not a fresh
+		// terminal outcome (a double-conclude must never double-count a give-up).
 		var exists int
 		if qerr := s.db.QueryRowContext(ctx, "SELECT 1 FROM issues WHERE id = ?", issueID).Scan(&exists); qerr == sql.ErrNoRows {
 			return fmt.Errorf("issue not found")
@@ -64,6 +66,10 @@ func (s *Service) ConcludeIssue(ctx context.Context, issueID int64, status, reso
 
 	// Release any run claim now that the issue is terminal.
 	s.db.ExecContext(ctx, "UPDATE issues SET active_run_id = NULL WHERE id = ?", issueID)
+	// Feed the auto-dispatch circuit breaker exactly once per real terminal
+	// transition: resolved resets the give-up streak, a non-resolved close bumps
+	// it (and may disarm auto-dispatch). A no-op for user-reported issues.
+	s.noteAutoTerminal(issueID, status)
 	s.notifyIssueResolved(issueID, status)
 	return nil
 }

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/windoze95/cantinarr-server/internal/arr"
 	"github.com/windoze95/cantinarr-server/internal/auth"
 	"github.com/windoze95/cantinarr-server/internal/downloads"
 	"github.com/windoze95/cantinarr-server/internal/instance"
@@ -46,6 +47,35 @@ type ContentNotifier interface {
 	NotifyNewEpisode(seriesTitle string, tmdbID int)
 }
 
+// IssueOpener is the auto-dispatch seam: the poller hands a stuck/blocked
+// download to it so the remediation feature can open an issue and kick off the
+// read-only agent. *remediation.AutoDispatcher satisfies it. It is declared here
+// (rather than importing remediation) so the hub stays decoupled and is wired
+// EXACTLY like ContentNotifier: nil (the zero value) means auto-dispatch is off,
+// so the poll path skips the detailed-queue diagnosis entirely.
+//
+// The implementation is responsible for the real gate (Settings.Enabled &&
+// Settings.AutoDispatch, read fresh each call so a toggle takes effect without a
+// restart), the DB-backed dedupe, the Runner enqueue, and the circuit breaker.
+// The hub only contributes the lightweight 2-consecutive-poll debounce so a
+// transient post-download state never reaches the opener.
+type IssueOpener interface {
+	// OpenAutoIssue is called once per problematic download confirmed on two
+	// consecutive polls. serviceType is "radarr"|"sonarr"; downloadID is the
+	// stable download-client hash; d is the classifier's verdict. It must not
+	// block the poll goroutine (the Runner is enqueued, never run inline).
+	OpenAutoIssue(serviceType, instanceID, downloadID string, d arr.Diagnosis)
+}
+
+// queueSignalItem bundles a queue item's stable download-client id with the
+// service-neutral classifier signal. The poll path builds these from the
+// detailed queue; a test builds them directly so the diagnose/debounce/dispatch
+// logic is exercised with a fake queue source (no live arr client).
+type queueSignalItem struct {
+	downloadID string
+	signal     arr.QueueSignal
+}
+
 // Client represents a connected WebSocket client.
 type Client struct {
 	hub     *Hub
@@ -72,9 +102,25 @@ type Hub struct {
 	// when a download completes. nil when push is not configured.
 	content ContentNotifier
 
+	// opener receives stuck/blocked downloads for auto-dispatch. nil (the zero
+	// value) disables the whole auto-dispatch path: the poll loop then skips the
+	// detailed-queue diagnosis. Set only when the remediation feature is wired.
+	opener IssueOpener
+
 	// Previous polling state for detecting transitions
 	prevRadarrQueue map[string]map[int]float64 // instanceID -> movieId -> progress
 	prevSonarrQueue map[string]map[int]float64 // instanceID -> seriesId -> progress
+
+	// prevArrProblems debounces auto-dispatch: it remembers the diagnosed
+	// problem label per download from the previous poll, keyed
+	// serviceType:instanceID:downloadID. The opener is called only when the SAME
+	// problem persists across two consecutive polls, so a transient post-download
+	// state (e.g. a bare importPending, normal for a few seconds) never
+	// false-triggers. This is debounce ONLY; the DB partial-unique index in
+	// OpenAutoIssue is the real one-issue-per-download guarantee. The map is
+	// reset to the current poll's problems each pass, so a resolved download
+	// drops out and a genuinely new recurrence re-confirms over two polls.
+	prevArrProblems map[string]string
 
 	// prevArrQueueHash tracks the queue composition (id/status/sizeleft
 	// tuples) per arr instance so any change can emit an invalidation ping.
@@ -95,7 +141,9 @@ type Hub struct {
 
 // NewHub creates a new WebSocket hub. content pushes new-content alerts when a
 // download completes; pass nil (or a nil *push.Notifier) when push is disabled.
-func NewHub(authService *auth.Service, registry *instance.Registry, store *instance.Store, content ContentNotifier) *Hub {
+// opener receives stuck/blocked downloads for auto-dispatch; pass nil (or a nil
+// remediation.AutoDispatcher) to keep the whole auto-dispatch path off.
+func NewHub(authService *auth.Service, registry *instance.Registry, store *instance.Store, content ContentNotifier, opener IssueOpener) *Hub {
 	return &Hub{
 		clients:            make(map[*Client]bool),
 		broadcast:          make(chan outboundMessage, 256),
@@ -105,12 +153,24 @@ func NewHub(authService *auth.Service, registry *instance.Registry, store *insta
 		registry:           registry,
 		store:              store,
 		content:            content,
+		opener:             opener,
 		prevRadarrQueue:    make(map[string]map[int]float64),
 		prevSonarrQueue:    make(map[string]map[int]float64),
 		prevArrQueueHash:   make(map[string]string),
+		prevArrProblems:    make(map[string]string),
 		prevDownloadsHash:  make(map[string]string),
 		downloadsErrLogged: make(map[string]bool),
 	}
+}
+
+// SetIssueOpener wires the auto-dispatch opener after construction. This exists
+// because the opener (a remediation AutoDispatcher) depends on the notifier
+// composite, which in turn depends on this hub — a construction cycle the
+// content notifier sidesteps because it does not. Call it BEFORE Run starts the
+// poll goroutine; it is not safe to call concurrently with a running poll loop.
+// Passing nil leaves auto-dispatch off.
+func (h *Hub) SetIssueOpener(opener IssueOpener) {
+	h.opener = opener
 }
 
 // Run starts the hub's main loop and polling goroutine.
@@ -404,6 +464,155 @@ func (h *Hub) noteArrQueueComposition(instanceID, serviceType string, tuples []s
 	})
 }
 
+// autoDispatchEnabled reports whether the auto-dispatch path is wired at all.
+// When the opener is nil the poll path skips the extra detailed-queue fetch and
+// the diagnosis entirely, so a server without the remediation feature pays
+// nothing. The opener itself still re-checks the live Enabled/AutoDispatch
+// toggles per call (so flipping them takes effect without a restart); this is
+// only the cheap "is it even wired" short-circuit.
+func (h *Hub) autoDispatchEnabled() bool { return h.opener != nil }
+
+// dispatchDetailedItems runs the Import Doctor over one instance's detailed
+// queue and forwards confirmed problems to the opener. It applies the
+// 2-consecutive-poll debounce: a problem fires only when the SAME problem label
+// for the same download was present on the previous poll too. It rebuilds the
+// per-download problem map for this instance each pass (keyed
+// serviceType:instanceID:downloadID), so a download that recovered or left the
+// queue drops out of the map and any later recurrence must re-confirm over two
+// polls. Items with no download id yet (not handed to the client) are skipped:
+// they have no stable dedupe key and are expected to be transient.
+//
+// The poll path supplies items from GetQueueDetailed(); a test supplies them
+// directly with a fake queue source. The opener is invoked synchronously here
+// but is required to be non-blocking (it enqueues the Runner, never runs it).
+func (h *Hub) dispatchDetailedItems(serviceType, instanceID string, items []queueSignalItem) {
+	if h.opener == nil {
+		return
+	}
+
+	// Build this poll's problem set and decide dispatches under the lock, but
+	// invoke the opener AFTER releasing it so a slow opener can't stall other
+	// instances' polls (mirrors pollDownloadClientInstance's discipline).
+	type dispatch struct {
+		downloadID string
+		diagnosis  arr.Diagnosis
+	}
+	var toOpen []dispatch
+	current := make(map[string]string)
+
+	h.pollMu.Lock()
+	for _, it := range items {
+		if it.downloadID == "" {
+			continue // no stable dedupe key yet; expected to be transient.
+		}
+		d := arr.Diagnose(it.signal)
+		if d.Severity != arr.SeverityWarning && d.Severity != arr.SeverityError {
+			continue
+		}
+		key := serviceType + ":" + instanceID + ":" + it.downloadID
+		current[key] = d.Problem
+		// Fire only if the SAME problem persisted from the previous poll.
+		if h.prevArrProblems[key] == d.Problem {
+			toOpen = append(toOpen, dispatch{downloadID: it.downloadID, diagnosis: d})
+		}
+	}
+	// Replace the remembered problems for THIS instance: drop stale keys (other
+	// downloads/instances are untouched), record the current ones.
+	prefix := serviceType + ":" + instanceID + ":"
+	for k := range h.prevArrProblems {
+		if strings.HasPrefix(k, prefix) {
+			delete(h.prevArrProblems, k)
+		}
+	}
+	for k, v := range current {
+		h.prevArrProblems[k] = v
+	}
+	h.pollMu.Unlock()
+
+	for _, d := range toOpen {
+		h.opener.OpenAutoIssue(serviceType, instanceID, d.downloadID, d.diagnosis)
+	}
+}
+
+// radarrQueueSignal projects a Radarr detailed queue item into the neutral
+// classifier signal plus its stable download id. It mirrors mcp.radarrSignal
+// (kept local so the hub need not import the mcp package).
+func radarrQueueSignal(item radarr.DetailedQueueItem) queueSignalItem {
+	messages := make([]arr.StatusMessage, 0, len(item.StatusMessages))
+	for _, m := range item.StatusMessages {
+		messages = append(messages, arr.StatusMessage{Title: m.Title, Messages: m.Messages})
+	}
+	return queueSignalItem{
+		downloadID: item.DownloadID,
+		signal: arr.QueueSignal{
+			Status:                item.Status,
+			TrackedDownloadStatus: item.TrackedDownloadStatus,
+			TrackedDownloadState:  item.TrackedDownloadState,
+			ErrorMessage:          item.ErrorMessage,
+			StatusMessages:        messages,
+			Protocol:              item.Protocol,
+		},
+	}
+}
+
+// sonarrQueueSignal projects a Sonarr detailed queue item into the neutral
+// classifier signal plus its stable download id. It mirrors mcp.sonarrSignal.
+func sonarrQueueSignal(item sonarr.DetailedQueueItem) queueSignalItem {
+	messages := make([]arr.StatusMessage, 0, len(item.StatusMessages))
+	for _, m := range item.StatusMessages {
+		messages = append(messages, arr.StatusMessage{Title: m.Title, Messages: m.Messages})
+	}
+	return queueSignalItem{
+		downloadID: item.DownloadID,
+		signal: arr.QueueSignal{
+			Status:                item.Status,
+			TrackedDownloadStatus: item.TrackedDownloadStatus,
+			TrackedDownloadState:  item.TrackedDownloadState,
+			ErrorMessage:          item.ErrorMessage,
+			StatusMessages:        messages,
+			Protocol:              item.Protocol,
+		},
+	}
+}
+
+// autoDispatchRadarr fetches the detailed queue (the lightweight GetQueue used
+// for progress lacks tracked-download fields, so it cannot drive Diagnose) and
+// runs the diagnose/debounce/dispatch pass. A fetch error is logged and skipped;
+// the progress poll above already ran off the lightweight queue, so a detailed
+// fetch failure never affects download_progress events.
+func (h *Hub) autoDispatchRadarr(instanceID string, client *radarr.Client) {
+	if !h.autoDispatchEnabled() {
+		return
+	}
+	items, err := client.GetQueueDetailed()
+	if err != nil {
+		log.Printf("websocket: auto-dispatch radarr detailed queue (%s): %v", instanceID, err)
+		return
+	}
+	signals := make([]queueSignalItem, 0, len(items))
+	for _, item := range items {
+		signals = append(signals, radarrQueueSignal(item))
+	}
+	h.dispatchDetailedItems("radarr", instanceID, signals)
+}
+
+// autoDispatchSonarr is the Sonarr analogue of autoDispatchRadarr.
+func (h *Hub) autoDispatchSonarr(instanceID string, client *sonarr.Client) {
+	if !h.autoDispatchEnabled() {
+		return
+	}
+	items, err := client.GetQueueDetailed()
+	if err != nil {
+		log.Printf("websocket: auto-dispatch sonarr detailed queue (%s): %v", instanceID, err)
+		return
+	}
+	signals := make([]queueSignalItem, 0, len(items))
+	for _, item := range items {
+		signals = append(signals, sonarrQueueSignal(item))
+	}
+	h.dispatchDetailedItems("sonarr", instanceID, signals)
+}
+
 func (h *Hub) pollAllRadarr() {
 	if h.store == nil || h.registry == nil {
 		return
@@ -504,6 +713,11 @@ func (h *Hub) pollRadarrInstance(instanceID string, client *radarr.Client) {
 
 	h.prevRadarrQueue[instanceID] = currentQueue
 	h.noteArrQueueComposition(instanceID, "radarr", tuples)
+
+	// Auto-dispatch pass: diagnose the detailed queue and open issues for
+	// confirmed stuck/blocked downloads. No-op (and no extra fetch) when the
+	// opener is nil. Runs on this poll goroutine; the opener is non-blocking.
+	h.autoDispatchRadarr(instanceID, client)
 }
 
 func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
@@ -573,4 +787,7 @@ func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
 
 	h.prevSonarrQueue[instanceID] = currentQueue
 	h.noteArrQueueComposition(instanceID, "sonarr", tuples)
+
+	// Auto-dispatch pass (see pollRadarrInstance). No-op when the opener is nil.
+	h.autoDispatchSonarr(instanceID, client)
 }

--- a/server/internal/websocket/hub_test.go
+++ b/server/internal/websocket/hub_test.go
@@ -1,1 +1,218 @@
 package websocket
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/arr"
+	"github.com/windoze95/cantinarr-server/internal/radarr"
+	"github.com/windoze95/cantinarr-server/internal/sonarr"
+)
+
+// fakeOpener records every OpenAutoIssue call so a test can assert the hub's
+// 2-consecutive-poll debounce: a problem must persist across two polls before it
+// reaches the opener, and the opener is then called once per confirming poll
+// (the real DB dedupe — exercised separately — collapses those into one issue).
+type fakeOpener struct {
+	mu    sync.Mutex
+	calls []openCall
+}
+
+type openCall struct {
+	serviceType string
+	instanceID  string
+	downloadID  string
+	problem     string
+}
+
+func (f *fakeOpener) OpenAutoIssue(serviceType, instanceID, downloadID string, d arr.Diagnosis) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, openCall{serviceType, instanceID, downloadID, d.Problem})
+}
+
+func (f *fakeOpener) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// newTestHub builds a hub wired with only the given opener. The other
+// dependencies are nil because the auto-dispatch dispatch path touches only the
+// opener and the debounce map; NewHub still initializes prevArrProblems.
+func newTestHub(opener IssueOpener) *Hub {
+	return NewHub(nil, nil, nil, nil, opener)
+}
+
+// stuckItem is a queue item whose tracked-download state classifies as an error
+// (a stalled torrent): warning/error severity, so it is eligible for dispatch.
+func stuckItem(downloadID string) queueSignalItem {
+	return queueSignalItem{
+		downloadID: downloadID,
+		signal: arr.QueueSignal{
+			Status:                "warning",
+			TrackedDownloadStatus: "error",
+			ErrorMessage:          "The download is stalled with no connections",
+		},
+	}
+}
+
+// importPendingItem is a bare importPending item — the doctor classifies it as a
+// warning, but it is normal for a few seconds post-download, which is exactly why
+// the debounce exists.
+func importPendingItem(downloadID string) queueSignalItem {
+	return queueSignalItem{
+		downloadID: downloadID,
+		signal: arr.QueueSignal{
+			Status:               "completed",
+			TrackedDownloadState: "importPending",
+		},
+	}
+}
+
+// TestAutoDispatchDebounceFiresOnSecondPoll proves a problem must persist across
+// two consecutive polls before the opener is called: the first poll only seeds
+// the debounce baseline, the second (and each later) poll dispatches.
+func TestAutoDispatchDebounceFiresOnSecondPoll(t *testing.T) {
+	opener := &fakeOpener{}
+	h := newTestHub(opener)
+
+	items := []queueSignalItem{stuckItem("hashA")}
+
+	// First poll: establishes the baseline, fires nothing.
+	h.dispatchDetailedItems("radarr", "inst1", items)
+	if opener.count() != 0 {
+		t.Fatalf("after first poll, opener calls = %d, want 0 (debounce baseline only)", opener.count())
+	}
+
+	// Second poll: same problem persists -> dispatch once.
+	h.dispatchDetailedItems("radarr", "inst1", items)
+	if opener.count() != 1 {
+		t.Fatalf("after second poll, opener calls = %d, want 1", opener.count())
+	}
+	got := opener.calls[0]
+	if got.serviceType != "radarr" || got.instanceID != "inst1" || got.downloadID != "hashA" {
+		t.Fatalf("dispatch = %+v, want radarr/inst1/hashA", got)
+	}
+}
+
+// TestAutoDispatchTransientImportPendingOpensNone proves a problem seen on only
+// ONE poll never reaches the opener. The item is problematic on the first poll
+// (establishing a baseline) but is gone (imported) on the second, so the
+// debounce never confirms it.
+func TestAutoDispatchTransientImportPendingOpensNone(t *testing.T) {
+	opener := &fakeOpener{}
+	h := newTestHub(opener)
+
+	// Poll 1: a bare importPending (transient post-download warning).
+	h.dispatchDetailedItems("radarr", "inst1", []queueSignalItem{importPendingItem("hashB")})
+	// Poll 2: the download imported and left the queue (empty queue).
+	h.dispatchDetailedItems("radarr", "inst1", []queueSignalItem{})
+
+	if opener.count() != 0 {
+		t.Fatalf("transient importPending opened %d issue(s), want 0", opener.count())
+	}
+}
+
+// TestAutoDispatchHealthyItemsNeverDispatch proves an ok-severity item is never
+// a candidate no matter how many polls it survives.
+func TestAutoDispatchHealthyItemsNeverDispatch(t *testing.T) {
+	opener := &fakeOpener{}
+	h := newTestHub(opener)
+
+	healthy := []queueSignalItem{{
+		downloadID: "hashC",
+		signal:     arr.QueueSignal{Status: "downloading", TrackedDownloadStatus: "ok"},
+	}}
+	for i := 0; i < 4; i++ {
+		h.dispatchDetailedItems("radarr", "inst1", healthy)
+	}
+	if opener.count() != 0 {
+		t.Fatalf("healthy item dispatched %d time(s), want 0", opener.count())
+	}
+}
+
+// TestAutoDispatchSkipsItemsWithoutDownloadID proves an item with no
+// download-client id (not yet handed to the client) is never dispatched — it has
+// no stable dedupe key and is expected to be transient.
+func TestAutoDispatchSkipsItemsWithoutDownloadID(t *testing.T) {
+	opener := &fakeOpener{}
+	h := newTestHub(opener)
+
+	noID := []queueSignalItem{stuckItem("")}
+	h.dispatchDetailedItems("radarr", "inst1", noID)
+	h.dispatchDetailedItems("radarr", "inst1", noID)
+	if opener.count() != 0 {
+		t.Fatalf("item without download id dispatched %d time(s), want 0", opener.count())
+	}
+}
+
+// TestAutoDispatchNilOpenerNoPanic proves the dispatch path is a clean no-op when
+// no opener is wired (the feature-off case).
+func TestAutoDispatchNilOpenerNoPanic(t *testing.T) {
+	h := newTestHub(nil)
+	// Must not panic and must touch nothing.
+	h.dispatchDetailedItems("radarr", "inst1", []queueSignalItem{stuckItem("hashD"), stuckItem("hashD")})
+}
+
+// TestAutoDispatchPerInstanceIsolation proves the debounce map is keyed per
+// service:instance:download, so two instances each confirm independently and a
+// download id reused across instances does not cross-confirm on a single poll.
+func TestAutoDispatchPerInstanceIsolation(t *testing.T) {
+	opener := &fakeOpener{}
+	h := newTestHub(opener)
+
+	itemsA := []queueSignalItem{stuckItem("dup")}
+
+	// inst1 poll 1 (baseline), inst2 poll 1 (baseline): no dispatch yet.
+	h.dispatchDetailedItems("radarr", "inst1", itemsA)
+	h.dispatchDetailedItems("radarr", "inst2", itemsA)
+	if opener.count() != 0 {
+		t.Fatalf("after first poll of each instance, calls = %d, want 0", opener.count())
+	}
+
+	// inst1 poll 2: confirms for inst1 only.
+	h.dispatchDetailedItems("radarr", "inst1", itemsA)
+	if opener.count() != 1 {
+		t.Fatalf("after inst1 second poll, calls = %d, want 1", opener.count())
+	}
+	if opener.calls[0].instanceID != "inst1" {
+		t.Fatalf("first dispatch instance = %q, want inst1", opener.calls[0].instanceID)
+	}
+
+	// inst2 poll 2: confirms for inst2 independently.
+	h.dispatchDetailedItems("radarr", "inst2", itemsA)
+	if opener.count() != 2 {
+		t.Fatalf("after inst2 second poll, calls = %d, want 2", opener.count())
+	}
+}
+
+// TestQueueSignalMappers confirms the real radarr/sonarr DetailedQueueItem types
+// project into the neutral classifier signal carrying the download id and the
+// tracked-download/error fields the lightweight GetQueue lacks — the reason the
+// auto-dispatch path needs the detailed queue.
+func TestQueueSignalMappers(t *testing.T) {
+	r := radarrQueueSignal(radarr.DetailedQueueItem{
+		DownloadID:           "rdl",
+		TrackedDownloadState: "importPending",
+		Protocol:             "usenet",
+	})
+	if r.downloadID != "rdl" || r.signal.TrackedDownloadState != "importPending" {
+		t.Fatalf("radarr mapping = %+v, want downloadID=rdl state=importPending", r)
+	}
+	if d := arr.Diagnose(r.signal); d.Severity != arr.SeverityWarning {
+		t.Fatalf("radarr importPending severity = %q, want warning", d.Severity)
+	}
+
+	s := sonarrQueueSignal(sonarr.DetailedQueueItem{
+		DownloadID:            "sdl",
+		TrackedDownloadStatus: "error",
+		ErrorMessage:          "The download is stalled with no connections",
+	})
+	if s.downloadID != "sdl" {
+		t.Fatalf("sonarr mapping downloadID = %q, want sdl", s.downloadID)
+	}
+	if d := arr.Diagnose(s.signal); d.Severity != arr.SeverityError {
+		t.Fatalf("sonarr stalled severity = %q, want error", d.Severity)
+	}
+}


### PR DESCRIPTION
## Wave 5 — AUTO-DISPATCH (server only, ships OFF)

Closes the remediation loop: when the *arr queue poller sees a download the **Import Doctor** flags as stuck/blocked, automatically open a deduped issue and kick off the read-only-first agent. This is the **highest-risk TRIGGER**, so it is **gated, deduped, debounced, and circuit-broken**, and `AutoDispatch` ships **OFF** by default.

`server/` only — no `app/` changes. `internal/remediation/settings.go` is intentionally untouched (a parallel Wave-4 change owns it); this only reads `CircuitBreakerGiveups`/`AutoDispatch` and calls `SetSettings`.

### Poll hook (`internal/websocket/hub.go`)
- New **nil-able `IssueOpener`** interface on the hub, wired **exactly like `ContentNotifier`** — nil disables the whole path (and skips the extra detailed-queue fetch entirely). Wired via `SetIssueOpener` *before* the poll loop starts, because the opener depends on the notifier composite which depends on the hub (a construction cycle `ContentNotifier` sidesteps because it doesn't).
- `pollRadarrInstance`/`pollSonarrInstance` now also fetch `GetQueueDetailed()` (the lightweight `GetQueue` used for progress lacks tracked-download fields, so it can't drive `arr.Diagnose`) and diagnose each item.
- Fires the opener only for items at `warning`/`error` severity.

### Dedupe + debounce
- **Dedupe key:** `serviceType:instanceID:downloadID` (the stable download-client hash, not the volatile queue id). The **Wave-1 partial-unique index** (`idx_issues_open_dedupe`) is the *sole* correctness guarantee — repeated confirming polls of the same stuck download collapse into **exactly one** open issue; a resolved-then-re-failed download opens a **new** issue (terminal rows no longer dedupe).
- **Debounce (noise reduction only):** an in-memory `prev[serviceType:instanceID:downloadID]→problem` map fires only when the **same** problem label persists across **2 consecutive polls**, so a transient bare `importPending` (normal for seconds post-download) never false-triggers. The map re-baselines per instance each poll (recovered/departed downloads drop out). After a restart the map is empty, so a genuinely-stuck item waits one extra cycle — and the DB index still prevents any duplicate.

### Off-the-poll-goroutine dispatch
`AutoDispatcher.OpenAutoIssue` (`internal/remediation/autodispatch.go`) gates at **call time** on the **live** `Settings.Enabled && Settings.AutoDispatch` (read fresh, so toggling takes effect without a restart), calls `Service.OpenAutoIssue` (Wave-1 dedupe insert), and on `created` `Enqueue`s the Runner — never runs the agent inline, so the 30s loop never blocks.

### Circuit breaker (§3.3)
Tracks **consecutive auto-dispatch give-ups** in a dedicated `settings` row (kept out of the `remediation_settings` blob: operational state, not config, and avoids a read-modify-write race + a `settings.go` touch). After `Settings.CircuitBreakerGiveups` (default 5) consecutive give-ups it persists `AutoDispatch=off` (master `Enabled` untouched) and `NotifyAdmins`, so a flapping/misconfigured indexer can't fan out dozens of unattended runs. An auto issue **resolving resets** the streak. Fed from the single `ConcludeIssue` chokepoint, **only on a real terminal transition** (a double-conclude can't double-count); user-reported give-ups never feed the breaker; `DismissIssue` (an admin action) doesn't either.

## Tests
Hub-level with a **fake queue source** + service-level with the **real DB dedupe**:
- a persistently-stuck `DetailedQueueItem` opens **exactly one** issue across repeated polls (and enqueues the Runner once);
- a transient `importPending` problematic on **one** poll opens **none**;
- the circuit breaker **disables `AutoDispatch` after N** consecutive give-ups and **resets on resolve**;
- plus: gate (both switches), per-instance isolation, no-download-id skip, nil-opener no-op, double-conclude no-double-count, signal mappers.

`go test ./...` passes (W1/W2/W3 suites still green); `go vet`/`gofmt` clean; `-race` clean on both touched packages. `AutoDispatch` stays OFF by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEChSmKSXg8UDF5TY8aWpE