### PR TITLE
feat(remediation): admin approval UI for the AI agent's proposed fixes (Wave 3, app)

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -150,6 +150,32 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
       ));
   }
 
+  /// Shows an admin notice (with a "Settings" action) when the remediation
+  /// circuit breaker disables auto-dispatch. The event text is server-authored
+  /// (a fixed template + structured counts); no untrusted model text is shown.
+  void _showAutodispatchDisabledSnack() {
+    final messenger = _scaffoldMessengerKey.currentState;
+    if (messenger == null) return;
+    messenger
+      ..clearSnackBars()
+      ..showSnackBar(SnackBar(
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: AppTheme.error,
+        duration: const Duration(seconds: 8),
+        content: const Text(
+          'Auto-fix paused: too many failed attempts. Re-enable it in AI '
+          'remediation settings.',
+          style: TextStyle(color: Colors.white),
+        ),
+        action: SnackBarAction(
+          label: 'Settings',
+          textColor: Colors.white,
+          onPressed: () =>
+              ref.read(appRouterProvider).push('/settings/ai-remediation'),
+        ),
+      ));
+  }
+
   @override
   Widget build(BuildContext context) {
     final authState = ref.watch(authProvider);
@@ -162,6 +188,15 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
       if (event == null) return;
       if (!ref.read(requestNotificationsEnabledProvider)) return;
       _showDecisionSnack(event);
+    });
+
+    // Surface the auto-dispatch circuit-breaker notice to admins.
+    ref.listen(autodispatchDisabledProvider, (_, next) {
+      if (next.valueOrNull == null) return;
+      final isAdmin =
+          ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
+      if (!isAdmin) return;
+      _showAutodispatchDisabledSnack();
     });
 
     // Show blank screen while restoring session to prevent login flash

--- a/app/lib/core/providers/realtime_provider.dart
+++ b/app/lib/core/providers/realtime_provider.dart
@@ -75,3 +75,21 @@ final issuesChangedProvider = StreamProvider.autoDispose<WsEvent>((ref) {
   return events.where(
       (e) => e.type == 'issue_created' || e.type == 'agent_action_pending');
 });
+
+/// Agent approval-queue pings (`agent_action_pending`,
+/// `agent_action_decided`). The agent-actions approval screen reloads its
+/// queue on either, so a proposal raised or decided elsewhere stays in sync.
+final agentActionsChangedProvider = StreamProvider.autoDispose<WsEvent>((ref) {
+  final events = ref.watch(realtimeEventsProvider);
+  return events.where((e) =>
+      e.type == 'agent_action_pending' || e.type == 'agent_action_decided');
+});
+
+/// Admin notice that the remediation auto-dispatch circuit breaker tripped and
+/// disabled auto-dispatch (`remediation_autodispatch_disabled`). Surfaced as a
+/// one-off in-app toast so an admin learns the agent stopped opening new auto
+/// issues. The event carries `reason`/`giveups`/`threshold` (no issue id).
+final autodispatchDisabledProvider = StreamProvider.autoDispose<WsEvent>((ref) {
+  final events = ref.watch(realtimeEventsProvider);
+  return events.where((e) => e.type == 'remediation_autodispatch_disabled');
+});

