### PR TITLE
feat(remediation): Wave 4 — ask_reporter + awaiting_user park/resume + reply-TTL

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -189,6 +189,9 @@ func main() {
 	remediationProcToken := newProcToken()
 	remediationRunner := remediation.NewRunner(database, remediationService, toolServer, creds, remediationProcToken)
 	remediationService.StartWorkers(ctx, remediationRunner, 2)
+	// Reply-TTL sweep (Wave 4): periodically close awaiting_user issues whose
+	// reporter never answered the agent's clarifying question within the window.
+	remediationService.StartReplyTTLSweeper(ctx)
 
 	// Discover handler (always created — checks credentials at request time)
 	apiCache := cache.New()

--- a/server/internal/mcp/agent_tools.go
+++ b/server/internal/mcp/agent_tools.go
@@ -19,13 +19,17 @@ import (
 // Wave 2 shipped report a finding (post_issue_message) and finish
 // (conclude_issue). Wave 3 adds propose_action: the agent's ONLY way to effect a
 // change. It records an admin-approvable proposal; the server replays it on
-// approval. The agent still has no mutation tool of its own.
+// approval. Wave 4 adds ask_reporter: the agent asks the issue's reporter a
+// clarifying question (intent/preference only) and the run parks as
+// awaiting_user until they reply. The agent still has no mutation tool of its
+// own — ask_reporter can only record a string.
 
 // Agent-only tool names. Exported so the Runner's allow-list can name them.
 const (
 	ToolPostIssueMessage = "post_issue_message"
 	ToolConcludeIssue    = "conclude_issue"
 	ToolProposeAction    = "propose_action"
+	ToolAskReporter      = "ask_reporter"
 )
 
 // Proposable action kinds accepted by propose_action. These mirror
@@ -155,16 +159,50 @@ var AgentToolProposeAction = Tool{
 	},
 }
 
+// AgentToolAskReporter lets the agent ask the issue's reporter a clarifying
+// question about their INTENT or PREFERENCE and pause until they reply. It is
+// NOT a mutation and NOT an authorization request: it can only record a string.
+// The rule is "the user answers a question; the admin authorizes an action" — a
+// clarifying question can never be a backdoor to mutate. Use it only for facts
+// the reporter alone knows (e.g. "this release is dual-audio English+Russian —
+// do you want English specifically?"). It is unavailable for auto-detected
+// issues with no reporter (the dispatch returns a benign no-op there).
+var AgentToolAskReporter = Tool{
+	Name:       ToolAskReporter,
+	Permission: auth.PermissionRemediationManage,
+	Description: "Ask the person who reported this issue a single clarifying question about what they want, then " +
+		"pause until they reply. Use this ONLY to learn the reporter's intent or preference — facts only they know " +
+		"(for example: a release is multi-language and you need to know which language they actually want). This is " +
+		"NOT a way to change anything and NOT how you get approval: it can only record a question. To change " +
+		"something you must use propose_action (an admin approves that). After you ask, the investigation pauses " +
+		"until the reporter answers, then resumes with their reply so you can act on it. If the issue was " +
+		"auto-detected and has no reporter, this does nothing — decide yourself or propose a fix to the admin.",
+	InputSchema: map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"issue_id": map[string]interface{}{
+				"type":        "integer",
+				"description": "The id of the issue being investigated.",
+			},
+			"question": map[string]interface{}{
+				"type":        "string",
+				"description": "The clarifying question to ask the reporter (plain language; about their intent/preference only).",
+			},
+		},
+		"required": []string{"issue_id", "question"},
+	},
+}
+
 // AgentTools returns the agent-only tool definitions, for the Runner to add to
 // its allow-list and hand to a model turn.
 func AgentTools() []Tool {
-	return []Tool{AgentToolPostIssueMessage, AgentToolConcludeIssue, AgentToolProposeAction}
+	return []Tool{AgentToolPostIssueMessage, AgentToolConcludeIssue, AgentToolProposeAction, AgentToolAskReporter}
 }
 
 // IsAgentTool reports whether a name is one of the agent-only tools.
 func IsAgentTool(name string) bool {
 	switch name {
-	case ToolPostIssueMessage, ToolConcludeIssue, ToolProposeAction:
+	case ToolPostIssueMessage, ToolConcludeIssue, ToolProposeAction, ToolAskReporter:
 		return true
 	}
 	return false
@@ -187,12 +225,17 @@ func (s *ToolServer) ToolsByName(names []string) []Tool {
 
 // AgentToolResult is the structured outcome of an agent-only tool call the Runner
 // needs to drive its loop: Concluded signals the investigation should terminate;
-// Parked signals it should pause for a human (an admin approval) after this turn.
+// Parked signals it should pause for a human after this turn. Parked covers both
+// a propose_action (pause for an ADMIN to approve) and an ask_reporter (pause for
+// the REPORTER to reply); AwaitingUser distinguishes the latter so the Runner
+// parks the issue as awaiting_user / the run as waiting_user rather than the
+// approval states.
 type AgentToolResult struct {
-	Text      string
-	Concluded bool
-	Status    string // terminal issue status when Concluded
-	Parked    bool   // true after a propose_action: the run pauses for admin approval
+	Text         string
+	Concluded    bool
+	Status       string // terminal issue status when Concluded
+	Parked       bool   // true after propose_action OR ask_reporter: the run pauses for a human
+	AwaitingUser bool   // true only after ask_reporter: park as awaiting_user (reporter reply), not awaiting_approval
 }
 
 // ExecuteAgentTool dispatches an agent-only tool. The Runner passes the
@@ -276,6 +319,38 @@ func (s *ToolServer) ExecuteAgentTool(ctx context.Context, name string, input js
 		return &AgentToolResult{
 			Text:   fmt.Sprintf("Proposal #%d recorded; awaiting admin approval — the investigation resumes with the outcome.", proposalID),
 			Parked: true,
+		}, nil
+
+	case ToolAskReporter:
+		var args struct {
+			Question string `json:"question"`
+		}
+		if err := json.Unmarshal(nonEmptyJSON(input), &args); err != nil {
+			return nil, fmt.Errorf("invalid %s input: %w", name, err)
+		}
+		if args.Question == "" {
+			return &AgentToolResult{Text: "No question provided; nothing asked."}, nil
+		}
+		// Record the question + ask-token on the issue/run. hasReporter is false for
+		// an auto-detected (reporter-less) issue: in that case AskReporter does NOT
+		// post anything or park — the agent must decide or propose to the admin.
+		hasReporter, err := s.issueStore.AskReporter(ctx, issueID, args.Question, toolUseID)
+		if err != nil {
+			// A storage error is data for the model, not an infrastructure crash:
+			// return it benignly so the agent can continue within its budget.
+			return &AgentToolResult{Text: "Could not post that question: " + err.Error()}, nil
+		}
+		if !hasReporter {
+			return &AgentToolResult{
+				Text: "This issue was auto-detected and has no reporter to ask. Decide based on what you found, or propose a fix for an admin.",
+			}, nil
+		}
+		// The reporter was asked: the run parks until they reply. The resume will
+		// append this tool_use's result with the reply text.
+		return &AgentToolResult{
+			Text:         "Question posted to the reporter; the investigation will resume with their reply.",
+			Parked:       true,
+			AwaitingUser: true,
 		}, nil
 
 	default:

--- a/server/internal/mcp/issuestore.go
+++ b/server/internal/mcp/issuestore.go
@@ -13,7 +13,10 @@ import (
 // implements this interface; mcp depends only on the interface.
 //
 // Wave 3 adds ProposeAction (the agent proposes a mutation; an admin approves
-// it; the server replays it — the model never executes anything itself).
+// it; the server replays it — the model never executes anything itself). Wave 4
+// adds AskReporter (the agent asks the reporter a clarifying question and the
+// run parks as awaiting_user until they reply — intent/preference only, never a
+// mutation).
 type IssueStore interface {
 	// PostIssueMessage appends an agent-authored message to an issue's thread.
 	PostIssueMessage(ctx context.Context, issueID int64, body string) error
@@ -23,6 +26,16 @@ type IssueStore interface {
 	// RemediationEnabled reports whether the remediation feature is switched on.
 	// Every agent-only tool early-returns a benign result when this is false.
 	RemediationEnabled(ctx context.Context) bool
+	// AskReporter posts a clarifying question (an agent-authored thread message)
+	// to the issue's reporter and records the ask so the Runner PARKS the run as
+	// awaiting_user until the reporter replies. It is intent/preference ONLY — it
+	// can only record a string and NEVER mutates anything. hasReporter is false
+	// when the issue has no reporter (an auto-detected issue): the caller must NOT
+	// park in that case and instead return a benign "no reporter to ask" result so
+	// the agent decides or proposes to the admin. toolUseID is the ask_reporter
+	// tool_use.id, stored on the run so the resume tool_result pairs back to the
+	// exact call when the reporter replies.
+	AskReporter(ctx context.Context, issueID int64, question, toolUseID string) (hasReporter bool, err error)
 	// ProposeAction records a proposed (admin-approvable) arr mutation against an
 	// issue. It validates params against the kind's schema, computes a stable
 	// fingerprint, and conditionally inserts an agent_actions row keyed by that

--- a/server/internal/remediation/approvals.go
+++ b/server/internal/remediation/approvals.go
@@ -221,6 +221,104 @@ func replaceToolResult(history ai.Transcript, toolUseID, outcome string) bool {
 	return false
 }
 
+// askReporterToolName is the agent-only tool whose result a reporter reply
+// answers. Kept as a literal (mirroring this file's "propose_action" usage) so
+// the resume helpers don't pull internal/mcp into the resume path.
+const askReporterToolName = "ask_reporter"
+
+// resumeOnReporterReply is the W4 counterpart to appendResumeResult: it feeds a
+// reporter/admin reply back into a run parked on ask_reporter as that tool's
+// tool_result and enqueues a resume. It REPLACES the placeholder ask_reporter
+// tool_result in place (keyed to the ask_reporter tool_use_id recovered from the
+// parked transcript) so the transcript stays well-formed — exactly one
+// tool_result per tool_use, no two consecutive user turns (which a real provider
+// rejects). Best-effort: if no parked run or ask tool_use can be found it only
+// logs (the message is still threaded) rather than crashing. Called from
+// PostReply when an awaiting_user issue receives a reporter/admin reply.
+func (s *Service) resumeOnReporterReply(issueID int64, reply string) {
+	runID, history, ok := s.loadAwaitingUserTranscript(issueID)
+	if !ok {
+		return
+	}
+	askToolUseID, found := findAskReporterToolUse(history)
+	if !found {
+		log.Printf("remediation: no ask_reporter tool_use to resume on issue %d (run %d)", issueID, runID)
+		return
+	}
+
+	// The reporter's reply is UNTRUSTED data fenced into the tool_result the model
+	// reads; it is never interpreted as an instruction. Prefix it so the agent
+	// treats it as the reporter's answer to its question.
+	outcome := "The reporter replied: " + reply
+	if !replaceToolResult(history, askToolUseID, outcome) {
+		// Defensive: the placeholder should exist (the Runner persisted it on park),
+		// but if not, append one so the resume still has a result to react to.
+		history = append(history, ai.TranscriptMessage{
+			Role: ai.RoleUser,
+			Content: []ai.TranscriptBlock{{
+				Type:      ai.BlockToolResult,
+				ToolUseID: askToolUseID,
+				Name:      askReporterToolName,
+				Content:   outcome,
+			}},
+		})
+	}
+	if data, err := json.Marshal(history); err == nil {
+		s.db.Exec("UPDATE agent_runs SET transcript_json = ? WHERE id = ?", string(data), runID)
+	}
+
+	// Mirror to the audit ledger (append-only; not used to rehydrate the transcript).
+	var nextSeq int
+	s.db.QueryRow("SELECT COALESCE(MAX(seq),0)+1 FROM agent_steps WHERE run_id = ?", runID).Scan(&nextSeq)
+	s.db.Exec(
+		`INSERT INTO agent_steps (run_id, issue_id, seq, kind, tool_name, tool_use_id, tool_output)
+		 VALUES (?, ?, ?, 'tool_result', ?, ?, ?)`,
+		runID, issueID, nextSeq, askReporterToolName, askToolUseID, outcome,
+	)
+
+	s.EnqueueResume(issueID)
+}
+
+// loadAwaitingUserTranscript loads the most recent run for an issue parked
+// waiting for a reporter reply (waiting_user) and decodes its transcript.
+func (s *Service) loadAwaitingUserTranscript(issueID int64) (runID int64, history ai.Transcript, ok bool) {
+	var transcriptJSON string
+	err := s.db.QueryRow(
+		"SELECT id, transcript_json FROM agent_runs WHERE issue_id = ? AND status = ? ORDER BY id DESC LIMIT 1",
+		issueID, runStatusWaitingUser,
+	).Scan(&runID, &transcriptJSON)
+	if err != nil {
+		if err != sql.ErrNoRows {
+			log.Printf("remediation: load awaiting_user run for issue %d: %v", issueID, err)
+		}
+		return 0, nil, false
+	}
+	if transcriptJSON != "" {
+		if err := json.Unmarshal([]byte(transcriptJSON), &history); err != nil {
+			log.Printf("remediation: decode awaiting_user transcript (run %d): %v", runID, err)
+			return 0, nil, false
+		}
+	}
+	return runID, history, true
+}
+
+// findAskReporterToolUse returns the tool_use_id of the LAST ask_reporter
+// tool_result block in the transcript (the freshly-parked placeholder). The last
+// one is the currently-awaited question: any earlier ask_reporter result already
+// carries a prior reply, so scanning newest-first keeps the right one even across
+// multiple ask/reply cycles in one run.
+func findAskReporterToolUse(history ai.Transcript) (string, bool) {
+	for i := len(history) - 1; i >= 0; i-- {
+		for j := range history[i].Content {
+			b := history[i].Content[j]
+			if b.Type == ai.BlockToolResult && b.Name == askReporterToolName && b.ToolUseID != "" {
+				return b.ToolUseID, true
+			}
+		}
+	}
+	return "", false
+}
+
 // loadActionForDecision loads the fields ApproveAction/DenyAction need, including
 // tool_use_id and run_id (for the resume) which the list/get DTO also carries.
 func (s *Service) loadActionForDecision(actionID int64) (*AgentAction, error) {

--- a/server/internal/remediation/approvals_test.go
+++ b/server/internal/remediation/approvals_test.go
@@ -495,6 +495,23 @@ func (h *serviceBackedHost) ExecuteAgentTool(ctx context.Context, name string, i
 		}
 		_ = id
 		return &mcp.AgentToolResult{Text: "proposal recorded", Parked: true}, nil
+	case mcp.ToolAskReporter:
+		// Mirror the real ExecuteAgentTool ask_reporter case: post the question +
+		// signal an awaiting_user park ONLY when the issue has a reporter; otherwise
+		// a benign no-op with NO park (the agent continues). The placeholder text
+		// matches the real tool's so the reply can find/replace it on resume.
+		var a struct {
+			Question string `json:"question"`
+		}
+		json.Unmarshal(input, &a)
+		hasReporter, err := h.svc.AskReporter(ctx, issueID, a.Question, toolUseID)
+		if err != nil {
+			return &mcp.AgentToolResult{Text: "could not ask: " + err.Error()}, nil
+		}
+		if !hasReporter {
+			return &mcp.AgentToolResult{Text: "no reporter to ask"}, nil
+		}
+		return &mcp.AgentToolResult{Text: "Question posted to the reporter; the investigation will resume with their reply.", Parked: true, AwaitingUser: true}, nil
 	}
 	return &mcp.AgentToolResult{Text: "noop"}, nil
 }

--- a/server/internal/remediation/ask_reporter_test.go
+++ b/server/internal/remediation/ask_reporter_test.go
@@ -1,0 +1,345 @@
+package remediation
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/ai"
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/mcp"
+)
+
+// askCycleRunner builds a Runner whose scripted model investigates (a read),
+// then asks the reporter a clarifying question via ask_reporter (the run parks
+// awaiting_user), then — on resume after the reply — proposes a grab_release and
+// parks again for approval. It returns the Runner, the Service (real agent-tool
+// side effects via serviceBackedHost), the fake executor, the issue id, and the
+// reporter id. The askToolUseID is the tool_use.id the ask_reporter call carries
+// so the test can assert the reply keys back to it.
+const askToolUseID = "toolu_ask_1"
+
+func askCycleRunner(t *testing.T, withReporter bool) (*Runner, *Service, *fakeExecutor, int64, int64) {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	svc := NewService(database, nil, nil, &fakeNotifier{})
+	fx := &fakeExecutor{out: "Release sent to the download client."}
+	svc.executor = fx
+	if _, err := svc.SetSettings(Settings{Enabled: true, Autonomy: AutonomyPropose, MaxSteps: 12, MaxTurnTokens: 1024, MaxWallClockSecs: 30, MaxCostMicros: 500000, DailyRunCap: 50, DailyCostCeilingMicros: 5000000, MaxUserWaitHours: 72}); err != nil {
+		t.Fatalf("set settings: %v", err)
+	}
+	if _, err := database.Exec("INSERT INTO users (id, username, password_hash, role) VALUES (?, 'admin', '', 'admin')", testAdminID); err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+
+	// Seed the issue with or without a reporter. A reporter-less issue mirrors an
+	// auto-detected one (ask_reporter must not park it).
+	var reporterID int64
+	if withReporter {
+		reporterID = seedUser(t, database, "reporter")
+	}
+	res, err := database.Exec(
+		"INSERT INTO issues (source, status, category, reporter_id, media_type, tmdb_id, title, detail) VALUES (?, 'open', ?, ?, 'movie', 42, 'Test Movie', 'wrong audio')",
+		map[bool]string{true: SourceUser, false: SourceAuto}[withReporter], sqlNullStr(CategoryWrongAudio), sqlNullInt64(reporterID),
+	)
+	if err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+	issueID, _ := res.LastInsertId()
+
+	askInput := json.RawMessage(`{"question":"This release is dual-audio English+Russian — do you want English specifically?"}`)
+	grabInput := json.RawMessage(`{"kind":"grab_release","params":{"media_type":"movie","guid":"abc-guid","indexer_id":3},"rationale":"reporter confirmed English"}`)
+	script := &scriptedTurn{turns: []ai.TranscriptMessage{
+		// Turn 1: investigate (a read), then ask the reporter. The Runner parks
+		// awaiting_user after dispatching ask_reporter.
+		{Role: ai.RoleAssistant, Content: []ai.TranscriptBlock{toolUse("r1", "get_manual_import_candidates")}},
+		{Role: ai.RoleAssistant, Content: []ai.TranscriptBlock{{Type: ai.BlockToolUse, ID: askToolUseID, Name: mcp.ToolAskReporter, Input: askInput}}},
+		// Turn 2 (resume, after the reply): propose a grab of the English release.
+		{Role: ai.RoleAssistant, Content: []ai.TranscriptBlock{{Type: ai.BlockToolUse, ID: "prop1", Name: mcp.ToolProposeAction, Input: grabInput}}},
+	}}
+
+	r := &Runner{
+		db:         database,
+		svc:        svc,
+		toolServer: &serviceBackedHost{svc: svc},
+		creds:      newFakeCreds(t, database),
+		procToken:  "test",
+		newTurn: func(provider, apiKey, model string) (ai.TurnRunner, error) {
+			return script, nil
+		},
+	}
+	return r, svc, fx, issueID, reporterID
+}
+
+// TestAskReporterParksAwaitingUserNoMutation is acceptance: ask_reporter parks
+// the issue awaiting_user (the run waiting_user) and performs NO mutation. The
+// agent's question lands on the thread and the reporter is pinged.
+func TestAskReporterParksAwaitingUserNoMutation(t *testing.T) {
+	r, svc, fx, issueID, reporterID := askCycleRunner(t, true)
+
+	if err := r.Run(context.Background(), issueID); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	issue, _ := svc.GetIssue(issueID)
+	if issue.Status != IssueAwaitingUser {
+		t.Fatalf("issue status after ask_reporter = %q, want awaiting_user", issue.Status)
+	}
+	// NO mutation happened (the agent only asked a question).
+	if fx.count() != 0 {
+		t.Fatalf("executor ran %d times after ask_reporter, want 0 (asking is never a mutation)", fx.count())
+	}
+	// No proposal was recorded either.
+	if pending, _ := svc.ListPendingActions(); len(pending) != 0 {
+		t.Fatalf("pending actions after ask_reporter = %d, want 0", len(pending))
+	}
+
+	// The run is parked waiting_user with the awaiting_user stop reason.
+	var runStatus, stopReason string
+	if err := svc.db.QueryRow("SELECT status, COALESCE(stop_reason,'') FROM agent_runs WHERE issue_id = ?", issueID).Scan(&runStatus, &stopReason); err != nil {
+		t.Fatalf("load run: %v", err)
+	}
+	if runStatus != runStatusWaitingUser || stopReason != stopAwaitingUser {
+		t.Fatalf("run status/stop = %q/%q, want waiting_user/awaiting_user", runStatus, stopReason)
+	}
+	// The active_run_id claim was released so a resume can re-claim.
+	var activeRun *int64
+	svc.db.QueryRow("SELECT active_run_id FROM issues WHERE id = ?", issueID).Scan(&activeRun)
+	if activeRun != nil {
+		t.Fatalf("active_run_id = %v after park, want NULL (released)", *activeRun)
+	}
+
+	// The question was posted as an agent message on the thread.
+	thread, _ := svc.IssueThread(issueID)
+	var askedOnThread bool
+	for _, m := range thread {
+		if m.AuthorKind == AuthorAgent && strings.Contains(m.Body, "English specifically") {
+			askedOnThread = true
+		}
+	}
+	if !askedOnThread {
+		t.Fatalf("expected the agent's question on the thread, got %+v", thread)
+	}
+	// The reporter was pinged (NotifyUser fired).
+	if notif, ok := svc.notifier.(*fakeNotifier); ok {
+		if len(notif.userEvents) == 0 {
+			t.Fatalf("expected a NotifyUser ping to the reporter %d, got none", reporterID)
+		}
+	}
+
+	// The parked transcript carries the ask_reporter tool_use + a placeholder
+	// tool_result keyed to it (so the reply can replace it in place on resume).
+	tj := loadTranscript(t, svc, issueID)
+	if !transcriptHasPlaceholderAsk(t, tj, askToolUseID) {
+		t.Fatalf("parked transcript missing a placeholder ask_reporter tool_result for %s: %s", askToolUseID, tj)
+	}
+}
+
+// TestReporterReplyResumesKeyedToAskToolUse is acceptance: a reporter reply
+// resumes the run, the reply is appended as the ask_reporter tool_result keyed to
+// the ask tool_use_id, the transcript stays WELL-FORMED (exactly one tool_result
+// for that id, no two consecutive user turns), and the agent continues (here it
+// proposes a fix, so the issue moves to awaiting_approval).
+func TestReporterReplyResumesKeyedToAskToolUse(t *testing.T) {
+	r, svc, fx, issueID, reporterID := askCycleRunner(t, true)
+
+	// 1) Investigate -> ask the reporter -> park awaiting_user.
+	if err := r.Run(context.Background(), issueID); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if issue, _ := svc.GetIssue(issueID); issue.Status != IssueAwaitingUser {
+		t.Fatalf("issue status = %q, want awaiting_user before reply", issue.Status)
+	}
+
+	// 2) The reporter replies. PostReply appends the reply as the ask_reporter
+	// tool_result (replacing the placeholder, keyed to askToolUseID) and enqueues a
+	// resume.
+	if err := svc.PostReply(issueID, AuthorUser, reporterID, "Yes, English please."); err != nil {
+		t.Fatalf("PostReply: %v", err)
+	}
+
+	// The reply is keyed to the ask_reporter tool_use_id, exactly one tool_result
+	// for it, and the transcript a real provider would accept (the W3 guard reused).
+	assertWellFormedResume(t, loadTranscript(t, svc, issueID), askToolUseID, "The reporter replied: Yes, English please.")
+
+	// A resume job was enqueued (drain it; the worker pool isn't running here).
+	select {
+	case j := <-svc.jobs:
+		if !j.resume || j.issueID != issueID {
+			t.Fatalf("enqueued job = %+v, want resume of issue %d", j, issueID)
+		}
+	default:
+		t.Fatalf("expected a resume job after the reporter reply")
+	}
+
+	// 3) Resume: the agent sees the reply (keyed to its ask) and proposes a fix, so
+	// the issue parks awaiting_approval. No mutation has run yet (propose != execute).
+	if err := r.Resume(context.Background(), issueID); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	issue, _ := svc.GetIssue(issueID)
+	if issue.Status != IssueAwaitingApproval {
+		t.Fatalf("issue status after resume = %q, want awaiting_approval (agent proposed per the reply)", issue.Status)
+	}
+	pending, _ := svc.ListPendingActions()
+	if len(pending) != 1 || pending[0].Kind != string(ActionGrabRelease) {
+		t.Fatalf("pending actions after resume = %+v, want one grab_release", pending)
+	}
+	if fx.count() != 0 {
+		t.Fatalf("executor ran %d times, want 0 (the proposal still needs admin approval)", fx.count())
+	}
+}
+
+// TestAskReporterNoReporterDoesNotPark is acceptance: ask_reporter on a
+// reporter-less (auto-detected) issue does NOT park — the dispatch returns a
+// benign "no reporter to ask" result, the agent continues in the SAME run (here
+// it proposes a fix), and the issue never enters awaiting_user.
+func TestAskReporterNoReporterDoesNotPark(t *testing.T) {
+	r, svc, fx, issueID, _ := askCycleRunner(t, false)
+
+	if err := r.Run(context.Background(), issueID); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// The issue NEVER parked awaiting_user. With no reporter the ask is a no-op,
+	// the agent's NEXT scripted turn (propose_action) runs in the same loop, so the
+	// issue ends awaiting_approval — proving the run did not stop at the ask.
+	issue, _ := svc.GetIssue(issueID)
+	if issue.Status == IssueAwaitingUser {
+		t.Fatalf("reporter-less issue parked awaiting_user, want it NOT to park")
+	}
+	if issue.Status != IssueAwaitingApproval {
+		t.Fatalf("issue status = %q, want awaiting_approval (agent continued past the no-op ask)", issue.Status)
+	}
+	// No run is left waiting_user.
+	var waitingUser int
+	svc.db.QueryRow("SELECT COUNT(*) FROM agent_runs WHERE issue_id = ? AND status = ?", issueID, runStatusWaitingUser).Scan(&waitingUser)
+	if waitingUser != 0 {
+		t.Fatalf("runs in waiting_user = %d for a reporter-less issue, want 0", waitingUser)
+	}
+	// Still no mutation (the agent proposed, which an admin must approve).
+	if fx.count() != 0 {
+		t.Fatalf("executor ran %d times, want 0", fx.count())
+	}
+}
+
+// TestReplyTTLClosesStaleAwaitingUser is acceptance: an awaiting_user issue with
+// no reply within the window is closed wont_fix(user_unresponsive) by the sweep,
+// with a thread message and the run finalized.
+func TestReplyTTLClosesStaleAwaitingUser(t *testing.T) {
+	r, svc, _, issueID, _ := askCycleRunner(t, true)
+
+	// Park the issue awaiting_user.
+	if err := r.Run(context.Background(), issueID); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if issue, _ := svc.GetIssue(issueID); issue.Status != IssueAwaitingUser {
+		t.Fatalf("issue status = %q, want awaiting_user", issue.Status)
+	}
+
+	// Age the issue past the TTL window (back-date updated_at so the sweep sees it
+	// as stale; the ask message would otherwise have just touched updated_at).
+	if _, err := svc.db.Exec("UPDATE issues SET updated_at = datetime('now','-100 hours') WHERE id = ?", issueID); err != nil {
+		t.Fatalf("age issue: %v", err)
+	}
+
+	// Sweep with a 72h window: the 100h-old issue is closed.
+	closed, err := svc.SweepStaleAwaitingUser(context.Background(), 72)
+	if err != nil {
+		t.Fatalf("SweepStaleAwaitingUser: %v", err)
+	}
+	if closed != 1 {
+		t.Fatalf("sweep closed %d issues, want 1", closed)
+	}
+
+	issue, _ := svc.GetIssue(issueID)
+	if issue.Status != IssueWontFix {
+		t.Fatalf("issue status after sweep = %q, want wont_fix", issue.Status)
+	}
+	// closed_at is set + the resolution records user_unresponsive.
+	var closedAt *string
+	var resolution string
+	if err := svc.db.QueryRow("SELECT closed_at, COALESCE(resolution,'') FROM issues WHERE id = ?", issueID).Scan(&closedAt, &resolution); err != nil {
+		t.Fatalf("load closed issue: %v", err)
+	}
+	if closedAt == nil {
+		t.Fatalf("closed_at is NULL after sweep, want set")
+	}
+	if resolution != ResolutionUserUnresponsive {
+		t.Fatalf("resolution = %q, want %q", resolution, ResolutionUserUnresponsive)
+	}
+	// A plain-language closing message was posted.
+	thread, _ := svc.IssueThread(issueID)
+	var closedMsg bool
+	for _, m := range thread {
+		if m.AuthorKind == AuthorAgent && strings.Contains(m.Body, "didn't hear back") {
+			closedMsg = true
+		}
+	}
+	if !closedMsg {
+		t.Fatalf("expected a closing agent message after the TTL sweep, got %+v", thread)
+	}
+	// The parked run was finalized (no longer waiting_user).
+	var waitingUser int
+	svc.db.QueryRow("SELECT COUNT(*) FROM agent_runs WHERE issue_id = ? AND status = ?", issueID, runStatusWaitingUser).Scan(&waitingUser)
+	if waitingUser != 0 {
+		t.Fatalf("a run is still waiting_user after the TTL close, want 0")
+	}
+
+	// Idempotent: a second sweep closes nothing (the issue already left awaiting_user).
+	closed2, err := svc.SweepStaleAwaitingUser(context.Background(), 72)
+	if err != nil {
+		t.Fatalf("second sweep: %v", err)
+	}
+	if closed2 != 0 {
+		t.Fatalf("second sweep closed %d, want 0 (idempotent)", closed2)
+	}
+}
+
+// TestSweepLeavesFreshAwaitingUserUntouched confirms the TTL sweep does NOT close
+// an awaiting_user issue whose ask is still within the window.
+func TestSweepLeavesFreshAwaitingUserUntouched(t *testing.T) {
+	r, svc, _, issueID, _ := askCycleRunner(t, true)
+	if err := r.Run(context.Background(), issueID); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// The issue was just parked (updated_at ~ now), well within 72h.
+	closed, err := svc.SweepStaleAwaitingUser(context.Background(), 72)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if closed != 0 {
+		t.Fatalf("sweep closed %d fresh issues, want 0", closed)
+	}
+	if issue, _ := svc.GetIssue(issueID); issue.Status != IssueAwaitingUser {
+		t.Fatalf("fresh issue status = %q, want still awaiting_user", issue.Status)
+	}
+}
+
+// transcriptHasPlaceholderAsk reports whether the transcript carries an
+// ask_reporter tool_result keyed to toolUseID whose content is still the park
+// placeholder (i.e. it has not yet been replaced by a reply).
+func transcriptHasPlaceholderAsk(t *testing.T, transcriptJSON, toolUseID string) bool {
+	t.Helper()
+	var history []map[string]any
+	if err := json.Unmarshal([]byte(transcriptJSON), &history); err != nil {
+		t.Fatalf("decode transcript: %v", err)
+	}
+	for _, msg := range history {
+		content, _ := msg["content"].([]any)
+		for _, raw := range content {
+			b, _ := raw.(map[string]any)
+			if b["type"] == "tool_result" && b["tool_use_id"] == toolUseID && b["name"] == mcp.ToolAskReporter {
+				c, _ := b["content"].(string)
+				return strings.Contains(c, "Question posted to the reporter")
+			}
+		}
+	}
+	return false
+}

--- a/server/internal/remediation/issuestore.go
+++ b/server/internal/remediation/issuestore.go
@@ -74,6 +74,52 @@ func (s *Service) RemediationEnabled(ctx context.Context) bool {
 	return s.Settings().Enabled
 }
 
+// AskReporter posts a clarifying question to the issue's reporter (an agent-
+// authored thread message) and signals the Runner to PARK the run as
+// awaiting_user until the reporter replies. It is intent/preference ONLY: it can
+// only record a string and never mutates anything (the rule is "the user answers
+// a question; the admin authorizes an action").
+//
+// When the issue has NO reporter (an auto-detected issue), it returns
+// hasReporter=false WITHOUT posting or notifying, so the caller does not park —
+// the agent then decides itself or proposes a fix to the admin.
+//
+// The question body is the model's plain-language text; it is stored verbatim
+// and never interpreted as an instruction. toolUseID is the ask_reporter
+// tool_use.id: the Runner persists a placeholder tool_result keyed to it on park,
+// and PostReply replaces that placeholder with the reply on resume — so the
+// transcript stays well-formed (exactly one tool_result per tool_use).
+func (s *Service) AskReporter(ctx context.Context, issueID int64, question, toolUseID string) (hasReporter bool, err error) {
+	var reporterID sql.NullInt64
+	if qerr := s.db.QueryRowContext(ctx, "SELECT reporter_id FROM issues WHERE id = ?", issueID).Scan(&reporterID); qerr != nil {
+		if qerr == sql.ErrNoRows {
+			return false, fmt.Errorf("issue not found")
+		}
+		return false, fmt.Errorf("load issue: %w", qerr)
+	}
+	if !reporterID.Valid {
+		// Auto-detected / reporter-less issue: do NOT park. The caller returns a
+		// benign "no reporter to ask" result and the agent decides or proposes.
+		return false, nil
+	}
+
+	// Post the question to the thread as an agent message (so the reporter sees it
+	// and can reply), then notify just the reporter. The body is stored verbatim
+	// but is never put on the notification (only the issue id travels).
+	if _, err := s.db.ExecContext(ctx,
+		"INSERT INTO issue_messages (issue_id, author_kind, author_id, body) VALUES (?, ?, NULL, ?)",
+		issueID, AuthorAgent, question,
+	); err != nil {
+		return false, fmt.Errorf("post reporter question: %w", err)
+	}
+	s.db.ExecContext(ctx, "UPDATE issues SET updated_at = CURRENT_TIMESTAMP WHERE id = ?", issueID)
+
+	if s.notifier != nil {
+		s.notifier.NotifyUser(reporterID.Int64, "issue_updated", map[string]interface{}{"issue_id": issueID})
+	}
+	return true, nil
+}
+
 // ProposeAction records a proposed (admin-approvable) arr mutation. It validates
 // params against the kind's schema (rejecting unknown fields / bad values),
 // computes the canonical fingerprint, and conditionally inserts an agent_actions

--- a/server/internal/remediation/models.go
+++ b/server/internal/remediation/models.go
@@ -50,6 +50,11 @@ const (
 	AuthorSystem = "system"
 )
 
+// ResolutionUserUnresponsive is the closing note set on an awaiting_user issue
+// that the reply-TTL sweep closes because the reporter never answered the
+// agent's clarifying question within the window (W4).
+const ResolutionUserUnresponsive = "user_unresponsive"
+
 // Action lifecycle status values (agent_actions.status). Used by later waves;
 // defined now so the table vocabulary is stable.
 const (

--- a/server/internal/remediation/runner.go
+++ b/server/internal/remediation/runner.go
@@ -62,6 +62,7 @@ const (
 	runStatusSucceeded       = "succeeded"
 	runStatusGaveUp          = "gave_up"
 	runStatusWaitingApproval = "waiting_approval"
+	runStatusWaitingUser     = "waiting_user" // parked on ask_reporter, awaiting a reporter reply
 
 	stopResolved         = "resolved"
 	stopMaxSteps         = "max_steps"
@@ -70,6 +71,8 @@ const (
 	stopModelError       = "model_error"
 	stopNoDiagnosis      = "no_diagnosis"
 	stopAwaitingApproval = "awaiting_approval"
+	stopAwaitingUser     = "awaiting_user"     // parked on ask_reporter
+	stopUserUnresponsive = "user_unresponsive" // reply-TTL elapsed with no reporter reply
 	stepTruncateBytes    = 4000
 )
 
@@ -308,15 +311,19 @@ func (r *Runner) Resume(ctx context.Context, issueID int64) error {
 	return r.loop(runCtx, turn, issue, st, model, settings)
 }
 
-// loadParkedRun returns the most recent run for an issue that is parked waiting
-// for an approval, along with the bounds spent so far and its stored transcript.
+// loadParkedRun returns the most recent run for an issue that is parked at a
+// human gate — either waiting for an admin approval (waiting_approval, after
+// propose_action) OR waiting for a reporter reply (waiting_user, after
+// ask_reporter) — along with the bounds spent so far and its stored transcript.
+// One resume path serves both: the decision/reply has already been appended to
+// the transcript (keyed to whichever tool_use was awaiting) before Resume runs.
 func (r *Runner) loadParkedRun(issueID int64) (runID int64, stepCount int, costMicros int64, transcriptJSON string, ok bool, err error) {
 	row := r.db.QueryRow(
 		`SELECT id, step_count, cost_micros, transcript_json
 		 FROM agent_runs
-		 WHERE issue_id = ? AND status = ?
+		 WHERE issue_id = ? AND status IN (?, ?)
 		 ORDER BY id DESC LIMIT 1`,
-		issueID, runStatusWaitingApproval,
+		issueID, runStatusWaitingApproval, runStatusWaitingUser,
 	)
 	err = row.Scan(&runID, &stepCount, &costMicros, &transcriptJSON)
 	if err == sql.ErrNoRows {
@@ -453,6 +460,7 @@ func (r *Runner) loop(ctx context.Context, turn ai.TurnRunner, issue *Issue, st 
 		concluded := false
 		concludeStatus := ""
 		parked := false
+		awaitingUser := false
 		for _, tu := range toolUses {
 			st.stepCount++
 			st.seq++
@@ -467,6 +475,9 @@ func (r *Runner) loop(ctx context.Context, turn ai.TurnRunner, issue *Issue, st 
 			}
 			if ctrl.parked {
 				parked = true
+			}
+			if ctrl.awaitingUser {
+				awaitingUser = true
 			}
 			r.persistStep(st.runID, issue.ID, st.seq, stepToolResult, tu.Name, tu.ID, string(tu.Input), out, isErr)
 			resultBlocks = append(resultBlocks, ai.TranscriptBlock{
@@ -497,10 +508,16 @@ func (r *Runner) loop(ctx context.Context, turn ai.TurnRunner, issue *Issue, st 
 		}
 
 		if parked {
-			// A NEW proposal was recorded. Park: finalize the run as waiting for an
-			// approval, set the issue awaiting_approval, release the run claim, and
-			// EXIT the loop (no goroutine held during the human wait). The bounds
-			// spent so far are already persisted on the run and carry over on resume.
+			// A human gate was reached. Park: finalize the run as waiting, set the
+			// matching issue state, release the run claim, and EXIT the loop (no
+			// goroutine held during the human wait). The bounds spent so far are
+			// already persisted on the run and carry over on resume.
+			//
+			// ask_reporter parks awaiting the REPORTER's reply (awaiting_user);
+			// propose_action parks awaiting an ADMIN's approval (awaiting_approval).
+			if awaitingUser {
+				return r.parkAwaitingUser(issue.ID, st.runID)
+			}
 			return r.park(issue.ID, st.runID)
 		}
 	}
@@ -511,19 +528,35 @@ func (r *Runner) loop(ctx context.Context, turn ai.TurnRunner, issue *Issue, st 
 // claim so the worker goroutine is free during the (possibly long) human wait.
 // The Runner re-enters via Resume once an admin decides.
 func (r *Runner) park(issueID, runID int64) error {
+	return r.parkWith(issueID, runID, runStatusWaitingApproval, stopAwaitingApproval, IssueAwaitingApproval)
+}
+
+// parkAwaitingUser finalizes a run that asked the reporter a clarifying question
+// (ask_reporter): it marks the run waiting_user, moves the issue to
+// awaiting_user, and releases the issue claim so the worker is free during the
+// (possibly long) wait for a reply. The Runner re-enters via Resume once the
+// reporter replies (PostReply appends the reply as the ask_reporter tool_result).
+func (r *Runner) parkAwaitingUser(issueID, runID int64) error {
+	return r.parkWith(issueID, runID, runStatusWaitingUser, stopAwaitingUser, IssueAwaitingUser)
+}
+
+// parkWith is the shared park transition for both human gates: it finalizes the
+// run (status + stop_reason, deadline cleared so the paused clock can't trip the
+// watchdog) and moves the issue to the parked state, releasing the active_run_id
+// claim so a resume can re-claim it. Guarded on the issue not already being
+// closed (an admin may have dismissed it mid-turn).
+func (r *Runner) parkWith(issueID, runID int64, runStatus, stopReason, issueStatus string) error {
 	if _, err := r.db.Exec(
 		"UPDATE agent_runs SET status = ?, stop_reason = ?, deadline_at = NULL WHERE id = ?",
-		runStatusWaitingApproval, stopAwaitingApproval, runID,
+		runStatus, stopReason, runID,
 	); err != nil {
-		log.Printf("remediation: park run %d: %v", runID, err)
+		log.Printf("remediation: park run %d (%s): %v", runID, runStatus, err)
 	}
-	// Move the issue to awaiting_approval and release the active_run_id claim so a
-	// resume can re-claim it. Guard on the issue not already being closed.
 	if _, err := r.db.Exec(
 		"UPDATE issues SET status = ?, active_run_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND closed_at IS NULL",
-		IssueAwaitingApproval, issueID,
+		issueStatus, issueID,
 	); err != nil {
-		log.Printf("remediation: park issue %d: %v", issueID, err)
+		log.Printf("remediation: park issue %d (%s): %v", issueID, issueStatus, err)
 	}
 	return nil
 }
@@ -534,7 +567,8 @@ type dispatchControl struct {
 	postedMessage  bool
 	concluded      bool
 	concludeStatus string
-	parked         bool // propose_action recorded a NEW proposal: pause for admin approval
+	parked         bool // propose_action OR ask_reporter signalled a pause for a human
+	awaitingUser   bool // ask_reporter: pause as awaiting_user (reporter reply), not awaiting_approval
 }
 
 // dispatchTool is the central enforcement check. For a read tool that cleared the
@@ -559,6 +593,9 @@ func (r *Runner) dispatchTool(ctx context.Context, issueID int64, tu ai.Transcri
 		}
 		if res.Parked {
 			ctrl.parked = true
+		}
+		if res.AwaitingUser {
+			ctrl.awaitingUser = true
 		}
 		return res.Text, false, ctrl
 

--- a/server/internal/remediation/service.go
+++ b/server/internal/remediation/service.go
@@ -290,10 +290,19 @@ func (s *Service) IssueThread(issueID int64) ([]IssueMessage, error) {
 // authorKind (the handler passes "admin" or "user"); body is UNTRUSTED and
 // stored verbatim. Touching updated_at keeps the issue sorted as recently
 // active. On a reporter/admin reply the other party is notified via the WS hub.
+//
+// W4 resume: when the issue is parked awaiting_user (the agent asked the reporter
+// a clarifying question via ask_reporter) and the reply comes from the reporter
+// or an admin, the reply is fed back into the parked run as the ask_reporter
+// tool_result and a resume is enqueued so the agent continues. A reply from
+// anyone else, or on a non-parked issue, only threads the message.
 func (s *Service) PostReply(issueID int64, authorKind string, authorID int64, body string) error {
-	// Confirm the issue exists (and read its reporter for notification routing).
-	var reporterID sql.NullInt64
-	err := s.db.QueryRow("SELECT reporter_id FROM issues WHERE id = ?", issueID).Scan(&reporterID)
+	// Confirm the issue exists (and read its reporter + status for routing).
+	var (
+		reporterID sql.NullInt64
+		status     string
+	)
+	err := s.db.QueryRow("SELECT reporter_id, status FROM issues WHERE id = ?", issueID).Scan(&reporterID, &status)
 	if err == sql.ErrNoRows {
 		return fmt.Errorf("issue not found")
 	}
@@ -318,7 +327,76 @@ func (s *Service) PostReply(issueID int64, authorKind string, authorID int64, bo
 			s.notifier.NotifyAdmins("issue_updated", map[string]interface{}{"issue_id": issueID})
 		}
 	}
+
+	// Resume a parked investigation: a reporter (or admin) reply to an
+	// awaiting_user issue answers the agent's ask_reporter question. Feed the reply
+	// to the run keyed to the ask tool_use, then enqueue the resume. (Defined in
+	// approvals.go alongside the W3 approval-resume helper, which it mirrors.)
+	if status == IssueAwaitingUser && (authorKind == AuthorUser || authorKind == AuthorAdmin) {
+		s.resumeOnReporterReply(issueID, body)
+	}
 	return nil
+}
+
+// SweepStaleAwaitingUser is the W4 reply-TTL: it closes every issue parked
+// awaiting_user whose last activity is older than maxWaitHours (the reporter
+// never answered the agent's clarifying question within the window). Each is
+// moved to wont_fix(user_unresponsive) with a plain-language thread message; the
+// parked run is finalized and the admins are notified (via ConcludeIssue's
+// resolution ping). It runs from a cheap periodic ticker (StartReplyTTLSweeper)
+// and is idempotent — an already-closed issue no longer matches. Returns the
+// number of issues closed (for logging/tests). maxWaitHours<=0 disables the sweep.
+func (s *Service) SweepStaleAwaitingUser(ctx context.Context, maxWaitHours int) (int, error) {
+	if maxWaitHours <= 0 {
+		return 0, nil
+	}
+	// Find awaiting_user issues whose updated_at is older than the window. The ask
+	// message touched updated_at when the question was posted, so the clock starts
+	// from "asked"; a reply would have moved the issue out of awaiting_user.
+	cutoff := fmt.Sprintf("-%d hours", maxWaitHours)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id FROM issues
+		 WHERE status = ? AND closed_at IS NULL
+		   AND updated_at <= datetime('now', ?)`,
+		IssueAwaitingUser, cutoff,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("query stale awaiting_user issues: %w", err)
+	}
+	var stale []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan stale issue: %w", err)
+		}
+		stale = append(stale, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	closed := 0
+	for _, id := range stale {
+		// Finalize any run still parked waiting on this reporter so it doesn't sit in
+		// waiting_user forever (best-effort; the run is no longer resumable once the
+		// issue is terminal).
+		s.db.ExecContext(ctx,
+			"UPDATE agent_runs SET status = ?, stop_reason = ?, finished_at = CURRENT_TIMESTAMP WHERE issue_id = ? AND status = ?",
+			runStatusGaveUp, stopUserUnresponsive, id, runStatusWaitingUser,
+		)
+		// Plain-language closing message, then move the issue terminal. ConcludeIssue
+		// stamps closed_at, releases the claim, and notifies the reporter + admins.
+		_ = s.PostIssueMessage(ctx, id, "I didn't hear back, so I'm closing this for now. If it's still a problem, please report it again and I'll take another look.")
+		if err := s.ConcludeIssue(ctx, id, IssueWontFix, ResolutionUserUnresponsive); err != nil {
+			// Already closed (raced with a reply) or gone: skip without failing the
+			// whole sweep.
+			continue
+		}
+		closed++
+	}
+	return closed, nil
 }
 
 // ListIssues returns issues for the admin queue (newest first), optionally

--- a/server/internal/remediation/service_test.go
+++ b/server/internal/remediation/service_test.go
@@ -244,6 +244,9 @@ func TestSettingsRoundTrip(t *testing.T) {
 	if d.MaxCostMicros != 500000 || d.DailyCostCeilingMicros != 5000000 {
 		t.Fatalf("default cost ceilings = %d/%d, want 500000/5000000", d.MaxCostMicros, d.DailyCostCeilingMicros)
 	}
+	if d.MaxUserWaitHours != 72 {
+		t.Fatalf("default max_user_wait_hours = %d, want 72", d.MaxUserWaitHours)
+	}
 
 	// Round-trip a populated settings value.
 	in := Settings{
@@ -260,6 +263,7 @@ func TestSettingsRoundTrip(t *testing.T) {
 		DailyRunCap:            10,
 		DailyCostCeilingMicros: 999999,
 		CircuitBreakerGiveups:  3,
+		MaxUserWaitHours:       48,
 	}
 	saved, err := svc.SetSettings(in)
 	if err != nil {

--- a/server/internal/remediation/settings.go
+++ b/server/internal/remediation/settings.go
@@ -45,6 +45,7 @@ type Settings struct {
 	DailyRunCap            int    `json:"daily_run_cap"`             // max runs/day
 	DailyCostCeilingMicros int    `json:"daily_cost_ceiling_micros"` // global cost ceiling/day (millionths USD)
 	CircuitBreakerGiveups  int    `json:"circuit_breaker_giveups"`   // consecutive auto give-ups -> auto-dispatch off
+	MaxUserWaitHours       int    `json:"max_user_wait_hours"`       // W4: reply-TTL — close an awaiting_user issue with no reply within this window
 }
 
 // Defaults returns the built-in remediation settings. Provider and Model are
@@ -66,6 +67,7 @@ func Defaults() Settings {
 		DailyRunCap:            50,
 		DailyCostCeilingMicros: 5000000, // ~$5/day, global
 		CircuitBreakerGiveups:  5,
+		MaxUserWaitHours:       72, // W4: 3 days for a reporter to answer before wont_fix(user_unresponsive)
 	}
 }
 
@@ -109,6 +111,9 @@ func (g *Settings) normalize() {
 	}
 	if g.CircuitBreakerGiveups <= 0 {
 		g.CircuitBreakerGiveups = d.CircuitBreakerGiveups
+	}
+	if g.MaxUserWaitHours <= 0 {
+		g.MaxUserWaitHours = d.MaxUserWaitHours
 	}
 }
 

--- a/server/internal/remediation/worker.go
+++ b/server/internal/remediation/worker.go
@@ -3,12 +3,18 @@ package remediation
 import (
 	"context"
 	"log"
+	"time"
 )
 
 // jobQueueSize bounds the buffered channel of pending investigation jobs. When
 // full, Enqueue drops the job (the issue is still recorded; an admin can act on
 // it) rather than blocking the request path.
 const jobQueueSize = 128
+
+// replyTTLSweepPeriod is how often the reply-TTL sweeper wakes to close stale
+// awaiting_user issues. The window itself (Settings.MaxUserWaitHours, default
+// 72h) is far longer, so an hourly tick is plenty responsive while staying cheap.
+const replyTTLSweepPeriod = time.Hour
 
 // job is one unit of work for the worker pool: investigate a fresh issue, or
 // resume a parked one after an admin decision. Carrying the kind lets a single
@@ -75,4 +81,34 @@ func (s *Service) StartWorkers(ctx context.Context, runner *Runner, n int) {
 			}
 		}(i)
 	}
+}
+
+// StartReplyTTLSweeper launches a cheap periodic sweep (W4 reply-TTL) that closes
+// awaiting_user issues whose reporter never answered within Settings
+// .MaxUserWaitHours, moving each to wont_fix(user_unresponsive). It returns
+// immediately and stops when ctx is cancelled. The window is read fresh from
+// settings each tick (so an admin change takes effect without a restart) and the
+// sweep is skipped entirely while the feature is off. Wire this in main.go next
+// to StartWorkers. Best-effort: a sweep error is logged, not fatal.
+func (s *Service) StartReplyTTLSweeper(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(replyTTLSweepPeriod)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				settings := s.Settings()
+				if !settings.Enabled {
+					continue // feature off: leave parked issues for an admin.
+				}
+				if n, err := s.SweepStaleAwaitingUser(ctx, settings.MaxUserWaitHours); err != nil {
+					log.Printf("remediation: reply-TTL sweep: %v", err)
+				} else if n > 0 {
+					log.Printf("remediation: reply-TTL sweep closed %d unanswered issue(s)", n)
+				}
+			}
+		}
+	}()
 }


### PR DESCRIPTION
## Wave 4 — ask-reporter + full multi-step (SERVER)

The AI remediation agent can now ask the issue's **reporter** a clarifying question (intent/preference only — never a mutation) and resume on their reply. This is the multi-step back-and-forth (e.g. *"this release is multi-language; do you want English specifically?"*). It **reuses the Wave-3 park/resume machinery** already on `main`. `server/` only.

### What changed

1. **`ask_reporter` agent-only tool** (`mcp/agent_tools.go` + `IssueStore.AskReporter`) — `{issue_id, question}`. Posts an `agent` thread message (the question), `NotifyUser(reporter, "issue_updated", {issue_id})`, and signals the Runner to **park as `awaiting_user`**. It is intent/preference ONLY (it can only record a string; it never mutates). **A reporter-less (auto-detected) issue does NOT park** — the dispatch returns a benign *"no reporter to ask; decide or propose to the admin."* Off the chat surface (Runner-only). The tool result is the Runner's park-on-ask signal (`AwaitingUser`), parallel to `propose_action`'s park but → issue `awaiting_user` / run `waiting_user`.

2. **Runner park on `ask_reporter`** (`runner.go`) — `parkAwaitingUser` finalizes the run `waiting_user`, sets the issue `awaiting_user`, persists the transcript (incl. the `ask_reporter` tool_use + a placeholder `tool_result`), clears `active_run_id`, and exits the loop. `park` (W3) and `parkAwaitingUser` (W4) share `parkWith`.

3. **`PostReply` → resume** (`service.go` + `approvals.go`) — when the issue is `awaiting_user` and the reply is from the reporter (or admin), after threading the reply it **appends the reply text as the `ask_reporter` `tool_result` by REPLACING the placeholder in place** (reuses `replaceToolResult`), keyed to the `ask_reporter` tool_use recovered from the parked transcript (`findAskReporterToolUse`, newest-first so multi-ask cycles key to the open question), then `EnqueueResume`. The agent continues (may `propose_action` per the answer, or `conclude_issue`).

4. **Generalized Resume** — `loadParkedRun` now matches BOTH `waiting_approval` (W3) and `waiting_user` (W4); the resume keys to whichever tool_use is awaiting. The W3 approval-resume path is unchanged.

5. **Reply-TTL** — added the single additive `Settings.MaxUserWaitHours` (default 72). A cheap hourly sweeper (`worker.go` `StartReplyTTLSweeper` → `Service.SweepStaleAwaitingUser`) closes an `awaiting_user` issue with no reply within the window as `wont_fix(user_unresponsive)` + a plain-language thread message + admin notify, and finalizes the parked run. Wired in `main.go` next to `StartWorkers`.

### How the reply→resume keys to the ask tool_use
On park, the Runner persists a placeholder `ask_reporter` `tool_result` keyed to the `ask_reporter` tool_use.id (the same one-result-per-tool_use shape W3 uses for `propose_action`). On reply, `PostReply` loads the parked `waiting_user` run's transcript, finds the **last** `ask_reporter` `tool_result` block (the open placeholder), and **replaces its content in place** with `"The reporter replied: <text>"` — so the transcript stays well-formed (exactly one `tool_result` per `tool_use`, no two consecutive user turns) and a real provider accepts it.

### Tests (`go test ./...` passes; `go vet` / `gofmt` clean)
New `ask_reporter_test.go`:
- `ask_reporter` parks `awaiting_user`, releases the claim, posts the question, pings the reporter, and performs **NO mutation / no proposal**.
- a reporter reply resumes the run with the reply **keyed to the `ask_reporter` tool_use_id** and a **WELL-FORMED transcript** (reuses the W3 `assertWellFormedResume` guard); the agent then proposes per the answer.
- `ask_reporter` on a **reporter-less** issue does **not** park (the agent continues in the same run).
- reply-TTL **closes a stale** `awaiting_user` issue (`wont_fix(user_unresponsive)` + thread message + finalized run; idempotent) and **leaves a fresh one untouched**.

The **W2 read-only enforcement** (`TestRunnerNeverOffersOrDispatchesMutatingTools`) and **W3 approve/execute/deny** tests still pass. No `app/` changes. Test-merges cleanly against current `main` (incl. the merged W5 auto-dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEChSmKSXg8UDF5TY8aWpE