--- a/app/lib/features/issues/data/agent_action_models.dart
+++ b/app/lib/features/issues/data/agent_action_models.dart
@@ -1,0 +1,364 @@
+// Data models for the AI-remediation *approval* surface (Wave 3, app side).
+//
+// These mirror the merged server JSON (snake_case) returned by the
+// `agent-actions` and `agent-runs` admin routes. The agent's `params`,
+// `rationale`, and `result_text` are UNTRUSTED — they are carried verbatim and
+// rendered as PASSIVE, non-editable text only. No field here ever becomes a
+// control, command, or button label.
+//
+// All enums are tolerant of unknown server values (mapped to an `unknown`
+// member) so a future action kind / status can never break parsing.
+
+import 'dart:convert';
+
+/// The kind of arr mutation the agent proposed. Drives the plain-language
+/// description on the ProposedActionCard. Unknown server kinds fall back to
+/// [unknown], which renders a generic "Apply a fix" description.
+enum AgentActionKind {
+  grabRelease('grab_release'),
+  remediateQueue('remediate_queue'),
+  manualImport('manual_import'),
+  triggerSearch('trigger_search'),
+  rescan('rescan'),
+  unknown('');
+
+  const AgentActionKind(this.value);
+
+  /// The snake_case value sent by the server.
+  final String value;
+
+  static AgentActionKind fromValue(String? value) => values.firstWhere(
+        (k) => k.value == value,
+        orElse: () => AgentActionKind.unknown,
+      );
+}
+
+/// The lifecycle state of a proposed action. Only `proposed` is actionable;
+/// every other state means the card is frozen (a decision was already made, or
+/// it is mid-execution). Tolerant of unknown server values.
+enum AgentActionStatus {
+  proposed('proposed', 'Awaiting approval'),
+  approved('approved', 'Approved'),
+  executing('executing', 'Applying…'),
+  executed('executed', 'Done'),
+  denied('denied', 'Denied'),
+  failed('failed', 'Failed'),
+  superseded('superseded', 'Superseded'),
+  unknown('', 'Unknown');
+
+  const AgentActionStatus(this.value, this.label);
+
+  final String value;
+  final String label;
+
+  /// True only while the action can still be approved or denied. Every other
+  /// state freezes the card (the server's CAS rejects a second decision anyway).
+  bool get isPending => this == AgentActionStatus.proposed;
+
+  /// True for a state reached by an admin decision (drives the "Approved · just
+  /// now" / "Denied" frozen footer).
+  bool get isDecided =>
+      this == AgentActionStatus.approved ||
+      this == AgentActionStatus.executing ||
+      this == AgentActionStatus.executed ||
+      this == AgentActionStatus.denied ||
+      this == AgentActionStatus.failed;
+
+  static AgentActionStatus fromValue(String? value) => values.firstWhere(
+        (s) => s.value == value,
+        orElse: () => AgentActionStatus.unknown,
+      );
+}
+
+/// One admin-approvable proposed mutation, as returned by
+/// `GET /api/admin/agent-actions`. The reified [params] are parsed into a
+/// small read-only [AgentActionParams] view for plain-language rendering; the
+/// raw map is retained so an unknown kind still shows its data.
+class AgentAction {
+  final int id;
+  final int issueId;
+
+  /// The run that produced this proposal, used to open the audit timeline.
+  /// Null if the server didn't link one.
+  final int? runId;
+
+  final AgentActionKind kind;
+
+  /// The raw server `kind` string, retained so an unknown kind can still be
+  /// shown verbatim (never executed).
+  final String kindRaw;
+
+  /// Parsed, typed view over the proposal's `params` JSON object (UNTRUSTED;
+  /// rendered as quoted, non-editable data).
+  final AgentActionParams params;
+
+  /// The agent's plain-language justification (UNTRUSTED — quoted text only).
+  final String rationale;
+
+  /// 'mutating' (always gated) | 'safe'. Carried for display; the app never
+  /// uses it to skip the approval gate.
+  final String risk;
+
+  final AgentActionStatus status;
+  final String statusRaw;
+
+  final int? decidedBy;
+  final DateTime? decidedAt;
+
+  /// The admin's deny note, if denied (UNTRUSTED — passive text).
+  final String? denyReason;
+
+  final DateTime? executedAt;
+
+  /// The execution outcome text, once executed/failed (UNTRUSTED — passive).
+  final String? resultText;
+
+  final DateTime? createdAt;
+
+  // Joined from the issue for the queue list view.
+  final String issueTitle;
+  final String issueMediaType;
+  final String? issueCategory;
+
+  const AgentAction({
+    required this.id,
+    required this.issueId,
+    required this.runId,
+    required this.kind,
+    required this.kindRaw,
+    required this.params,
+    required this.rationale,
+    required this.risk,
+    required this.status,
+    required this.statusRaw,
+    required this.decidedBy,
+    required this.decidedAt,
+    required this.denyReason,
+    required this.executedAt,
+    required this.resultText,
+    required this.createdAt,
+    required this.issueTitle,
+    required this.issueMediaType,
+    required this.issueCategory,
+  });
+
+  factory AgentAction.fromJson(Map<String, dynamic> json) {
+    // `params` arrives as a JSON object; tolerate a stringified object or a
+    // missing/non-object value so a malformed proposal never crashes the queue.
+    final rawParams = json['params'];
+    Map<String, dynamic> paramsMap = const {};
+    if (rawParams is Map) {
+      paramsMap = rawParams.map((k, v) => MapEntry(k.toString(), v));
+    } else if (rawParams is String && rawParams.isNotEmpty) {
+      try {
+        final decoded = jsonDecode(rawParams);
+        if (decoded is Map) {
+          paramsMap = decoded.map((k, v) => MapEntry(k.toString(), v));
+        }
+      } catch (_) {
+        // Leave params empty; the card still renders kind + rationale.
+      }
+    }
+
+    return AgentAction(
+      id: (json['id'] as num?)?.toInt() ?? 0,
+      issueId: (json['issue_id'] as num?)?.toInt() ?? 0,
+      runId: (json['run_id'] as num?)?.toInt(),
+      kind: AgentActionKind.fromValue(json['kind'] as String?),
+      kindRaw: json['kind'] as String? ?? '',
+      params: AgentActionParams(paramsMap),
+      rationale: json['rationale'] as String? ?? '',
+      risk: json['risk'] as String? ?? 'mutating',
+      status: AgentActionStatus.fromValue(json['status'] as String?),
+      statusRaw: json['status'] as String? ?? '',
+      decidedBy: (json['decided_by'] as num?)?.toInt(),
+      decidedAt:
+          DateTime.tryParse(json['decided_at'] as String? ?? '')?.toLocal(),
+      denyReason: json['deny_reason'] as String?,
+      executedAt:
+          DateTime.tryParse(json['executed_at'] as String? ?? '')?.toLocal(),
+      resultText: json['result_text'] as String?,
+      createdAt:
+          DateTime.tryParse(json['created_at'] as String? ?? '')?.toLocal(),
+      issueTitle: json['issue_title'] as String? ?? '',
+      issueMediaType: json['issue_media_type'] as String? ?? '',
+      issueCategory: json['issue_category'] as String?,
+    );
+  }
+}
+
+/// A small read-only view over a proposal's `params` JSON object. Every getter
+/// returns UNTRUSTED data that callers render quoted and non-editable; the view
+/// never interprets a value as a command. Unknown keys are simply absent.
+class AgentActionParams {
+  final Map<String, dynamic> _raw;
+
+  const AgentActionParams(this._raw);
+
+  /// The raw decoded params map (UNTRUSTED). Exposed so an unknown kind can
+  /// list its fields generically.
+  Map<String, dynamic> get raw => _raw;
+
+  bool get isEmpty => _raw.isEmpty;
+
+  String? _str(String key) {
+    final v = _raw[key];
+    if (v == null) return null;
+    final s = v.toString().trim();
+    return s.isEmpty ? null : s;
+  }
+
+  int? _int(String key) {
+    final v = _raw[key];
+    if (v is num) return v.toInt();
+    if (v is String) return int.tryParse(v);
+    return null;
+  }
+
+  bool _bool(String key) => _raw[key] == true;
+
+  String? get mediaType => _str('media_type');
+
+  /// grab_release: the release GUID (an opaque indexer id, shown truncated).
+  String? get guid => _str('guid');
+  int? get indexerId => _int('indexer_id');
+  int? get queueIdToReplace {
+    final v = _int('queue_id_to_replace');
+    return (v != null && v > 0) ? v : null;
+  }
+
+  /// remediate_queue / manual_import: the target queue item id.
+  int? get queueId => _int('queue_id');
+
+  /// remediate_queue: remove | blocklist_search | change_category.
+  String? get queueAction => _str('action');
+
+  /// manual_import: whether to force past arr's safety checks.
+  bool get force => _bool('force');
+
+  /// trigger_search / rescan: the media id and optional season.
+  int? get tmdbId => _int('tmdb_id');
+  int? get season {
+    final v = _int('season');
+    return (v != null && v > 0) ? v : null;
+  }
+}
+
+/// One run of the agent's investigation, for the read-only audit timeline
+/// (`GET /api/admin/agent-runs/{id}` → `run`).
+class AgentRun {
+  final int id;
+  final int issueId;
+  final String trigger;
+  final String status;
+  final String model;
+  final int stepCount;
+  final int inputTokens;
+  final int outputTokens;
+  final int cacheCreationTokens;
+  final int cacheReadTokens;
+  final int costMicros;
+  final String? stopReason;
+  final DateTime? startedAt;
+  final DateTime? finishedAt;
+
+  const AgentRun({
+    required this.id,
+    required this.issueId,
+    required this.trigger,
+    required this.status,
+    required this.model,
+    required this.stepCount,
+    required this.inputTokens,
+    required this.outputTokens,
+    required this.cacheCreationTokens,
+    required this.cacheReadTokens,
+    required this.costMicros,
+    required this.stopReason,
+    required this.startedAt,
+    required this.finishedAt,
+  });
+
+  /// The accumulated run cost as a short "$0.0123" string (micros → USD).
+  String get costLabel {
+    final usd = costMicros / 1000000.0;
+    return '\$${usd.toStringAsFixed(usd < 0.01 ? 4 : 2)}';
+  }
+
+  factory AgentRun.fromJson(Map<String, dynamic> json) => AgentRun(
+        id: (json['id'] as num?)?.toInt() ?? 0,
+        issueId: (json['issue_id'] as num?)?.toInt() ?? 0,
+        trigger: json['trigger'] as String? ?? '',
+        status: json['status'] as String? ?? '',
+        model: json['model'] as String? ?? '',
+        stepCount: (json['step_count'] as num?)?.toInt() ?? 0,
+        inputTokens: (json['input_tokens'] as num?)?.toInt() ?? 0,
+        outputTokens: (json['output_tokens'] as num?)?.toInt() ?? 0,
+        cacheCreationTokens:
+            (json['cache_creation_tokens'] as num?)?.toInt() ?? 0,
+        cacheReadTokens: (json['cache_read_tokens'] as num?)?.toInt() ?? 0,
+        costMicros: (json['cost_micros'] as num?)?.toInt() ?? 0,
+        stopReason: json['stop_reason'] as String?,
+        startedAt:
+            DateTime.tryParse(json['started_at'] as String? ?? '')?.toLocal(),
+        finishedAt:
+            DateTime.tryParse(json['finished_at'] as String? ?? '')?.toLocal(),
+      );
+}
+
+/// One step of the agent's audit ledger (`agent-runs/{id}` → `steps[]`). All
+/// text fields (`text`, `toolInput`, `toolOutput`) are UNTRUSTED — rendered as
+/// passive, truncated text in the timeline.
+class AgentStep {
+  final int id;
+  final int seq;
+
+  /// 'assistant' | 'tool_call' | 'tool_result' | 'system' | 'giveup'.
+  final String kind;
+  final String? toolName;
+  final String? toolInput;
+  final String? toolOutput;
+  final String? text;
+  final bool isError;
+  final DateTime? createdAt;
+
+  const AgentStep({
+    required this.id,
+    required this.seq,
+    required this.kind,
+    required this.toolName,
+    required this.toolInput,
+    required this.toolOutput,
+    required this.text,
+    required this.isError,
+    required this.createdAt,
+  });
+
+  factory AgentStep.fromJson(Map<String, dynamic> json) => AgentStep(
+        id: (json['id'] as num?)?.toInt() ?? 0,
+        seq: (json['seq'] as num?)?.toInt() ?? 0,
+        kind: json['kind'] as String? ?? '',
+        toolName: json['tool_name'] as String?,
+        toolInput: json['tool_input'] as String?,
+        toolOutput: json['tool_output'] as String?,
+        text: json['text'] as String?,
+        isError: json['is_error'] as bool? ?? false,
+        createdAt:
+            DateTime.tryParse(json['created_at'] as String? ?? '')?.toLocal(),
+      );
+}
+
+/// The `GET /api/admin/agent-runs/{id}` payload: a run plus its ordered steps.
+class AgentRunDetail {
+  final AgentRun run;
+  final List<AgentStep> steps;
+
+  const AgentRunDetail({required this.run, required this.steps});
+
+  factory AgentRunDetail.fromJson(Map<String, dynamic> json) => AgentRunDetail(
+        run: AgentRun.fromJson(json['run'] as Map<String, dynamic>? ?? const {}),
+        steps: ((json['steps'] as List?) ?? const [])
+            .map((e) => AgentStep.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+}

--- a/app/lib/features/issues/data/issues_service.dart
+++ b/app/lib/features/issues/data/issues_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 
+import 'agent_action_models.dart';
 import 'issue_models.dart';
 
 /// REST client for the issue-reporting / AI-remediation feature.
@@ -96,5 +97,65 @@ class IssuesService {
       data: settings.toJson(),
     );
     return RemediationSettings.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  // ---- Agent actions (admin approval queue) --------------------------------
+
+  /// List proposed agent actions awaiting an admin decision — the approval
+  /// queue. Defaults to `proposed`; pass another [status] to inspect a
+  /// different bucket (e.g. `executed`). The server has no `issue_id` filter,
+  /// so a per-issue view fetches `proposed` and filters client-side
+  /// ([pendingActionsForIssue]).
+  Future<List<AgentAction>> listPendingActions({String status = 'proposed'}) async {
+    final resp = await _dio.get(
+      '/api/admin/agent-actions',
+      queryParameters: {if (status.isNotEmpty) 'status': status},
+    );
+    final data = resp.data as Map<String, dynamic>?;
+    return ((data?['actions'] as List?) ?? const [])
+        .map((e) => AgentAction.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// The proposed actions for one issue, filtered client-side from the queue
+  /// (there is no server-side `issue_id` filter). Used to surface the
+  /// ProposedActionCard inline in the issue thread.
+  Future<List<AgentAction>> pendingActionsForIssue(int issueId) async {
+    final all = await listPendingActions();
+    return all.where((a) => a.issueId == issueId).toList();
+  }
+
+  /// Approve a proposed action, optionally replacing its params with an admin
+  /// [override] (a JSON object for the action's kind). Returns the updated
+  /// action (now `executing`/`executed`/`failed`) so the UI can freeze the card
+  /// from the authoritative server state.
+  ///
+  /// The server tolerates an empty body, so when there's no override we send
+  /// none rather than an empty object.
+  Future<AgentAction> approveAction(int id, {Object? override}) async {
+    final resp = await _dio.post(
+      '/api/admin/agent-actions/$id/approve',
+      data: override == null ? null : {'override': override},
+    );
+    return AgentAction.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Deny a proposed action with an optional [note]. A denial returns the
+  /// investigation to `investigating` server-side (not a terminal failure).
+  /// Returns the updated (now `denied`) action.
+  Future<AgentAction> denyAction(int id, {String? note}) async {
+    final trimmed = note?.trim();
+    final resp = await _dio.post(
+      '/api/admin/agent-actions/$id/deny',
+      data: {'note': trimmed ?? ''},
+    );
+    return AgentAction.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Fetch one agent run plus its ordered audit steps, for the read-only
+  /// "agent activity" timeline.
+  Future<AgentRunDetail> getRun(int id) async {
+    final resp = await _dio.get('/api/admin/agent-runs/$id');
+    return AgentRunDetail.fromJson(resp.data as Map<String, dynamic>);
   }
 }

--- a/app/lib/features/issues/logic/issues_provider.dart
+++ b/app/lib/features/issues/logic/issues_provider.dart
@@ -96,3 +96,87 @@ class OpenIssuesNotifier extends StateNotifier<int> {
 /// Open-issue count for the signed-in admin (0 for non-admins).
 final openIssuesProvider =
     StateNotifierProvider<OpenIssuesNotifier, int>(OpenIssuesNotifier.new);
+
+/// Tracks the number of agent-proposed actions awaiting an admin decision, for
+/// admins only.
+///
+/// Drives the drawer "Agent fixes" entry badge. It is seeded from REST, kept
+/// live by `agent_action_pending` (which carries the authoritative
+/// `pending_count`) and `agent_action_decided` (which doesn't, so we refetch),
+/// and refreshed after an approve/deny. Non-admin accounts always report 0 and
+/// never call the admin-only endpoint. Mirrors `PendingApprovalsNotifier`.
+class PendingAgentActionsNotifier extends StateNotifier<int> {
+  PendingAgentActionsNotifier(this._ref) : super(0) {
+    _service = _ref.read(issuesServiceProvider);
+    _bind();
+    _ref.listen(authProvider, (_, __) => _bind());
+  }
+
+  final Ref _ref;
+  late final IssuesService _service;
+  StreamSubscription<WsEvent>? _sub;
+  bool _isAdmin = false;
+
+  void _bind() {
+    final admin = _ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    if (admin == _isAdmin) return;
+    _isAdmin = admin;
+    _sub?.cancel();
+    _sub = null;
+    if (!admin) {
+      _set(0);
+      return;
+    }
+    refresh();
+    _sub = _ref
+        .read(realtimeEventsProvider)
+        .where((e) =>
+            e.type == 'agent_action_pending' ||
+            e.type == 'agent_action_decided')
+        .listen(_onPing);
+  }
+
+  /// Applies the authoritative `pending_count` an `agent_action_pending` event
+  /// carries; otherwise (a decided event, or a ping without the count) refetch.
+  void _onPing(WsEvent event) {
+    final raw = event.data['pending_count'];
+    if (raw is num) {
+      _set(raw.toInt());
+    } else {
+      refresh();
+    }
+  }
+
+  /// Re-reads the proposed-action queue depth. Call after an approve/deny so
+  /// the badge reflects the resolved queue immediately.
+  Future<void> refresh() async {
+    if (!_isAdmin) return;
+    try {
+      final actions = await _service.listPendingActions();
+      _set(actions.length);
+    } catch (_) {
+      // Best-effort: keep the last known count on a transient failure (covers
+      // the pre-merge 404 too).
+    }
+  }
+
+  /// Sets the count directly from a caller that already holds the authoritative
+  /// queue (the agent-actions screen), avoiding a redundant fetch.
+  void setCount(int value) => _set(value);
+
+  void _set(int value) {
+    state = value < 0 ? 0 : value;
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}
+
+/// Proposed-action queue depth for the signed-in admin (0 for non-admins).
+final pendingAgentActionsProvider =
+    StateNotifierProvider<PendingAgentActionsNotifier, int>(
+  PendingAgentActionsNotifier.new,
+);

--- a/app/lib/features/issues/ui/agent_run_screen.dart
+++ b/app/lib/features/issues/ui/agent_run_screen.dart
@@ -1,0 +1,301 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../data/agent_action_models.dart';
+import '../logic/issues_provider.dart';
+
+/// Read-only audit timeline for one agent run (`GET /api/admin/agent-runs/{id}`).
+///
+/// Renders the run's bounds/cost summary and its ordered steps (each model turn
+/// and tool call) as a passive timeline. Every step's text — tool input/output,
+/// assistant reasoning — is UNTRUSTED and rendered as selectable, truncated
+/// text only. Nothing here is a control.
+class AgentRunScreen extends ConsumerStatefulWidget {
+  final int runId;
+
+  const AgentRunScreen({super.key, required this.runId});
+
+  @override
+  ConsumerState<AgentRunScreen> createState() => _AgentRunScreenState();
+}
+
+class _AgentRunScreenState extends ConsumerState<AgentRunScreen> {
+  AgentRunDetail? _detail;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = _detail == null;
+      _error = null;
+    });
+    try {
+      final detail = await ref.read(issuesServiceProvider).getRun(widget.runId);
+      if (!mounted) return;
+      setState(() {
+        _detail = detail;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final detail = _detail;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Agent activity')),
+      body: _isLoading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent))
+          : detail == null
+              ? Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(_friendlyError(_error ?? 'Could not load run'),
+                            style: const TextStyle(color: AppTheme.error),
+                            textAlign: TextAlign.center),
+                        const SizedBox(height: 12),
+                        ElevatedButton(
+                            onPressed: _load, child: const Text('Retry')),
+                      ],
+                    ),
+                  ),
+                )
+              : RefreshIndicator(
+                  color: AppTheme.accent,
+                  onRefresh: _load,
+                  child: ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.all(16),
+                    children: [
+                      _RunSummary(run: detail.run),
+                      const SizedBox(height: 16),
+                      if (detail.steps.isEmpty)
+                        const Padding(
+                          padding: EdgeInsets.only(top: 24),
+                          child: Center(
+                            child: Text('No steps recorded.',
+                                style: TextStyle(
+                                    color: AppTheme.textSecondary)),
+                          ),
+                        )
+                      else
+                        for (final step in detail.steps)
+                          _StepTile(step: step),
+                    ],
+                  ),
+                ),
+    );
+  }
+}
+
+/// The run's bounds + cost ledger, shown above the step timeline.
+class _RunSummary extends StatelessWidget {
+  final AgentRun run;
+  const _RunSummary({required this.run});
+
+  @override
+  Widget build(BuildContext context) {
+    final chips = <String>[
+      if (run.model.isNotEmpty) run.model,
+      '${run.stepCount} step${run.stepCount == 1 ? '' : 's'}',
+      run.costLabel,
+      if (run.stopReason != null && run.stopReason!.isNotEmpty)
+        'stopped: ${run.stopReason}',
+    ];
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppTheme.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Run #${run.id} · ${run.status}',
+            style: const TextStyle(
+                color: AppTheme.textPrimary,
+                fontSize: 14,
+                fontWeight: FontWeight.w700),
+          ),
+          if (run.startedAt != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              'Started ${DateFormat('MMM d, h:mm a').format(run.startedAt!)}',
+              style: const TextStyle(
+                  color: AppTheme.textSecondary, fontSize: 12),
+            ),
+          ],
+          const SizedBox(height: 10),
+          Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: chips.map(_chip).toList(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _chip(String label) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: AppTheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(color: AppTheme.border),
+      ),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: AppTheme.textSecondary,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// One step of the audit ledger. Tool calls show the tool name + a quoted,
+/// truncated input/output; assistant turns show the reasoning text; give-ups
+/// and errors are tinted. All text is passive.
+class _StepTile extends StatelessWidget {
+  final AgentStep step;
+  const _StepTile({required this.step});
+
+  @override
+  Widget build(BuildContext context) {
+    final (icon, color, heading) = _describe(step);
+    final details = <Widget>[];
+
+    if (step.text != null && step.text!.trim().isNotEmpty) {
+      details.add(_text(step.text!.trim()));
+    }
+    if (step.toolInput != null && step.toolInput!.trim().isNotEmpty) {
+      details.add(_quoted('input', step.toolInput!.trim()));
+    }
+    if (step.toolOutput != null && step.toolOutput!.trim().isNotEmpty) {
+      details.add(_quoted('result', step.toolOutput!.trim()));
+    }
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 14),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Icon(icon, size: 16, color: color),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  heading,
+                  style: TextStyle(
+                    color: step.isError ? AppTheme.error : AppTheme.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                ...details,
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _text(String t) => Padding(
+        padding: const EdgeInsets.only(top: 4),
+        child: SelectableText(
+          t,
+          style: const TextStyle(
+              color: AppTheme.textPrimary, fontSize: 13, height: 1.35),
+        ),
+      );
+
+  Widget _quoted(String label, String value) => Padding(
+        padding: const EdgeInsets.only(top: 6),
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: AppTheme.surfaceVariant,
+            borderRadius: BorderRadius.circular(6),
+            border: const Border(
+              left: BorderSide(color: AppTheme.border, width: 2),
+            ),
+          ),
+          child: SelectableText(
+            value,
+            maxLines: 8,
+            style: const TextStyle(
+              color: AppTheme.textSecondary,
+              fontSize: 12,
+              height: 1.35,
+              fontFamily: 'monospace',
+            ),
+          ),
+        ),
+      );
+
+  (IconData, Color, String) _describe(AgentStep s) {
+    if (s.isError) {
+      return (Icons.error_outline, AppTheme.error, _toolHeading(s, 'Error'));
+    }
+    switch (s.kind) {
+      case 'assistant':
+        return (Icons.smart_toy, AppTheme.accent, 'Agent');
+      case 'tool_call':
+        return (
+          Icons.build_outlined,
+          AppTheme.downloading,
+          _toolHeading(s, 'Tool call')
+        );
+      case 'tool_result':
+        return (
+          Icons.south,
+          AppTheme.textSecondary,
+          _toolHeading(s, 'Result')
+        );
+      case 'giveup':
+        return (Icons.flag_outlined, AppTheme.error, 'Gave up');
+      case 'system':
+        return (Icons.info_outline, AppTheme.textSecondary, 'System');
+      default:
+        return (Icons.circle, AppTheme.textSecondary, s.kind);
+    }
+  }
+
+  String _toolHeading(AgentStep s, String fallback) =>
+      (s.toolName != null && s.toolName!.isNotEmpty) ? s.toolName! : fallback;
+}

--- a/app/lib/features/issues/ui/issue_thread_screen.dart
+++ b/app/lib/features/issues/ui/issue_thread_screen.dart
@@ -4,10 +4,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
+import 'package:go_router/go_router.dart';
+
 import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../data/agent_action_models.dart';
 import '../data/issue_models.dart';
 import '../logic/issues_provider.dart';
+import 'proposed_action_card.dart';
 
 /// The issue conversation: a read-mostly transcript rendered with the AI-chat
 /// bubble grammar, plus a reply field.
@@ -32,6 +37,11 @@ class _IssueThreadScreenState extends ConsumerState<IssueThreadScreen> {
   IssueThread? _thread;
   bool _isLoading = true;
   String? _error;
+
+  /// Proposed actions for this issue, fetched alongside the thread for admins
+  /// so an admin can approve/deny from the conversation. Empty for non-admins
+  /// (the queue endpoint is admin-only) and when nothing is pending.
+  List<AgentAction> _actions = const [];
 
   final _replyController = TextEditingController();
   final _scrollController = ScrollController();
@@ -63,11 +73,28 @@ class _IssueThreadScreenState extends ConsumerState<IssueThreadScreen> {
   Future<void> _load({bool initial = false}) async {
     if (initial) setState(() => _isLoading = _thread == null);
     try {
-      final thread =
-          await ref.read(issuesServiceProvider).getThread(widget.issueId);
+      final service = ref.read(issuesServiceProvider);
+      final thread = await service.getThread(widget.issueId);
       if (!mounted) return;
+
+      // For an admin, also pull any proposed actions for this issue so the
+      // ProposedActionCard can be surfaced inline. Best-effort and admin-only
+      // (the endpoint is admin-gated); failures leave the actions empty.
+      final isAdmin =
+          ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
+      List<AgentAction> actions = const [];
+      if (isAdmin) {
+        try {
+          actions = await service.pendingActionsForIssue(widget.issueId);
+        } catch (_) {
+          // Leave actions empty; the thread still renders.
+        }
+        if (!mounted) return;
+      }
+
       setState(() {
         _thread = thread;
+        _actions = actions;
         _isLoading = false;
         _error = null;
       });
@@ -164,6 +191,12 @@ class _IssueThreadScreenState extends ConsumerState<IssueThreadScreen> {
 
   Widget _buildBody(IssueThread thread) {
     final issue = thread.issue;
+    // The most recent run linked to a proposal on this issue, used for the
+    // "View agent activity" affordance (the issue payload itself carries no
+    // run id). Null when no proposal carries one.
+    final runId = _actions
+        .map((a) => a.runId)
+        .firstWhere((id) => id != null, orElse: () => null);
     return Column(
       children: [
         Expanded(
@@ -176,8 +209,33 @@ class _IssueThreadScreenState extends ConsumerState<IssueThreadScreen> {
               padding: const EdgeInsets.all(16),
               children: [
                 _IssueSummaryCard(issue: issue),
+                if (runId != null) ...[
+                  const SizedBox(height: 8),
+                  Align(
+                    alignment: Alignment.centerLeft,
+                    child: TextButton.icon(
+                      onPressed: () => context.push('/agent-runs/$runId'),
+                      icon: const Icon(Icons.timeline, size: 16),
+                      style: TextButton.styleFrom(
+                        foregroundColor: AppTheme.textSecondary,
+                        padding: EdgeInsets.zero,
+                        minimumSize: const Size(0, 32),
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                      label: const Text('View agent activity'),
+                    ),
+                  ),
+                ],
                 const SizedBox(height: 16),
                 for (final msg in thread.messages) _MessageRow(message: msg),
+                // Proposed-action cards surfaced inline so an admin can act from
+                // the conversation. Each freezes on decide; the list reloads.
+                for (final action in _actions)
+                  ProposedActionCard(
+                    key: ValueKey(action.id),
+                    action: action,
+                    onDecided: (_) => _load(),
+                  ),
                 if (issue.status.isActive) const _WorkingIndicator(),
               ],
             ),

--- a/app/lib/features/issues/ui/pending_agent_actions_screen.dart
+++ b/app/lib/features/issues/ui/pending_agent_actions_screen.dart
@@ -1,0 +1,199 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/providers/realtime_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/agent_action_models.dart';
+import '../logic/issues_provider.dart';
+import 'proposed_action_card.dart';
+
+/// Admin approval queue for the AI-remediation agent: the proposed *arr fixes
+/// awaiting a decision, grouped by the issue they belong to.
+///
+/// Mirrors `PendingRequestsScreen`: a [RefreshIndicator] over a scrolling list,
+/// kept live by `agent_action_pending` / `agent_action_decided` pings, and
+/// seeding the drawer badge on load. Each proposal renders as a
+/// [ProposedActionCard]; once approved/denied the card freezes and the list
+/// reloads so the resolved proposal drops out of the queue.
+class PendingAgentActionsScreen extends ConsumerStatefulWidget {
+  const PendingAgentActionsScreen({super.key});
+
+  @override
+  ConsumerState<PendingAgentActionsScreen> createState() =>
+      _PendingAgentActionsScreenState();
+}
+
+class _PendingAgentActionsScreenState
+    extends ConsumerState<PendingAgentActionsScreen> {
+  List<AgentAction>? _actions;
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _isLoading = _actions == null;
+      _error = null;
+    });
+    try {
+      final actions = await ref.read(issuesServiceProvider).listPendingActions();
+      if (!mounted) return;
+      setState(() {
+        _actions = actions;
+        _isLoading = false;
+      });
+      // Keep the drawer badge in sync with the queue we just loaded.
+      ref.read(pendingAgentActionsProvider.notifier).setCount(actions.length);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = e.toString();
+        _isLoading = false;
+      });
+    }
+  }
+
+  /// After a decision, refresh the queue + badge so the resolved proposal drops
+  /// out and any sibling counts update.
+  void _onDecided(AgentAction _) => _load();
+
+  @override
+  Widget build(BuildContext context) {
+    // A proposal raised or decided elsewhere reloads the queue.
+    ref.listen(agentActionsChangedProvider, (_, __) => _load());
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Agent fixes')),
+      body: _isLoading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent))
+          : _error != null && _actions == null
+              ? _ErrorView(message: _friendlyError(_error!), onRetry: _load)
+              : RefreshIndicator(
+                  color: AppTheme.accent,
+                  onRefresh: _load,
+                  child: (_actions?.isEmpty ?? true)
+                      ? ListView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          children: const [
+                            SizedBox(height: 120),
+                            Center(
+                              child: Text(
+                                'No fixes awaiting approval.',
+                                style:
+                                    TextStyle(color: AppTheme.textSecondary),
+                              ),
+                            ),
+                          ],
+                        )
+                      : _buildGroupedList(_actions!),
+                ),
+    );
+  }
+
+  Widget _buildGroupedList(List<AgentAction> actions) {
+    // Group by issue id, preserving the server's newest-first order. The
+    // grouped layout makes "two proposals for the same problem" legible.
+    final order = <int>[];
+    final groups = <int, List<AgentAction>>{};
+    for (final a in actions) {
+      groups.putIfAbsent(a.issueId, () {
+        order.add(a.issueId);
+        return [];
+      }).add(a);
+    }
+
+    return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.fromLTRB(12, 8, 12, 24),
+      itemCount: order.length,
+      itemBuilder: (context, index) {
+        final issueId = order[index];
+        final group = groups[issueId]!;
+        final title = group.first.issueTitle.isEmpty
+            ? 'Issue #$issueId'
+            : group.first.issueTitle;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Issue header — tap to open the full thread.
+            InkWell(
+              onTap: () async {
+                await context.push('/issues/$issueId');
+                if (mounted) _load();
+              },
+              borderRadius: BorderRadius.circular(8),
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(4, 12, 4, 4),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        title,
+                        style: const TextStyle(
+                          color: AppTheme.textPrimary,
+                          fontSize: 15,
+                          fontWeight: FontWeight.bold,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    const Icon(Icons.chevron_right,
+                        size: 18, color: AppTheme.textSecondary),
+                  ],
+                ),
+              ),
+            ),
+            for (final action in group)
+              ProposedActionCard(
+                key: ValueKey(action.id),
+                action: action,
+                onDecided: _onDecided,
+                onViewActivity: action.runId != null
+                    ? () => context.push('/agent-runs/${action.runId}')
+                    : null,
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ErrorView extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorView({required this.message, required this.onRetry});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(message,
+                style: const TextStyle(color: AppTheme.error),
+                textAlign: TextAlign.center),
+            const SizedBox(height: 12),
+            ElevatedButton(onPressed: onRetry, child: const Text('Retry')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/issues/ui/proposed_action_card.dart
+++ b/app/lib/features/issues/ui/proposed_action_card.dart
@@ -1,0 +1,575 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../data/agent_action_models.dart';
+import '../logic/issues_provider.dart';
+
+/// SAFETY-CRITICAL widget: the card an admin uses to approve or deny one of the
+/// agent's proposed *arr fixes.
+///
+/// Invariants this widget upholds:
+///  * Everything the agent produced — `params`, `rationale`, the kind summary —
+///    is rendered as PASSIVE, non-editable text. No agent-supplied string ever
+///    becomes a button label or a control. The only controls are the two
+///    fixed, server-authored Approve / Deny buttons.
+///  * Approve / Deny appear only for an admin AND only while the action is
+///    still `proposed`. A reporter (or any non-admin) sees a read-only "waiting
+///    on an admin" footer.
+///  * Once a decision is made — locally here, or already decided server-side —
+///    the card FREEZES ("Approved · just now" / "Denied") and never re-enables.
+///    The server's compare-and-swap rejects a second decision anyway; this is
+///    the matching guard at the UI layer.
+class ProposedActionCard extends ConsumerStatefulWidget {
+  final AgentAction action;
+
+  /// Invoked after a successful approve/deny with the server's updated action,
+  /// so the parent can refresh its queue + badge.
+  final ValueChanged<AgentAction>? onDecided;
+
+  /// Optional affordance to open the agent's activity timeline for this
+  /// action's run. Shown only when the action carries a run id.
+  final VoidCallback? onViewActivity;
+
+  const ProposedActionCard({
+    super.key,
+    required this.action,
+    this.onDecided,
+    this.onViewActivity,
+  });
+
+  @override
+  ConsumerState<ProposedActionCard> createState() => _ProposedActionCardState();
+}
+
+class _ProposedActionCardState extends ConsumerState<ProposedActionCard> {
+  /// The authoritative action shown. Starts from the prop and is replaced by
+  /// the server's response after a decision so the frozen footer is accurate.
+  late AgentAction _action;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _action = widget.action;
+  }
+
+  @override
+  void didUpdateWidget(ProposedActionCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A live refresh upstream (queue reload / WS ping) may hand us a newer
+    // snapshot of the same action — adopt it unless we're mid-decision.
+    if (!_busy && widget.action.id == _action.id) {
+      _action = widget.action;
+    }
+  }
+
+  String _friendlyError(Object e) {
+    final m = RegExp(r'"error":"([^"]+)"').firstMatch(e.toString());
+    return m != null ? m.group(1)! : 'Something went wrong';
+  }
+
+  Future<void> _approve() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      final updated =
+          await ref.read(issuesServiceProvider).approveAction(_action.id);
+      if (!mounted) return;
+      setState(() {
+        _action = updated;
+        _busy = false;
+      });
+      widget.onDecided?.call(updated);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Approved — applying the fix.')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _busy = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_friendlyError(e))),
+      );
+    }
+  }
+
+  Future<void> _deny() async {
+    if (_busy) return;
+    final controller = TextEditingController();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        backgroundColor: AppTheme.surface,
+        title: const Text('Deny this fix',
+            style: TextStyle(color: AppTheme.textPrimary)),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          maxLines: 3,
+          minLines: 1,
+          style: const TextStyle(color: AppTheme.textPrimary),
+          decoration: const InputDecoration(
+            labelText: 'Reason (optional)',
+            labelStyle: TextStyle(color: AppTheme.textSecondary),
+            border: OutlineInputBorder(),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppTheme.error,
+              foregroundColor: Colors.white,
+            ),
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Deny'),
+          ),
+        ],
+      ),
+    );
+
+    final note = controller.text.trim();
+    // Defer disposal until after the dialog's exit transition completes — the
+    // TextField still references the controller while the route animates out,
+    // so disposing synchronously here would use it after disposal.
+    WidgetsBinding.instance.addPostFrameCallback((_) => controller.dispose());
+    if (confirmed != true || !mounted) return;
+
+    setState(() => _busy = true);
+    try {
+      final updated = await ref
+          .read(issuesServiceProvider)
+          .denyAction(_action.id, note: note.isEmpty ? null : note);
+      if (!mounted) return;
+      setState(() {
+        _action = updated;
+        _busy = false;
+      });
+      widget.onDecided?.call(updated);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Denied — the agent will try another way.')),
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _busy = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(_friendlyError(e))),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isAdmin =
+        ref.watch(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    final action = _action;
+    final pending = action.status.isPending;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: pending
+              ? AppTheme.requested.withValues(alpha: 0.6)
+              : AppTheme.border,
+          width: pending ? 1.2 : 0.8,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header: a fixed icon + a fixed "proposed a fix" line (NOT agent text).
+          const Row(
+            children: [
+              Icon(Icons.build_circle_outlined,
+                  size: 18, color: AppTheme.requested),
+              SizedBox(width: 8),
+              Text(
+                'The agent proposed a fix',
+                style: TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+
+          // Plain-language summary of the action kind (server-authored copy,
+          // chosen by the typed kind enum — never an agent string).
+          Text(
+            _ActionCopy.summary(action),
+            style: const TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 15,
+              height: 1.35,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+
+          // The quoted, non-editable params (release / quality / queue id …).
+          ..._buildParamRows(action),
+
+          // The agent's rationale, quoted as untrusted passive text.
+          if (action.rationale.trim().isNotEmpty) ...[
+            const SizedBox(height: 12),
+            _QuotedBlock(
+              label: "Agent's reasoning",
+              text: action.rationale.trim(),
+            ),
+          ],
+
+          // The execution result / deny note, once decided.
+          if (action.resultText != null &&
+              action.resultText!.trim().isNotEmpty) ...[
+            const SizedBox(height: 12),
+            _QuotedBlock(label: 'Result', text: action.resultText!.trim()),
+          ],
+          if (action.denyReason != null &&
+              action.denyReason!.trim().isNotEmpty) ...[
+            const SizedBox(height: 12),
+            _QuotedBlock(label: 'Deny note', text: action.denyReason!.trim()),
+          ],
+
+          const SizedBox(height: 14),
+
+          // Controls (admin + still proposed) OR a frozen status footer.
+          if (pending && isAdmin)
+            _buildButtons()
+          else
+            _buildFrozenFooter(action, isAdmin: isAdmin),
+
+          if (widget.onViewActivity != null && action.runId != null) ...[
+            const SizedBox(height: 6),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton.icon(
+                onPressed: widget.onViewActivity,
+                icon: const Icon(Icons.timeline, size: 16),
+                style: TextButton.styleFrom(
+                  foregroundColor: AppTheme.textSecondary,
+                  padding: EdgeInsets.zero,
+                  minimumSize: const Size(0, 32),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                label: const Text('View agent activity'),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildParamRows(AgentAction action) {
+    final rows = _ActionCopy.paramRows(action);
+    if (rows.isEmpty) return const [];
+    return [
+      const SizedBox(height: 10),
+      ...rows.map((r) => Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: _ParamRow(label: r.$1, value: r.$2, mono: r.$3),
+          )),
+    ];
+  }
+
+  Widget _buildButtons() {
+    return Row(
+      children: [
+        Expanded(
+          child: ElevatedButton.icon(
+            onPressed: _busy ? null : _approve,
+            icon: _busy
+                ? const SizedBox(
+                    width: 14,
+                    height: 14,
+                    child: CircularProgressIndicator(
+                        strokeWidth: 2, color: Colors.white),
+                  )
+                : const Icon(Icons.check_circle_outline, size: 18),
+            label: const Text('Approve'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppTheme.available,
+              foregroundColor: Colors.white,
+              disabledBackgroundColor:
+                  AppTheme.available.withValues(alpha: 0.5),
+            ),
+          ),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: OutlinedButton.icon(
+            onPressed: _busy ? null : _deny,
+            icon: const Icon(Icons.cancel_outlined, size: 18),
+            label: const Text('Deny'),
+            style: OutlinedButton.styleFrom(
+              foregroundColor: AppTheme.error,
+              side: const BorderSide(color: AppTheme.error),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFrozenFooter(AgentAction action, {required bool isAdmin}) {
+    // A reporter / non-admin viewing a still-pending proposal.
+    if (action.status.isPending && !isAdmin) {
+      return const Row(
+        children: [
+          Icon(Icons.hourglass_empty, size: 16, color: AppTheme.requested),
+          SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              'Waiting on an admin to approve a fix.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
+          ),
+        ],
+      );
+    }
+
+    final decided = _ActionCopy.frozenFooter(action);
+    return Row(
+      children: [
+        Icon(decided.$2, size: 16, color: decided.$3),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            decided.$1,
+            style: TextStyle(
+              color: decided.$3,
+              fontSize: 13,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Server-authored, kind-driven copy for the card. Centralizes the plain
+/// language so the action enum — never an agent string — selects the wording.
+class _ActionCopy {
+  /// A one-line plain-language summary of what approving will do.
+  static String summary(AgentAction a) {
+    switch (a.kind) {
+      case AgentActionKind.grabRelease:
+        return a.params.queueIdToReplace != null
+            ? 'Grab a different release and remove the current one'
+            : 'Grab a specific release';
+      case AgentActionKind.remediateQueue:
+        switch (a.params.queueAction) {
+          case 'remove':
+            return 'Remove the stuck item from the download queue';
+          case 'blocklist_search':
+            return 'Blocklist the current release and search for a replacement';
+          case 'change_category':
+            return 'Change the download category to unblock the import';
+          default:
+            return 'Fix the stuck download-queue item';
+        }
+      case AgentActionKind.manualImport:
+        return a.params.force
+            ? 'Force-import the downloaded files (overrides safety checks)'
+            : 'Manually import the downloaded files';
+      case AgentActionKind.triggerSearch:
+        return 'Start an automatic search for this title';
+      case AgentActionKind.rescan:
+        return 'Rescan the files on disk and re-run the import';
+      case AgentActionKind.unknown:
+        return 'Apply a fix';
+    }
+  }
+
+  /// The quoted, non-editable data rows for the action's params. Each tuple is
+  /// (label, value, useMonospace). Values are UNTRUSTED display data.
+  static List<(String, String, bool)> paramRows(AgentAction a) {
+    final p = a.params;
+    final rows = <(String, String, bool)>[];
+
+    String mediaLabel() => p.mediaType == 'tv' ? 'TV' : 'Movie';
+
+    switch (a.kind) {
+      case AgentActionKind.grabRelease:
+        if (p.mediaType != null) rows.add(('Type', mediaLabel(), false));
+        if (p.guid != null) {
+          rows.add(('Release', _shorten(p.guid!), true));
+        }
+        if (p.indexerId != null) {
+          rows.add(('Indexer', '#${p.indexerId}', false));
+        }
+        if (p.queueIdToReplace != null) {
+          rows.add(('Replaces queue item', '#${p.queueIdToReplace}', false));
+        }
+      case AgentActionKind.remediateQueue:
+        if (p.mediaType != null) rows.add(('Type', mediaLabel(), false));
+        if (p.queueId != null) {
+          rows.add(('Queue item', '#${p.queueId}', false));
+        }
+        if (p.queueAction != null) {
+          rows.add(('Action', p.queueAction!, true));
+        }
+      case AgentActionKind.manualImport:
+        if (p.mediaType != null) rows.add(('Type', mediaLabel(), false));
+        if (p.queueId != null) {
+          rows.add(('Queue item', '#${p.queueId}', false));
+        }
+        rows.add(('Force', p.force ? 'yes' : 'no', false));
+      case AgentActionKind.triggerSearch:
+        if (p.mediaType != null) rows.add(('Type', mediaLabel(), false));
+        if (p.tmdbId != null) rows.add(('TMDB id', '${p.tmdbId}', false));
+        if (p.season != null) rows.add(('Season', '${p.season}', false));
+      case AgentActionKind.rescan:
+        if (p.mediaType != null) rows.add(('Type', mediaLabel(), false));
+        if (p.tmdbId != null) rows.add(('TMDB id', '${p.tmdbId}', false));
+      case AgentActionKind.unknown:
+        // Unknown kind: list whatever params arrived, generically + verbatim.
+        p.raw.forEach((k, v) {
+          rows.add((k, v?.toString() ?? '—', true));
+        });
+    }
+    return rows;
+  }
+
+  /// The frozen footer text + icon + color once a decision is made.
+  static (String, IconData, Color) frozenFooter(AgentAction a) {
+    final when = a.decidedAt != null ? _relative(a.decidedAt!) : null;
+    final by = a.executedAt != null ? _relative(a.executedAt!) : when;
+    switch (a.status) {
+      case AgentActionStatus.executed:
+        return ('Approved${by != null ? ' · $by' : ''} · applied',
+            Icons.check_circle, AppTheme.available);
+      case AgentActionStatus.approved:
+      case AgentActionStatus.executing:
+        return ('Approved${when != null ? ' · $when' : ''} · applying…',
+            Icons.check_circle, AppTheme.available);
+      case AgentActionStatus.denied:
+        return ('Denied${when != null ? ' · $when' : ''}', Icons.cancel,
+            AppTheme.error);
+      case AgentActionStatus.failed:
+        return ('Approved, but the fix failed', Icons.error_outline,
+            AppTheme.error);
+      case AgentActionStatus.superseded:
+        return ('Superseded by a newer proposal', Icons.history,
+            AppTheme.textSecondary);
+      case AgentActionStatus.proposed:
+      case AgentActionStatus.unknown:
+        return (a.status.label, Icons.info_outline, AppTheme.textSecondary);
+    }
+  }
+
+  /// Truncates a long opaque id (e.g. a release GUID) for display.
+  static String _shorten(String s) {
+    if (s.length <= 48) return s;
+    return '${s.substring(0, 28)}…${s.substring(s.length - 12)}';
+  }
+
+  static String _relative(DateTime t) {
+    final d = DateTime.now().difference(t);
+    if (d.inSeconds < 45) return 'just now';
+    if (d.inMinutes < 60) {
+      final m = d.inMinutes;
+      return '${m}m ago';
+    }
+    if (d.inHours < 24) {
+      final h = d.inHours;
+      return '${h}h ago';
+    }
+    final days = d.inDays;
+    return '${days}d ago';
+  }
+}
+
+/// One quoted, non-editable data row: "Label  value". The value is UNTRUSTED.
+class _ParamRow extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool mono;
+
+  const _ParamRow({required this.label, required this.value, this.mono = false});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        SizedBox(
+          width: 120,
+          child: Text(
+            label,
+            style: const TextStyle(
+                color: AppTheme.textSecondary, fontSize: 12, height: 1.3),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          // Passive, selectable, never a control.
+          child: SelectableText(
+            value,
+            style: TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 13,
+              height: 1.3,
+              fontFamily: mono ? 'monospace' : null,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// A labeled, quoted block of UNTRUSTED agent/result text. Bordered and
+/// passive so it reads as data, never as something to act on.
+class _QuotedBlock extends StatelessWidget {
+  final String label;
+  final String text;
+
+  const _QuotedBlock({required this.label, required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: const TextStyle(
+              color: AppTheme.textSecondary,
+              fontSize: 11,
+              fontWeight: FontWeight.w600),
+        ),
+        const SizedBox(height: 4),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: AppTheme.surfaceVariant,
+            borderRadius: BorderRadius.circular(8),
+            border: const Border(
+              left: BorderSide(color: AppTheme.border, width: 3),
+            ),
+          ),
+          child: SelectableText(
+            text,
+            style: const TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 13,
+              height: 1.4,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -122,7 +122,9 @@ class PushService {
 
   /// Routes a tapped notification to the right screen from its custom payload:
   /// the approvals queue for `request_pending`; the media detail page for an
-  /// approval decision or a new-content alert.
+  /// approval decision or a new-content alert; the agent approval queue for a
+  /// pending fix; the issue thread for an issue/decision update; and the
+  /// remediation settings for the auto-dispatch circuit-breaker notice.
   void _routeNotification(Object? arguments) {
     final data = _asStringMap(arguments);
     final type = data['type'] as String?;
@@ -131,6 +133,13 @@ class PushService {
     switch (type) {
       case 'request_pending':
         router.push('/approvals');
+      case 'agent_action_pending':
+        // A fix needs approval — go straight to the agent approval queue.
+        router.push('/agent-actions');
+      case 'remediation_autodispatch_disabled':
+        // The circuit breaker turned auto-dispatch off — open the settings the
+        // admin uses to re-enable it.
+        router.push('/settings/ai-remediation');
       case 'request_decision':
       case 'new_movie':
       case 'new_episode':
@@ -141,7 +150,7 @@ class PushService {
       case 'issue_created':
       case 'issue_updated':
       case 'issue_resolved':
-      case 'agent_action_pending':
+      case 'agent_action_decided':
         final issueId = _asInt(data['issue_id']);
         if (issueId == null || issueId <= 0) return;
         router.push('/issues/$issueId');

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -343,7 +343,10 @@ class _AppShellState extends ConsumerState<AppShell>
     // the hamburger dot. Always 0 for non-admins. Watched here (not just in
     // the drawer) so the badge stays live app-wide.
     final openIssues = ref.watch(openIssuesProvider);
-    final menuBadgeCount = pendingApprovals + openIssues;
+    // Agent-proposed fixes awaiting approval — drives the drawer "Agent fixes"
+    // entry and the hamburger dot. Always 0 for non-admins.
+    final pendingAgentActions = ref.watch(pendingAgentActionsProvider);
+    final menuBadgeCount = pendingApprovals + openIssues + pendingAgentActions;
     final showSearchResults = searchState.searchMode == SearchMode.search ||
         searchState.searchMode == SearchMode.aiReady;
     final libraryStatus = searchState.isSearching && showSearchResults
@@ -746,6 +749,7 @@ class _AppShellState extends ConsumerState<AppShell>
         ref.watch(authProvider).valueOrNull?.user?.isAdmin ?? false;
     final pendingApprovals = ref.watch(pendingApprovalsProvider);
     final openIssues = ref.watch(openIssuesProvider);
+    final pendingAgentActions = ref.watch(pendingAgentActionsProvider);
 
     return SafeArea(
       child: Column(
@@ -803,6 +807,15 @@ class _AppShellState extends ConsumerState<AppShell>
               onTap: () {
                 if (isOverlay) Navigator.pop(context);
                 context.push('/issues');
+              },
+            ),
+            _DrawerItem(
+              icon: Icons.build_circle_outlined,
+              title: 'Agent fixes',
+              badgeCount: pendingAgentActions,
+              onTap: () {
+                if (isOverlay) Navigator.pop(context);
+                context.push('/agent-actions');
               },
             ),
             const Divider(color: AppTheme.border),

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -15,9 +15,11 @@ import '../features/discover/data/tmdb_models.dart';
 import '../features/downloads/ui/downloads_history_screen.dart';
 import '../features/downloads/ui/downloads_module_shell.dart';
 import '../features/downloads/ui/downloads_queue_screen.dart';
+import '../features/issues/ui/agent_run_screen.dart';
 import '../features/issues/ui/ai_remediation_settings_screen.dart';
 import '../features/issues/ui/issue_thread_screen.dart';
 import '../features/issues/ui/issues_list_screen.dart';
+import '../features/issues/ui/pending_agent_actions_screen.dart';
 import '../features/media_detail/ui/media_detail_screen.dart';
 import '../features/notifications/ui/notification_preferences_screen.dart';
 import '../features/radarr/ui/radarr_calendar_screen.dart';
@@ -374,6 +376,19 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         builder: (context, state) {
           final id = int.tryParse(state.pathParameters['id'] ?? '') ?? 0;
           return IssueThreadScreen(issueId: id);
+        },
+      ),
+      GoRoute(
+        path: '/agent-actions',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (_, __) => const PendingAgentActionsScreen(),
+      ),
+      GoRoute(
+        path: '/agent-runs/:id',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (context, state) {
+          final id = int.tryParse(state.pathParameters['id'] ?? '') ?? 0;
+          return AgentRunScreen(runId: id);
         },
       ),
       GoRoute(

--- a/app/test/issues/agent_action_models_test.dart
+++ b/app/test/issues/agent_action_models_test.dart
@@ -1,0 +1,177 @@
+import 'package:cantinarr/features/issues/data/agent_action_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AgentActionKind / AgentActionStatus', () {
+    test('map wire values, tolerate unknowns', () {
+      expect(AgentActionKind.fromValue('grab_release'),
+          AgentActionKind.grabRelease);
+      expect(AgentActionKind.fromValue('a_future_kind'),
+          AgentActionKind.unknown);
+      expect(AgentActionKind.fromValue(null), AgentActionKind.unknown);
+
+      expect(AgentActionStatus.fromValue('proposed'),
+          AgentActionStatus.proposed);
+      expect(AgentActionStatus.fromValue('something_new'),
+          AgentActionStatus.unknown);
+    });
+
+    test('isPending only for proposed; isDecided for terminal decisions', () {
+      expect(AgentActionStatus.proposed.isPending, isTrue);
+      expect(AgentActionStatus.executing.isPending, isFalse);
+      expect(AgentActionStatus.denied.isPending, isFalse);
+
+      expect(AgentActionStatus.executed.isDecided, isTrue);
+      expect(AgentActionStatus.denied.isDecided, isTrue);
+      expect(AgentActionStatus.failed.isDecided, isTrue);
+      expect(AgentActionStatus.proposed.isDecided, isFalse);
+    });
+  });
+
+  group('AgentAction.fromJson', () {
+    test('parses the merged server contract incl. joined issue fields', () {
+      final a = AgentAction.fromJson({
+        'id': 12,
+        'issue_id': 5,
+        'run_id': 9,
+        'kind': 'grab_release',
+        'params': {
+          'media_type': 'tv',
+          'guid': 'abc-123-def',
+          'indexer_id': 2,
+          'queue_id_to_replace': 44,
+        },
+        'rationale': 'The current release is dual-audio; this one is English.',
+        'risk': 'mutating',
+        'status': 'proposed',
+        'decided_by': null,
+        'decided_at': null,
+        'deny_reason': null,
+        'executed_at': null,
+        'result_text': null,
+        'created_at': '2026-06-23T10:00:00Z',
+        'issue_title': 'The Show',
+        'issue_media_type': 'tv',
+        'issue_category': 'wrong_audio',
+      });
+
+      expect(a.id, 12);
+      expect(a.issueId, 5);
+      expect(a.runId, 9);
+      expect(a.kind, AgentActionKind.grabRelease);
+      expect(a.status, AgentActionStatus.proposed);
+      expect(a.rationale, contains('English'));
+      expect(a.issueTitle, 'The Show');
+      expect(a.issueCategory, 'wrong_audio');
+
+      // Typed params view.
+      expect(a.params.mediaType, 'tv');
+      expect(a.params.guid, 'abc-123-def');
+      expect(a.params.indexerId, 2);
+      expect(a.params.queueIdToReplace, 44);
+    });
+
+    test('tolerates a stringified params object and a null run_id', () {
+      final a = AgentAction.fromJson({
+        'id': 1,
+        'issue_id': 2,
+        'run_id': null,
+        'kind': 'remediate_queue',
+        'params': '{"media_type":"movie","queue_id":7,"action":"blocklist_search"}',
+        'rationale': '',
+        'status': 'proposed',
+      });
+      expect(a.runId, isNull);
+      expect(a.params.mediaType, 'movie');
+      expect(a.params.queueId, 7);
+      expect(a.params.queueAction, 'blocklist_search');
+    });
+
+    test('malformed params never crash; an unknown kind still parses', () {
+      final a = AgentAction.fromJson({
+        'id': 1,
+        'issue_id': 2,
+        'kind': 'a_future_kind',
+        'params': '{not valid json',
+        'status': 'proposed',
+      });
+      expect(a.kind, AgentActionKind.unknown);
+      expect(a.kindRaw, 'a_future_kind');
+      expect(a.params.isEmpty, isTrue);
+    });
+
+    test('decided action carries decision + result fields', () {
+      final a = AgentAction.fromJson({
+        'id': 3,
+        'issue_id': 4,
+        'kind': 'rescan',
+        'params': {'media_type': 'movie', 'tmdb_id': 27205},
+        'status': 'executed',
+        'decided_by': 1,
+        'decided_at': '2026-06-23T10:05:00Z',
+        'executed_at': '2026-06-23T10:05:02Z',
+        'result_text': 'Rescan triggered; import pass queued.',
+      });
+      expect(a.status, AgentActionStatus.executed);
+      expect(a.decidedBy, 1);
+      expect(a.decidedAt, isNotNull);
+      expect(a.resultText, contains('Rescan'));
+      expect(a.params.tmdbId, 27205);
+    });
+  });
+
+  group('AgentRun / AgentStep / AgentRunDetail', () {
+    test('parses a run + ordered steps with a cost label', () {
+      final d = AgentRunDetail.fromJson({
+        'run': {
+          'id': 9,
+          'issue_id': 5,
+          'trigger': 'user_report',
+          'status': 'succeeded',
+          'model': 'claude-haiku-4-5',
+          'step_count': 3,
+          'input_tokens': 1200,
+          'output_tokens': 300,
+          'cache_creation_tokens': 0,
+          'cache_read_tokens': 800,
+          'cost_micros': 4200,
+          'stop_reason': 'resolved',
+          'started_at': '2026-06-23T10:00:00Z',
+          'finished_at': '2026-06-23T10:00:30Z',
+        },
+        'steps': [
+          {
+            'id': 1,
+            'seq': 0,
+            'kind': 'tool_call',
+            'tool_name': 'diagnose_queue',
+            'tool_input': '{"media_type":"tv"}',
+          },
+          {
+            'id': 2,
+            'seq': 1,
+            'kind': 'tool_result',
+            'tool_name': 'diagnose_queue',
+            'tool_output': 'stalled: no seeders',
+            'is_error': false,
+          },
+          {
+            'id': 3,
+            'seq': 2,
+            'kind': 'assistant',
+            'text': 'Proposing a blocklist + search.',
+          },
+        ],
+      });
+
+      expect(d.run.id, 9);
+      expect(d.run.model, 'claude-haiku-4-5');
+      expect(d.run.cacheReadTokens, 800);
+      expect(d.run.costLabel, '\$0.0042');
+      expect(d.steps, hasLength(3));
+      expect(d.steps.first.toolName, 'diagnose_queue');
+      expect(d.steps[1].kind, 'tool_result');
+      expect(d.steps.last.text, contains('blocklist'));
+    });
+  });
+}

--- a/app/test/issues/proposed_action_card_test.dart
+++ b/app/test/issues/proposed_action_card_test.dart
@@ -1,0 +1,242 @@
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/issues/data/agent_action_models.dart';
+import 'package:cantinarr/features/issues/data/issues_service.dart';
+import 'package:cantinarr/features/issues/logic/issues_provider.dart';
+import 'package:cantinarr/features/issues/ui/proposed_action_card.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Builds a proposed grab_release action for the card under test.
+AgentAction _proposed() => AgentAction.fromJson({
+      'id': 12,
+      'issue_id': 5,
+      'run_id': 9,
+      'kind': 'grab_release',
+      'params': {
+        'media_type': 'tv',
+        'guid': 'Show.S02E04.1080p.WEB.H264-GROUP',
+        'indexer_id': 2,
+        'queue_id_to_replace': 44,
+      },
+      'rationale': 'The current release has Russian audio; this one is English.',
+      'risk': 'mutating',
+      'status': 'proposed',
+      'created_at': '2026-06-23T10:00:00Z',
+      'issue_title': 'The Show',
+      'issue_media_type': 'tv',
+      'issue_category': 'wrong_audio',
+    });
+
+/// A fake service that returns canned decision results without any network I/O.
+class _FakeIssuesService extends IssuesService {
+  _FakeIssuesService() : super(backendDio: Dio());
+
+  AgentAction Function(AgentAction)? onDeny;
+  AgentAction Function(AgentAction)? onApprove;
+
+  @override
+  Future<AgentAction> denyAction(int id, {String? note}) async {
+    final base = _proposed();
+    return (onDeny ?? _denied)(base);
+  }
+
+  @override
+  Future<AgentAction> approveAction(int id, {Object? override}) async {
+    final base = _proposed();
+    return (onApprove ?? _executed)(base);
+  }
+
+  static AgentAction _denied(AgentAction _) => AgentAction.fromJson({
+        'id': 12,
+        'issue_id': 5,
+        'kind': 'grab_release',
+        'params': const {},
+        'status': 'denied',
+        'deny_reason': 'Not the right release.',
+        'decided_at': '2026-06-23T10:05:00Z',
+      });
+
+  static AgentAction _executed(AgentAction _) => AgentAction.fromJson({
+        'id': 12,
+        'issue_id': 5,
+        'kind': 'grab_release',
+        'params': const {},
+        'status': 'executed',
+        'decided_at': '2026-06-23T10:05:00Z',
+        'executed_at': '2026-06-23T10:05:02Z',
+        'result_text': 'Grabbed the replacement release.',
+      });
+}
+
+const _adminState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(),
+  ),
+  user: UserProfile(id: 1, username: 'admin', role: 'admin'),
+);
+
+const _userState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(),
+  ),
+  user: UserProfile(id: 2, username: 'reporter', role: 'user'),
+);
+
+class _FakeAuthNotifier extends AuthNotifier {
+  final AuthState authState;
+  _FakeAuthNotifier(this.authState);
+
+  @override
+  Future<AuthState> build() async => authState;
+}
+
+/// Dismisses any in-flight SnackBar and lets its animation finish so a
+/// transient toast can't leak its focus scope into the next test.
+Future<void> _drainSnackBar(WidgetTester tester) async {
+  final messengerState =
+      tester.state<ScaffoldMessengerState>(find.byType(ScaffoldMessenger));
+  messengerState.clearSnackBars();
+  await tester.pumpAndSettle();
+}
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required AuthState auth,
+  required IssuesService service,
+  required AgentAction action,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authProvider.overrideWith(() => _FakeAuthNotifier(auth)),
+        issuesServiceProvider.overrideWithValue(service),
+      ],
+      child: MaterialApp(
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: ProposedActionCard(action: action),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+void main() {
+  testWidgets('renders kind, params, and rationale as passive data',
+      (tester) async {
+    await _pump(
+      tester,
+      auth: _adminState,
+      service: _FakeIssuesService(),
+      action: _proposed(),
+    );
+
+    // Plain-language, kind-driven summary (server copy, not an agent string).
+    expect(find.text('Grab a different release and remove the current one'),
+        findsOneWidget);
+    // The release GUID is shown as quoted data.
+    expect(find.textContaining('Show.S02E04.1080p'), findsOneWidget);
+    // The agent's rationale is quoted verbatim.
+    expect(find.textContaining('Russian audio'), findsOneWidget);
+    // Admin sees the two fixed controls.
+    expect(find.widgetWithText(ElevatedButton, 'Approve'), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, 'Deny'), findsOneWidget);
+  });
+
+  testWidgets('a non-admin sees a read-only "waiting on an admin" footer',
+      (tester) async {
+    await _pump(
+      tester,
+      auth: _userState,
+      service: _FakeIssuesService(),
+      action: _proposed(),
+    );
+
+    expect(find.text('Waiting on an admin to approve a fix.'), findsOneWidget);
+    expect(find.widgetWithText(ElevatedButton, 'Approve'), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, 'Deny'), findsNothing);
+  });
+
+  testWidgets('freezes after a deny decision and never re-enables',
+      (tester) async {
+    await _pump(
+      tester,
+      auth: _adminState,
+      service: _FakeIssuesService(),
+      action: _proposed(),
+    );
+
+    // Open the deny dialog and confirm.
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Deny'));
+    await tester.pumpAndSettle();
+    // The dialog's Deny button (distinct from the card's) confirms.
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Deny'));
+    await tester.pump(); // run the decision future
+    await tester.pump(); // rebuild frozen
+
+    // The card is now frozen: a "Denied" footer, and the controls are gone.
+    expect(find.textContaining('Denied'), findsWidgets);
+    expect(find.widgetWithText(ElevatedButton, 'Approve'), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, 'Deny'), findsNothing);
+
+    await _drainSnackBar(tester);
+  });
+
+  testWidgets('freezes after an approve decision (Approved · applied)',
+      (tester) async {
+    await _pump(
+      tester,
+      auth: _adminState,
+      service: _FakeIssuesService(),
+      action: _proposed(),
+    );
+
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
+    await tester.pump(); // run the decision future
+    await tester.pump(); // rebuild frozen
+
+    // The frozen footer (distinct from the transient "Approved — applying…"
+    // SnackBar). The controls are gone.
+    expect(find.textContaining('· applied'), findsOneWidget);
+    expect(find.widgetWithText(ElevatedButton, 'Approve'), findsNothing);
+    expect(find.widgetWithText(OutlinedButton, 'Deny'), findsNothing);
+
+    await _drainSnackBar(tester);
+  });
+
+  testWidgets('an already-decided action renders frozen for an admin',
+      (tester) async {
+    final decided = AgentAction.fromJson({
+      'id': 13,
+      'issue_id': 5,
+      'kind': 'rescan',
+      'params': {'media_type': 'movie', 'tmdb_id': 27205},
+      'status': 'executed',
+      'decided_at': '2026-06-23T10:05:00Z',
+      'executed_at': '2026-06-23T10:05:02Z',
+      'result_text': 'Rescan triggered.',
+    });
+    await _pump(
+      tester,
+      auth: _adminState,
+      service: _FakeIssuesService(),
+      action: decided,
+    );
+
+    expect(find.widgetWithText(ElevatedButton, 'Approve'), findsNothing);
+    expect(find.textContaining('Approved'), findsOneWidget);
+    expect(find.textContaining('Rescan triggered.'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
Builds the **app side of Wave 3** — the screen + card where an admin approves or denies the AI remediation agent's proposed *arr fixes, making the propose→approve→execute loop usable from the phone. Built against the merged server (PRs #94–#98). **No `server/` changes.**

## What's here

**Data layer** (`features/issues/data/agent_action_models.dart`, `issues_service.dart`)
- `AgentAction` / `AgentRun` / `AgentStep` / `AgentRunDetail` models mirroring the merged server JSON exactly. Tolerant parsing throughout: `kind`/`status` are tolerant enums (unknown → `unknown`), and `params`/`rationale`/`result_text` are treated as **UNTRUSTED** and rendered as passive text only. A small `AgentActionParams` view reifies the typed params per kind.
- `IssuesService` gains `listPendingActions` / `pendingActionsForIssue` / `approveAction({override})` / `denyAction(note)` / `getRun`. (The server has no `issue_id` filter on the actions route, so the per-issue view filters the proposed queue client-side.)

**`ProposedActionCard`** (safety-critical widget)
- Bordered card with a fixed, **kind-driven** plain-language summary (e.g. "Grab a different release and remove the current one"), the release/quality/queue params shown as **quoted, non-editable data**, and the agent's `rationale` quoted verbatim. No agent-supplied string ever becomes a control or button label.
- **Approve** (`AppTheme.available`) / **Deny** (`AppTheme.error`, reason dialog) appear only for an admin AND only while `proposed`; a reporter sees a read-only "waiting on an admin" footer.
- **Freezes on decide** ("Approved · applied" / "Denied") from the server's returned action and never re-enables (the server's CAS rejects a second decision anyway).

**Surfaces**
- `PendingAgentActionsScreen` at `/agent-actions`: the approval queue grouped by issue, seeded from the list and kept live by `agent_action_pending` / `agent_action_decided`.
- `pendingAgentActionsProvider` (clone of `PendingApprovalsNotifier`) + a drawer **"Agent fixes"** item with a badge, contributing to the hamburger dot.
- The card is also surfaced **inline in the issue thread** for admins, so an admin can act from the conversation. All agent/user message bodies stay passive.
- `AgentRunScreen` at `/agent-runs/:id`: a read-only audit timeline, reached via "View agent activity".
- **Push deep-links** (`push_service.dart`): `agent_action_pending` → the approval queue; `agent_action_decided`/`issue_updated` → the thread; `remediation_autodispatch_disabled` → an admin SnackBar (in `app.dart`) + the remediation settings.

## Bug fixed along the way
The deny dialog disposed its `TextEditingController` before the route's exit transition finished (use-after-dispose, surfaced by the widget test). Disposal is now deferred to a post-frame callback.

## Verification
- `flutter analyze`: **no issues** in any touched file (pre-existing infos in unrelated files only).
- `flutter test`: green (104 total). New tests cover `AgentAction`/`AgentRun` parsing + the `ProposedActionCard` rendering kind/params/rationale, admin-gating, and freezing on approve/deny.

## Note on server fields
Every field needed was present in the merged response. One thing the app had to work around: an issue's payload carries **no run id**, so the "View agent activity" affordance derives the run id from a proposed `AgentAction`'s `run_id` (the actions route does return `run_id`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SEChSmKSXg8UDF5TY8aWpE