### PR TITLE
feat(chaptarr): per-user default *arr instance override + Chaptarr books module

### DIFF
--- a/app/lib/core/models/app_module.dart
+++ b/app/lib/core/models/app_module.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 /// Types of modules available in the app.
-enum ModuleType { dashboard, radarr, sonarr, downloads, tautulli, assistant }
+enum ModuleType { dashboard, radarr, sonarr, chaptarr, downloads, tautulli, assistant }
 
 /// Represents a navigable module in the app (shown in drawer).
 class AppModule {

--- a/app/lib/core/models/backend_connection.dart
+++ b/app/lib/core/models/backend_connection.dart
@@ -83,6 +83,12 @@ class BackendConnection {
   List<ServiceInstance> get sonarrInstances =>
       instances.where((i) => i.serviceType == 'sonarr').toList();
 
+  /// Get all Chaptarr (books) instances. The backend only includes a chaptarr
+  /// instance in this list for users an admin has explicitly granted access, so
+  /// its mere presence means the user may see the Books module.
+  List<ServiceInstance> get chaptarrInstances =>
+      instances.where((i) => i.serviceType == 'chaptarr').toList();
+
   /// Get all download client instances
   /// (SABnzbd, qBittorrent, NZBGet or Transmission).
   List<ServiceInstance> get downloadInstances => instances
@@ -110,12 +116,21 @@ class BackendConnection {
     if (sonarr.isEmpty) return null;
     return sonarr.firstWhere((i) => i.isDefault, orElse: () => sonarr.first);
   }
+
+  /// Get the default Chaptarr instance, if any (the user's granted instance).
+  ServiceInstance? get defaultChaptarrInstance {
+    final chaptarr = chaptarrInstances;
+    if (chaptarr.isEmpty) return null;
+    return chaptarr.firstWhere((i) => i.isDefault,
+        orElse: () => chaptarr.first);
+  }
 }
 
 /// Which services the backend has configured.
 class AvailableServices {
   final bool radarr;
   final bool sonarr;
+  final bool chaptarr;
   final bool ai;
   final bool tmdb;
   final bool trakt;
@@ -123,6 +138,7 @@ class AvailableServices {
   const AvailableServices({
     this.radarr = false,
     this.sonarr = false,
+    this.chaptarr = false,
     this.ai = false,
     this.tmdb = false,
     this.trakt = false,
@@ -132,6 +148,7 @@ class AvailableServices {
       AvailableServices(
         radarr: json['radarr'] as bool? ?? false,
         sonarr: json['sonarr'] as bool? ?? false,
+        chaptarr: json['chaptarr'] as bool? ?? false,
         ai: json['ai'] as bool? ?? false,
         tmdb: json['tmdb'] as bool? ?? false,
         trakt: json['trakt'] as bool? ?? false,
@@ -140,6 +157,7 @@ class AvailableServices {
   Map<String, dynamic> toJson() => {
         'radarr': radarr,
         'sonarr': sonarr,
+        'chaptarr': chaptarr,
         'ai': ai,
         'tmdb': tmdb,
         'trakt': trakt,

--- a/app/lib/core/providers/instance_provider.dart
+++ b/app/lib/core/providers/instance_provider.dart
@@ -6,20 +6,24 @@ import '../models/backend_connection.dart';
 class InstanceState {
   final List<ServiceInstance> radarrInstances;
   final List<ServiceInstance> sonarrInstances;
+  final List<ServiceInstance> chaptarrInstances;
   final List<ServiceInstance> downloadInstances;
   final List<ServiceInstance> tautulliInstances;
   final String? activeRadarrInstanceId;
   final String? activeSonarrInstanceId;
+  final String? activeChaptarrInstanceId;
   final String? activeDownloadInstanceId;
   final String? activeTautulliInstanceId;
 
   const InstanceState({
     this.radarrInstances = const [],
     this.sonarrInstances = const [],
+    this.chaptarrInstances = const [],
     this.downloadInstances = const [],
     this.tautulliInstances = const [],
     this.activeRadarrInstanceId,
     this.activeSonarrInstanceId,
+    this.activeChaptarrInstanceId,
     this.activeDownloadInstanceId,
     this.activeTautulliInstanceId,
   });
@@ -27,22 +31,27 @@ class InstanceState {
   InstanceState copyWith({
     List<ServiceInstance>? radarrInstances,
     List<ServiceInstance>? sonarrInstances,
+    List<ServiceInstance>? chaptarrInstances,
     List<ServiceInstance>? downloadInstances,
     List<ServiceInstance>? tautulliInstances,
     String? activeRadarrInstanceId,
     String? activeSonarrInstanceId,
+    String? activeChaptarrInstanceId,
     String? activeDownloadInstanceId,
     String? activeTautulliInstanceId,
   }) =>
       InstanceState(
         radarrInstances: radarrInstances ?? this.radarrInstances,
         sonarrInstances: sonarrInstances ?? this.sonarrInstances,
+        chaptarrInstances: chaptarrInstances ?? this.chaptarrInstances,
         downloadInstances: downloadInstances ?? this.downloadInstances,
         tautulliInstances: tautulliInstances ?? this.tautulliInstances,
         activeRadarrInstanceId:
             activeRadarrInstanceId ?? this.activeRadarrInstanceId,
         activeSonarrInstanceId:
             activeSonarrInstanceId ?? this.activeSonarrInstanceId,
+        activeChaptarrInstanceId:
+            activeChaptarrInstanceId ?? this.activeChaptarrInstanceId,
         activeDownloadInstanceId:
             activeDownloadInstanceId ?? this.activeDownloadInstanceId,
         activeTautulliInstanceId:
@@ -71,6 +80,19 @@ class InstanceState {
     }
     return sonarrInstances.firstWhere((i) => i.isDefault,
         orElse: () => sonarrInstances.first);
+  }
+
+  /// Get the active Chaptarr instance, falling back to default.
+  ServiceInstance? get activeChaptarrInstance {
+    if (chaptarrInstances.isEmpty) return null;
+    if (activeChaptarrInstanceId != null) {
+      final found = chaptarrInstances
+          .where((i) => i.id == activeChaptarrInstanceId)
+          .toList();
+      if (found.isNotEmpty) return found.first;
+    }
+    return chaptarrInstances.firstWhere((i) => i.isDefault,
+        orElse: () => chaptarrInstances.first);
   }
 
   /// Get the active download client instance, falling back to default.
@@ -109,12 +131,14 @@ class InstanceNotifier extends Notifier<InstanceState> {
 
     final radarr = connection.radarrInstances;
     final sonarr = connection.sonarrInstances;
+    final chaptarr = connection.chaptarrInstances;
     final downloads = connection.downloadInstances;
     final tautulli = connection.tautulliInstances;
 
     return InstanceState(
       radarrInstances: radarr,
       sonarrInstances: sonarr,
+      chaptarrInstances: chaptarr,
       downloadInstances: downloads,
       tautulliInstances: tautulli,
       activeRadarrInstanceId: radarr.isNotEmpty
@@ -123,6 +147,11 @@ class InstanceNotifier extends Notifier<InstanceState> {
           : null,
       activeSonarrInstanceId: sonarr.isNotEmpty
           ? (sonarr.firstWhere((i) => i.isDefault, orElse: () => sonarr.first))
+              .id
+          : null,
+      activeChaptarrInstanceId: chaptarr.isNotEmpty
+          ? (chaptarr.firstWhere((i) => i.isDefault,
+                  orElse: () => chaptarr.first))
               .id
           : null,
       activeDownloadInstanceId: downloads.isNotEmpty
@@ -142,6 +171,10 @@ class InstanceNotifier extends Notifier<InstanceState> {
 
   void setActiveSonarrInstance(String instanceId) {
     state = state.copyWith(activeSonarrInstanceId: instanceId);
+  }
+
+  void setActiveChaptarrInstance(String instanceId) {
+    state = state.copyWith(activeChaptarrInstanceId: instanceId);
   }
 
   void setActiveDownloadInstance(String instanceId) {

--- a/app/lib/core/providers/module_provider.dart
+++ b/app/lib/core/providers/module_provider.dart
@@ -86,6 +86,20 @@ class ModuleNotifier extends Notifier<ModuleState> {
         ));
       }
 
+      // Chaptarr (books) instances. NOT admin-gated here: the backend only
+      // surfaces a chaptarr instance to users an admin has explicitly granted,
+      // so any chaptarr instance present in the connection is one this user may
+      // see (admins see all). Visibility is enforced server-side.
+      for (final inst in connection.chaptarrInstances) {
+        modules.add(AppModule(
+          type: ModuleType.chaptarr,
+          label: inst.name,
+          icon: Icons.menu_book,
+          instanceId: inst.id,
+          instanceName: inst.name,
+        ));
+      }
+
       // Download client instances (admin only)
       if (isAdmin) {
         for (final inst in connection.downloadInstances) {

--- a/app/lib/features/chaptarr/data/chaptarr_api_service.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_api_service.dart
@@ -1,0 +1,347 @@
+import 'package:dio/dio.dart';
+import 'chaptarr_models.dart';
+
+/// Networking layer for Chaptarr (a Readarr-family books service), proxied
+/// through the Cantinarr backend. Note the Readarr API is v1 (not v3).
+class ChaptarrApiService {
+  final Dio _dio;
+  final String _instanceId;
+
+  ChaptarrApiService({required Dio backendDio, required String instanceId})
+      : _dio = backendDio,
+        _instanceId = instanceId;
+
+  /// Returns the base path prefix for API calls.
+  String get _basePath => '/api/instances/$_instanceId/api/v1';
+
+  Future<ChaptarrSystemStatus> getSystemStatus() async {
+    final resp = await _dio.get('$_basePath/system/status');
+    return ChaptarrSystemStatus.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<List<ChaptarrAuthor>> getAuthors() async {
+    final resp = await _dio.get('$_basePath/author');
+    return (resp.data as List<dynamic>)
+        .map((a) => ChaptarrAuthor.fromJson(a as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<ChaptarrAuthor> getAuthorById(int id) async {
+    final resp = await _dio.get('$_basePath/author/$id');
+    return ChaptarrAuthor.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<List<ChaptarrAuthor>> lookupAuthor(String term) async {
+    final resp = await _dio
+        .get('$_basePath/author/lookup', queryParameters: {'term': term});
+    return (resp.data as List<dynamic>)
+        .map((a) => ChaptarrAuthor.fromJson(a as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Lists books, optionally narrowed to one author. Each book carries its
+  /// editions inline — drives the per-book status line.
+  Future<List<ChaptarrBook>> getBooks({int? authorId}) async {
+    final resp = await _dio.get('$_basePath/book', queryParameters: {
+      if (authorId != null) 'authorId': authorId,
+    });
+    return (resp.data as List<dynamic>)
+        .map((b) => ChaptarrBook.fromJson(b as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<ChaptarrBook> getBookById(int id) async {
+    final resp = await _dio.get('$_basePath/book/$id');
+    return ChaptarrBook.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<List<ChaptarrBook>> lookupBook(String term) async {
+    final resp = await _dio
+        .get('$_basePath/book/lookup', queryParameters: {'term': term});
+    return (resp.data as List<dynamic>)
+        .map((b) => ChaptarrBook.fromJson(b as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Lists downloaded book files, optionally narrowed to an author or book.
+  Future<List<ChaptarrBookFile>> getBookFiles({
+    int? authorId,
+    int? bookId,
+  }) async {
+    final resp = await _dio.get('$_basePath/bookfile', queryParameters: {
+      if (authorId != null) 'authorId': authorId,
+      if (bookId != null) 'bookId': bookId,
+    });
+    return (resp.data as List<dynamic>)
+        .map((f) => ChaptarrBookFile.fromJson(f as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<ChaptarrQualityProfile>> getQualityProfiles() async {
+    final resp = await _dio.get('$_basePath/qualityprofile');
+    return (resp.data as List<dynamic>)
+        .map((p) => ChaptarrQualityProfile.fromJson(p as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<ChaptarrMetadataProfile>> getMetadataProfiles() async {
+    final resp = await _dio.get('$_basePath/metadataprofile');
+    return (resp.data as List<dynamic>)
+        .map((p) => ChaptarrMetadataProfile.fromJson(p as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<ChaptarrRootFolder>> getRootFolders() async {
+    final resp = await _dio.get('$_basePath/rootfolder');
+    return (resp.data as List<dynamic>)
+        .map((f) => ChaptarrRootFolder.fromJson(f as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<ChaptarrAuthor> addAuthor(Map<String, dynamic> body) async {
+    final resp = await _dio.post('$_basePath/author', data: body);
+    return ChaptarrAuthor.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<ChaptarrBook> addBook(Map<String, dynamic> body) async {
+    final resp = await _dio.post('$_basePath/book', data: body);
+    return ChaptarrBook.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<ChaptarrBook> updateBook(Map<String, dynamic> body) async {
+    final id = body['id'];
+    final resp = await _dio.put('$_basePath/book/$id', data: body);
+    return ChaptarrBook.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<void> deleteAuthor(int id, {bool deleteFiles = false}) async {
+    await _dio.delete('$_basePath/author/$id',
+        queryParameters: {'deleteFiles': deleteFiles});
+  }
+
+  Future<void> deleteBook(int id, {bool deleteFiles = false}) async {
+    await _dio.delete('$_basePath/book/$id',
+        queryParameters: {'deleteFiles': deleteFiles});
+  }
+
+  /// Toggles monitoring for a set of books in one call. Chaptarr exposes a
+  /// dedicated bulk endpoint, so unlike Sonarr's per-season GET-flip-PUT this
+  /// is a single POST. Admin only (proxy requires instances:manage).
+  Future<void> setBookMonitored(List<int> bookIds, bool monitored) async {
+    await _dio.put('$_basePath/book/monitor',
+        data: {'bookIds': bookIds, 'monitored': monitored});
+  }
+
+  /// Triggers an indexer search for every monitored book of an author.
+  Future<void> searchAuthor(int authorId) async {
+    await _dio.post('$_basePath/command', data: {
+      'name': 'AuthorSearch',
+      'authorId': authorId,
+    });
+  }
+
+  /// Triggers an automatic indexer search for the given books.
+  Future<void> searchBook(List<int> bookIds) async {
+    await _dio.post('$_basePath/command', data: {
+      'name': 'BookSearch',
+      'bookIds': bookIds,
+    });
+  }
+
+  /// Triggers a search for all monitored books that are missing a file.
+  Future<void> searchMissing() async {
+    await _dio.post('$_basePath/command', data: {'name': 'MissingBookSearch'});
+  }
+
+  Future<List<Map<String, dynamic>>> getQueue() async {
+    final resp = await _dio.get('$_basePath/queue', queryParameters: {
+      'includeAuthor': true,
+      'includeBook': true,
+      'pageSize': 50,
+    });
+    final records =
+        (resp.data as Map<String, dynamic>)['records'] as List<dynamic>?;
+    return records?.cast<Map<String, dynamic>>() ?? [];
+  }
+
+  /// Fetches the queue with full author + book details, typed.
+  Future<List<ChaptarrQueueItem>> getQueueDetailed({
+    int page = 1,
+    int pageSize = 100,
+  }) async {
+    final resp = await _dio.get('$_basePath/queue', queryParameters: {
+      'page': page,
+      'pageSize': pageSize,
+      'includeAuthor': true,
+      'includeBook': true,
+    });
+    final records =
+        (resp.data as Map<String, dynamic>)['records'] as List<dynamic>? ?? [];
+    return records
+        .map((r) => ChaptarrQueueItem.fromJson(r as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Removes a queue item, optionally from the download client / blocklist.
+  /// [changeCategory] hands the download to the post-import category instead of
+  /// deleting it (e.g. for Unpackerr); [skipRedownload] suppresses the
+  /// automatic re-grab on a blocklist removal.
+  Future<void> deleteQueueItem(
+    int id, {
+    bool removeFromClient = true,
+    bool blocklist = false,
+    bool skipRedownload = false,
+    bool changeCategory = false,
+  }) async {
+    await _dio.delete('$_basePath/queue/$id', queryParameters: {
+      'removeFromClient': removeFromClient,
+      'blocklist': blocklist,
+      'skipRedownload': skipRedownload,
+      'changeCategory': changeCategory,
+    });
+  }
+
+  /// Fetches a page of history events, newest first.
+  Future<ChaptarrHistoryPage> getHistory({
+    int page = 1,
+    int pageSize = 50,
+  }) async {
+    final resp = await _dio.get('$_basePath/history', queryParameters: {
+      'page': page,
+      'pageSize': pageSize,
+      'sortKey': 'date',
+      'sortDirection': 'descending',
+    });
+    return ChaptarrHistoryPage.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// History for an author, newest first. Uses the non-paged /history/author
+  /// endpoint.
+  Future<List<ChaptarrHistoryRecord>> getAuthorHistory(int authorId) async {
+    final resp = await _dio.get('$_basePath/history/author',
+        queryParameters: {'authorId': authorId});
+    final records = (resp.data as List<dynamic>)
+        .map((r) => ChaptarrHistoryRecord.fromJson(r as Map<String, dynamic>))
+        .toList();
+    records.sort(
+        (a, b) => (b.date ?? DateTime(0)).compareTo(a.date ?? DateTime(0)));
+    return records;
+  }
+
+  /// History for a single book, newest first. Uses the non-paged
+  /// /history/author endpoint filtered by bookId.
+  Future<List<ChaptarrHistoryRecord>> getBookHistory(int bookId) async {
+    final resp = await _dio
+        .get('$_basePath/history/author', queryParameters: {'bookId': bookId});
+    final records = (resp.data as List<dynamic>)
+        .map((r) => ChaptarrHistoryRecord.fromJson(r as Map<String, dynamic>))
+        .toList();
+    records.sort(
+        (a, b) => (b.date ?? DateTime(0)).compareTo(a.date ?? DateTime(0)));
+    return records;
+  }
+
+  /// Fetches a page of monitored books that are missing a file, newest release
+  /// date first. Records include author context.
+  Future<ChaptarrWantedPage> getWantedMissing({
+    int page = 1,
+    int pageSize = 50,
+  }) async {
+    final resp = await _dio.get('$_basePath/wanted/missing', queryParameters: {
+      'page': page,
+      'pageSize': pageSize,
+      'sortKey': 'releaseDate',
+      'sortDirection': 'descending',
+      'monitored': true,
+      'includeAuthor': true,
+    });
+    return ChaptarrWantedPage.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Fetches a page of monitored books whose file is below the quality profile
+  /// cutoff, newest release date first. Records include author context.
+  Future<ChaptarrWantedPage> getWantedCutoff({
+    int page = 1,
+    int pageSize = 50,
+  }) async {
+    final resp = await _dio.get('$_basePath/wanted/cutoff', queryParameters: {
+      'page': page,
+      'pageSize': pageSize,
+      'sortKey': 'releaseDate',
+      'sortDirection': 'descending',
+      'monitored': true,
+      'includeAuthor': true,
+    });
+    return ChaptarrWantedPage.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Interactive release search for one book.
+  /// Slow (10-60s): indexers are queried live.
+  Future<List<ChaptarrRelease>> getReleases(int bookId) async {
+    final resp = await _dio.get(
+      '$_basePath/release',
+      queryParameters: {'bookId': bookId},
+      options: Options(receiveTimeout: const Duration(seconds: 120)),
+    );
+    return (resp.data as List<dynamic>)
+        .map((r) => ChaptarrRelease.fromJson(r as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Sends a release from interactive search to the download client.
+  Future<void> grabRelease(String guid, int indexerId) async {
+    await _dio.post(
+      '$_basePath/release',
+      data: {'guid': guid, 'indexerId': indexerId},
+      options: Options(receiveTimeout: const Duration(seconds: 60)),
+    );
+  }
+
+  // --- Import Doctor (admin; proxy requires instances:manage) ---
+
+  /// Lists the importable files Chaptarr found for a finished download, with any
+  /// rejection reasons. Backs the manual-import recovery flow.
+  Future<List<ChaptarrManualImportCandidate>> getManualImportCandidates(
+    String downloadId,
+  ) async {
+    final resp = await _dio.get(
+      '$_basePath/manualimport',
+      queryParameters: {
+        'downloadId': downloadId,
+        'filterExistingFiles': false,
+      },
+      options: Options(receiveTimeout: const Duration(seconds: 60)),
+    );
+    return (resp.data as List<dynamic>)
+        .map((c) =>
+            ChaptarrManualImportCandidate.fromJson(c as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Imports the given candidate files. [importMode] must be lowercase
+  /// (`move`/`copy`/`auto`); `copy` preserves seeding for torrents.
+  Future<void> executeManualImport(
+    List<Map<String, dynamic>> files, {
+    String importMode = 'move',
+  }) async {
+    await _dio.post('$_basePath/command', data: {
+      'name': 'ManualImport',
+      'importMode': importMode,
+      'files': files,
+    });
+  }
+
+  /// Nudges Chaptarr to run its completed-download import pass now (clears items
+  /// stuck "waiting to import").
+  Future<void> processMonitoredDownloads() async {
+    await _dio.post('$_basePath/command',
+        data: {'name': 'ProcessMonitoredDownloads'});
+  }
+
+  /// Rescans an author's files on disk (retries imports blocked by a transient
+  /// path/permissions problem).
+  Future<void> rescanAuthor(int authorId) async {
+    await _dio.post('$_basePath/command',
+        data: {'name': 'RescanAuthor', 'authorId': authorId});
+  }
+}

--- a/app/lib/features/chaptarr/data/chaptarr_models.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_models.dart
@@ -1,0 +1,947 @@
+/// The medium a book file is stored in. Mirrors the Go `FormatOf` helper:
+/// ebook formats (EPUB/MOBI/…) vs audiobook formats (MP3/M4B/…).
+enum BookFormat { ebook, audiobook, unknown }
+
+/// Classifies a Chaptarr/Readarr quality name into a [BookFormat]. Matches the
+/// server's `FormatOf` helper: a case-insensitive substring check against the
+/// known ebook and audiobook quality names. Unknown/empty names fall through to
+/// [BookFormat.unknown].
+BookFormat bookFormatFromQuality(String? qualityName) {
+  if (qualityName == null || qualityName.isEmpty) return BookFormat.unknown;
+  final q = qualityName.toUpperCase();
+  const ebookTokens = [
+    'EPUB',
+    'MOBI',
+    'AZW3',
+    'AZW',
+    'PDF',
+    'CBZ',
+    'CBR',
+    'KEPUB'
+  ];
+  for (final t in ebookTokens) {
+    if (q.contains(t)) return BookFormat.ebook;
+  }
+  const audioTokens = [
+    'MP3',
+    'M4B',
+    'M4A',
+    'FLAC',
+    'AAC',
+    'OGG',
+    'OPUS',
+    'AUDIO'
+  ];
+  for (final t in audioTokens) {
+    if (q.contains(t)) return BookFormat.audiobook;
+  }
+  return BookFormat.unknown;
+}
+
+/// An author managed by Chaptarr.
+class ChaptarrAuthor {
+  final int id;
+  final String authorName;
+  final String? foreignAuthorId;
+  final String? titleSlug;
+  final String? overview;
+  final String? status;
+  final bool monitored;
+  final String? path;
+  final int qualityProfileId;
+  final int metadataProfileId;
+  final ChaptarrAuthorStatistics? statistics;
+  final List<ChaptarrImage> images;
+  final List<String> genres;
+
+  const ChaptarrAuthor({
+    required this.id,
+    required this.authorName,
+    this.foreignAuthorId,
+    this.titleSlug,
+    this.overview,
+    this.status,
+    this.monitored = true,
+    this.path,
+    this.qualityProfileId = 0,
+    this.metadataProfileId = 0,
+    this.statistics,
+    this.images = const [],
+    this.genres = const [],
+  });
+
+  factory ChaptarrAuthor.fromJson(Map<String, dynamic> json) => ChaptarrAuthor(
+        id: json['id'] as int? ?? 0,
+        authorName: json['authorName'] as String? ?? 'Unknown Author',
+        foreignAuthorId: json['foreignAuthorId'] as String?,
+        titleSlug: json['titleSlug'] as String?,
+        overview: json['overview'] as String?,
+        status: json['status'] as String?,
+        monitored: json['monitored'] as bool? ?? true,
+        path: json['path'] as String?,
+        qualityProfileId: json['qualityProfileId'] as int? ?? 0,
+        metadataProfileId: json['metadataProfileId'] as int? ?? 0,
+        statistics: json['statistics'] != null
+            ? ChaptarrAuthorStatistics.fromJson(
+                json['statistics'] as Map<String, dynamic>)
+            : null,
+        images: (json['images'] as List<dynamic>?)
+                ?.map((i) => ChaptarrImage.fromJson(i as Map<String, dynamic>))
+                .toList() ??
+            [],
+        genres: (json['genres'] as List<dynamic>?)
+                ?.map((g) => g.toString())
+                .toList() ??
+            [],
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'authorName': authorName,
+        'foreignAuthorId': foreignAuthorId,
+        'titleSlug': titleSlug,
+        'overview': overview,
+        'status': status,
+        'monitored': monitored,
+        'path': path,
+        'qualityProfileId': qualityProfileId,
+        'metadataProfileId': metadataProfileId,
+        'images': images.map((i) => i.toJson()).toList(),
+        'genres': genres,
+      };
+
+  String? get coverUrl => _pickCoverUrl(images);
+
+  double get percentComplete {
+    if (statistics == null || statistics!.bookCount == 0) return 0;
+    return statistics!.bookFileCount / statistics!.bookCount;
+  }
+
+  /// e.g. "12 / 15 books".
+  String get bookCountLabel {
+    final s = statistics;
+    if (s == null) return '0 books';
+    return '${s.bookFileCount} / ${s.bookCount} books';
+  }
+}
+
+/// An artwork reference (cover/poster/fanart) on an author or book.
+class ChaptarrImage {
+  final String coverType;
+  final String? url;
+  final String? remoteUrl;
+
+  const ChaptarrImage({required this.coverType, this.url, this.remoteUrl});
+
+  factory ChaptarrImage.fromJson(Map<String, dynamic> json) => ChaptarrImage(
+        coverType: json['coverType'] as String? ?? '',
+        url: json['url'] as String?,
+        remoteUrl: json['remoteUrl'] as String?,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'coverType': coverType,
+        'url': url,
+        'remoteUrl': remoteUrl,
+      };
+}
+
+/// Picks a remote cover URL from a list of images, preferring `cover`/`poster`
+/// art and falling back to the first image with any remote URL.
+String? _pickCoverUrl(List<ChaptarrImage> images) {
+  for (final type in ['cover', 'poster']) {
+    final match = images.where((i) => i.coverType == type);
+    if (match.isNotEmpty && match.first.remoteUrl != null) {
+      return match.first.remoteUrl;
+    }
+  }
+  final withUrl = images.where((i) => i.remoteUrl != null);
+  return withUrl.isNotEmpty ? withUrl.first.remoteUrl : null;
+}
+
+class ChaptarrAuthorStatistics {
+  final int bookCount;
+  final int bookFileCount;
+  final int availableBookCount;
+  final int totalBookCount;
+  final int sizeOnDisk;
+  final double percentOfBooks;
+
+  const ChaptarrAuthorStatistics({
+    this.bookCount = 0,
+    this.bookFileCount = 0,
+    this.availableBookCount = 0,
+    this.totalBookCount = 0,
+    this.sizeOnDisk = 0,
+    this.percentOfBooks = 0,
+  });
+
+  factory ChaptarrAuthorStatistics.fromJson(Map<String, dynamic> json) =>
+      ChaptarrAuthorStatistics(
+        bookCount: json['bookCount'] as int? ?? 0,
+        bookFileCount: json['bookFileCount'] as int? ?? 0,
+        availableBookCount: json['availableBookCount'] as int? ?? 0,
+        totalBookCount: json['totalBookCount'] as int? ?? 0,
+        sizeOnDisk: (json['sizeOnDisk'] as num?)?.toInt() ?? 0,
+        percentOfBooks: (json['percentOfBooks'] as num?)?.toDouble() ?? 0,
+      );
+
+  String get sizeFormatted => _formatBytes(sizeOnDisk);
+}
+
+class ChaptarrBookStatistics {
+  final int bookFileCount;
+  final int bookCount;
+  final int sizeOnDisk;
+  final double percentOfBooks;
+
+  const ChaptarrBookStatistics({
+    this.bookFileCount = 0,
+    this.bookCount = 0,
+    this.sizeOnDisk = 0,
+    this.percentOfBooks = 0,
+  });
+
+  factory ChaptarrBookStatistics.fromJson(Map<String, dynamic> json) =>
+      ChaptarrBookStatistics(
+        bookFileCount: json['bookFileCount'] as int? ?? 0,
+        bookCount: json['bookCount'] as int? ?? 0,
+        sizeOnDisk: (json['sizeOnDisk'] as num?)?.toInt() ?? 0,
+        percentOfBooks: (json['percentOfBooks'] as num?)?.toDouble() ?? 0,
+      );
+
+  String get sizeFormatted => _formatBytes(sizeOnDisk);
+}
+
+/// One edition of a book (a specific publication: ebook/audiobook, publisher,
+/// ISBN). Mirrors Sonarr's per-season granularity for a book.
+class ChaptarrEdition {
+  final int id;
+  final int bookId;
+  final String? title;
+  final String? format;
+  final String? asin;
+  final String? isbn13;
+  final String? overview;
+  final String? publisher;
+  final int pageCount;
+  final bool monitored;
+  final bool manualAdd;
+  final bool isEbook;
+  final List<ChaptarrImage> images;
+
+  const ChaptarrEdition({
+    required this.id,
+    this.bookId = 0,
+    this.title,
+    this.format,
+    this.asin,
+    this.isbn13,
+    this.overview,
+    this.publisher,
+    this.pageCount = 0,
+    this.monitored = true,
+    this.manualAdd = false,
+    this.isEbook = false,
+    this.images = const [],
+  });
+
+  factory ChaptarrEdition.fromJson(Map<String, dynamic> json) =>
+      ChaptarrEdition(
+        id: json['id'] as int? ?? 0,
+        bookId: json['bookId'] as int? ?? 0,
+        title: json['title'] as String?,
+        format: json['format'] as String?,
+        asin: json['asin'] as String?,
+        isbn13: json['isbn13'] as String?,
+        overview: json['overview'] as String?,
+        publisher: json['publisher'] as String?,
+        pageCount: json['pageCount'] as int? ?? 0,
+        monitored: json['monitored'] as bool? ?? true,
+        manualAdd: json['manualAdd'] as bool? ?? false,
+        isEbook: json['isEbook'] as bool? ?? false,
+        images: (json['images'] as List<dynamic>?)
+                ?.map((i) => ChaptarrImage.fromJson(i as Map<String, dynamic>))
+                .toList() ??
+            [],
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'bookId': bookId,
+        'title': title,
+        'format': format,
+        'asin': asin,
+        'isbn13': isbn13,
+        'overview': overview,
+        'publisher': publisher,
+        'pageCount': pageCount,
+        'monitored': monitored,
+        'manualAdd': manualAdd,
+        'isEbook': isEbook,
+        'images': images.map((i) => i.toJson()).toList(),
+      };
+
+  /// The medium this edition represents: audiobook when Chaptarr flags it as
+  /// non-ebook, ebook otherwise (also inferring from the `format` string).
+  BookFormat get bookFormat {
+    if (!isEbook) return BookFormat.audiobook;
+    final fromFormat = bookFormatFromQuality(format);
+    return fromFormat == BookFormat.unknown ? BookFormat.ebook : fromFormat;
+  }
+}
+
+/// A book managed by Chaptarr. Carries its editions (and, when fetched with
+/// author context, the owning author) plus statistics for the status line.
+class ChaptarrBook {
+  final int id;
+  final String title;
+  final int authorId;
+  final String? foreignBookId;
+  final String? titleSlug;
+  final String? overview;
+  final DateTime? releaseDate;
+  final bool monitored;
+  final bool anyEditionOk;
+  final int pageCount;
+  final ChaptarrAuthorContext? author;
+  final ChaptarrBookStatistics? statistics;
+  final List<ChaptarrEdition> editions;
+  final List<ChaptarrImage> images;
+  final List<String> genres;
+
+  const ChaptarrBook({
+    required this.id,
+    required this.title,
+    this.authorId = 0,
+    this.foreignBookId,
+    this.titleSlug,
+    this.overview,
+    this.releaseDate,
+    this.monitored = true,
+    this.anyEditionOk = true,
+    this.pageCount = 0,
+    this.author,
+    this.statistics,
+    this.editions = const [],
+    this.images = const [],
+    this.genres = const [],
+  });
+
+  factory ChaptarrBook.fromJson(Map<String, dynamic> json) => ChaptarrBook(
+        id: json['id'] as int? ?? 0,
+        title: json['title'] as String? ?? 'Untitled',
+        authorId: json['authorId'] as int? ?? 0,
+        foreignBookId: json['foreignBookId'] as String?,
+        titleSlug: json['titleSlug'] as String?,
+        overview: json['overview'] as String?,
+        releaseDate: DateTime.tryParse(json['releaseDate'] as String? ?? ''),
+        monitored: json['monitored'] as bool? ?? true,
+        anyEditionOk: json['anyEditionOk'] as bool? ?? true,
+        pageCount: json['pageCount'] as int? ?? 0,
+        author: json['author'] != null
+            ? ChaptarrAuthorContext.fromJson(
+                json['author'] as Map<String, dynamic>)
+            : null,
+        statistics: json['statistics'] != null
+            ? ChaptarrBookStatistics.fromJson(
+                json['statistics'] as Map<String, dynamic>)
+            : null,
+        editions: (json['editions'] as List<dynamic>?)
+                ?.map(
+                    (e) => ChaptarrEdition.fromJson(e as Map<String, dynamic>))
+                .toList() ??
+            [],
+        images: (json['images'] as List<dynamic>?)
+                ?.map((i) => ChaptarrImage.fromJson(i as Map<String, dynamic>))
+                .toList() ??
+            [],
+        genres: (json['genres'] as List<dynamic>?)
+                ?.map((g) => g.toString())
+                .toList() ??
+            [],
+      );
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'title': title,
+        'authorId': authorId,
+        'foreignBookId': foreignBookId,
+        'titleSlug': titleSlug,
+        'overview': overview,
+        'releaseDate': releaseDate?.toIso8601String(),
+        'monitored': monitored,
+        'anyEditionOk': anyEditionOk,
+        'pageCount': pageCount,
+        'editions': editions.map((e) => e.toJson()).toList(),
+        'images': images.map((i) => i.toJson()).toList(),
+        'genres': genres,
+      };
+
+  String? get coverUrl => _pickCoverUrl(images);
+
+  double get percentComplete {
+    if (statistics == null || statistics!.bookCount == 0) return 0;
+    return statistics!.bookFileCount / statistics!.bookCount;
+  }
+
+  bool get hasFile => (statistics?.bookFileCount ?? 0) > 0;
+
+  /// The set of book formats represented across this book's editions.
+  Set<BookFormat> get formats {
+    final set = <BookFormat>{};
+    for (final e in editions) {
+      final f = e.bookFormat;
+      if (f != BookFormat.unknown) set.add(f);
+    }
+    return set;
+  }
+}
+
+/// A downloaded book file: drives the "EPUB — 4.6 MB" status line. The raw
+/// `quality` map is kept for verbatim round-tripping, like Sonarr's
+/// episodeFile.
+class ChaptarrBookFile {
+  final int id;
+  final int authorId;
+  final int bookId;
+  final int editionId;
+  final String? path;
+  final int size;
+  final DateTime? dateAdded;
+
+  /// The raw `quality` blob exactly as returned (kept for verbatim round-trip);
+  /// use [qualityName] for the display string.
+  final Map<String, dynamic>? quality;
+
+  const ChaptarrBookFile({
+    required this.id,
+    this.authorId = 0,
+    this.bookId = 0,
+    this.editionId = 0,
+    this.path,
+    this.size = 0,
+    this.dateAdded,
+    this.quality,
+  });
+
+  factory ChaptarrBookFile.fromJson(Map<String, dynamic> json) =>
+      ChaptarrBookFile(
+        id: json['id'] as int? ?? 0,
+        authorId: json['authorId'] as int? ?? 0,
+        bookId: json['bookId'] as int? ?? 0,
+        editionId: json['editionId'] as int? ?? 0,
+        path: json['path'] as String?,
+        size: (json['size'] as num?)?.toInt() ?? 0,
+        dateAdded: DateTime.tryParse(json['dateAdded'] as String? ?? ''),
+        quality: json['quality'] as Map<String, dynamic>?,
+      );
+
+  String? get qualityName =>
+      (quality?['quality'] as Map<String, dynamic>?)?['name'] as String?;
+
+  BookFormat get format => bookFormatFromQuality(qualityName);
+
+  String get sizeFormatted => _formatBytes(size);
+}
+
+/// Lightweight author reference embedded on a book (when fetched with
+/// includeAuthor).
+class ChaptarrAuthorContext {
+  final int id;
+  final String authorName;
+  final String? foreignAuthorId;
+
+  const ChaptarrAuthorContext({
+    required this.id,
+    this.authorName = '',
+    this.foreignAuthorId,
+  });
+
+  factory ChaptarrAuthorContext.fromJson(Map<String, dynamic> json) =>
+      ChaptarrAuthorContext(
+        id: json['id'] as int? ?? 0,
+        authorName: json['authorName'] as String? ?? '',
+        foreignAuthorId: json['foreignAuthorId'] as String?,
+      );
+}
+
+/// Lightweight book reference embedded on a queue/import item (when fetched
+/// with includeBook).
+class ChaptarrBookContext {
+  final int id;
+  final String title;
+  final DateTime? releaseDate;
+
+  const ChaptarrBookContext({
+    required this.id,
+    this.title = '',
+    this.releaseDate,
+  });
+
+  factory ChaptarrBookContext.fromJson(Map<String, dynamic> json) =>
+      ChaptarrBookContext(
+        id: json['id'] as int? ?? 0,
+        title: json['title'] as String? ?? '',
+        releaseDate: DateTime.tryParse(json['releaseDate'] as String? ?? ''),
+      );
+}
+
+class ChaptarrQualityProfile {
+  final int id;
+  final String name;
+
+  const ChaptarrQualityProfile({required this.id, required this.name});
+
+  factory ChaptarrQualityProfile.fromJson(Map<String, dynamic> json) =>
+      ChaptarrQualityProfile(
+        id: json['id'] as int,
+        name: json['name'] as String,
+      );
+}
+
+class ChaptarrMetadataProfile {
+  final int id;
+  final String name;
+
+  const ChaptarrMetadataProfile({required this.id, required this.name});
+
+  factory ChaptarrMetadataProfile.fromJson(Map<String, dynamic> json) =>
+      ChaptarrMetadataProfile(
+        id: json['id'] as int,
+        name: json['name'] as String,
+      );
+}
+
+class ChaptarrRootFolder {
+  final int id;
+  final String path;
+  final int? freeSpace;
+
+  const ChaptarrRootFolder(
+      {required this.id, required this.path, this.freeSpace});
+
+  factory ChaptarrRootFolder.fromJson(Map<String, dynamic> json) =>
+      ChaptarrRootFolder(
+        id: json['id'] as int,
+        path: json['path'] as String,
+        freeSpace: json['freeSpace'] as int?,
+      );
+}
+
+class ChaptarrSystemStatus {
+  final String version;
+
+  const ChaptarrSystemStatus({required this.version});
+
+  factory ChaptarrSystemStatus.fromJson(Map<String, dynamic> json) =>
+      ChaptarrSystemStatus(version: json['version'] as String? ?? 'Unknown');
+}
+
+String _formatBytes(num bytes) {
+  if (bytes <= 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  var value = bytes.toDouble();
+  var unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+  final decimals = value >= 100 || unit == 0 ? 0 : 1;
+  return '${value.toStringAsFixed(decimals)} ${units[unit]}';
+}
+
+/// One grouped status message on a queue item (a title plus its messages) —
+/// the data behind LunaSea's "Messages" surface and our Import Doctor.
+class ChaptarrStatusMessage {
+  final String title;
+  final List<String> messages;
+
+  const ChaptarrStatusMessage({this.title = '', this.messages = const []});
+
+  factory ChaptarrStatusMessage.fromJson(Map<String, dynamic> json) =>
+      ChaptarrStatusMessage(
+        title: json['title'] as String? ?? '',
+        messages: ((json['messages'] as List<dynamic>?) ?? [])
+            .map((m) => m.toString())
+            .where((m) => m.isNotEmpty)
+            .toList(),
+      );
+}
+
+/// One item in the Chaptarr download queue (fetched with author + book
+/// details).
+class ChaptarrQueueItem {
+  final int id;
+  final int? authorId;
+  final int? bookId;
+  final String title;
+  final String? authorTitle;
+  final String? bookTitle;
+  final String status;
+  final String? trackedDownloadState;
+  final String? trackedDownloadStatus;
+  final String protocol;
+  final String? indexer;
+  final String? downloadClient;
+  final double size;
+  final double sizeleft;
+  final String? timeleft;
+  final String? errorMessage;
+  final List<String> statusMessages;
+  final List<ChaptarrStatusMessage> statusMessageGroups;
+  final String? downloadId;
+  final String? quality;
+
+  const ChaptarrQueueItem({
+    required this.id,
+    this.authorId,
+    this.bookId,
+    required this.title,
+    this.authorTitle,
+    this.bookTitle,
+    this.status = '',
+    this.trackedDownloadState,
+    this.trackedDownloadStatus,
+    this.protocol = 'unknown',
+    this.indexer,
+    this.downloadClient,
+    this.size = 0,
+    this.sizeleft = 0,
+    this.timeleft,
+    this.errorMessage,
+    this.statusMessages = const [],
+    this.statusMessageGroups = const [],
+    this.downloadId,
+    this.quality,
+  });
+
+  factory ChaptarrQueueItem.fromJson(Map<String, dynamic> json) {
+    final messages = <String>[];
+    final groups = <ChaptarrStatusMessage>[];
+    for (final entry in (json['statusMessages'] as List<dynamic>? ?? [])) {
+      final map = entry as Map<String, dynamic>;
+      groups.add(ChaptarrStatusMessage.fromJson(map));
+      for (final msg in (map['messages'] as List<dynamic>? ?? [])) {
+        final text = msg.toString();
+        if (text.isNotEmpty) messages.add(text);
+      }
+      if (map['messages'] == null || (map['messages'] as List).isEmpty) {
+        final title = map['title'] as String?;
+        if (title != null && title.isNotEmpty) messages.add(title);
+      }
+    }
+    final book = json['book'] as Map<String, dynamic>?;
+    return ChaptarrQueueItem(
+      id: json['id'] as int? ?? 0,
+      authorId: json['authorId'] as int?,
+      bookId: book?['id'] as int? ?? json['bookId'] as int?,
+      title: json['title'] as String? ?? 'Unknown',
+      authorTitle:
+          (json['author'] as Map<String, dynamic>?)?['authorName'] as String?,
+      bookTitle: book?['title'] as String?,
+      status: json['status'] as String? ?? '',
+      trackedDownloadState: json['trackedDownloadState'] as String?,
+      trackedDownloadStatus: json['trackedDownloadStatus'] as String?,
+      protocol: json['protocol'] as String? ?? 'unknown',
+      indexer: json['indexer'] as String?,
+      downloadClient: json['downloadClient'] as String?,
+      size: (json['size'] as num?)?.toDouble() ?? 0,
+      sizeleft: (json['sizeleft'] as num?)?.toDouble() ?? 0,
+      timeleft: json['timeleft'] as String?,
+      errorMessage: json['errorMessage'] as String?,
+      statusMessages: messages,
+      statusMessageGroups: groups,
+      downloadId: json['downloadId'] as String?,
+      quality: (json['quality'] as Map<String, dynamic>?)?['quality']?['name']
+          as String?,
+    );
+  }
+
+  double get progress =>
+      size > 0 ? ((size - sizeleft) / size).clamp(0.0, 1.0) : 0;
+  String get sizeFormatted => _formatBytes(size);
+  String get downloadedFormatted => _formatBytes(size - sizeleft);
+  bool get hasIssues =>
+      (errorMessage?.isNotEmpty ?? false) ||
+      statusMessages.isNotEmpty ||
+      trackedDownloadStatus == 'warning' ||
+      trackedDownloadStatus == 'error';
+
+  /// e.g. "Author Name • Book title", or null when context is missing.
+  String? get bookLabel {
+    final hasBook = bookTitle != null && bookTitle!.isNotEmpty;
+    final hasAuthor = authorTitle != null && authorTitle!.isNotEmpty;
+    if (hasAuthor && hasBook) return '$authorTitle • $bookTitle';
+    if (hasBook) return bookTitle;
+    if (hasAuthor) return authorTitle;
+    return null;
+  }
+}
+
+/// A single Chaptarr history event.
+class ChaptarrHistoryRecord {
+  final int id;
+  final String sourceTitle;
+  final String eventType;
+  final DateTime? date;
+  final String? quality;
+  final int? authorId;
+  final int? bookId;
+  final Map<String, String> data;
+  final String? downloadId;
+
+  const ChaptarrHistoryRecord({
+    required this.id,
+    this.sourceTitle = '',
+    this.eventType = '',
+    this.date,
+    this.quality,
+    this.authorId,
+    this.bookId,
+    this.data = const {},
+    this.downloadId,
+  });
+
+  factory ChaptarrHistoryRecord.fromJson(Map<String, dynamic> json) =>
+      ChaptarrHistoryRecord(
+        id: json['id'] as int? ?? 0,
+        sourceTitle: json['sourceTitle'] as String? ?? '',
+        eventType: json['eventType'] as String? ?? '',
+        date: DateTime.tryParse(json['date'] as String? ?? ''),
+        quality: (json['quality'] as Map<String, dynamic>?)?['quality']?['name']
+            as String?,
+        authorId: json['authorId'] as int?,
+        bookId: json['bookId'] as int?,
+        data: ((json['data'] as Map<String, dynamic>?) ?? {})
+            .map((k, v) => MapEntry(k, v?.toString() ?? '')),
+        downloadId: json['downloadId'] as String?,
+      );
+
+  /// Indexer the release was grabbed from, e.g. "NZBgeek (Prowlarr)".
+  String? get indexer => data['indexer'];
+
+  /// Release group parsed from the grab, when present.
+  String? get releaseGroup => data['releaseGroup'];
+}
+
+/// Paged envelope for Chaptarr history.
+class ChaptarrHistoryPage {
+  final List<ChaptarrHistoryRecord> records;
+  final int totalRecords;
+
+  const ChaptarrHistoryPage({this.records = const [], this.totalRecords = 0});
+
+  factory ChaptarrHistoryPage.fromJson(Map<String, dynamic> json) =>
+      ChaptarrHistoryPage(
+        records: (json['records'] as List<dynamic>?)
+                ?.map((r) =>
+                    ChaptarrHistoryRecord.fromJson(r as Map<String, dynamic>))
+                .toList() ??
+            [],
+        totalRecords: json['totalRecords'] as int? ?? 0,
+      );
+}
+
+/// One wanted book (missing or cutoff unmet) with author context.
+class ChaptarrWantedRecord {
+  final int id;
+  final int authorId;
+  final int bookId;
+  final String? title;
+  final DateTime? releaseDate;
+  final bool monitored;
+  final String? authorTitle;
+
+  const ChaptarrWantedRecord({
+    required this.id,
+    this.authorId = 0,
+    this.bookId = 0,
+    this.title,
+    this.releaseDate,
+    this.monitored = true,
+    this.authorTitle,
+  });
+
+  factory ChaptarrWantedRecord.fromJson(Map<String, dynamic> json) =>
+      ChaptarrWantedRecord(
+        id: json['id'] as int? ?? 0,
+        authorId: json['authorId'] as int? ?? 0,
+        bookId: json['id'] as int? ?? 0,
+        title: json['title'] as String?,
+        releaseDate: DateTime.tryParse(json['releaseDate'] as String? ?? ''),
+        monitored: json['monitored'] as bool? ?? true,
+        authorTitle:
+            (json['author'] as Map<String, dynamic>?)?['authorName'] as String?,
+      );
+}
+
+/// Paged envelope for Chaptarr wanted books (missing / cutoff unmet).
+class ChaptarrWantedPage {
+  final List<ChaptarrWantedRecord> records;
+  final int totalRecords;
+
+  const ChaptarrWantedPage({this.records = const [], this.totalRecords = 0});
+
+  factory ChaptarrWantedPage.fromJson(Map<String, dynamic> json) =>
+      ChaptarrWantedPage(
+        records: (json['records'] as List<dynamic>?)
+                ?.map((r) =>
+                    ChaptarrWantedRecord.fromJson(r as Map<String, dynamic>))
+                .toList() ??
+            [],
+        totalRecords: json['totalRecords'] as int? ?? 0,
+      );
+}
+
+/// A release returned by Chaptarr's interactive search.
+class ChaptarrRelease {
+  final String guid;
+  final int indexerId;
+  final String title;
+  final String? quality;
+  final int size;
+  final int age;
+  final double ageHours;
+  final String? indexer;
+  final String protocol;
+  final int? seeders;
+  final int? leechers;
+  final bool rejected;
+  final List<String> rejections;
+
+  const ChaptarrRelease({
+    required this.guid,
+    required this.indexerId,
+    required this.title,
+    this.quality,
+    this.size = 0,
+    this.age = 0,
+    this.ageHours = 0,
+    this.indexer,
+    this.protocol = 'unknown',
+    this.seeders,
+    this.leechers,
+    this.rejected = false,
+    this.rejections = const [],
+  });
+
+  factory ChaptarrRelease.fromJson(Map<String, dynamic> json) =>
+      ChaptarrRelease(
+        guid: json['guid'] as String? ?? '',
+        indexerId: json['indexerId'] as int? ?? 0,
+        title: json['title'] as String? ?? 'Unknown',
+        quality: (json['quality'] as Map<String, dynamic>?)?['quality']?['name']
+            as String?,
+        size: (json['size'] as num?)?.toInt() ?? 0,
+        age: json['age'] as int? ?? 0,
+        ageHours: (json['ageHours'] as num?)?.toDouble() ?? 0,
+        indexer: json['indexer'] as String?,
+        protocol: json['protocol'] as String? ?? 'unknown',
+        seeders: json['seeders'] as int?,
+        leechers: json['leechers'] as int?,
+        rejected: json['rejected'] as bool? ?? false,
+        rejections: (json['rejections'] as List<dynamic>?)
+                ?.map((r) => r is Map<String, dynamic>
+                    ? (r['reason']?.toString() ?? '')
+                    : r.toString())
+                .where((r) => r.isNotEmpty)
+                .toList() ??
+            [],
+      );
+
+  bool get isTorrent => protocol == 'torrent';
+  String get sizeFormatted => _formatBytes(size);
+  String get ageFormatted {
+    if (age >= 1) return '${age}d';
+    if (ageHours >= 1) return '${ageHours.round()}h';
+    return '<1h';
+  }
+}
+
+/// Why a manual-import candidate was rejected. `type` is "permanent" or
+/// "temporary"; permanent rejections only import with force.
+class ChaptarrImportRejection {
+  final String reason;
+  final String type;
+
+  const ChaptarrImportRejection({this.reason = '', this.type = ''});
+
+  factory ChaptarrImportRejection.fromJson(Map<String, dynamic> json) =>
+      ChaptarrImportRejection(
+        reason: json['reason'] as String? ?? '',
+        type: json['type'] as String? ?? '',
+      );
+
+  bool get isPermanent => type.toLowerCase() == 'permanent';
+}
+
+/// One importable file returned by GET /manualimport for a book. Mirrors
+/// [SonarrManualImportCandidate] but keyed by `authorId` + `bookId`. The
+/// `quality` blob is kept VERBATIM and round-tripped back into the ManualImport
+/// command unchanged (re-modelling it loses fields Chaptarr needs).
+class ChaptarrManualImportCandidate {
+  final int id;
+  final String path;
+  final String? folderName;
+  final String name;
+  final int size;
+  final int? authorId;
+  final int? bookId;
+  final Map<String, dynamic>? quality;
+  final String? releaseGroup;
+  final String? downloadId;
+  final List<ChaptarrImportRejection> rejections;
+
+  const ChaptarrManualImportCandidate({
+    required this.id,
+    required this.path,
+    this.folderName,
+    this.name = '',
+    this.size = 0,
+    this.authorId,
+    this.bookId,
+    this.quality,
+    this.releaseGroup,
+    this.downloadId,
+    this.rejections = const [],
+  });
+
+  factory ChaptarrManualImportCandidate.fromJson(Map<String, dynamic> json) =>
+      ChaptarrManualImportCandidate(
+        id: json['id'] as int? ?? 0,
+        path: json['path'] as String? ?? '',
+        folderName: json['folderName'] as String?,
+        name: json['name'] as String? ??
+            (json['relativePath'] as String?) ??
+            (json['path'] as String? ?? ''),
+        size: (json['size'] as num?)?.toInt() ?? 0,
+        authorId: (json['author'] as Map<String, dynamic>?)?['id'] as int?,
+        bookId: (json['book'] as Map<String, dynamic>?)?['id'] as int?,
+        quality: json['quality'] as Map<String, dynamic>?,
+        releaseGroup: json['releaseGroup'] as String?,
+        downloadId: json['downloadId'] as String?,
+        rejections: ((json['rejections'] as List<dynamic>?) ?? [])
+            .map((r) =>
+                ChaptarrImportRejection.fromJson(r as Map<String, dynamic>))
+            .toList(),
+      );
+
+  bool get hasPermanentRejection => rejections.any((r) => r.isPermanent);
+
+  /// A candidate is importable once Chaptarr has matched it to a book.
+  bool get isMapped => bookId != null;
+  String get sizeFormatted => _formatBytes(size);
+
+  /// The file entry for the ManualImport command, with quality sent back
+  /// exactly as received.
+  Map<String, dynamic> toImportFile() => {
+        'path': path,
+        if (folderName != null) 'folderName': folderName,
+        if (authorId != null) 'authorId': authorId,
+        if (bookId != null) 'bookId': bookId,
+        if (quality != null) 'quality': quality,
+        if (releaseGroup != null) 'releaseGroup': releaseGroup,
+        if (downloadId != null) 'downloadId': downloadId,
+      };
+}

--- a/app/lib/features/chaptarr/logic/chaptarr_library_provider.dart
+++ b/app/lib/features/chaptarr/logic/chaptarr_library_provider.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/foundation.dart';
+import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_models.dart';
+
+/// Library filters for the Chaptarr author list. Mirrors SonarrFilter but for
+/// the author-centric book library (continuing/ended are TV-only and dropped).
+enum ChaptarrLibraryFilter { all, monitored, missing }
+
+class ChaptarrLibraryState {
+  final List<ChaptarrAuthor> authors;
+  final List<ChaptarrAuthor> filtered;
+  final bool isLoading;
+  final String? error;
+  final String searchQuery;
+  final ChaptarrLibraryFilter filter;
+
+  const ChaptarrLibraryState({
+    this.authors = const [],
+    this.filtered = const [],
+    this.isLoading = false,
+    this.error,
+    this.searchQuery = '',
+    this.filter = ChaptarrLibraryFilter.all,
+  });
+
+  ChaptarrLibraryState copyWith({
+    List<ChaptarrAuthor>? authors,
+    List<ChaptarrAuthor>? filtered,
+    bool? isLoading,
+    String? error,
+    String? searchQuery,
+    ChaptarrLibraryFilter? filter,
+  }) =>
+      ChaptarrLibraryState(
+        authors: authors ?? this.authors,
+        filtered: filtered ?? this.filtered,
+        isLoading: isLoading ?? this.isLoading,
+        error: error,
+        searchQuery: searchQuery ?? this.searchQuery,
+        filter: filter ?? this.filter,
+      );
+
+  int get monitoredCount => authors.where((a) => a.monitored).length;
+  int get completeCount =>
+      authors.where((a) => a.percentComplete >= 1.0).length;
+  int get partialCount => authors
+      .where((a) => a.percentComplete > 0 && a.percentComplete < 1.0)
+      .length;
+}
+
+/// Holds the Chaptarr author library for one instance. A hand-rolled
+/// ChangeNotifier (mirrors SonarrSeriesNotifier) instantiated per screen, so a
+/// `ref.listen(activeChaptarrInstanceId)` re-init swaps instances cleanly.
+class ChaptarrLibraryNotifier extends ChangeNotifier {
+  final ChaptarrApiService _service;
+
+  ChaptarrLibraryState _state = const ChaptarrLibraryState();
+  ChaptarrLibraryState get state => _state;
+  set state(ChaptarrLibraryState value) {
+    _state = value;
+    notifyListeners();
+  }
+
+  ChaptarrLibraryNotifier(this._service);
+
+  Future<void> loadAuthors() async {
+    state = state.copyWith(isLoading: true);
+    try {
+      final authors = await _service.getAuthors();
+      authors.sort((a, b) =>
+          a.authorName.toLowerCase().compareTo(b.authorName.toLowerCase()));
+      state = state.copyWith(
+        isLoading: false,
+        authors: authors,
+        filtered: _applyFilters(authors, state.searchQuery, state.filter),
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: 'Failed to load library: $e',
+      );
+    }
+  }
+
+  void search(String query) {
+    state = state.copyWith(
+      searchQuery: query,
+      filtered: _applyFilters(state.authors, query, state.filter),
+    );
+  }
+
+  void setFilter(ChaptarrLibraryFilter filter) {
+    state = state.copyWith(
+      filter: filter,
+      filtered: _applyFilters(state.authors, state.searchQuery, filter),
+    );
+  }
+
+  Future<void> deleteAuthor(int id, {bool deleteFiles = false}) async {
+    await _service.deleteAuthor(id, deleteFiles: deleteFiles);
+    await loadAuthors();
+  }
+
+  Future<void> searchForAuthor(int authorId) async {
+    await _service.searchAuthor(authorId);
+  }
+
+  List<ChaptarrAuthor> _applyFilters(
+    List<ChaptarrAuthor> authors,
+    String query,
+    ChaptarrLibraryFilter filter,
+  ) {
+    var result = authors;
+
+    if (query.isNotEmpty) {
+      final q = query.toLowerCase();
+      result =
+          result.where((a) => a.authorName.toLowerCase().contains(q)).toList();
+    }
+
+    result = switch (filter) {
+      ChaptarrLibraryFilter.all => result,
+      ChaptarrLibraryFilter.monitored =>
+        result.where((a) => a.monitored).toList(),
+      ChaptarrLibraryFilter.missing => result
+          .where((a) => a.monitored && a.percentComplete < 1.0)
+          .toList(),
+    };
+
+    return result;
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
@@ -1,0 +1,355 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_models.dart';
+import 'chaptarr_book_screen.dart';
+import 'widgets/book_status.dart';
+import 'widgets/format_badge.dart';
+
+/// Author detail: an author summary plus the author's books, each with its
+/// format badges, availability line and a monitor toggle. Tapping a book drills
+/// into its editions/files. Mirrors [SonarrSeriesDetailScreen].
+class ChaptarrAuthorDetailScreen extends ConsumerStatefulWidget {
+  final String instanceId;
+  final int authorId;
+  final String? authorName;
+
+  const ChaptarrAuthorDetailScreen({
+    super.key,
+    required this.instanceId,
+    required this.authorId,
+    this.authorName,
+  });
+
+  @override
+  ConsumerState<ChaptarrAuthorDetailScreen> createState() =>
+      _ChaptarrAuthorDetailScreenState();
+}
+
+class _ChaptarrAuthorDetailScreenState
+    extends ConsumerState<ChaptarrAuthorDetailScreen> {
+  late final ChaptarrApiService _service;
+  ChaptarrAuthor? _author;
+  List<ChaptarrBook> _books = [];
+  bool _isLoading = true;
+  String? _error;
+  final Set<int> _togglingBooks = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _service = ChaptarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: widget.instanceId,
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    setState(() => _isLoading = true);
+    try {
+      // Kick off both requests, then await — effectively parallel without the
+      // heterogeneous Future.wait cast.
+      final authorFuture = _service.getAuthorById(widget.authorId);
+      final booksFuture = _service.getBooks(authorId: widget.authorId);
+      final author = await authorFuture;
+      final books = await booksFuture;
+      if (!mounted) return;
+      books.sort((a, b) => (b.releaseDate ?? DateTime(0))
+          .compareTo(a.releaseDate ?? DateTime(0)));
+      setState(() {
+        _author = author;
+        _books = books;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load author: $e';
+      });
+    }
+  }
+
+  Future<void> _toggleBookMonitored(ChaptarrBook book) async {
+    final target = !book.monitored;
+    setState(() => _togglingBooks.add(book.id));
+    try {
+      await _service.setBookMonitored([book.id], target);
+      if (!mounted) return;
+      // Reflect the change locally without a full reload.
+      setState(() {
+        _books = _books
+            .map((b) => b.id == book.id ? _withMonitored(b, target) : b)
+            .toList();
+      });
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Could not change monitoring: $e')));
+    } finally {
+      if (mounted) setState(() => _togglingBooks.remove(book.id));
+    }
+  }
+
+  void _openBook(ChaptarrBook book) {
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute(
+        builder: (_) => ChaptarrBookScreen(
+          instanceId: widget.instanceId,
+          bookId: book.id,
+          bookTitle: book.title,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final title = _author?.authorName ?? widget.authorName ?? 'Author';
+
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      appBar: AppBar(
+        backgroundColor: AppTheme.background,
+        title: Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh, color: AppTheme.textPrimary),
+            tooltip: 'Refresh',
+            onPressed: _isLoading ? null : _load,
+          ),
+        ],
+      ),
+      body: _error != null && _author == null
+          ? FullScreenError(message: _error!, onRetry: _load)
+          : RefreshIndicator(
+              onRefresh: _load,
+              color: AppTheme.accent,
+              child: ListView(
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                children: [
+                  if (_error != null)
+                    ErrorBanner(message: _error!, onRetry: _load),
+                  if (_author != null) _AuthorSummaryCard(author: _author!),
+                  const SizedBox(height: 4),
+                  ..._books.map((b) => _BookCard(
+                        book: b,
+                        busy: _togglingBooks.contains(b.id),
+                        onTap: () => _openBook(b),
+                        onToggleMonitored: () => _toggleBookMonitored(b),
+                      )),
+                  if (_books.isEmpty && !_isLoading)
+                    const Padding(
+                      padding: EdgeInsets.all(32),
+                      child: Center(
+                        child: Text('No books',
+                            style: TextStyle(color: AppTheme.textSecondary)),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+    );
+  }
+}
+
+/// Rebuilds a [ChaptarrBook] with a new monitored flag (the model is immutable
+/// and exposes no copyWith).
+ChaptarrBook _withMonitored(ChaptarrBook b, bool monitored) => ChaptarrBook(
+      id: b.id,
+      title: b.title,
+      authorId: b.authorId,
+      foreignBookId: b.foreignBookId,
+      titleSlug: b.titleSlug,
+      overview: b.overview,
+      releaseDate: b.releaseDate,
+      monitored: monitored,
+      anyEditionOk: b.anyEditionOk,
+      pageCount: b.pageCount,
+      author: b.author,
+      statistics: b.statistics,
+      editions: b.editions,
+      images: b.images,
+      genres: b.genres,
+    );
+
+/// "X/Y Books Available" with a colour: green at 100%, red otherwise.
+class _AvailabilityLine extends StatelessWidget {
+  final ChaptarrAuthorStatistics? stats;
+  const _AvailabilityLine({required this.stats});
+
+  @override
+  Widget build(BuildContext context) {
+    final s = stats;
+    if (s == null || s.bookCount == 0) {
+      return const Text('0% • 0/0 Books Available',
+          style: TextStyle(color: AppTheme.textSecondary, fontSize: 13));
+    }
+    final pct = (s.bookFileCount / s.bookCount * 100).round();
+    final complete = s.bookFileCount >= s.bookCount;
+    return Text(
+      '$pct% • ${s.bookFileCount}/${s.bookCount} Books Available',
+      style: TextStyle(
+        color: complete ? AppTheme.available : AppTheme.error,
+        fontSize: 13,
+        fontWeight: FontWeight.w500,
+      ),
+    );
+  }
+}
+
+class _AuthorSummaryCard extends StatelessWidget {
+  final ChaptarrAuthor author;
+  const _AuthorSummaryCard({required this.author});
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = author.statistics;
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppTheme.border, width: 0.5),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(author.authorName,
+                    style: const TextStyle(
+                        color: AppTheme.textPrimary,
+                        fontSize: 17,
+                        fontWeight: FontWeight.bold)),
+                if (stats != null && stats.sizeOnDisk > 0) ...[
+                  const SizedBox(height: 4),
+                  Text(stats.sizeFormatted,
+                      style: const TextStyle(
+                          color: AppTheme.textSecondary, fontSize: 13)),
+                ],
+                const SizedBox(height: 6),
+                _AvailabilityLine(stats: stats),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BookCard extends StatelessWidget {
+  final ChaptarrBook book;
+  final bool busy;
+  final VoidCallback onTap;
+  final VoidCallback onToggleMonitored;
+
+  const _BookCard({
+    required this.book,
+    required this.busy,
+    required this.onTap,
+    required this.onToggleMonitored,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final status = bookFileStatusLine(book);
+    final formats = book.formats.toList()..sort((a, b) => a.index - b.index);
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: AppTheme.surface,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: AppTheme.border, width: 0.5),
+        ),
+        child: Row(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(6),
+              child: SizedBox(
+                width: 44,
+                height: 60,
+                child: book.coverUrl != null
+                    ? CachedNetworkImage(
+                        imageUrl: book.coverUrl!, fit: BoxFit.cover)
+                    : Container(
+                        color: AppTheme.surfaceVariant,
+                        child: Icon(
+                          Icons.menu_book_outlined,
+                          color: book.monitored
+                              ? AppTheme.available
+                              : AppTheme.unavailable,
+                          size: 22,
+                        ),
+                      ),
+              ),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(book.title,
+                      style: const TextStyle(
+                          color: AppTheme.textPrimary,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis),
+                  if (formats.isNotEmpty) ...[
+                    const SizedBox(height: 6),
+                    Wrap(
+                      spacing: 6,
+                      runSpacing: 4,
+                      children: formats
+                          .map((f) => ChaptarrFormatBadge(format: f))
+                          .toList(),
+                    ),
+                  ],
+                  const SizedBox(height: 6),
+                  Text(
+                    status.text,
+                    style: TextStyle(
+                        color: status.color,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+            IconButton(
+              onPressed: busy ? null : onToggleMonitored,
+              tooltip: book.monitored ? 'Stop monitoring' : 'Monitor',
+              icon: busy
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(
+                          strokeWidth: 2, color: AppTheme.accent))
+                  : Icon(
+                      book.monitored ? Icons.bookmark : Icons.bookmark_border,
+                      color: book.monitored
+                          ? AppTheme.accent
+                          : AppTheme.textSecondary,
+                    ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_author_list.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_list.dart
@@ -1,0 +1,215 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/chaptarr_models.dart';
+
+/// List of Chaptarr authors with swipe-to-delete and progress indicators.
+/// Mirrors [SonarrSeriesList] adapted to the author-centric book library.
+class ChaptarrAuthorList extends StatelessWidget {
+  final List<ChaptarrAuthor> authors;
+  final void Function(ChaptarrAuthor) onTap;
+  final void Function(ChaptarrAuthor)? onSearch;
+  final void Function(ChaptarrAuthor)? onDelete;
+  final bool embedded;
+
+  const ChaptarrAuthorList({
+    super.key,
+    required this.authors,
+    required this.onTap,
+    this.onSearch,
+    this.onDelete,
+    this.embedded = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (authors.isEmpty) {
+      return const Center(
+        child: Text('No authors found',
+            style: TextStyle(color: AppTheme.textSecondary)),
+      );
+    }
+
+    return ListView.separated(
+      shrinkWrap: embedded,
+      physics: embedded ? const NeverScrollableScrollPhysics() : null,
+      itemCount: authors.length,
+      separatorBuilder: (_, __) =>
+          const Divider(color: AppTheme.border, height: 1),
+      itemBuilder: (context, index) {
+        final author = authors[index];
+        final tile = _AuthorTile(
+          author: author,
+          onTap: () => onTap(author),
+          onSearch: onSearch != null ? () => onSearch!(author) : null,
+        );
+        if (onDelete == null) return tile;
+        return Dismissible(
+          key: ValueKey(author.id),
+          direction: DismissDirection.endToStart,
+          background: Container(
+            color: AppTheme.error,
+            alignment: Alignment.centerRight,
+            padding: const EdgeInsets.only(right: 20),
+            child: const Icon(Icons.delete, color: Colors.white),
+          ),
+          confirmDismiss: (_) => _confirmDelete(context, author.authorName),
+          onDismissed: (_) => onDelete!(author),
+          child: tile,
+        );
+      },
+    );
+  }
+
+  Future<bool?> _confirmDelete(BuildContext context, String name) {
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppTheme.surface,
+        title: const Text('Delete Author'),
+        content: Text('Remove "$name" from Chaptarr?'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AuthorTile extends StatelessWidget {
+  final ChaptarrAuthor author;
+  final VoidCallback onTap;
+  final VoidCallback? onSearch;
+
+  const _AuthorTile({
+    required this.author,
+    required this.onTap,
+    this.onSearch,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = author.statistics;
+    final percent = author.percentComplete;
+
+    return ListTile(
+      onTap: onTap,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      leading: ClipRRect(
+        borderRadius: BorderRadius.circular(6),
+        child: SizedBox(
+          width: 45,
+          height: 67,
+          child: author.coverUrl != null
+              ? CachedNetworkImage(
+                  imageUrl: author.coverUrl!,
+                  fit: BoxFit.cover,
+                )
+              : Container(
+                  color: AppTheme.surfaceVariant,
+                  child: const Icon(Icons.person,
+                      color: AppTheme.textSecondary, size: 20),
+                ),
+        ),
+      ),
+      title: Text(
+        author.authorName,
+        style: const TextStyle(
+            color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+                decoration: BoxDecoration(
+                  color: _statusColor.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  _statusText,
+                  style: TextStyle(
+                    color: _statusColor,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+              if (stats != null) ...[
+                const SizedBox(width: 6),
+                Text(
+                  author.bookCountLabel,
+                  style: const TextStyle(
+                      color: AppTheme.textSecondary, fontSize: 11),
+                ),
+              ],
+            ],
+          ),
+          if (stats != null && stats.bookCount > 0) ...[
+            const SizedBox(height: 6),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(3),
+              child: LinearProgressIndicator(
+                value: percent,
+                backgroundColor: AppTheme.surfaceVariant,
+                valueColor: AlwaysStoppedAnimation(
+                  percent >= 1.0 ? AppTheme.available : AppTheme.accent,
+                ),
+                minHeight: 4,
+              ),
+            ),
+          ],
+        ],
+      ),
+      trailing: onSearch != null
+          ? PopupMenuButton<String>(
+              icon: const Icon(Icons.more_vert, color: AppTheme.textSecondary),
+              color: AppTheme.surfaceVariant,
+              tooltip: 'Actions',
+              onSelected: (value) {
+                if (value == 'search') onSearch!();
+              },
+              itemBuilder: (_) => [
+                const PopupMenuItem(
+                  value: 'search',
+                  child: Row(
+                    children: [
+                      Icon(Icons.search,
+                          size: 18, color: AppTheme.textSecondary),
+                      SizedBox(width: 10),
+                      Text('Automatic search'),
+                    ],
+                  ),
+                ),
+              ],
+            )
+          : null,
+    );
+  }
+
+  Color get _statusColor {
+    if (author.percentComplete >= 1.0) return AppTheme.available;
+    if (author.status == 'continuing') return AppTheme.downloading;
+    if (author.status == 'ended') return AppTheme.textSecondary;
+    return AppTheme.requested;
+  }
+
+  String get _statusText {
+    if (author.percentComplete >= 1.0) return 'Complete';
+    if (author.status == 'continuing') return 'Continuing';
+    if (author.status == 'ended') return 'Ended';
+    return 'Partial';
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_book_detail_sheet.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_book_detail_sheet.dart
@@ -1,0 +1,350 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/status_pill.dart';
+import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_models.dart';
+import 'chaptarr_releases_screen.dart';
+import 'widgets/book_status.dart';
+import 'widgets/format_badge.dart';
+
+/// Opens the book detail bottom sheet for one book. Returns `true` when the
+/// caller should refresh (an Automatic/Interactive search was started from the
+/// sheet). Mirrors [showModalBottomSheet] usage around the Sonarr episode sheet.
+Future<bool?> showChaptarrBookDetailSheet(
+  BuildContext context, {
+  required String instanceId,
+  required int bookId,
+  String? bookTitle,
+}) {
+  return showModalBottomSheet<bool>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    builder: (_) => _ChaptarrBookDetailSheet(
+      instanceId: instanceId,
+      bookId: bookId,
+      bookTitle: bookTitle,
+    ),
+  );
+}
+
+/// Bottom sheet for a single book: status, overview and recent history, with
+/// Automatic/Interactive search actions. Mirrors [EpisodeDetailSheet], but
+/// fetches the book + history itself (the caller passes only ids).
+class _ChaptarrBookDetailSheet extends ConsumerStatefulWidget {
+  final String instanceId;
+  final int bookId;
+  final String? bookTitle;
+
+  const _ChaptarrBookDetailSheet({
+    required this.instanceId,
+    required this.bookId,
+    this.bookTitle,
+  });
+
+  @override
+  ConsumerState<_ChaptarrBookDetailSheet> createState() =>
+      _ChaptarrBookDetailSheetState();
+}
+
+class _ChaptarrBookDetailSheetState
+    extends ConsumerState<_ChaptarrBookDetailSheet> {
+  late final ChaptarrApiService _service;
+  ChaptarrBook? _book;
+  List<ChaptarrHistoryRecord> _history = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = ChaptarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: widget.instanceId,
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    try {
+      // Kick off both requests, then await — effectively parallel without the
+      // heterogeneous Future.wait cast.
+      final bookFuture = _service.getBookById(widget.bookId);
+      final historyFuture = _service.getBookHistory(widget.bookId);
+      final book = await bookFuture;
+      final history = await historyFuture;
+      if (!mounted) return;
+      setState(() {
+        _book = book;
+        _history = history.take(8).toList();
+        _loading = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _automaticSearch() async {
+    try {
+      await _service.searchBook([widget.bookId]);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Book search started')));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Failed to start search: $e')));
+    }
+  }
+
+  void _interactiveSearch() {
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute(
+        builder: (_) => ChaptarrReleasesScreen(
+          instanceId: widget.instanceId,
+          bookId: widget.bookId,
+          bookTitle: _book?.title ?? widget.bookTitle,
+        ),
+      ),
+    );
+  }
+
+  ({String label, Color color}) get _shortStatus {
+    final book = _book;
+    if (book == null) {
+      return (label: 'Loading…', color: AppTheme.textSecondary);
+    }
+    final line = bookFileStatusLine(book);
+    return (label: line.text, color: line.color);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final book = _book;
+    final title = book?.title ?? widget.bookTitle ?? 'Book';
+    final status = _shortStatus;
+    final release = book?.releaseDate;
+    final formats = book?.formats.toList() ?? [];
+    formats.sort((a, b) => a.index - b.index);
+
+    return Padding(
+      padding:
+          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: Container(
+        constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(context).size.height * 0.85),
+        decoration: const BoxDecoration(
+          color: AppTheme.surface,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: AppTheme.textSecondary,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                title,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold),
+              ),
+              if (book?.author?.authorName.isNotEmpty ?? false) ...[
+                const SizedBox(height: 4),
+                Text(book!.author!.authorName,
+                    style: const TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 14)),
+              ],
+              const SizedBox(height: 6),
+              if (release != null)
+                Text(DateFormat('MMMM d, yyyy').format(release),
+                    style: const TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 13)),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                children: [
+                  StatusPill(text: status.label, color: status.color),
+                  ...formats.map((f) => ChaptarrFormatBadge(format: f)),
+                ],
+              ),
+              if (book?.overview != null && book!.overview!.isNotEmpty) ...[
+                const SizedBox(height: 14),
+                Text(book.overview!,
+                    style: const TextStyle(
+                        color: AppTheme.textPrimary,
+                        fontSize: 14,
+                        height: 1.4)),
+              ],
+              const SizedBox(height: 16),
+              const Text('History',
+                  style: TextStyle(
+                      color: AppTheme.textSecondary,
+                      fontSize: 13,
+                      fontWeight: FontWeight.w600)),
+              const SizedBox(height: 8),
+              _buildHistory(),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: () {
+                        Navigator.of(context).pop(true);
+                        _automaticSearch();
+                      },
+                      icon: const Icon(Icons.search,
+                          size: 18, color: AppTheme.available),
+                      label: const Text('Automatic',
+                          style: TextStyle(color: AppTheme.textPrimary)),
+                      style: OutlinedButton.styleFrom(
+                        side: const BorderSide(color: AppTheme.border),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10)),
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: () {
+                        Navigator.of(context).pop(true);
+                        _interactiveSearch();
+                      },
+                      icon: const Icon(Icons.manage_search,
+                          size: 18, color: AppTheme.available),
+                      label: const Text('Interactive',
+                          style: TextStyle(color: AppTheme.textPrimary)),
+                      style: OutlinedButton.styleFrom(
+                        side: const BorderSide(color: AppTheme.border),
+                        shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10)),
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildHistory() {
+    if (_loading) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 12),
+        child: Center(
+            child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                    strokeWidth: 2, color: AppTheme.accent))),
+      );
+    }
+    if (_history.isEmpty) {
+      return const Text('No history yet.',
+          style: TextStyle(color: AppTheme.textSecondary, fontSize: 13));
+    }
+    return Column(
+      children: _history.map((h) => _HistoryTile(record: h)).toList(),
+    );
+  }
+}
+
+String _historyEventLabel(ChaptarrHistoryRecord r) {
+  switch (r.eventType) {
+    case 'grabbed':
+      final indexer = r.indexer;
+      return indexer != null && indexer.isNotEmpty
+          ? 'Grabbed from $indexer'
+          : 'Grabbed';
+    case 'bookFileImported':
+    case 'downloadFolderImported':
+      return 'Imported';
+    case 'downloadFailed':
+      return 'Download failed';
+    case 'bookFileDeleted':
+      return 'File deleted';
+    case 'bookFileRenamed':
+      return 'File renamed';
+    case 'downloadIgnored':
+      return 'Download ignored';
+    default:
+      return r.eventType.isEmpty ? 'Event' : r.eventType;
+  }
+}
+
+String _historyTime(DateTime? date) {
+  if (date == null) return '';
+  final local = date.toLocal();
+  final diff = DateTime.now().difference(local);
+  final String rel;
+  if (diff.inMinutes < 1) {
+    rel = 'Just now';
+  } else if (diff.inMinutes < 60) {
+    rel = '${diff.inMinutes}m ago';
+  } else if (diff.inHours < 24) {
+    rel = '${diff.inHours}h ago';
+  } else if (diff.inDays < 30) {
+    rel = '${diff.inDays}d ago';
+  } else {
+    rel = DateFormat('MMM d, yyyy').format(local);
+  }
+  return '$rel • ${DateFormat('MMM d, yyyy • h:mm a').format(local)}';
+}
+
+class _HistoryTile extends StatelessWidget {
+  final ChaptarrHistoryRecord record;
+  const _HistoryTile({required this.record});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            record.sourceTitle.isNotEmpty
+                ? record.sourceTitle
+                : _historyEventLabel(record),
+            style: const TextStyle(
+                color: AppTheme.textPrimary,
+                fontSize: 13,
+                fontWeight: FontWeight.w500),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+          const SizedBox(height: 2),
+          Text(_historyTime(record.date),
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 11)),
+          const SizedBox(height: 2),
+          Text(_historyEventLabel(record),
+              style: const TextStyle(color: AppTheme.requested, fontSize: 12)),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_book_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_book_screen.dart
@@ -1,0 +1,375 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_models.dart';
+import 'chaptarr_book_detail_sheet.dart';
+import 'chaptarr_releases_screen.dart';
+import 'widgets/book_status.dart';
+import 'widgets/format_badge.dart';
+
+/// Editions/files for one book: each edition's title, format badge and the
+/// matched file's quality+size (or a Missing/Unreleased line). Tapping the book
+/// header opens its detail sheet; the action bar runs a per-book search.
+/// Mirrors [SonarrSeasonScreen].
+class ChaptarrBookScreen extends ConsumerStatefulWidget {
+  final String instanceId;
+  final int bookId;
+  final String? bookTitle;
+
+  const ChaptarrBookScreen({
+    super.key,
+    required this.instanceId,
+    required this.bookId,
+    this.bookTitle,
+  });
+
+  @override
+  ConsumerState<ChaptarrBookScreen> createState() => _ChaptarrBookScreenState();
+}
+
+class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
+  late final ChaptarrApiService _service;
+  ChaptarrBook? _book;
+  List<ChaptarrBookFile> _files = [];
+  bool _isLoading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = ChaptarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: widget.instanceId,
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    setState(() => _isLoading = true);
+    try {
+      // Kick off both requests, then await — effectively parallel without the
+      // heterogeneous Future.wait cast.
+      final bookFuture = _service.getBookById(widget.bookId);
+      final filesFuture = _service.getBookFiles(bookId: widget.bookId);
+      final book = await bookFuture;
+      final files = await filesFuture;
+      if (!mounted) return;
+      setState(() {
+        _book = book;
+        _files = files;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load book: $e';
+      });
+    }
+  }
+
+  Future<void> _automaticSearch() async {
+    try {
+      await _service.searchBook([widget.bookId]);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Searching for ${_book?.title ?? 'book'}…')));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Search failed: $e')));
+    }
+  }
+
+  void _interactiveSearch() {
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute(
+        builder: (_) => ChaptarrReleasesScreen(
+          instanceId: widget.instanceId,
+          bookId: widget.bookId,
+          bookTitle: _book?.title ?? widget.bookTitle,
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openDetail() async {
+    final changed = await showChaptarrBookDetailSheet(
+      context,
+      instanceId: widget.instanceId,
+      bookId: widget.bookId,
+      bookTitle: _book?.title ?? widget.bookTitle,
+    );
+    // The book sheet returns true after an Automatic/Interactive search.
+    if (changed == true && mounted) _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final title = _book?.title ?? widget.bookTitle ?? 'Book';
+    final author = _book?.author?.authorName;
+
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      appBar: AppBar(
+        backgroundColor: AppTheme.background,
+        title: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(title, maxLines: 1, overflow: TextOverflow.ellipsis),
+            if (author != null && author.isNotEmpty)
+              Text(
+                author,
+                style: const TextStyle(
+                    color: AppTheme.textSecondary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w400),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+          ],
+        ),
+      ),
+      body: Column(
+        children: [
+          Expanded(child: _buildBody()),
+          _ActionBar(
+            onAutomatic: _automaticSearch,
+            onInteractive: _interactiveSearch,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading && _book == null) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null && _book == null) {
+      return FullScreenError(message: _error!, onRetry: _load);
+    }
+    final book = _book;
+    if (book == null) {
+      return const Center(
+        child: Text('No book',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 16)),
+      );
+    }
+    final fileByEdition = {
+      for (final f in _files) f.editionId: f,
+    };
+    final editions = [...book.editions];
+    return RefreshIndicator(
+      onRefresh: _load,
+      color: AppTheme.accent,
+      child: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        children: [
+          if (_error != null) ErrorBanner(message: _error!, onRetry: _load),
+          _BookHeader(book: book, onTap: _openDetail),
+          const Divider(color: AppTheme.border, height: 1),
+          if (editions.isEmpty)
+            const Padding(
+              padding: EdgeInsets.all(24),
+              child: Center(
+                child: Text('No editions',
+                    style: TextStyle(color: AppTheme.textSecondary)),
+              ),
+            )
+          else
+            ...editions.map((e) => _EditionTile(
+                  edition: e,
+                  file: fileByEdition[e.id],
+                  onTap: _openDetail,
+                )),
+        ],
+      ),
+    );
+  }
+}
+
+/// The book summary header — cover icon, title, availability line. Tapping it
+/// opens the detail sheet.
+class _BookHeader extends StatelessWidget {
+  final ChaptarrBook book;
+  final VoidCallback onTap;
+
+  const _BookHeader({required this.book, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final status = bookFileStatusLine(book);
+    final release = book.releaseDate;
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(book.title,
+                      style: const TextStyle(
+                          color: AppTheme.textPrimary,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600)),
+                  if (release != null) ...[
+                    const SizedBox(height: 2),
+                    Text(DateFormat('MMMM d, yyyy').format(release),
+                        style: const TextStyle(
+                            color: AppTheme.textSecondary, fontSize: 12)),
+                  ],
+                  const SizedBox(height: 4),
+                  Text(
+                    status.text,
+                    style: TextStyle(
+                        color: status.color,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500),
+                  ),
+                ],
+              ),
+            ),
+            const Icon(Icons.chevron_right, color: AppTheme.textSecondary),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// One edition row: format badge, edition title and the matched file's
+/// quality+size (when downloaded).
+class _EditionTile extends StatelessWidget {
+  final ChaptarrEdition edition;
+  final ChaptarrBookFile? file;
+  final VoidCallback onTap;
+
+  const _EditionTile({
+    required this.edition,
+    required this.file,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final f = file;
+    final fileLine = f != null
+        ? '${f.qualityName ?? 'Downloaded'} — ${f.sizeFormatted}'
+        : 'Not downloaded';
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      ChaptarrFormatBadge(format: edition.bookFormat),
+                      if (edition.title != null &&
+                          edition.title!.isNotEmpty) ...[
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            edition.title!,
+                            style: const TextStyle(
+                                color: AppTheme.textPrimary,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w500),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    fileLine,
+                    style: TextStyle(
+                        color: f != null
+                            ? AppTheme.available
+                            : AppTheme.textSecondary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ActionBar extends StatelessWidget {
+  final VoidCallback onAutomatic;
+  final VoidCallback onInteractive;
+
+  const _ActionBar({required this.onAutomatic, required this.onInteractive});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.fromLTRB(
+          12, 10, 12, 10 + MediaQuery.of(context).padding.bottom),
+      decoration: const BoxDecoration(
+        color: AppTheme.surface,
+        border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: OutlinedButton.icon(
+              onPressed: onAutomatic,
+              icon:
+                  const Icon(Icons.search, size: 18, color: AppTheme.available),
+              label: const Text('Automatic',
+                  style: TextStyle(color: AppTheme.textPrimary)),
+              style: OutlinedButton.styleFrom(
+                side: const BorderSide(color: AppTheme.border),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10)),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+              ),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: OutlinedButton.icon(
+              onPressed: onInteractive,
+              icon: const Icon(Icons.manage_search,
+                  size: 18, color: AppTheme.available),
+              label: const Text('Interactive',
+                  style: TextStyle(color: AppTheme.textPrimary)),
+              style: OutlinedButton.styleFrom(
+                side: const BorderSide(color: AppTheme.border),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10)),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_history_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_history_screen.dart
@@ -1,0 +1,327 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_models.dart';
+
+/// Paginated Chaptarr history: grabs, imports, failures, deletions, renames.
+class ChaptarrHistoryScreen extends ConsumerStatefulWidget {
+  const ChaptarrHistoryScreen({super.key});
+
+  @override
+  ConsumerState<ChaptarrHistoryScreen> createState() =>
+      _ChaptarrHistoryScreenState();
+}
+
+class _ChaptarrHistoryScreenState extends ConsumerState<ChaptarrHistoryScreen> {
+  static const _pageSize = 50;
+
+  final _scrollController = ScrollController();
+  List<ChaptarrHistoryRecord> _records = [];
+  int _totalRecords = 0;
+  int _page = 1;
+  bool _isLoading = true;
+  bool _isLoadingMore = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.extentAfter < 400) _loadMore();
+  }
+
+  ChaptarrApiService? _buildService() {
+    final instanceId = ref.read(instanceProvider).activeChaptarrInstance?.id;
+    if (instanceId == null) return null;
+    return ChaptarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: instanceId,
+    );
+  }
+
+  Future<void> _load() async {
+    final service = _buildService();
+    if (service == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Chaptarr instance configured';
+      });
+      return;
+    }
+
+    setState(() => _isLoading = true);
+    try {
+      final page = await service.getHistory(page: 1, pageSize: _pageSize);
+      if (!mounted) return;
+      setState(() {
+        _records = page.records;
+        _totalRecords = page.totalRecords;
+        _page = 1;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load history: $e';
+      });
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_isLoading || _isLoadingMore || !_hasMore) return;
+    final service = _buildService();
+    if (service == null) return;
+
+    setState(() => _isLoadingMore = true);
+    try {
+      final next =
+          await service.getHistory(page: _page + 1, pageSize: _pageSize);
+      if (!mounted) return;
+      setState(() {
+        _page += 1;
+        _records = [..._records, ...next.records];
+        _totalRecords = next.totalRecords;
+        _isLoadingMore = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _isLoadingMore = false);
+    }
+  }
+
+  bool get _hasMore => _records.length < _totalRecords;
+
+  @override
+  Widget build(BuildContext context) {
+    // Reload when the active instance changes.
+    ref.listen(instanceProvider.select((s) => s.activeChaptarrInstanceId),
+        (_, __) => _load());
+
+    if (_isLoading && _records.isEmpty) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null && _records.isEmpty) {
+      return FullScreenError(message: _error!, onRetry: _load);
+    }
+    if (_records.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _load,
+        color: AppTheme.accent,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [
+            SizedBox(height: 160),
+            Icon(Icons.history, size: 48, color: AppTheme.textSecondary),
+            SizedBox(height: 12),
+            Center(
+              child: Text('No history yet',
+                  style:
+                      TextStyle(color: AppTheme.textSecondary, fontSize: 16)),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _load,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _records.length + (_hasMore ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index >= _records.length) {
+            return const Padding(
+              padding: EdgeInsets.all(16),
+              child: Center(
+                child: SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(
+                      color: AppTheme.accent, strokeWidth: 2.5),
+                ),
+              ),
+            );
+          }
+
+          final record = _records[index];
+          final showHeader =
+              index == 0 || !_sameDay(record.date, _records[index - 1].date);
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (showHeader && record.date != null)
+                _DayHeader(label: _dayLabel(record.date!.toLocal())),
+              _HistoryTile(record: record),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+bool _sameDay(DateTime? a, DateTime? b) {
+  if (a == null || b == null) return a == b;
+  final la = a.toLocal();
+  final lb = b.toLocal();
+  return la.year == lb.year && la.month == lb.month && la.day == lb.day;
+}
+
+String _dayLabel(DateTime localDate) {
+  final now = DateTime.now();
+  final today = DateTime(now.year, now.month, now.day);
+  final day = DateTime(localDate.year, localDate.month, localDate.day);
+  final diff = today.difference(day).inDays;
+  if (diff == 0) return 'Today';
+  if (diff == 1) return 'Yesterday';
+  if (localDate.year == now.year) {
+    return DateFormat('EEEE, MMM d').format(localDate);
+  }
+  return DateFormat('MMM d, yyyy').format(localDate);
+}
+
+String _timeLabel(DateTime? date) {
+  if (date == null) return '';
+  final local = date.toLocal();
+  final diff = DateTime.now().difference(local);
+  if (_sameDay(local, DateTime.now())) {
+    if (diff.inMinutes < 1) return 'just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    return '${diff.inHours}h ago';
+  }
+  return DateFormat('h:mm a').format(local);
+}
+
+({IconData icon, Color color, String label}) _eventStyle(String eventType) {
+  switch (eventType) {
+    case 'grabbed':
+      return (
+        icon: Icons.download_outlined,
+        color: AppTheme.downloading,
+        label: 'Grabbed'
+      );
+    case 'bookImported':
+    case 'downloadFolderImported':
+    case 'authorFolderImported':
+      return (
+        icon: Icons.check_circle_outline,
+        color: AppTheme.available,
+        label: 'Imported'
+      );
+    case 'downloadFailed':
+      return (
+        icon: Icons.error_outline,
+        color: AppTheme.error,
+        label: 'Download failed'
+      );
+    case 'bookFileDeleted':
+      return (
+        icon: Icons.delete_outline,
+        color: AppTheme.unavailable,
+        label: 'File deleted'
+      );
+    case 'bookFileRenamed':
+      return (
+        icon: Icons.drive_file_rename_outline,
+        color: AppTheme.accent,
+        label: 'Renamed'
+      );
+    case 'downloadIgnored':
+      return (icon: Icons.block, color: AppTheme.unavailable, label: 'Ignored');
+    default:
+      return (
+        icon: Icons.history,
+        color: AppTheme.textSecondary,
+        label: eventType.isEmpty ? 'Unknown' : eventType
+      );
+  }
+}
+
+class _DayHeader extends StatelessWidget {
+  final String label;
+
+  const _DayHeader({required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 4),
+      child: Text(
+        label,
+        style: const TextStyle(
+          color: AppTheme.accent,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+}
+
+class _HistoryTile extends StatelessWidget {
+  final ChaptarrHistoryRecord record;
+
+  const _HistoryTile({required this.record});
+
+  @override
+  Widget build(BuildContext context) {
+    final style = _eventStyle(record.eventType);
+    final subtitleParts = [
+      style.label,
+      if (record.quality != null && record.quality!.isNotEmpty) record.quality!,
+    ];
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      leading: Container(
+        width: 36,
+        height: 36,
+        decoration: BoxDecoration(
+          color: style.color.withValues(alpha: 0.15),
+          shape: BoxShape.circle,
+        ),
+        child: Icon(style.icon, color: style.color, size: 20),
+      ),
+      title: Text(
+        record.sourceTitle.isNotEmpty ? record.sourceTitle : style.label,
+        style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 13.5,
+            fontWeight: FontWeight.w500),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        subtitleParts.join(' • '),
+        style: TextStyle(color: style.color, fontSize: 12),
+      ),
+      trailing: Text(
+        _timeLabel(record.date),
+        style: const TextStyle(color: AppTheme.textSecondary, fontSize: 11),
+      ),
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_home_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_home_screen.dart
@@ -1,0 +1,226 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_models.dart';
+import '../logic/chaptarr_library_provider.dart';
+import 'chaptarr_author_detail_screen.dart';
+import 'chaptarr_author_list.dart';
+
+/// Chaptarr library management screen (the Library tab of the Chaptarr module).
+/// Instance-aware: uses the active Chaptarr instance from the instance provider.
+class ChaptarrHomeScreen extends ConsumerStatefulWidget {
+  const ChaptarrHomeScreen({super.key});
+
+  @override
+  ConsumerState<ChaptarrHomeScreen> createState() => _ChaptarrHomeScreenState();
+}
+
+class _ChaptarrHomeScreenState extends ConsumerState<ChaptarrHomeScreen> {
+  ChaptarrLibraryNotifier? _notifier;
+  final _searchController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _initNotifier());
+  }
+
+  void _initNotifier() {
+    final instanceState = ref.read(instanceProvider);
+    final activeInstance = instanceState.activeChaptarrInstance;
+    if (activeInstance == null) return;
+
+    final backendDio = ref.read(backendClientProvider);
+    final service = ChaptarrApiService(
+      backendDio: backendDio,
+      instanceId: activeInstance.id,
+    );
+    _notifier = ChaptarrLibraryNotifier(service);
+    _notifier!.loadAuthors();
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _triggerAutomaticSearch(ChaptarrAuthor author) async {
+    try {
+      await _notifier!.searchForAuthor(author.id);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Author search started')));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Failed to start search: $e')));
+    }
+  }
+
+  void _openAuthor(ChaptarrAuthor author) {
+    final instanceId = ref.read(instanceProvider).activeChaptarrInstance?.id;
+    if (instanceId == null) return;
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute(
+        builder: (_) => ChaptarrAuthorDetailScreen(
+          instanceId: instanceId,
+          authorId: author.id,
+          authorName: author.authorName,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Rebuild when active instance changes
+    ref.listen(instanceProvider.select((s) => s.activeChaptarrInstanceId),
+        (_, __) => _initNotifier());
+
+    if (_notifier == null) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+
+    return ListenableBuilder(
+      listenable: _notifier!,
+      builder: (context, _) {
+        final state = _notifier!.state;
+
+        return Column(
+          children: [
+            // Stats bar
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              color: AppTheme.surface,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  _StatChip(
+                      label: 'Total',
+                      count: state.authors.length,
+                      color: AppTheme.textPrimary),
+                  _StatChip(
+                      label: 'Complete',
+                      count: state.completeCount,
+                      color: AppTheme.available),
+                  _StatChip(
+                      label: 'Partial',
+                      count: state.partialCount,
+                      color: AppTheme.requested),
+                ],
+              ),
+            ),
+
+            // Search + filter
+            Padding(
+              padding: const EdgeInsets.all(12),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _searchController,
+                      onChanged: _notifier!.search,
+                      decoration: InputDecoration(
+                        hintText: 'Search authors...',
+                        prefixIcon: const Icon(Icons.search),
+                        suffixIcon: _searchController.text.isNotEmpty
+                            ? IconButton(
+                                icon: const Icon(Icons.close),
+                                onPressed: () {
+                                  _searchController.clear();
+                                  _notifier!.search('');
+                                },
+                              )
+                            : null,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  PopupMenuButton<ChaptarrLibraryFilter>(
+                    icon: const Icon(Icons.filter_list,
+                        color: AppTheme.textPrimary),
+                    onSelected: _notifier!.setFilter,
+                    itemBuilder: (_) => ChaptarrLibraryFilter.values
+                        .map((f) => PopupMenuItem(
+                              value: f,
+                              child: Row(
+                                children: [
+                                  if (f == state.filter)
+                                    const Icon(Icons.check,
+                                        size: 18, color: AppTheme.accent),
+                                  if (f != state.filter)
+                                    const SizedBox(width: 18),
+                                  const SizedBox(width: 8),
+                                  Text(f.name[0].toUpperCase() +
+                                      f.name.substring(1)),
+                                ],
+                              ),
+                            ))
+                        .toList(),
+                  ),
+                ],
+              ),
+            ),
+
+            if (state.error != null)
+              ErrorBanner(
+                message: state.error!,
+                onRetry: _notifier!.loadAuthors,
+              ),
+
+            Expanded(
+              child: state.isLoading && state.authors.isEmpty
+                  ? const Center(
+                      child: CircularProgressIndicator(color: AppTheme.accent))
+                  : RefreshIndicator(
+                      onRefresh: _notifier!.loadAuthors,
+                      color: AppTheme.accent,
+                      child: ChaptarrAuthorList(
+                        authors: state.filtered,
+                        onTap: _openAuthor,
+                        onSearch: _triggerAutomaticSearch,
+                        onDelete: (author) => _notifier!
+                            .deleteAuthor(author.id, deleteFiles: false),
+                      ),
+                    ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _StatChip extends StatelessWidget {
+  final String label;
+  final int count;
+  final Color color;
+
+  const _StatChip({
+    required this.label,
+    required this.count,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(count.toString(),
+            style: TextStyle(
+                color: color, fontSize: 20, fontWeight: FontWeight.bold)),
+        Text(label,
+            style:
+                const TextStyle(color: AppTheme.textSecondary, fontSize: 12)),
+      ],
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_import_doctor_sheet.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_import_doctor_sheet.dart
@@ -1,0 +1,509 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../sonarr/logic/import_doctor.dart';
+import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_models.dart';
+
+/// Opens the Import Doctor for a stuck Chaptarr download. Returns `true` when a
+/// fix was applied so the caller can refresh its queue.
+Future<bool?> showChaptarrImportDoctorSheet(
+  BuildContext context, {
+  required ChaptarrApiService service,
+  required ChaptarrQueueItem item,
+}) {
+  return showModalBottomSheet<bool>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    builder: (_) => _ChaptarrImportDoctorSheet(service: service, item: item),
+  );
+}
+
+/// The "Import Doctor": explains why a download is stuck (full transparency,
+/// including the raw Chaptarr messages) and offers one-click fixes. Destructive
+/// actions (remove / blocklist / hand-off) ask for confirmation first.
+class _ChaptarrImportDoctorSheet extends StatefulWidget {
+  final ChaptarrApiService service;
+  final ChaptarrQueueItem item;
+
+  const _ChaptarrImportDoctorSheet({required this.service, required this.item});
+
+  @override
+  State<_ChaptarrImportDoctorSheet> createState() =>
+      _ChaptarrImportDoctorSheetState();
+}
+
+class _ChaptarrImportDoctorSheetState
+    extends State<_ChaptarrImportDoctorSheet> {
+  ChaptarrApiService get _service => widget.service;
+  bool _busy = false;
+
+  void _toast(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  Future<bool> _confirm(
+      String title, String message, String confirmLabel) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppTheme.surface,
+        title: Text(title),
+        content: Text(message,
+            style: const TextStyle(color: AppTheme.textSecondary)),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+            child: Text(confirmLabel),
+          ),
+        ],
+      ),
+    );
+    return ok ?? false;
+  }
+
+  /// Runs a fix and, on success, closes the sheet returning `true` so the
+  /// caller refreshes.
+  Future<void> _run(
+      Future<void> Function() action, String successMessage) async {
+    setState(() => _busy = true);
+    try {
+      await action();
+      if (!mounted) return;
+      _toast(successMessage);
+      Navigator.of(context).pop(true);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _busy = false);
+      _toast('Failed: $e');
+    }
+  }
+
+  Future<void> _onAction(DoctorAction action) async {
+    final item = widget.item;
+    switch (action) {
+      case DoctorAction.process:
+        await _run(
+            _service.processMonitoredDownloads, 'Running the import pass…');
+      case DoctorAction.rescan:
+        if (item.authorId == null) {
+          _toast('No author to rescan.');
+          return;
+        }
+        await _run(() => _service.rescanAuthor(item.authorId!),
+            'Rescanning the author…');
+      case DoctorAction.manualImport:
+        await _runManualImport(force: false);
+      case DoctorAction.forceImport:
+        await _runManualImport(force: true);
+      case DoctorAction.remove:
+        if (!await _confirm(
+            'Remove download',
+            'This deletes the download from the client. The release is not blocklisted, so it could be grabbed again.',
+            'Remove')) {
+          return;
+        }
+        await _run(
+            () => _service.deleteQueueItem(item.id), 'Removed from the queue.');
+      case DoctorAction.blocklistSearch:
+        if (!await _confirm(
+            'Remove, blocklist & search',
+            'This deletes the download, blocklists the release so it is not grabbed again, and starts a fresh search for a different one.',
+            'Do it')) {
+          return;
+        }
+        await _run(() async {
+          await _service.deleteQueueItem(item.id, blocklist: true);
+          if (item.bookId != null) {
+            await _service.searchBook([item.bookId!]);
+          }
+        }, 'Blocklisted and searching for a replacement…');
+      case DoctorAction.changeCategory:
+        if (!await _confirm(
+            'Hand off to download client',
+            'This stops Chaptarr managing the download and moves it to the post-import category (for tools like Unpackerr). It stays in your client.',
+            'Hand off')) {
+          return;
+        }
+        await _run(
+            () => _service.deleteQueueItem(item.id,
+                removeFromClient: false, changeCategory: true),
+            'Handed off to the download client.');
+    }
+  }
+
+  Future<void> _runManualImport({required bool force}) async {
+    final downloadId = widget.item.downloadId;
+    if (downloadId == null || downloadId.isEmpty) {
+      _toast('This download has no client id yet — nothing to import.');
+      return;
+    }
+    setState(() => _busy = true);
+    List<ChaptarrManualImportCandidate> candidates;
+    try {
+      candidates = await _service.getManualImportCandidates(downloadId);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _busy = false);
+      _toast('Could not fetch files: $e');
+      return;
+    }
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (candidates.isEmpty) {
+      _toast('No importable files found in the download folder.');
+      return;
+    }
+
+    final importable = candidates
+        .where((c) => c.isMapped && (force || !c.hasPermanentRejection))
+        .toList();
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => _CandidatesDialog(
+        candidates: candidates,
+        importableCount: importable.length,
+        force: force,
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    if (importable.isEmpty) {
+      _toast(force
+          ? 'None of the files are matched to a book, so they cannot be imported.'
+          : 'No files qualify — use Force import to import despite the warnings.');
+      return;
+    }
+
+    final files = importable.map((c) => c.toImportFile()).toList();
+    final mode = widget.item.protocol == 'torrent' ? 'copy' : 'move';
+    await _run(() => _service.executeManualImport(files, importMode: mode),
+        'Importing ${files.length} file(s)…');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final item = widget.item;
+    final diagnosis = diagnoseChaptarrQueueItem(item);
+    final (icon, color) = _severityVisual(diagnosis.severity);
+
+    final rawMessages = <String>[
+      if (item.errorMessage != null && item.errorMessage!.isNotEmpty)
+        item.errorMessage!,
+      for (final g in item.statusMessageGroups) ...[
+        if (g.messages.isEmpty && g.title.isNotEmpty) g.title,
+        ...g.messages,
+      ],
+    ];
+
+    return Padding(
+      padding:
+          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      child: Container(
+        constraints: BoxConstraints(
+            maxHeight: MediaQuery.of(context).size.height * 0.85),
+        decoration: const BoxDecoration(
+          color: AppTheme.surface,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: AppTheme.textSecondary,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(icon, color: color, size: 26),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: Text(
+                      diagnosis.problem.isNotEmpty
+                          ? diagnosis.problem
+                          : 'Download status',
+                      style: const TextStyle(
+                          color: AppTheme.textPrimary,
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Text(item.bookLabel ?? item.title,
+                  style: const TextStyle(
+                      color: AppTheme.textSecondary, fontSize: 12),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis),
+              if (diagnosis.transparency.isNotEmpty) ...[
+                const SizedBox(height: 14),
+                Text(diagnosis.transparency,
+                    style: const TextStyle(
+                        color: AppTheme.textPrimary,
+                        fontSize: 14,
+                        height: 1.4)),
+              ],
+              if (rawMessages.isNotEmpty) ...[
+                const SizedBox(height: 16),
+                const Text('Messages',
+                    style: TextStyle(
+                        color: AppTheme.textSecondary,
+                        fontSize: 13,
+                        fontWeight: FontWeight.w600)),
+                const SizedBox(height: 6),
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: AppTheme.requested.withValues(alpha: 0.08),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      for (final m in rawMessages)
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 2),
+                          child: Text('• $m',
+                              style: const TextStyle(
+                                  color: AppTheme.textSecondary,
+                                  fontSize: 12,
+                                  height: 1.35)),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+              const SizedBox(height: 18),
+              if (_busy)
+                const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 12),
+                  child: Center(
+                      child: CircularProgressIndicator(color: AppTheme.accent)),
+                )
+              else if (diagnosis.actions.isEmpty)
+                const Text('No automatic fix is needed.',
+                    style:
+                        TextStyle(color: AppTheme.textSecondary, fontSize: 13))
+              else
+                ...diagnosis.actions.asMap().entries.map((e) => Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: _ActionButton(
+                        meta: _actionMeta(e.value),
+                        primary: e.key == 0,
+                        onTap: () => _onAction(e.value),
+                      ),
+                    )),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+(IconData, Color) _severityVisual(DoctorSeverity s) => switch (s) {
+      DoctorSeverity.error => (Icons.error_outline, AppTheme.error),
+      DoctorSeverity.warning => (
+          Icons.warning_amber_rounded,
+          AppTheme.requested
+        ),
+      DoctorSeverity.info => (Icons.info_outline, AppTheme.downloading),
+      DoctorSeverity.ok => (Icons.check_circle_outline, AppTheme.available),
+    };
+
+class _ActionMeta {
+  final String label;
+  final IconData icon;
+  final bool destructive;
+  const _ActionMeta(this.label, this.icon, {this.destructive = false});
+}
+
+_ActionMeta _actionMeta(DoctorAction action) => switch (action) {
+      DoctorAction.process =>
+        const _ActionMeta('Process now', Icons.play_arrow_rounded),
+      DoctorAction.manualImport =>
+        const _ActionMeta('Manual import', Icons.download_done),
+      DoctorAction.forceImport => const _ActionMeta('Force import', Icons.bolt),
+      DoctorAction.rescan => const _ActionMeta('Rescan files', Icons.refresh),
+      DoctorAction.remove =>
+        const _ActionMeta('Remove', Icons.delete_outline, destructive: true),
+      DoctorAction.blocklistSearch => const _ActionMeta(
+          'Remove, block & search', Icons.block,
+          destructive: true),
+      DoctorAction.changeCategory => const _ActionMeta(
+          'Hand off to client', Icons.outbox,
+          destructive: true),
+    };
+
+class _ActionButton extends StatelessWidget {
+  final _ActionMeta meta;
+  final bool primary;
+  final VoidCallback onTap;
+
+  const _ActionButton(
+      {required this.meta, required this.primary, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = meta.destructive ? AppTheme.error : AppTheme.accent;
+    if (primary && !meta.destructive) {
+      return SizedBox(
+        width: double.infinity,
+        child: ElevatedButton.icon(
+          onPressed: onTap,
+          icon: Icon(meta.icon, size: 18),
+          label: Text(meta.label),
+          style: ElevatedButton.styleFrom(
+            backgroundColor: AppTheme.accent,
+            foregroundColor: AppTheme.background,
+            padding: const EdgeInsets.symmetric(vertical: 13),
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+          ),
+        ),
+      );
+    }
+    return SizedBox(
+      width: double.infinity,
+      child: OutlinedButton.icon(
+        onPressed: onTap,
+        icon: Icon(meta.icon, size: 18, color: color),
+        label: Text(meta.label, style: TextStyle(color: color)),
+        style: OutlinedButton.styleFrom(
+          side: BorderSide(color: color.withValues(alpha: 0.5)),
+          padding: const EdgeInsets.symmetric(vertical: 13),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows the importable files (with mappings + rejections) before importing —
+/// full transparency about exactly what will land.
+class _CandidatesDialog extends StatelessWidget {
+  final List<ChaptarrManualImportCandidate> candidates;
+  final int importableCount;
+  final bool force;
+
+  const _CandidatesDialog({
+    required this.candidates,
+    required this.importableCount,
+    required this.force,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: AppTheme.surface,
+      title: Text(force ? 'Force import' : 'Manual import'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              importableCount == 0
+                  ? 'None of these files can be imported as-is:'
+                  : 'Will import $importableCount of ${candidates.length} file(s):',
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
+            const SizedBox(height: 10),
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: candidates.map((c) {
+                  final willImport =
+                      c.isMapped && (force || !c.hasPermanentRejection);
+                  return Padding(
+                    padding: const EdgeInsets.only(bottom: 10),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              willImport
+                                  ? Icons.check_circle
+                                  : Icons.remove_circle_outline,
+                              size: 15,
+                              color: willImport
+                                  ? AppTheme.available
+                                  : AppTheme.textSecondary,
+                            ),
+                            const SizedBox(width: 6),
+                            Expanded(
+                              child: Text(c.name,
+                                  style: const TextStyle(
+                                      color: AppTheme.textPrimary,
+                                      fontSize: 12),
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis),
+                            ),
+                          ],
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(left: 21, top: 2),
+                          child: Text(
+                            [
+                              c.sizeFormatted,
+                              if (c.isMapped) 'matched' else 'no book match',
+                            ].join(' • '),
+                            style: const TextStyle(
+                                color: AppTheme.textSecondary, fontSize: 11),
+                          ),
+                        ),
+                        if (c.rejections.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(left: 21, top: 2),
+                            child: Text(
+                              c.rejections.map((r) => r.reason).join('; '),
+                              style: const TextStyle(
+                                  color: AppTheme.requested, fontSize: 11),
+                            ),
+                          ),
+                      ],
+                    ),
+                  );
+                }).toList(),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel')),
+        TextButton(
+          onPressed:
+              importableCount == 0 ? null : () => Navigator.pop(context, true),
+          child: Text(force ? 'Force import' : 'Import'),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_module_shell.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_module_shell.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/instance_dropdown.dart';
+
+/// Chaptarr module shell with bottom nav: Library | Queue | History | Wanted.
+/// Calendar is intentionally omitted (books have no air schedule). Shows the
+/// instance dropdown in the header when 2+ instances exist.
+class ChaptarrModuleShell extends ConsumerWidget {
+  final int currentIndex;
+  final ValueChanged<int> onTabChanged;
+  final Widget child;
+
+  const ChaptarrModuleShell({
+    super.key,
+    required this.currentIndex,
+    required this.onTabChanged,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final instanceState = ref.watch(instanceProvider);
+
+    return Scaffold(
+      appBar: instanceState.chaptarrInstances.length > 1
+          ? AppBar(
+              title: InstanceDropdown(
+                instances: instanceState.chaptarrInstances,
+                activeInstanceId: instanceState.activeChaptarrInstanceId,
+                onChanged: (id) => ref
+                    .read(instanceProvider.notifier)
+                    .setActiveChaptarrInstance(id),
+              ),
+              backgroundColor: AppTheme.background,
+              elevation: 0,
+            )
+          : null,
+      body: child,
+      bottomNavigationBar: Container(
+        decoration: const BoxDecoration(
+          border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
+        ),
+        child: BottomNavigationBar(
+          currentIndex: currentIndex,
+          onTap: onTabChanged,
+          items: const [
+            BottomNavigationBarItem(
+              icon: Icon(Icons.menu_book_outlined),
+              activeIcon: Icon(Icons.menu_book),
+              label: 'Library',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.downloading_outlined),
+              activeIcon: Icon(Icons.downloading),
+              label: 'Queue',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.history_outlined),
+              activeIcon: Icon(Icons.history),
+              label: 'History',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.warning_amber_outlined),
+              activeIcon: Icon(Icons.warning_amber),
+              label: 'Wanted',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_queue_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_queue_screen.dart
@@ -1,0 +1,268 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/providers/realtime_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_models.dart';
+import 'chaptarr_import_doctor_sheet.dart';
+import 'widgets/chaptarr_queue_item_card.dart';
+
+/// Shows the current Chaptarr download queue with per-item actions.
+class ChaptarrQueueScreen extends ConsumerStatefulWidget {
+  const ChaptarrQueueScreen({super.key});
+
+  @override
+  ConsumerState<ChaptarrQueueScreen> createState() =>
+      _ChaptarrQueueScreenState();
+}
+
+class _ChaptarrQueueScreenState extends ConsumerState<ChaptarrQueueScreen> {
+  List<ChaptarrQueueItem> _queue = [];
+  bool _isLoading = true;
+  String? _error;
+  Timer? _refreshTimer;
+  Timer? _wsRefetchDebounce;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadQueue();
+      // Fallback poll only — queue changes arrive as arr_queue_changed
+      // pings over the WebSocket; this covers gaps when the socket is down.
+      _refreshTimer =
+          Timer.periodic(const Duration(seconds: 45), (_) => _autoRefresh());
+    });
+  }
+
+  @override
+  void dispose() {
+    _refreshTimer?.cancel();
+    _wsRefetchDebounce?.cancel();
+    super.dispose();
+  }
+
+  void _autoRefresh() {
+    if (!mounted) return;
+    // Skip silent refreshes when another route is on top of this screen.
+    final route = ModalRoute.of(context);
+    if (route != null && !route.isCurrent) return;
+    _loadQueue(silent: true);
+  }
+
+  /// Debounced refetch triggered by WebSocket invalidation pings, so a
+  /// burst of changes only causes one REST roundtrip.
+  void _scheduleWsRefetch() {
+    _wsRefetchDebounce?.cancel();
+    _wsRefetchDebounce = Timer(const Duration(milliseconds: 500), _autoRefresh);
+  }
+
+  ChaptarrApiService? _buildService() {
+    final instanceId = ref.read(instanceProvider).activeChaptarrInstance?.id;
+    if (instanceId == null) return null;
+    return ChaptarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: instanceId,
+    );
+  }
+
+  Future<void> _loadQueue({bool silent = false}) async {
+    final service = _buildService();
+    if (service == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Chaptarr instance configured';
+      });
+      return;
+    }
+
+    if (!silent) setState(() => _isLoading = true);
+    try {
+      final queue = await service.getQueueDetailed();
+      if (!mounted) return;
+      setState(() {
+        _queue = queue;
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      // Keep showing the last known data on silent refresh failures.
+      if (silent) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load queue: $e';
+      });
+    }
+  }
+
+  void _showDoctor(ChaptarrQueueItem item) {
+    final service = _buildService();
+    if (service == null) return;
+    showChaptarrImportDoctorSheet(context, service: service, item: item)
+        .then((changed) {
+      if (changed == true) _loadQueue(silent: true);
+    });
+  }
+
+  Future<void> _removeItem(ChaptarrQueueItem item) async {
+    final result = await showDialog<({bool removeFromClient, bool blocklist})>(
+      context: context,
+      builder: (_) => const _RemoveQueueItemDialog(),
+    );
+    if (result == null || !mounted) return;
+
+    final service = _buildService();
+    if (service == null) return;
+    try {
+      await service.deleteQueueItem(
+        item.id,
+        removeFromClient: result.removeFromClient,
+        blocklist: result.blocklist,
+      );
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Removed from queue')));
+      _loadQueue(silent: true);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Failed to remove: $e')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Rebuild when instance changes
+    ref.listen(instanceProvider.select((s) => s.activeChaptarrInstanceId),
+        (_, __) => _loadQueue());
+
+    // Refetch on server-pushed queue-change pings for the active instance;
+    // the periodic poll remains as a fallback when the socket is down.
+    final wsInstanceId =
+        ref.watch(instanceProvider.select((s) => s.activeChaptarrInstance?.id));
+    if (wsInstanceId != null) {
+      ref.listen(
+          arrQueueChangedProvider(
+              (instanceId: wsInstanceId, serviceType: 'chaptarr')), (_, next) {
+        if (next.valueOrNull != null) _scheduleWsRefetch();
+      });
+    }
+
+    if (_isLoading) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(_error!,
+                style: const TextStyle(color: AppTheme.textSecondary)),
+            const SizedBox(height: 16),
+            ElevatedButton(onPressed: _loadQueue, child: const Text('Retry')),
+          ],
+        ),
+      );
+    }
+    if (_queue.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _loadQueue,
+        color: AppTheme.accent,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [
+            SizedBox(height: 160),
+            Icon(Icons.check_circle_outline,
+                size: 48, color: AppTheme.available),
+            SizedBox(height: 12),
+            Center(
+              child: Text('Queue is empty',
+                  style:
+                      TextStyle(color: AppTheme.textSecondary, fontSize: 16)),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _loadQueue,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _queue.length,
+        itemBuilder: (context, index) {
+          final item = _queue[index];
+          return ChaptarrQueueItemCard(
+            item: item,
+            onRemove: () => _removeItem(item),
+            onTap: item.hasIssues ? () => _showDoctor(item) : null,
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Confirmation dialog for removing a queue item, with download client and
+/// blocklist checkboxes.
+class _RemoveQueueItemDialog extends StatefulWidget {
+  const _RemoveQueueItemDialog();
+
+  @override
+  State<_RemoveQueueItemDialog> createState() => _RemoveQueueItemDialogState();
+}
+
+class _RemoveQueueItemDialogState extends State<_RemoveQueueItemDialog> {
+  bool _removeFromClient = true;
+  bool _blocklist = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      backgroundColor: AppTheme.surface,
+      title: const Text('Remove from Queue'),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          CheckboxListTile(
+            value: _removeFromClient,
+            onChanged: (v) => setState(() => _removeFromClient = v ?? true),
+            title: const Text('Remove from download client',
+                style: TextStyle(color: AppTheme.textPrimary, fontSize: 14)),
+            controlAffinity: ListTileControlAffinity.leading,
+            contentPadding: EdgeInsets.zero,
+            activeColor: AppTheme.accent,
+          ),
+          CheckboxListTile(
+            value: _blocklist,
+            onChanged: (v) => setState(() => _blocklist = v ?? false),
+            title: const Text('Add to blocklist',
+                style: TextStyle(color: AppTheme.textPrimary, fontSize: 14)),
+            controlAffinity: ListTileControlAffinity.leading,
+            contentPadding: EdgeInsets.zero,
+            activeColor: AppTheme.accent,
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel')),
+        TextButton(
+          onPressed: () => Navigator.pop(context,
+              (removeFromClient: _removeFromClient, blocklist: _blocklist)),
+          style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+          child: const Text('Remove'),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_releases_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_releases_screen.dart
@@ -1,0 +1,440 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_models.dart';
+
+enum _ReleaseSort { smart, seeders, size, age }
+
+/// Interactive release search for one book.
+/// Queries all indexers live (slow), lists releases and lets the admin grab one
+/// manually. Mirrors [SonarrReleasesScreen].
+class ChaptarrReleasesScreen extends ConsumerStatefulWidget {
+  final String instanceId;
+  final int bookId;
+  final String? bookTitle;
+
+  const ChaptarrReleasesScreen({
+    super.key,
+    required this.instanceId,
+    required this.bookId,
+    this.bookTitle,
+  });
+
+  @override
+  ConsumerState<ChaptarrReleasesScreen> createState() =>
+      _ChaptarrReleasesScreenState();
+}
+
+class _ChaptarrReleasesScreenState
+    extends ConsumerState<ChaptarrReleasesScreen> {
+  late final ChaptarrApiService _service;
+  List<ChaptarrRelease> _releases = [];
+  bool _isLoading = true;
+  bool _isGrabbing = false;
+  String? _error;
+  _ReleaseSort _sort = _ReleaseSort.smart;
+  bool _ascending = false;
+  final Set<String> _expandedGuids = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _service = ChaptarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: widget.instanceId,
+    );
+    WidgetsBinding.instance.addPostFrameCallback((_) => _search());
+  }
+
+  Future<void> _search() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+    try {
+      final releases = await _service.getReleases(widget.bookId);
+      if (!mounted) return;
+      setState(() {
+        _releases = releases;
+        _isLoading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Release search failed: $e';
+      });
+    }
+  }
+
+  List<ChaptarrRelease> get _sorted {
+    final list = [..._releases];
+    switch (_sort) {
+      case _ReleaseSort.smart:
+        list.sort(_smartCompare);
+        return list;
+      case _ReleaseSort.seeders:
+        list.sort((a, b) => (a.seeders ?? -1).compareTo(b.seeders ?? -1));
+      case _ReleaseSort.size:
+        list.sort((a, b) => a.size.compareTo(b.size));
+      case _ReleaseSort.age:
+        list.sort((a, b) => a.ageHours.compareTo(b.ageHours));
+    }
+    return _ascending ? list : list.reversed.toList();
+  }
+
+  /// Approved releases first; usenet sorted by age (newest first is ascending
+  /// age), torrents by seeders; usenet listed before torrents.
+  static int _smartCompare(ChaptarrRelease a, ChaptarrRelease b) {
+    if (a.rejected != b.rejected) return a.rejected ? 1 : -1;
+    if (a.protocol != b.protocol) {
+      if (a.protocol == 'usenet') return -1;
+      if (b.protocol == 'usenet') return 1;
+    }
+    if (a.isTorrent && b.isTorrent) {
+      return (b.seeders ?? 0).compareTo(a.seeders ?? 0);
+    }
+    return a.ageHours.compareTo(b.ageHours);
+  }
+
+  String _sortLabel(_ReleaseSort sort) => switch (sort) {
+        _ReleaseSort.smart => 'Default',
+        _ReleaseSort.seeders => 'Seeders',
+        _ReleaseSort.size => 'Size',
+        _ReleaseSort.age => 'Age',
+      };
+
+  void _onSortSelected(_ReleaseSort sort) {
+    setState(() {
+      if (_sort == sort && sort != _ReleaseSort.smart) {
+        _ascending = !_ascending;
+      } else {
+        _sort = sort;
+        // Sensible default direction per field.
+        _ascending = sort == _ReleaseSort.age;
+      }
+    });
+  }
+
+  Future<void> _confirmGrab(ChaptarrRelease release) async {
+    if (_isGrabbing) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppTheme.surface,
+        title: const Text('Grab Release'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(release.title,
+                style:
+                    const TextStyle(color: AppTheme.textPrimary, fontSize: 13)),
+            if (release.rejected && release.rejections.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              Text(
+                'This release was rejected:\n'
+                '${release.rejections.map((r) => '• $r').join('\n')}',
+                style: const TextStyle(color: AppTheme.requested, fontSize: 12),
+              ),
+            ],
+            const SizedBox(height: 12),
+            const Text('Send this release to the download client?',
+                style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+          ],
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Grab'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    setState(() => _isGrabbing = true);
+    try {
+      await _service.grabRelease(release.guid, release.indexerId);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Release sent to download client')));
+      Navigator.of(context).pop();
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isGrabbing = false);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Failed to grab release: $e')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      appBar: AppBar(
+        backgroundColor: AppTheme.background,
+        title: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Interactive Search'),
+            if (widget.bookTitle != null && widget.bookTitle!.isNotEmpty)
+              Text(
+                widget.bookTitle!,
+                style: const TextStyle(
+                    color: AppTheme.textSecondary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w400),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+          ],
+        ),
+        actions: [
+          PopupMenuButton<_ReleaseSort>(
+            icon: const Icon(Icons.sort, color: AppTheme.textPrimary),
+            color: AppTheme.surfaceVariant,
+            tooltip: 'Sort releases',
+            onSelected: _onSortSelected,
+            itemBuilder: (_) => _ReleaseSort.values
+                .map((s) => PopupMenuItem(
+                      value: s,
+                      child: Row(
+                        children: [
+                          if (s == _sort && s != _ReleaseSort.smart)
+                            Icon(
+                                _ascending
+                                    ? Icons.arrow_upward
+                                    : Icons.arrow_downward,
+                                size: 16,
+                                color: AppTheme.accent)
+                          else if (s == _sort)
+                            const Icon(Icons.check,
+                                size: 16, color: AppTheme.accent)
+                          else
+                            const SizedBox(width: 16),
+                          const SizedBox(width: 8),
+                          Text(_sortLabel(s)),
+                        ],
+                      ),
+                    ))
+                .toList(),
+          ),
+          IconButton(
+            icon: const Icon(Icons.refresh, color: AppTheme.textPrimary),
+            tooltip: 'Search again',
+            onPressed: _isLoading ? null : _search,
+          ),
+        ],
+      ),
+      body: Stack(
+        children: [
+          _buildBody(),
+          if (_isGrabbing)
+            Container(
+              color: Colors.black54,
+              child: const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent)),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CircularProgressIndicator(color: AppTheme.accent),
+            SizedBox(height: 20),
+            Text('Searching indexers...',
+                style: TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w500)),
+            SizedBox(height: 6),
+            Text('This can take up to a minute.',
+                style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+          ],
+        ),
+      );
+    }
+    if (_error != null) {
+      return FullScreenError(message: _error!, onRetry: _search);
+    }
+    if (_releases.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.search_off,
+                size: 48, color: AppTheme.textSecondary),
+            const SizedBox(height: 12),
+            const Text('No releases found',
+                style: TextStyle(color: AppTheme.textSecondary, fontSize: 16)),
+            const SizedBox(height: 20),
+            ElevatedButton(
+                onPressed: _search, child: const Text('Search Again')),
+          ],
+        ),
+      );
+    }
+
+    final releases = _sorted;
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: releases.length,
+      separatorBuilder: (_, __) =>
+          const Divider(color: AppTheme.border, height: 1),
+      itemBuilder: (context, index) {
+        final release = releases[index];
+        return _ReleaseTile(
+          release: release,
+          expanded: _expandedGuids.contains(release.guid),
+          onToggleExpand: () => setState(() {
+            if (!_expandedGuids.add(release.guid)) {
+              _expandedGuids.remove(release.guid);
+            }
+          }),
+          onTap: () => _confirmGrab(release),
+        );
+      },
+    );
+  }
+}
+
+class _ReleaseTile extends StatelessWidget {
+  final ChaptarrRelease release;
+  final bool expanded;
+  final VoidCallback onToggleExpand;
+  final VoidCallback onTap;
+
+  const _ReleaseTile({
+    required this.release,
+    required this.expanded,
+    required this.onToggleExpand,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Opacity(
+        opacity: release.rejected ? 0.6 : 1,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                release.title,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontSize: 13,
+                    fontWeight: FontWeight.w500),
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+              const SizedBox(height: 6),
+              Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: [
+                  _ReleaseBadge(
+                    text: release.protocol.toUpperCase(),
+                    color: release.isTorrent
+                        ? AppTheme.downloading
+                        : AppTheme.available,
+                  ),
+                  if (release.quality != null)
+                    _ReleaseBadge(
+                        text: release.quality!, color: AppTheme.accent),
+                  _ReleaseBadge(
+                      text: release.sizeFormatted,
+                      color: AppTheme.textSecondary),
+                  _ReleaseBadge(
+                      text: release.ageFormatted,
+                      color: AppTheme.textSecondary),
+                  if (release.indexer != null && release.indexer!.isNotEmpty)
+                    _ReleaseBadge(
+                        text: release.indexer!, color: AppTheme.textSecondary),
+                  if (release.isTorrent)
+                    _ReleaseBadge(
+                      text:
+                          'S:${release.seeders ?? 0} L:${release.leechers ?? 0}',
+                      color: (release.seeders ?? 0) > 0
+                          ? AppTheme.available
+                          : AppTheme.error,
+                    ),
+                ],
+              ),
+              if (release.rejected && release.rejections.isNotEmpty) ...[
+                const SizedBox(height: 6),
+                GestureDetector(
+                  onTap: onToggleExpand,
+                  behavior: HitTestBehavior.opaque,
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.warning_amber_rounded,
+                          size: 14, color: AppTheme.requested),
+                      const SizedBox(width: 4),
+                      const Text('Rejected',
+                          style: TextStyle(
+                              color: AppTheme.requested,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w500)),
+                      Icon(expanded ? Icons.expand_less : Icons.expand_more,
+                          size: 16, color: AppTheme.requested),
+                    ],
+                  ),
+                ),
+                if (expanded)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text(
+                      release.rejections.map((r) => '• $r').join('\n'),
+                      style: const TextStyle(
+                          color: AppTheme.textSecondary, fontSize: 12),
+                    ),
+                  ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ReleaseBadge extends StatelessWidget {
+  final String text;
+  final Color color;
+
+  const _ReleaseBadge({required this.text, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+            color: color, fontSize: 10.5, fontWeight: FontWeight.w500),
+      ),
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_wanted_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_wanted_screen.dart
@@ -1,0 +1,304 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_models.dart';
+
+enum _WantedView { missing, cutoff }
+
+/// Paginated Chaptarr wanted books: missing files and cutoff-unmet quality.
+class ChaptarrWantedScreen extends ConsumerStatefulWidget {
+  const ChaptarrWantedScreen({super.key});
+
+  @override
+  ConsumerState<ChaptarrWantedScreen> createState() =>
+      _ChaptarrWantedScreenState();
+}
+
+class _ChaptarrWantedScreenState extends ConsumerState<ChaptarrWantedScreen> {
+  static const _pageSize = 50;
+
+  final _scrollController = ScrollController();
+  _WantedView _view = _WantedView.missing;
+  List<ChaptarrWantedRecord> _records = [];
+  int _totalRecords = 0;
+  int _page = 1;
+  bool _isLoading = true;
+  bool _isLoadingMore = false;
+
+  /// Bumped by every fresh load (view switch, instance switch, refresh) so
+  /// in-flight responses from a superseded fetch are dropped instead of
+  /// merged into the new list.
+  int _loadGeneration = 0;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.extentAfter < 400) _loadMore();
+  }
+
+  ChaptarrApiService? _buildService() {
+    final instanceId = ref.read(instanceProvider).activeChaptarrInstance?.id;
+    if (instanceId == null) return null;
+    return ChaptarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: instanceId,
+    );
+  }
+
+  Future<ChaptarrWantedPage> _fetch(ChaptarrApiService service, int page) {
+    return _view == _WantedView.missing
+        ? service.getWantedMissing(page: page, pageSize: _pageSize)
+        : service.getWantedCutoff(page: page, pageSize: _pageSize);
+  }
+
+  Future<void> _load() async {
+    final service = _buildService();
+    if (service == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Chaptarr instance configured';
+      });
+      return;
+    }
+
+    final view = _view;
+    final gen = ++_loadGeneration;
+    setState(() => _isLoading = true);
+    try {
+      final page = await _fetch(service, 1);
+      if (!mounted || gen != _loadGeneration || view != _view) return;
+      setState(() {
+        _records = page.records;
+        _totalRecords = page.totalRecords;
+        _page = 1;
+        _isLoading = false;
+        // A superseded _loadMore bails without clearing this flag; reset it
+        // here so pagination isn't blocked after a refresh/switch.
+        _isLoadingMore = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted || gen != _loadGeneration || view != _view) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load wanted books: $e';
+      });
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_isLoading || _isLoadingMore || !_hasMore) return;
+    final service = _buildService();
+    if (service == null) return;
+
+    final view = _view;
+    final gen = _loadGeneration;
+    setState(() => _isLoadingMore = true);
+    try {
+      final next = await _fetch(service, _page + 1);
+      if (!mounted || gen != _loadGeneration || view != _view) return;
+      setState(() {
+        _page += 1;
+        _records = [..._records, ...next.records];
+        _totalRecords = next.totalRecords;
+        _isLoadingMore = false;
+      });
+    } catch (_) {
+      if (!mounted || gen != _loadGeneration || view != _view) return;
+      setState(() => _isLoadingMore = false);
+    }
+  }
+
+  bool get _hasMore => _records.length < _totalRecords;
+
+  void _onViewChanged(_WantedView view) {
+    if (view == _view) return;
+    setState(() {
+      _view = view;
+      _records = [];
+      _totalRecords = 0;
+      _page = 1;
+      _error = null;
+    });
+    _load();
+  }
+
+  Future<void> _automaticSearch(ChaptarrWantedRecord record) async {
+    final service = _buildService();
+    if (service == null) return;
+    try {
+      await service.searchBook([record.bookId]);
+      if (!mounted) return;
+      final label = [
+        if (record.authorTitle != null) record.authorTitle,
+        if (record.title != null) record.title,
+      ].whereType<String>().join(' — ');
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content:
+              Text('Search started${label.isNotEmpty ? ' for $label' : ''}')));
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Failed to start search: $e')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Reload when the active instance changes.
+    ref.listen(instanceProvider.select((s) => s.activeChaptarrInstanceId),
+        (_, __) => _load());
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+          child: SegmentedButton<_WantedView>(
+            showSelectedIcon: false,
+            segments: const [
+              ButtonSegment(value: _WantedView.missing, label: Text('Missing')),
+              ButtonSegment(
+                  value: _WantedView.cutoff, label: Text('Cutoff Unmet')),
+            ],
+            selected: {_view},
+            onSelectionChanged: (value) => _onViewChanged(value.first),
+          ),
+        ),
+        Expanded(child: _buildBody()),
+      ],
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading && _records.isEmpty) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null && _records.isEmpty) {
+      return FullScreenError(message: _error!, onRetry: _load);
+    }
+    if (_records.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _load,
+        color: AppTheme.accent,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: [
+            const SizedBox(height: 160),
+            const Icon(Icons.check_circle_outline,
+                size: 48, color: AppTheme.available),
+            const SizedBox(height: 12),
+            Center(
+              child: Text(
+                _view == _WantedView.missing
+                    ? 'Nothing missing — library is healthy'
+                    : 'No cutoff unmet books — quality goals met',
+                style: const TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 16),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _load,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        controller: _scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: _records.length + (_hasMore ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index >= _records.length) {
+            return const Padding(
+              padding: EdgeInsets.all(16),
+              child: Center(
+                child: SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(
+                      color: AppTheme.accent, strokeWidth: 2.5),
+                ),
+              ),
+            );
+          }
+
+          final record = _records[index];
+          return _WantedTile(
+            record: record,
+            onAutomaticSearch: () => _automaticSearch(record),
+          );
+        },
+      ),
+    );
+  }
+}
+
+String _releaseDateLabel(DateTime? releaseDate) {
+  if (releaseDate == null) return 'No release date';
+  final local = releaseDate.toLocal();
+  final now = DateTime.now();
+  if (local.year == now.year) return DateFormat('MMM d').format(local);
+  return DateFormat('MMM d, yyyy').format(local);
+}
+
+class _WantedTile extends StatelessWidget {
+  final ChaptarrWantedRecord record;
+  final VoidCallback onAutomaticSearch;
+
+  const _WantedTile({
+    required this.record,
+    required this.onAutomaticSearch,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final subtitleParts = [
+      if (record.title != null && record.title!.isNotEmpty) record.title!,
+      _releaseDateLabel(record.releaseDate),
+    ];
+
+    return ListTile(
+      contentPadding: const EdgeInsets.only(left: 16, right: 4),
+      title: Text(
+        record.authorTitle ?? record.title ?? 'Unknown author',
+        style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 13.5,
+            fontWeight: FontWeight.w500),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        subtitleParts.join(' • '),
+        style: const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: IconButton(
+        icon: const Icon(Icons.search, color: AppTheme.accent, size: 22),
+        tooltip: 'Automatic search',
+        onPressed: onAutomaticSearch,
+      ),
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/widgets/book_status.dart
+++ b/app/lib/features/chaptarr/ui/widgets/book_status.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../data/chaptarr_models.dart';
+
+/// (text, colour) pair for a book's one-line availability status.
+typedef BookStatus = ({String text, Color color});
+
+/// Computes a book's availability line, mirroring [episodeStatusLine]'s
+/// priority order adapted to books (which have no live queue lookup here):
+/// 1. has a file              -> "{format} — {size}" / "Downloaded"  (green)
+/// 2. no file, already out    -> "Missing"     (red)
+/// 3. no file, not yet out    -> "Unreleased"  (blue)
+BookStatus bookFileStatusLine(ChaptarrBook book) {
+  if (book.hasFile) {
+    final size = book.statistics?.sizeFormatted;
+    final formats = book.formats;
+    final label =
+        formats.length == 1 ? _formatLabel(formats.first) : 'Downloaded';
+    final suffix = (size != null && size != '0 B') ? ' — $size' : '';
+    return (text: '$label$suffix', color: AppTheme.available);
+  }
+  return _isReleased(book.releaseDate)
+      ? (text: 'Missing', color: AppTheme.error)
+      : (text: 'Unreleased', color: AppTheme.downloading);
+}
+
+/// A book is "released" once its release date has passed (a null date is
+/// treated as released, matching Sonarr's "aired with no date" handling).
+bool _isReleased(DateTime? releaseDate) {
+  if (releaseDate == null) return true;
+  return !releaseDate.isAfter(DateTime.now());
+}
+
+String _formatLabel(BookFormat format) => switch (format) {
+      BookFormat.audiobook => 'Audiobook',
+      BookFormat.ebook => 'eBook',
+      BookFormat.unknown => 'Downloaded',
+    };

--- a/app/lib/features/chaptarr/ui/widgets/chaptarr_queue_item_card.dart
+++ b/app/lib/features/chaptarr/ui/widgets/chaptarr_queue_item_card.dart
@@ -1,0 +1,326 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../../../core/widgets/status_pill.dart';
+import '../../data/chaptarr_models.dart';
+
+/// Short status label for a queue item (e.g. "Import pending", "Downloading").
+String chaptarrQueueStatusLabel(ChaptarrQueueItem item) {
+  if (item.trackedDownloadStatus == 'error' || item.status == 'failed') {
+    return 'Error';
+  }
+  switch (item.trackedDownloadState) {
+    case 'importPending':
+      return 'Import pending';
+    case 'importing':
+      return 'Importing';
+    case 'imported':
+      return 'Imported';
+    case 'importBlocked':
+      return 'Import blocked';
+    case 'failedPending':
+      return 'Failed';
+  }
+  if (item.trackedDownloadStatus == 'warning') return 'Warning';
+  switch (item.status) {
+    case 'downloading':
+      return 'Downloading';
+    case 'paused':
+      return 'Paused';
+    case 'queued':
+      return 'Queued';
+    case 'completed':
+      return 'Completed';
+    case 'delay':
+      return 'Delayed';
+    case 'downloadClientUnavailable':
+      return 'Client unavailable';
+    case 'warning':
+      return 'Warning';
+    default:
+      return item.status.isEmpty ? 'Unknown' : item.status;
+  }
+}
+
+/// Status colour for a queue item, matched to the design system tokens.
+Color chaptarrQueueStatusColor(ChaptarrQueueItem item) {
+  if (item.trackedDownloadStatus == 'error' ||
+      item.status == 'failed' ||
+      item.trackedDownloadState == 'failedPending') {
+    return AppTheme.error;
+  }
+  if (item.trackedDownloadStatus == 'warning' || item.status == 'warning') {
+    return AppTheme.requested;
+  }
+  switch (item.trackedDownloadState) {
+    case 'importPending':
+    case 'importing':
+    case 'importBlocked':
+      return AppTheme.requested;
+    case 'imported':
+      return AppTheme.available;
+  }
+  switch (item.status) {
+    case 'downloading':
+      return AppTheme.downloading;
+    case 'completed':
+      return AppTheme.available;
+    case 'paused':
+    case 'queued':
+    case 'delay':
+    case 'downloadClientUnavailable':
+      return AppTheme.unavailable;
+    default:
+      return AppTheme.downloading;
+  }
+}
+
+/// A rich queue item card: status, protocol, indexer, download client, progress
+/// bar, time left and any error/status messages. Shared by the Chaptarr queue
+/// screen and the per-book detail sheet.
+class ChaptarrQueueItemCard extends StatelessWidget {
+  final ChaptarrQueueItem item;
+
+  /// When provided, an "Issues" affordance opens this callback instead of
+  /// showing the inline issues box (used by the Import Doctor).
+  final VoidCallback? onTap;
+
+  /// When provided, a Remove action is offered in the overflow menu.
+  final VoidCallback? onRemove;
+
+  const ChaptarrQueueItemCard({
+    super.key,
+    required this.item,
+    this.onTap,
+    this.onRemove,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final statusColor = chaptarrQueueStatusColor(item);
+    final issues = <String>[
+      if (item.errorMessage != null && item.errorMessage!.isNotEmpty)
+        item.errorMessage!,
+      ...item.statusMessages,
+    ];
+    final protocol = item.protocol;
+    final bookLabel = item.bookLabel;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      padding: const EdgeInsets.fromLTRB(12, 10, 4, 12),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppTheme.border, width: 0.5),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      bookLabel ?? item.title,
+                      style: const TextStyle(
+                          color: AppTheme.textPrimary,
+                          fontWeight: FontWeight.w600,
+                          fontSize: 14),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    if (bookLabel != null)
+                      Padding(
+                        padding: const EdgeInsets.only(top: 2),
+                        child: Text(
+                          item.title,
+                          style: const TextStyle(
+                              color: AppTheme.textSecondary, fontSize: 11),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              if (onRemove != null)
+                PopupMenuButton<String>(
+                  icon: const Icon(Icons.more_vert,
+                      color: AppTheme.textSecondary, size: 20),
+                  color: AppTheme.surfaceVariant,
+                  onSelected: (value) {
+                    if (value == 'remove') onRemove!();
+                  },
+                  itemBuilder: (_) => const [
+                    PopupMenuItem(
+                      value: 'remove',
+                      child: Row(
+                        children: [
+                          Icon(Icons.delete_outline,
+                              size: 18, color: AppTheme.error),
+                          SizedBox(width: 8),
+                          Text('Remove'),
+                        ],
+                      ),
+                    ),
+                  ],
+                )
+              else
+                const SizedBox(width: 8),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Wrap(
+              spacing: 6,
+              runSpacing: 4,
+              children: [
+                StatusPill(
+                    text: chaptarrQueueStatusLabel(item), color: statusColor),
+                StatusPill(
+                  text: protocol.toUpperCase(),
+                  color: protocol == 'torrent'
+                      ? AppTheme.downloading
+                      : AppTheme.available,
+                ),
+                if (item.quality != null)
+                  StatusPill(text: item.quality!, color: AppTheme.accent),
+                if (item.indexer != null && item.indexer!.isNotEmpty)
+                  StatusPill(
+                      text: item.indexer!, color: AppTheme.textSecondary),
+                if (item.downloadClient != null &&
+                    item.downloadClient!.isNotEmpty)
+                  StatusPill(
+                      text: item.downloadClient!,
+                      color: AppTheme.textSecondary),
+              ],
+            ),
+          ),
+          const SizedBox(height: 10),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(3),
+              child: LinearProgressIndicator(
+                value: item.progress,
+                minHeight: 5,
+                backgroundColor: AppTheme.surfaceVariant,
+                valueColor: AlwaysStoppedAnimation(statusColor),
+              ),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    '${(item.progress * 100).toStringAsFixed(1)}% • '
+                    '${item.downloadedFormatted} of ${item.sizeFormatted}',
+                    style: const TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 11),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (item.timeleft != null && item.timeleft!.isNotEmpty)
+                  Text(
+                    item.timeleft!,
+                    style: const TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 11),
+                  ),
+              ],
+            ),
+          ),
+          if (item.hasIssues && issues.isNotEmpty)
+            Padding(
+              padding: const EdgeInsets.only(top: 8, right: 8),
+              child: onTap != null
+                  ? _IssuesButton(count: issues.length, onTap: onTap!)
+                  : _IssuesBox(text: issues.join('\n')),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The inline amber issues box (default rendering when no Doctor handler set).
+class _IssuesBox extends StatelessWidget {
+  final String text;
+  const _IssuesBox({required this.text});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: AppTheme.error.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.warning_amber_rounded,
+              size: 16, color: AppTheme.requested),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              text,
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 11),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A tappable "Messages" affordance that defers to the Import Doctor.
+class _IssuesButton extends StatelessWidget {
+  final int count;
+  final VoidCallback onTap;
+  const _IssuesButton({required this.count, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(6),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+        decoration: BoxDecoration(
+          color: AppTheme.requested.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: Row(
+          children: [
+            const Icon(Icons.warning_amber_rounded,
+                size: 16, color: AppTheme.requested),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                count == 1
+                    ? '1 message — tap to resolve'
+                    : '$count messages — tap to resolve',
+                style: const TextStyle(
+                    color: AppTheme.requested,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w500),
+              ),
+            ),
+            const Icon(Icons.chevron_right,
+                size: 18, color: AppTheme.requested),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/chaptarr/ui/widgets/format_badge.dart
+++ b/app/lib/features/chaptarr/ui/widgets/format_badge.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../data/chaptarr_models.dart';
+
+/// A small themed chip marking a book/edition/file's medium: an audiobook
+/// (headphones) or an ebook (book). Audiobooks are first-class, so they get the
+/// accent colour; ebooks read as a quieter "downloading" blue. Unknown formats
+/// render nothing.
+class ChaptarrFormatBadge extends StatelessWidget {
+  final BookFormat format;
+
+  const ChaptarrFormatBadge({super.key, required this.format});
+
+  @override
+  Widget build(BuildContext context) {
+    final ({IconData icon, String label, Color color})? spec = switch (format) {
+      BookFormat.audiobook => (
+          icon: Icons.headphones,
+          label: 'Audiobook',
+          color: AppTheme.accent,
+        ),
+      BookFormat.ebook => (
+          icon: Icons.menu_book,
+          label: 'eBook',
+          color: AppTheme.downloading,
+        ),
+      BookFormat.unknown => null,
+    };
+    if (spec == null) return const SizedBox.shrink();
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: spec.color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(spec.icon, size: 12, color: spec.color),
+          const SizedBox(width: 4),
+          Text(
+            spec.label,
+            style: TextStyle(
+                color: spec.color, fontSize: 10.5, fontWeight: FontWeight.w500),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/settings/data/request_settings_service.dart
+++ b/app/lib/features/settings/data/request_settings_service.dart
@@ -206,6 +206,22 @@ class RequestSettingsService {
         data: settings.toJson());
   }
 
+  /// The user's per-service default-instance overrides, keyed by service type.
+  /// Only set overrides are returned; absent keys inherit the global default.
+  Future<Map<String, String>> getUserDefaultInstances(int userId) async {
+    final resp = await _dio.get('/api/admin/users/$userId/default-instances');
+    final data = (resp.data as Map?) ?? const {};
+    return data.map((k, v) => MapEntry(k.toString(), v.toString()));
+  }
+
+  /// Sets the user's default-instance overrides. A null value clears that
+  /// override (for chaptarr, clearing revokes access). Returns the updated map.
+  Future<void> updateUserDefaultInstances(
+      int userId, Map<String, String?> defaults) async {
+    await _dio.put('/api/admin/users/$userId/default-instances',
+        data: defaults);
+  }
+
   Future<List<PendingRequestItem>> listPending() async {
     final resp = await _dio.get('/api/admin/requests');
     return ((resp.data as List?) ?? const [])
@@ -213,7 +229,8 @@ class RequestSettingsService {
         .toList();
   }
 
-  Future<void> approve(int id, {String? seasonScope, int? qualityProfileId}) async {
+  Future<void> approve(int id,
+      {String? seasonScope, int? qualityProfileId}) async {
     final body = <String, dynamic>{};
     if (seasonScope != null) body['season_scope'] = seasonScope;
     if (qualityProfileId != null && qualityProfileId != 0) {

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -48,6 +48,7 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
   static const _serviceTypes = <(String, String)>[
     ('radarr', 'Radarr'),
     ('sonarr', 'Sonarr'),
+    ('chaptarr', 'Chaptarr'),
     ('sabnzbd', 'SABnzbd'),
     ('qbittorrent', 'qBittorrent'),
     ('nzbget', 'NZBGet'),
@@ -70,8 +71,9 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
       _serviceType == 'nzbget' ||
       _serviceType == 'transmission';
 
-  /// Only the arr services support a device-direct connection test; the
-  /// rest are validated by the backend when saving.
+  /// Only the v3 arr services support a device-direct connection test (it hits
+  /// `/api/v3/system/status`); the rest — including Chaptarr, which is `/api/v1`
+  /// — are validated by the backend when saving.
   bool get _supportsDirectTest =>
       _serviceType == 'radarr' || _serviceType == 'sonarr';
 
@@ -277,6 +279,8 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
     switch (_serviceType) {
       case 'sonarr':
         return 'http://192.168.1.100:8989';
+      case 'chaptarr':
+        return 'http://192.168.1.100:8787';
       case 'sabnzbd':
         return 'http://192.168.1.100:8080';
       case 'qbittorrent':
@@ -401,7 +405,9 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
                         ? 'Your SABnzbd API key'
                         : (_serviceType == 'tautulli'
                             ? 'Your Tautulli API key'
-                            : 'Your Radarr/Sonarr API key')),
+                            : (_serviceType == 'chaptarr'
+                                ? 'Your Chaptarr API key'
+                                : 'Your Radarr/Sonarr API key'))),
               ),
               obscureText: true,
             ),

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -373,6 +373,8 @@ IconData _serviceIcon(String serviceType) {
       return Icons.movie_outlined;
     case 'sonarr':
       return Icons.tv_outlined;
+    case 'chaptarr':
+      return Icons.menu_book;
     case 'sabnzbd':
     case 'qbittorrent':
     case 'nzbget':
@@ -391,6 +393,8 @@ String _serviceLabel(String serviceType) {
       return 'Radarr';
     case 'sonarr':
       return 'Sonarr';
+    case 'chaptarr':
+      return 'Chaptarr';
     case 'sabnzbd':
       return 'SABnzbd';
     case 'qbittorrent':

--- a/app/lib/features/settings/ui/user_request_settings_screen.dart
+++ b/app/lib/features/settings/ui/user_request_settings_screen.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/models/backend_connection.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/request_settings_service.dart';
+import '../../auth/logic/auth_provider.dart';
 import '../../request/data/request_service.dart';
 
 /// Admin screen for editing one user's per-user request overrides. A null
@@ -42,6 +44,10 @@ class _UserRequestSettingsScreenState
   int? _qualityRadarr;
   int? _qualitySonarr;
 
+  // The user's per-service default-instance overrides, keyed by service type
+  // (null = inherit the global default; for chaptarr, null = no access).
+  Map<String, String?> _defaultInstances = {};
+
   @override
   void initState() {
     super.initState();
@@ -66,6 +72,7 @@ class _UserRequestSettingsScreenState
     try {
       final user = await _service.getUserSettings(widget.userId);
       final admin = await _service.getAdminSettings();
+      final defaults = await _service.getUserDefaultInstances(widget.userId);
       if (!mounted) return;
       setState(() {
         _global = admin.settings;
@@ -77,6 +84,7 @@ class _UserRequestSettingsScreenState
         _allowQualityChoice = user.allowQualityChoice;
         _qualityRadarr = user.qualityProfileRadarr;
         _qualitySonarr = user.qualityProfileSonarr;
+        _defaultInstances = Map<String, String?>.from(defaults);
         _isLoading = false;
       });
     } catch (e) {
@@ -103,6 +111,13 @@ class _UserRequestSettingsScreenState
           qualityProfileSonarr: _qualitySonarr,
         ),
       );
+      // Send the override for every service type that has instances so a
+      // cleared selection serializes to null (which clears it server-side).
+      final defaults = <String, String?>{
+        for (final type in _instancesByType().keys)
+          type: _defaultInstances[type],
+      };
+      await _service.updateUserDefaultInstances(widget.userId, defaults);
       if (!mounted) return;
       setState(() => _saving = false);
       ScaffoldMessenger.of(context)
@@ -118,7 +133,7 @@ class _UserRequestSettingsScreenState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('Request Settings — ${widget.username}')),
+      appBar: AppBar(title: Text('User Settings — ${widget.username}')),
       body: _isLoading
           ? const Center(
               child: CircularProgressIndicator(color: AppTheme.accent))
@@ -158,7 +173,8 @@ class _UserRequestSettingsScreenState
         ),
         _TriBool(
           title: 'Require approval',
-          subtitle: 'Requests from this user must be approved before being sent.',
+          subtitle:
+              'Requests from this user must be approved before being sent.',
           value: _requireApproval,
           inheritedDefault: global.requireApproval,
           onChanged: (v) => setState(() => _requireApproval = v),
@@ -192,6 +208,7 @@ class _UserRequestSettingsScreenState
           value: _qualitySonarr,
           onChanged: (v) => setState(() => _qualitySonarr = v),
         ),
+        ..._buildDefaultInstancesSection(),
         const SizedBox(height: 24),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -218,6 +235,124 @@ class _UserRequestSettingsScreenState
         const SizedBox(height: 32),
       ],
     );
+  }
+
+  /// The admin's connection lists every configured instance; group them by
+  /// service type (first-seen order) so we can render one dropdown per type.
+  /// Service types whose default instance is a per-user "source" override.
+  /// Download clients and Tautulli are admin-only infrastructure (not a
+  /// per-user content source), so they are excluded from this section.
+  static const _sourceServiceTypes = {'radarr', 'sonarr', 'chaptarr'};
+
+  Map<String, List<ServiceInstance>> _instancesByType() {
+    final instances =
+        ref.read(authProvider).valueOrNull?.connection?.instances ?? const [];
+    final grouped = <String, List<ServiceInstance>>{};
+    for (final inst in instances) {
+      if (!_sourceServiceTypes.contains(inst.serviceType)) continue;
+      grouped.putIfAbsent(inst.serviceType, () => []).add(inst);
+    }
+    return grouped;
+  }
+
+  /// A "Default instances" section with one dropdown per service type that has
+  /// at least one configured instance.
+  List<Widget> _buildDefaultInstancesSection() {
+    final grouped = _instancesByType();
+    if (grouped.isEmpty) return const [];
+    return [
+      const Divider(color: AppTheme.border),
+      const Padding(
+        padding: EdgeInsets.fromLTRB(16, 8, 16, 4),
+        child: Text(
+          'Default instances',
+          style: TextStyle(
+            color: AppTheme.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+      const Padding(
+        padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
+        child: Text(
+          'Pin which instance this user defaults to per service. Chaptarr (Books) '
+          'has no global default — choosing an instance grants access.',
+          style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        ),
+      ),
+      for (final entry in grouped.entries)
+        _defaultInstanceField(serviceType: entry.key, instances: entry.value),
+    ];
+  }
+
+  Widget _defaultInstanceField({
+    required String serviceType,
+    required List<ServiceInstance> instances,
+  }) {
+    // Chaptarr has no global default, so an unset value means "no access";
+    // every other service type falls back to its global default.
+    final isChaptarr = serviceType == 'chaptarr';
+    final value = _defaultInstances[serviceType];
+    // Guard against a stored id that's no longer in the instance list.
+    final hasValue = value != null && instances.any((i) => i.id == value);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 12),
+      child: DropdownButtonFormField<String?>(
+        initialValue: hasValue ? value : null,
+        isExpanded: true,
+        dropdownColor: AppTheme.surfaceVariant,
+        decoration: InputDecoration(
+          labelText: 'Default ${_serviceLabel(serviceType)} instance',
+          labelStyle: const TextStyle(color: AppTheme.textSecondary),
+          enabledBorder: const OutlineInputBorder(
+            borderSide: BorderSide(color: AppTheme.border),
+          ),
+          focusedBorder: const OutlineInputBorder(
+            borderSide: BorderSide(color: AppTheme.accent),
+          ),
+        ),
+        style: const TextStyle(color: AppTheme.textPrimary),
+        items: [
+          DropdownMenuItem<String?>(
+            value: null,
+            child: Text(
+              isChaptarr ? 'No access' : 'Inherit (global default)',
+              style: const TextStyle(color: AppTheme.textSecondary),
+            ),
+          ),
+          ...instances.map(
+            (i) => DropdownMenuItem<String?>(
+              value: i.id,
+              child: Text(i.name),
+            ),
+          ),
+        ],
+        onChanged: (v) => setState(() => _defaultInstances[serviceType] = v),
+      ),
+    );
+  }
+
+  String _serviceLabel(String serviceType) {
+    switch (serviceType) {
+      case 'radarr':
+        return 'Radarr';
+      case 'sonarr':
+        return 'Sonarr';
+      case 'chaptarr':
+        return 'Chaptarr';
+      case 'sabnzbd':
+        return 'SABnzbd';
+      case 'qbittorrent':
+        return 'qBittorrent';
+      case 'nzbget':
+        return 'NZBGet';
+      case 'transmission':
+        return 'Transmission';
+      case 'tautulli':
+        return 'Tautulli';
+      default:
+        return serviceType;
+    }
   }
 
   Widget _seasonScopeField(GlobalRequestSettings global) {

--- a/app/lib/features/settings/ui/users_screen.dart
+++ b/app/lib/features/settings/ui/users_screen.dart
@@ -121,10 +121,9 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
   Future<void> _resendInvite(UserSummary user) async {
     String? link;
     try {
-      final resp =
-          await ref.read(authProvider.notifier).generateConnectToken(
-                user.username,
-              );
+      final resp = await ref.read(authProvider.notifier).generateConnectToken(
+            user.username,
+          );
       link = resp.link;
     } catch (e) {
       if (mounted) {
@@ -260,7 +259,8 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-            content: Text(_friendlyError(e, 'Failed to update sign-in methods')),
+            content:
+                Text(_friendlyError(e, 'Failed to update sign-in methods')),
           ),
         );
       }
@@ -478,7 +478,7 @@ class _UserTile extends StatelessWidget {
             value: 'request_settings',
             child: ListTile(
               leading: Icon(Icons.tune),
-              title: Text('Request settings…'),
+              title: Text('User settings…'),
               contentPadding: EdgeInsets.zero,
             ),
           ),
@@ -528,12 +528,14 @@ class _UserTile extends StatelessWidget {
         // Admins always keep both methods, so toggles are only for other users.
         if (!user.isAdmin)
           PopupMenuItem(
-            value: user.passwordEnabled ? 'disable_password' : 'enable_password',
+            value:
+                user.passwordEnabled ? 'disable_password' : 'enable_password',
             child: ListTile(
               leading: Icon(
                   user.passwordEnabled ? Icons.lock_outline : Icons.lock_open),
-              title: Text(
-                  user.passwordEnabled ? 'Disable password' : 'Enable password'),
+              title: Text(user.passwordEnabled
+                  ? 'Disable password'
+                  : 'Enable password'),
               contentPadding: EdgeInsets.zero,
             ),
           ),

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -888,6 +888,8 @@ class _AppShellState extends ConsumerState<AppShell>
           instances.setActiveDownloadInstance(instanceId);
         case ModuleType.tautulli:
           instances.setActiveTautulliInstance(instanceId);
+        case ModuleType.chaptarr:
+          instances.setActiveChaptarrInstance(instanceId);
         default:
           break;
       }
@@ -899,6 +901,8 @@ class _AppShellState extends ConsumerState<AppShell>
         context.go('/radarr/library');
       case ModuleType.sonarr:
         context.go('/sonarr/library');
+      case ModuleType.chaptarr:
+        context.go('/chaptarr/library');
       case ModuleType.downloads:
         context.go('/downloads/queue');
       case ModuleType.tautulli:

--- a/app/lib/features/sonarr/logic/import_doctor.dart
+++ b/app/lib/features/sonarr/logic/import_doctor.dart
@@ -1,3 +1,4 @@
+import '../../chaptarr/data/chaptarr_models.dart';
 import '../../radarr/data/radarr_models.dart';
 import '../data/sonarr_models.dart';
 
@@ -416,4 +417,17 @@ QueueDiagnosis diagnoseRadarrQueueItem(RadarrQueueItem item) =>
       trackedDownloadState: item.trackedDownloadState,
       errorMessage: item.errorMessage,
       statusMessageGroups: item.statusMessageGroups,
+    );
+
+/// Classifies a Chaptarr queue item (thin wrapper over [diagnoseQueueSignal]).
+/// ChaptarrStatusMessage is shape-identical to SonarrStatusMessage; bridge the
+/// groups so the one neutral catalog keeps driving all three services.
+QueueDiagnosis diagnoseChaptarrQueueItem(ChaptarrQueueItem item) =>
+    diagnoseQueueSignal(
+      trackedDownloadStatus: item.trackedDownloadStatus,
+      trackedDownloadState: item.trackedDownloadState,
+      errorMessage: item.errorMessage,
+      statusMessageGroups: item.statusMessageGroups
+          .map((g) => SonarrStatusMessage(title: g.title, messages: g.messages))
+          .toList(),
     );

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -7,6 +7,11 @@ import '../features/auth/ui/auth_screen.dart';
 import '../features/auth/ui/passkey_create_screen.dart';
 import '../features/auth/ui/passkey_management_screen.dart';
 import '../features/auth/ui/set_password_screen.dart';
+import '../features/chaptarr/ui/chaptarr_history_screen.dart';
+import '../features/chaptarr/ui/chaptarr_home_screen.dart';
+import '../features/chaptarr/ui/chaptarr_module_shell.dart';
+import '../features/chaptarr/ui/chaptarr_queue_screen.dart';
+import '../features/chaptarr/ui/chaptarr_wanted_screen.dart';
 import '../features/dashboard/ui/dashboard_movies_tab.dart';
 import '../features/dashboard/ui/dashboard_releases_tab.dart';
 import '../features/dashboard/ui/dashboard_shell.dart';
@@ -234,6 +239,51 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   GoRoute(
                     path: '/sonarr/calendar',
                     builder: (_, __) => const SonarrCalendarScreen(),
+                  ),
+                ],
+              ),
+            ],
+          ),
+
+          // Chaptarr module (Library/Queue/History/Wanted tabs)
+          StatefulShellRoute.indexedStack(
+            builder: (context, state, navigationShell) {
+              return ChaptarrModuleShell(
+                currentIndex: navigationShell.currentIndex,
+                onTabChanged: (index) => navigationShell.goBranch(index),
+                child: navigationShell,
+              );
+            },
+            branches: [
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/chaptarr/library',
+                    builder: (_, __) => const ChaptarrHomeScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/chaptarr/queue',
+                    builder: (_, __) => const ChaptarrQueueScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/chaptarr/history',
+                    builder: (_, __) => const ChaptarrHistoryScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/chaptarr/wanted',
+                    builder: (_, __) => const ChaptarrWantedScreen(),
                   ),
                 ],
               ),

--- a/app/test/chaptarr/chaptarr_logic_test.dart
+++ b/app/test/chaptarr/chaptarr_logic_test.dart
@@ -1,0 +1,87 @@
+import 'package:cantinarr/features/chaptarr/data/chaptarr_models.dart';
+import 'package:cantinarr/features/sonarr/logic/import_doctor.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+ChaptarrQueueItem _item({
+  String status = 'ok',
+  String state = 'downloading',
+  String? error,
+  List<ChaptarrStatusMessage> messages = const [],
+}) =>
+    ChaptarrQueueItem(
+      id: 1,
+      title: 'release',
+      status: 'downloading',
+      trackedDownloadStatus: status,
+      trackedDownloadState: state,
+      errorMessage: error,
+      statusMessageGroups: messages,
+    );
+
+ChaptarrStatusMessage _msg(String text) =>
+    ChaptarrStatusMessage(title: 'release', messages: [text]);
+
+void main() {
+  group('bookFormatFromQuality', () {
+    test('ebook formats classify as ebook', () {
+      for (final q in ['EPUB', 'epub', 'MOBI', 'AZW3', 'PDF', 'CBZ', 'KEPUB']) {
+        expect(bookFormatFromQuality(q), BookFormat.ebook, reason: q);
+      }
+    });
+
+    test('audiobook formats classify as audiobook', () {
+      for (final q in [
+        'MP3-320',
+        'M4B',
+        'M4A',
+        'FLAC',
+        'AAC',
+        'OGG',
+        'Audiobook',
+      ]) {
+        expect(bookFormatFromQuality(q), BookFormat.audiobook, reason: q);
+      }
+    });
+
+    test('null/empty/unrecognized classify as unknown', () {
+      expect(bookFormatFromQuality(null), BookFormat.unknown);
+      expect(bookFormatFromQuality(''), BookFormat.unknown);
+      expect(bookFormatFromQuality('SomethingElse'), BookFormat.unknown);
+    });
+  });
+
+  // diagnoseChaptarrQueueItem bridges ChaptarrStatusMessage -> the shared neutral
+  // engine; these confirm the bridge feeds the catalog correctly for books.
+  group('diagnoseChaptarrQueueItem', () {
+    test('healthy download is OK with no actions', () {
+      final d = diagnoseChaptarrQueueItem(_item());
+      expect(d.severity, DoctorSeverity.ok);
+      expect(d.isHealthy, isTrue);
+    });
+
+    test('stalled torrent error → blocklist+search', () {
+      final d = diagnoseChaptarrQueueItem(_item(
+        status: 'error',
+        error: 'The download is stalled with no connections',
+      ));
+      expect(d.severity, DoctorSeverity.error);
+      expect(d.actions, contains(DoctorAction.blocklistSearch));
+    });
+
+    test('sample rejection (via status message bridge) → force import', () {
+      final d = diagnoseChaptarrQueueItem(_item(
+        status: 'warning',
+        state: 'importBlocked',
+        messages: [_msg('Sample')],
+      ));
+      expect(d.severity, DoctorSeverity.warning);
+      expect(d.actions, contains(DoctorAction.forceImport));
+    });
+
+    test('stuck importPending with no messages → process', () {
+      final d = diagnoseChaptarrQueueItem(_item(state: 'importPending'));
+      expect(d.problem, 'Waiting to import');
+      expect(d.actions, contains(DoctorAction.process));
+    });
+  });
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -138,6 +138,13 @@ func NewRouter(
 			// Send a test push to a specific user's devices (delivery diagnostics).
 			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Post("/users/{userID}/test-push", pushHandler.TestPushToUser)
 
+			// Per-user default *arr instance overrides (admin-managed). Pins which
+			// instance is a given user's default source per service type, and —
+			// for service types with no global default (chaptarr) — grants the
+			// user access to that instance.
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Get("/users/{userID}/default-instances", instanceHandler.GetUserDefaultInstances)
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Put("/users/{userID}/default-instances", instanceHandler.UpdateUserDefaultInstances)
+
 			// Credential management
 			r.With(auth.RequirePermission(auth.PermissionCredentialsManage)).Get("/credentials", credHandler.Get)
 			r.With(auth.RequirePermission(auth.PermissionCredentialsManage)).Put("/credentials", credHandler.Update)
@@ -281,7 +288,7 @@ func NewRouter(
 			// every other request (writes, commands, interactive search, config,
 			// and non-arr services) requires instances:manage. See
 			// auth.RequireArrProxyAccess.
-			r.With(auth.RequireArrProxyAccess).HandleFunc("/instances/{instanceID}/*", proxyHandler.InstanceProxy())
+			r.With(auth.RequireArrProxyAccess(instanceStore)).HandleFunc("/instances/{instanceID}/*", proxyHandler.InstanceProxy())
 		})
 
 		// Download client routes (admin only)
@@ -378,31 +385,67 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 			IsDefault   bool   `json:"is_default"`
 		}
 
-		var instances []instanceInfo
+		// The config payload is per-user: the default instance for a service
+		// type can be overridden per user (admin-managed), and service types
+		// with no global default (chaptarr) are visible only to users an admin
+		// has explicitly granted an instance. Admins see every instance.
+		claims := auth.GetClaims(r.Context())
+		var userID int64
+		isAdmin := false
+		if claims != nil {
+			userID = claims.UserID
+			isAdmin = auth.HasPermission(claims.Role, auth.PermissionInstancesManage)
+		}
+		overrides := map[string]string{}
+		if userID != 0 {
+			if ov, err := store.ListUserDefaults(userID); err == nil {
+				overrides = ov
+			}
+		}
+
+		instances := []instanceInfo{}
 		allInstances, err := store.ListAll()
 		if err == nil {
 			for _, inst := range allInstances {
+				// Access gate for service types without a global default: a
+				// chaptarr instance is visible only to admins or the specific
+				// user granted THAT instance.
+				if inst.ServiceType == "chaptarr" && !isAdmin && overrides["chaptarr"] != inst.ID {
+					continue
+				}
+				// Effective default: a per-user override wins over the global
+				// is_default flag for its service type.
+				isDefault := inst.IsDefault
+				if pinned, ok := overrides[inst.ServiceType]; ok {
+					isDefault = pinned == inst.ID
+				}
 				instances = append(instances, instanceInfo{
 					ID:          inst.ID,
 					ServiceType: inst.ServiceType,
 					Name:        inst.Name,
-					IsDefault:   inst.IsDefault,
+					IsDefault:   isDefault,
 				})
 			}
 		}
-		if instances == nil {
-			instances = []instanceInfo{}
-		}
 
-		// Derive radarr/sonarr availability from instances
-		hasRadarr := false
-		hasSonarr := false
+		// Derive service availability from the per-user filtered instance list,
+		// so a user without a chaptarr grant sees services.chaptarr == false.
+		services := map[string]bool{
+			"radarr":   false,
+			"sonarr":   false,
+			"chaptarr": false,
+			"ai":       creds.IsAIConfigured(),
+			"tmdb":     creds.IsConfigured(credentials.KeyTMDBAccessToken),
+			"trakt":    creds.IsConfigured(credentials.KeyTraktClientID),
+		}
 		for _, inst := range instances {
-			if inst.ServiceType == "radarr" {
-				hasRadarr = true
-			}
-			if inst.ServiceType == "sonarr" {
-				hasSonarr = true
+			switch inst.ServiceType {
+			case "radarr":
+				services["radarr"] = true
+			case "sonarr":
+				services["sonarr"] = true
+			case "chaptarr":
+				services["chaptarr"] = true
 			}
 		}
 
@@ -413,14 +456,8 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"server_name": cfg.ServerName,
-			"services": map[string]bool{
-				"radarr": hasRadarr,
-				"sonarr": hasSonarr,
-				"ai":     creds.IsAIConfigured(),
-				"tmdb":   creds.IsConfigured(credentials.KeyTMDBAccessToken),
-				"trakt":  creds.IsConfigured(credentials.KeyTraktClientID),
-			},
+			"server_name":     cfg.ServerName,
+			"services":        services,
 			"instances":       instances,
 			"issues_enabled":  remSettings.Enabled,
 			"allow_reporting": remSettings.AllowReporting,

--- a/server/internal/auth/arr_proxy.go
+++ b/server/internal/auth/arr_proxy.go
@@ -3,33 +3,45 @@ package auth
 import (
 	"net/http"
 	"strings"
+
+	"github.com/go-chi/chi/v5"
 )
 
-// arrReadResources is the allowlist of Radarr/Sonarr v3 resources a non-admin
-// user may read (GET) through the instance proxy. It is deliberately limited to
-// browsing data and excludes every credential-bearing or privileged endpoint:
-// indexers, download clients, notifications, import lists, and config/host
-// (which carries the instance's own API key) are all absent, as are interactive
-// indexer search ("release") and command endpoints. Those remain admin-only.
+// arrReadResources is the allowlist of Servarr resources a non-admin user may
+// read (GET) through the instance proxy, keyed by the first path segment after
+// the API-version marker ("/api/v3/" for Radarr/Sonarr, "/api/v1/" for
+// Chaptarr). It is deliberately limited to browsing data and excludes every
+// credential-bearing or privileged endpoint: indexers, download clients,
+// notifications, import lists, and config/host (which carries the instance's own
+// API key) are all absent, as are interactive indexer search ("release") and
+// command endpoints. Those remain admin-only.
 var arrReadResources = map[string]bool{
-	"movie":          true, // Radarr: library list, detail, lookup
-	"series":         true, // Sonarr: library list, detail, lookup
-	"episode":        true, // Sonarr: episodes for a series
-	"calendar":       true, // upcoming / aired releases
-	"queue":          true, // active download queue (progress only)
-	"history":        true, // grab / import history
-	"wanted":         true, // wanted/missing, wanted/cutoff
-	"qualityprofile": true, // profile names shown on items
-	"rootfolder":     true, // root folder list
+	"movie":           true, // Radarr: library list, detail, lookup
+	"series":          true, // Sonarr: library list, detail, lookup
+	"episode":         true, // Sonarr: episodes for a series
+	"author":          true, // Chaptarr: library list, detail, lookup
+	"book":            true, // Chaptarr: books for an author, detail, lookup
+	"bookfile":        true, // Chaptarr: imported book files
+	"calendar":        true, // upcoming / aired releases
+	"queue":           true, // active download queue (progress only)
+	"history":         true, // grab / import history
+	"wanted":          true, // wanted/missing, wanted/cutoff
+	"qualityprofile":  true, // profile names shown on items
+	"metadataprofile": true, // Chaptarr: metadata profile names
+	"rootfolder":      true, // root folder list
 }
 
+// arrAPIMarkers are the API-version path segments whose read resources are
+// browsable by non-admins: v3 (Radarr/Sonarr) and v1 (Chaptarr/Readarr).
+var arrAPIMarkers = []string{"/api/v3/", "/api/v1/"}
+
 // isArrReadResource reports whether forwardPath — the portion of an instance
-// proxy request after the "/api/v3/" marker, e.g. "movie/123" or
+// proxy request after the API-version marker, e.g. "movie/123", "author/7", or
 // "wanted/missing" — targets an allowlisted read resource.
 func isArrReadResource(forwardPath string) bool {
 	// Reject path traversal so an allowlisted prefix can't be used to reach a
 	// non-allowlisted endpoint (e.g. "movie/../config/host") once the reverse
-	// proxy forwards the path to Radarr/Sonarr.
+	// proxy forwards the path to the upstream service.
 	if forwardPath == "" || strings.Contains(forwardPath, "..") {
 		return false
 	}
@@ -40,43 +52,78 @@ func isArrReadResource(forwardPath string) bool {
 	return arrReadResources[resource]
 }
 
-// isArrReadPath reports whether urlPath is a Radarr/Sonarr read path. urlPath is
-// the full incoming request path, e.g. "/api/instances/<id>/api/v3/movie".
-// Anything that is not a v3 path (other services proxied through the same route,
-// such as download clients) returns false and therefore requires admin access.
+// isArrReadPath reports whether urlPath is a Servarr read path. urlPath is the
+// full incoming request path, e.g. "/api/instances/<id>/api/v3/movie" or
+// ".../api/v1/author". Anything that is not a recognized arr API path (other
+// services proxied through the same route, such as download clients) returns
+// false and therefore requires admin access.
 func isArrReadPath(urlPath string) bool {
-	const marker = "/api/v3/"
-	i := strings.Index(urlPath, marker)
-	if i < 0 {
-		return false
+	for _, marker := range arrAPIMarkers {
+		if i := strings.Index(urlPath, marker); i >= 0 {
+			return isArrReadResource(urlPath[i+len(marker):])
+		}
 	}
-	return isArrReadResource(urlPath[i+len(marker):])
+	return false
+}
+
+// InstanceAccessChecker resolves an instance's service type and whether a user
+// has been granted access to it. Implemented by *instance.Store; declared as an
+// interface here so the auth package does not import instance (which would form
+// an import cycle).
+type InstanceAccessChecker interface {
+	LookupServiceType(instanceID string) (string, bool, error)
+	UserHasInstanceAccess(userID int64, instanceID string) (bool, error)
 }
 
 // RequireArrProxyAccess authorizes instance-proxy requests. A GET to an
-// allowlisted Radarr/Sonarr read resource requires arr:browse (held by the user
+// allowlisted Servarr read resource requires arr:browse (held by the user
 // role), giving non-admins read-only access to their library, calendar, queue,
 // history, and wanted lists. Every other request — any write, command,
 // interactive search, config endpoint, or non-arr service — requires the
-// admin-level instances:manage. It must run after AuthMiddleware.
-func RequireArrProxyAccess(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		claims := GetClaims(r.Context())
-		if claims == nil {
-			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
-			return
-		}
+// admin-level instances:manage.
+//
+// Service types with no global default (chaptarr) are additionally per-user
+// access-gated: a non-admin may touch a chaptarr instance only if an admin has
+// explicitly granted it to them (a user_default_instances row). The middleware
+// must run after AuthMiddleware and on a route carrying the {instanceID} param.
+func RequireArrProxyAccess(access InstanceAccessChecker) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			claims := GetClaims(r.Context())
+			if claims == nil {
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
 
-		required := PermissionInstancesManage
-		if r.Method == http.MethodGet && isArrReadPath(r.URL.Path) {
-			required = PermissionArrBrowse
-		}
+			isAdmin := HasPermission(claims.Role, PermissionInstancesManage)
 
-		if !HasPermission(claims.Role, required) {
-			http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
-			return
-		}
+			// Per-user access gate for service types without a global default: a
+			// chaptarr instance is reachable by a non-admin only if an admin has
+			// explicitly granted that instance to them. Admins bypass the gate.
+			if !isAdmin {
+				instanceID := chi.URLParam(r, "instanceID")
+				if instanceID != "" {
+					if serviceType, ok, err := access.LookupServiceType(instanceID); err == nil && ok && serviceType == "chaptarr" {
+						granted, err := access.UserHasInstanceAccess(claims.UserID, instanceID)
+						if err != nil || !granted {
+							http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
+							return
+						}
+					}
+				}
+			}
 
-		next.ServeHTTP(w, r)
-	})
+			required := PermissionInstancesManage
+			if r.Method == http.MethodGet && isArrReadPath(r.URL.Path) {
+				required = PermissionArrBrowse
+			}
+
+			if !HasPermission(claims.Role, required) {
+				http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
 }

--- a/server/internal/auth/arr_proxy_test.go
+++ b/server/internal/auth/arr_proxy_test.go
@@ -5,14 +5,31 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
 )
+
+// mockAccess is a stub InstanceAccessChecker for the proxy-gate tests.
+type mockAccess struct {
+	serviceType string
+	exists      bool
+	granted     bool
+}
+
+func (m mockAccess) LookupServiceType(instanceID string) (string, bool, error) {
+	return m.serviceType, m.exists, nil
+}
+
+func (m mockAccess) UserHasInstanceAccess(userID int64, instanceID string) (bool, error) {
+	return m.granted, nil
+}
 
 func TestIsArrReadPath(t *testing.T) {
 	tests := []struct {
 		path string
 		want bool
 	}{
-		// Allowlisted read resources.
+		// Allowlisted Radarr/Sonarr v3 read resources.
 		{"/api/instances/abc/api/v3/movie", true},
 		{"/api/instances/abc/api/v3/movie/123", true},
 		{"/api/instances/abc/api/v3/movie/lookup", true},
@@ -25,7 +42,20 @@ func TestIsArrReadPath(t *testing.T) {
 		{"/api/instances/abc/api/v3/qualityprofile", true},
 		{"/api/instances/abc/api/v3/rootfolder", true},
 
-		// Privileged / credential-bearing — must NOT be user-readable.
+		// Allowlisted Chaptarr v1 read resources.
+		{"/api/instances/abc/api/v1/author", true},
+		{"/api/instances/abc/api/v1/author/7", true},
+		{"/api/instances/abc/api/v1/book/123", true},
+		{"/api/instances/abc/api/v1/book/lookup", true},
+		{"/api/instances/abc/api/v1/bookfile", true},
+		{"/api/instances/abc/api/v1/queue", true},
+		{"/api/instances/abc/api/v1/history", true},
+		{"/api/instances/abc/api/v1/wanted/missing", true},
+		{"/api/instances/abc/api/v1/qualityprofile", true},
+		{"/api/instances/abc/api/v1/metadataprofile", true},
+		{"/api/instances/abc/api/v1/rootfolder", true},
+
+		// Privileged / credential-bearing — must NOT be user-readable (v3 or v1).
 		{"/api/instances/abc/api/v3/config/host", false},
 		{"/api/instances/abc/api/v3/notification", false},
 		{"/api/instances/abc/api/v3/downloadclient", false},
@@ -34,20 +64,33 @@ func TestIsArrReadPath(t *testing.T) {
 		{"/api/instances/abc/api/v3/system/status", false},
 		{"/api/instances/abc/api/v3/command", false},
 		{"/api/instances/abc/api/v3/release", false},
+		{"/api/instances/abc/api/v1/config/host", false},
+		{"/api/instances/abc/api/v1/command", false},
+		{"/api/instances/abc/api/v1/release", false},
 
 		// Path traversal must not escape the allowlist.
 		{"/api/instances/abc/api/v3/movie/../config/host", false},
+		{"/api/instances/abc/api/v1/author/../config/host", false},
 
-		// Non-arr / non-v3 proxy paths (e.g. download clients) are not reads.
+		// Non-arr proxy paths (e.g. download clients) are not reads.
 		{"/api/instances/abc/api/v2/torrents/info", false},
 		{"/api/instances/abc/", false},
 		{"/api/instances/abc/api/v3/", false},
+		{"/api/instances/abc/api/v1/", false},
 	}
 	for _, tt := range tests {
 		if got := isArrReadPath(tt.path); got != tt.want {
 			t.Errorf("isArrReadPath(%q) = %v, want %v", tt.path, got, tt.want)
 		}
 	}
+}
+
+// withRouteContext attaches a chi route context carrying the {instanceID} URL
+// param, as the real router would, so the middleware can resolve the instance.
+func withRouteContext(req *http.Request, instanceID string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("instanceID", instanceID)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
 func TestRequireArrProxyAccess(t *testing.T) {
@@ -70,16 +113,62 @@ func TestRequireArrProxyAccess(t *testing.T) {
 		{"admin adds movie", RoleAdmin, http.MethodPost, "/api/instances/abc/api/v3/movie", http.StatusOK},
 	}
 
+	// For radarr/sonarr the access checker reports a non-gated service type, so
+	// only the resource/permission rules apply.
+	access := mockAccess{serviceType: "sonarr", exists: true}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nextCalled := false
-			h := RequireArrProxyAccess(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := RequireArrProxyAccess(access)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				nextCalled = true
 				w.WriteHeader(http.StatusOK)
 			}))
 
-			req := httptest.NewRequest(tt.method, tt.path, nil)
-			req = req.WithContext(context.WithValue(req.Context(), ClaimsKey, &Claims{Role: tt.role}))
+			req := withRouteContext(httptest.NewRequest(tt.method, tt.path, nil), "abc")
+			req = req.WithContext(context.WithValue(req.Context(), ClaimsKey, &Claims{Role: tt.role, UserID: 1}))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Fatalf("status = %d, want %d", rec.Code, tt.want)
+			}
+			if wantNext := tt.want == http.StatusOK; nextCalled != wantNext {
+				t.Fatalf("nextCalled = %v, want %v", nextCalled, wantNext)
+			}
+		})
+	}
+}
+
+// TestRequireArrProxyAccess_ChaptarrGate verifies the per-user access grant for
+// chaptarr, which has no global default: a non-admin needs an explicit grant to
+// touch the instance at all, admins bypass the grant, and even a granted
+// non-admin still cannot perform writes (those require instances:manage).
+func TestRequireArrProxyAccess_ChaptarrGate(t *testing.T) {
+	tests := []struct {
+		name    string
+		role    string
+		method  string
+		path    string
+		granted bool
+		want    int
+	}{
+		{"granted user reads chaptarr", RoleUser, http.MethodGet, "/api/instances/chaptarr-1/api/v1/author", true, http.StatusOK},
+		{"non-granted user blocked", RoleUser, http.MethodGet, "/api/instances/chaptarr-1/api/v1/author", false, http.StatusForbidden},
+		{"granted user cannot write", RoleUser, http.MethodPost, "/api/instances/chaptarr-1/api/v1/release", true, http.StatusForbidden},
+		{"admin reads without grant", RoleAdmin, http.MethodGet, "/api/instances/chaptarr-1/api/v1/author", false, http.StatusOK},
+		{"admin writes without grant", RoleAdmin, http.MethodPost, "/api/instances/chaptarr-1/api/v1/release", false, http.StatusOK},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			access := mockAccess{serviceType: "chaptarr", exists: true, granted: tt.granted}
+			nextCalled := false
+			h := RequireArrProxyAccess(access)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := withRouteContext(httptest.NewRequest(tt.method, tt.path, nil), "chaptarr-1")
+			req = req.WithContext(context.WithValue(req.Context(), ClaimsKey, &Claims{Role: tt.role, UserID: 7}))
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 
@@ -94,10 +183,10 @@ func TestRequireArrProxyAccess(t *testing.T) {
 }
 
 func TestRequireArrProxyAccess_RequiresClaims(t *testing.T) {
-	h := RequireArrProxyAccess(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := RequireArrProxyAccess(mockAccess{})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("handler should not run without claims")
 	}))
-	req := httptest.NewRequest(http.MethodGet, "/api/instances/abc/api/v3/movie", nil)
+	req := withRouteContext(httptest.NewRequest(http.MethodGet, "/api/instances/abc/api/v3/movie", nil), "abc")
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 	if rec.Code != http.StatusUnauthorized {

--- a/server/internal/chaptarr/client.go
+++ b/server/internal/chaptarr/client.go
@@ -1,0 +1,800 @@
+// Package chaptarr is a typed HTTP client for a Chaptarr server, a Readarr fork
+// that manages books as both ebooks and audiobooks. It speaks the Servarr
+// /api/v1 API and is a structural mirror of the Sonarr client, translating the
+// series>season>episode model to Readarr's author>book>edition>bookFile model.
+package chaptarr
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+func NewClient(baseURL, apiKey string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// Image is a cover/poster reference returned on authors, books, and editions.
+type Image struct {
+	CoverType string `json:"coverType"`
+	URL       string `json:"url"`
+	RemoteURL string `json:"remoteUrl"`
+}
+
+// AuthorStatistics is the per-author book rollup Chaptarr returns on an author.
+type AuthorStatistics struct {
+	BookCount          int     `json:"bookCount"`
+	BookFileCount      int     `json:"bookFileCount"`
+	AvailableBookCount int     `json:"availableBookCount"`
+	TotalBookCount     int     `json:"totalBookCount"`
+	SizeOnDisk         int64   `json:"sizeOnDisk"`
+	PercentOfBooks     float64 `json:"percentOfBooks"`
+}
+
+type Author struct {
+	ID                int              `json:"id"`
+	AuthorName        string           `json:"authorName"`
+	ForeignAuthorID   string           `json:"foreignAuthorId"`
+	TitleSlug         string           `json:"titleSlug"`
+	Overview          string           `json:"overview"`
+	Status            string           `json:"status"`
+	Monitored         bool             `json:"monitored"`
+	Path              string           `json:"path,omitempty"`
+	QualityProfileID  int              `json:"qualityProfileId"`
+	MetadataProfileID int              `json:"metadataProfileId"`
+	Statistics        AuthorStatistics `json:"statistics"`
+	Images            []Image          `json:"images"`
+	Genres            []string         `json:"genres"`
+}
+
+// BookStatistics is the per-book file rollup Chaptarr returns on a book.
+type BookStatistics struct {
+	BookFileCount  int     `json:"bookFileCount"`
+	BookCount      int     `json:"bookCount"`
+	SizeOnDisk     int64   `json:"sizeOnDisk"`
+	PercentOfBooks float64 `json:"percentOfBooks"`
+}
+
+// Edition is one published edition of a book (a specific format/ISBN). Chaptarr
+// models ebooks and audiobooks as distinct editions of the same book.
+type Edition struct {
+	ID        int     `json:"id"`
+	BookID    int     `json:"bookId"`
+	Title     string  `json:"title"`
+	Format    string  `json:"format"`
+	ASIN      string  `json:"asin"`
+	ISBN13    string  `json:"isbn13"`
+	Overview  string  `json:"overview"`
+	Publisher string  `json:"publisher"`
+	PageCount int     `json:"pageCount"`
+	Monitored bool    `json:"monitored"`
+	ManualAdd bool    `json:"manualAdd"`
+	IsEbook   bool    `json:"isEbook"`
+	Images    []Image `json:"images"`
+}
+
+type Book struct {
+	ID            int            `json:"id"`
+	Title         string         `json:"title"`
+	AuthorID      int            `json:"authorId"`
+	ForeignBookID string         `json:"foreignBookId"`
+	TitleSlug     string         `json:"titleSlug"`
+	Overview      string         `json:"overview"`
+	ReleaseDate   *time.Time     `json:"releaseDate,omitempty"`
+	Monitored     bool           `json:"monitored"`
+	AnyEditionOk  bool           `json:"anyEditionOk"`
+	PageCount     int            `json:"pageCount"`
+	Author        *AuthorContext `json:"author,omitempty"`
+	Statistics    BookStatistics `json:"statistics"`
+	Editions      []Edition      `json:"editions"`
+	Images        []Image        `json:"images"`
+	Genres        []string       `json:"genres"`
+}
+
+type BookFile struct {
+	ID            int             `json:"id"`
+	AuthorID      int             `json:"authorId"`
+	BookID        int             `json:"bookId"`
+	EditionID     int             `json:"editionId"`
+	Path          string          `json:"path"`
+	Size          int64           `json:"size"`
+	DateAdded     *time.Time      `json:"dateAdded,omitempty"`
+	Quality       json.RawMessage `json:"quality"`
+	MediaInfo     json.RawMessage `json:"mediaInfo"`
+	QualityWeight int             `json:"qualityWeight"`
+}
+
+type QualityProfile struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type MetadataProfile struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type RootFolder struct {
+	ID         int    `json:"id"`
+	Path       string `json:"path"`
+	FreeSpace  int64  `json:"freeSpace"`
+	Accessible bool   `json:"accessible"`
+}
+
+// LookupResult is one entry from author/lookup or book/lookup. It carries the
+// fields needed to render a lookup row and seed an add: identifiers, a cover,
+// and (for book lookups) the nested author the book belongs to.
+type LookupResult struct {
+	Title           string  `json:"title"`
+	AuthorName      string  `json:"authorName"`
+	ForeignAuthorID string  `json:"foreignAuthorId"`
+	ForeignBookID   string  `json:"foreignBookId"`
+	Overview        string  `json:"overview"`
+	Year            int     `json:"year"`
+	Images          []Image `json:"images"`
+	Author          *Author `json:"author,omitempty"`
+	RemoteCover     string  `json:"remoteCover,omitempty"`
+}
+
+// AddAuthorRequest mirrors Sonarr's AddSeriesRequest shape for adding an author
+// to the Chaptarr library.
+type AddAuthorRequest struct {
+	AuthorName        string `json:"authorName"`
+	ForeignAuthorID   string `json:"foreignAuthorId"`
+	QualityProfileID  int    `json:"qualityProfileId"`
+	MetadataProfileID int    `json:"metadataProfileId"`
+	RootFolderPath    string `json:"rootFolderPath"`
+	Monitored         bool   `json:"monitored"`
+	AddOptions        struct {
+		// Monitor is Chaptarr's monitor scope applied at add time: one of
+		// all/future/missing/existing/none. Empty means Chaptarr's default.
+		Monitor               string `json:"monitor,omitempty"`
+		SearchForMissingBooks bool   `json:"searchForMissingBooks"`
+	} `json:"addOptions"`
+}
+
+// AddBookRequest adds a single book. Readarr nests the author inside the
+// book-add payload, so an author ref is required for authors not yet tracked.
+type AddBookRequest struct {
+	ForeignBookID string           `json:"foreignBookId"`
+	Monitored     bool             `json:"monitored"`
+	Author        AddAuthorRequest `json:"author"`
+	AddOptions    struct {
+		SearchForNewBook bool `json:"searchForNewBook"`
+	} `json:"addOptions"`
+	Editions []Edition `json:"editions,omitempty"`
+}
+
+// AuthorContext is the lean author object embedded in queue/history/book records.
+type AuthorContext struct {
+	ID              int    `json:"id"`
+	AuthorName      string `json:"authorName"`
+	ForeignAuthorID string `json:"foreignAuthorId"`
+}
+
+// BookContext is the lean book object embedded in queue/history records.
+type BookContext struct {
+	ID          int        `json:"id"`
+	Title       string     `json:"title"`
+	ReleaseDate *time.Time `json:"releaseDate,omitempty"`
+}
+
+// StatusMessage is one grouped warning/error Chaptarr attaches to a queue item.
+type StatusMessage struct {
+	Title    string   `json:"title"`
+	Messages []string `json:"messages"`
+}
+
+type QueueItem struct {
+	ID                    int             `json:"id"`
+	AuthorID              int             `json:"authorId"`
+	BookID                int             `json:"bookId"`
+	Title                 string          `json:"title"`
+	Status                string          `json:"status"`
+	TrackedDownloadStatus string          `json:"trackedDownloadStatus"`
+	TrackedDownloadState  string          `json:"trackedDownloadState"`
+	Timeleft              string          `json:"timeleft"`
+	Size                  float64         `json:"size"`
+	Sizeleft              float64         `json:"sizeleft"`
+	DownloadClient        string          `json:"downloadClient"`
+	DownloadID            string          `json:"downloadId"`
+	Indexer               string          `json:"indexer"`
+	Protocol              string          `json:"protocol"`
+	ErrorMessage          string          `json:"errorMessage"`
+	StatusMessages        []StatusMessage `json:"statusMessages"`
+	Author                *AuthorContext  `json:"author,omitempty"`
+	Book                  *BookContext    `json:"book,omitempty"`
+}
+
+// DetailedQueueItem is the queue record with author and book context. Chaptarr
+// returns the same shape as QueueItem; the alias keeps callers symmetric with
+// the Sonarr/Radarr clients, which distinguish a leaner queue view.
+type DetailedQueueItem = QueueItem
+
+type HistoryRecord struct {
+	ID          int               `json:"id"`
+	EventType   string            `json:"eventType"`
+	SourceTitle string            `json:"sourceTitle"`
+	Date        *time.Time        `json:"date,omitempty"`
+	Quality     json.RawMessage   `json:"quality"`
+	AuthorID    int               `json:"authorId"`
+	BookID      int               `json:"bookId"`
+	Author      *AuthorContext    `json:"author,omitempty"`
+	Book        *BookContext      `json:"book,omitempty"`
+	Data        map[string]string `json:"data,omitempty"`
+}
+
+type HistoryPage struct {
+	Page         int             `json:"page"`
+	PageSize     int             `json:"pageSize"`
+	TotalRecords int             `json:"totalRecords"`
+	Records      []HistoryRecord `json:"records"`
+}
+
+type WantedRecord struct {
+	ID          int            `json:"id"`
+	AuthorID    int            `json:"authorId"`
+	BookID      int            `json:"bookId"`
+	Title       string         `json:"title"`
+	ReleaseDate *time.Time     `json:"releaseDate,omitempty"`
+	Monitored   bool           `json:"monitored"`
+	Author      *AuthorContext `json:"author,omitempty"`
+}
+
+type WantedPage struct {
+	Page         int            `json:"page"`
+	PageSize     int            `json:"pageSize"`
+	TotalRecords int            `json:"totalRecords"`
+	Records      []WantedRecord `json:"records"`
+}
+
+type Release struct {
+	GUID       string          `json:"guid"`
+	IndexerID  int             `json:"indexerId"`
+	Indexer    string          `json:"indexer"`
+	Title      string          `json:"title"`
+	Size       int64           `json:"size"`
+	Seeders    *int            `json:"seeders"`
+	Leechers   *int            `json:"leechers"`
+	Protocol   string          `json:"protocol"`
+	AgeHours   float64         `json:"ageHours"`
+	Quality    json.RawMessage `json:"quality"`
+	Rejected   bool            `json:"rejected"`
+	Rejections []string        `json:"rejections"`
+}
+
+type DiskSpace struct {
+	Path       string `json:"path"`
+	Label      string `json:"label"`
+	FreeSpace  int64  `json:"freeSpace"`
+	TotalSpace int64  `json:"totalSpace"`
+}
+
+// HealthCheck is one entry from Chaptarr's system health report: a config-level
+// problem (download client unreachable, remote path mapping, indexers down, no
+// root folder, low disk, etc.). Type is one of ok/notice/warning/error.
+type HealthCheck struct {
+	Source  string `json:"source"`
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	WikiURL string `json:"wikiUrl"`
+}
+
+// ManualImportRejection is a single reason Chaptarr would not auto-import a
+// file, plus whether the rejection is permanent (a force import will likely
+// still fail) or temporary.
+type ManualImportRejection struct {
+	Reason string `json:"reason"`
+	Type   string `json:"type"`
+}
+
+// ManualImportCandidate is a file Chaptarr found for a download, as returned by
+// GET /manualimport. Quality is kept as raw JSON so it can be round-tripped
+// verbatim back into the ManualImport command (modeling and re-serializing it
+// risks losing fields Chaptarr requires).
+type ManualImportCandidate struct {
+	ID           int                     `json:"id"`
+	Path         string                  `json:"path"`
+	FolderName   string                  `json:"folderName"`
+	Name         string                  `json:"name"`
+	Size         int64                   `json:"size"`
+	AuthorID     int                     `json:"-"`
+	BookID       int                     `json:"-"`
+	Quality      json.RawMessage         `json:"quality"`
+	ReleaseGroup string                  `json:"releaseGroup"`
+	DownloadID   string                  `json:"downloadId"`
+	Rejections   []ManualImportRejection `json:"rejections"`
+}
+
+// UnmarshalJSON decodes a manual-import candidate, lifting the nested author id
+// (Chaptarr nests it under "author": {"id": ...}) into AuthorID and the book id
+// (nested under "book": {"id": ...}, else top-level "bookId") into BookID.
+func (m *ManualImportCandidate) UnmarshalJSON(data []byte) error {
+	type alias ManualImportCandidate
+	aux := struct {
+		*alias
+		Author *struct {
+			ID int `json:"id"`
+		} `json:"author"`
+		Book *struct {
+			ID int `json:"id"`
+		} `json:"book"`
+		BookID int `json:"bookId"`
+	}{alias: (*alias)(m)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.Author != nil {
+		m.AuthorID = aux.Author.ID
+	}
+	if aux.Book != nil {
+		m.BookID = aux.Book.ID
+	} else {
+		m.BookID = aux.BookID
+	}
+	return nil
+}
+
+// ManualImportFile is one file to import via the ManualImport command. Quality
+// is passed back verbatim from the candidate. AuthorID and BookID must be set
+// for Chaptarr or the file is silently skipped.
+type ManualImportFile struct {
+	Path         string          `json:"path"`
+	FolderName   string          `json:"folderName,omitempty"`
+	AuthorID     int             `json:"authorId"`
+	BookID       int             `json:"bookId"`
+	Quality      json.RawMessage `json:"quality,omitempty"`
+	ReleaseGroup string          `json:"releaseGroup,omitempty"`
+	DownloadID   string          `json:"downloadId,omitempty"`
+}
+
+// do executes a request with an optional JSON body, fails on non-2xx status
+// (including a snippet of the response body), and decodes JSON into out when
+// out is non-nil.
+func (c *Client) do(method, path string, body, out any) error {
+	return c.doWith(c.httpClient, method, path, body, out)
+}
+
+func (c *Client) doWith(client *http.Client, method, path string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request body: %w", err)
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequest(method, c.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Api-Key", c.apiKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("chaptarr %s %s returned status %d: %s",
+			method, strings.SplitN(path, "?", 2)[0], resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c *Client) doRequest(method, path string) (*http.Response, error) {
+	req, err := http.NewRequest(method, c.baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Api-Key", c.apiKey)
+	return c.httpClient.Do(req)
+}
+
+// LookupAuthor searches Chaptarr's metadata for authors matching term.
+func (c *Client) LookupAuthor(term string) ([]LookupResult, error) {
+	resp, err := c.doRequest("GET", "/api/v1/author/lookup?term="+url.QueryEscape(term))
+	if err != nil {
+		return nil, fmt.Errorf("chaptarr author lookup: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var results []LookupResult
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		return nil, fmt.Errorf("decode chaptarr author lookup: %w", err)
+	}
+	return results, nil
+}
+
+// LookupBook searches Chaptarr's metadata for books matching term.
+func (c *Client) LookupBook(term string) ([]LookupResult, error) {
+	resp, err := c.doRequest("GET", "/api/v1/book/lookup?term="+url.QueryEscape(term))
+	if err != nil {
+		return nil, fmt.Errorf("chaptarr book lookup: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var results []LookupResult
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
+		return nil, fmt.Errorf("decode chaptarr book lookup: %w", err)
+	}
+	return results, nil
+}
+
+// GetAllAuthors lists every author in the Chaptarr library.
+func (c *Client) GetAllAuthors() ([]Author, error) {
+	var authors []Author
+	if err := c.do("GET", "/api/v1/author", nil, &authors); err != nil {
+		return nil, fmt.Errorf("chaptarr author list: %w", err)
+	}
+	return authors, nil
+}
+
+// GetAuthor returns a single author by id.
+func (c *Client) GetAuthor(id int) (*Author, error) {
+	resp, err := c.doRequest("GET", fmt.Sprintf("/api/v1/author/%d", id))
+	if err != nil {
+		return nil, fmt.Errorf("chaptarr get author: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var author Author
+	if err := json.NewDecoder(resp.Body).Decode(&author); err != nil {
+		return nil, fmt.Errorf("decode chaptarr author: %w", err)
+	}
+	return &author, nil
+}
+
+// GetBooks lists the books of one author.
+func (c *Client) GetBooks(authorID int) ([]Book, error) {
+	var books []Book
+	path := fmt.Sprintf("/api/v1/book?authorId=%d", authorID)
+	if err := c.do("GET", path, nil, &books); err != nil {
+		return nil, fmt.Errorf("chaptarr books: %w", err)
+	}
+	return books, nil
+}
+
+// GetBook returns a single book by id.
+func (c *Client) GetBook(id int) (*Book, error) {
+	resp, err := c.doRequest("GET", fmt.Sprintf("/api/v1/book/%d", id))
+	if err != nil {
+		return nil, fmt.Errorf("chaptarr get book: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var book Book
+	if err := json.NewDecoder(resp.Body).Decode(&book); err != nil {
+		return nil, fmt.Errorf("decode chaptarr book: %w", err)
+	}
+	return &book, nil
+}
+
+// GetBookFiles lists the book files on disk for one author.
+func (c *Client) GetBookFiles(authorID int) ([]BookFile, error) {
+	var files []BookFile
+	path := fmt.Sprintf("/api/v1/bookfile?authorId=%d", authorID)
+	if err := c.do("GET", path, nil, &files); err != nil {
+		return nil, fmt.Errorf("chaptarr book files: %w", err)
+	}
+	return files, nil
+}
+
+func (c *Client) GetQualityProfiles() ([]QualityProfile, error) {
+	resp, err := c.doRequest("GET", "/api/v1/qualityprofile")
+	if err != nil {
+		return nil, fmt.Errorf("chaptarr quality profiles: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var profiles []QualityProfile
+	if err := json.NewDecoder(resp.Body).Decode(&profiles); err != nil {
+		return nil, fmt.Errorf("decode quality profiles: %w", err)
+	}
+	return profiles, nil
+}
+
+func (c *Client) GetMetadataProfiles() ([]MetadataProfile, error) {
+	resp, err := c.doRequest("GET", "/api/v1/metadataprofile")
+	if err != nil {
+		return nil, fmt.Errorf("chaptarr metadata profiles: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var profiles []MetadataProfile
+	if err := json.NewDecoder(resp.Body).Decode(&profiles); err != nil {
+		return nil, fmt.Errorf("decode metadata profiles: %w", err)
+	}
+	return profiles, nil
+}
+
+func (c *Client) GetRootFolders() ([]RootFolder, error) {
+	resp, err := c.doRequest("GET", "/api/v1/rootfolder")
+	if err != nil {
+		return nil, fmt.Errorf("chaptarr root folders: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var folders []RootFolder
+	if err := json.NewDecoder(resp.Body).Decode(&folders); err != nil {
+		return nil, fmt.Errorf("decode root folders: %w", err)
+	}
+	return folders, nil
+}
+
+// AddAuthor adds an author to the Chaptarr library.
+func (c *Client) AddAuthor(req AddAuthorRequest) (*Author, error) {
+	var author Author
+	if err := c.do("POST", "/api/v1/author", req, &author); err != nil {
+		return nil, fmt.Errorf("chaptarr add author: %w", err)
+	}
+	return &author, nil
+}
+
+// AddBook adds a single book (and, if needed, its author) to the library.
+func (c *Client) AddBook(req AddBookRequest) (*Book, error) {
+	var book Book
+	if err := c.do("POST", "/api/v1/book", req, &book); err != nil {
+		return nil, fmt.Errorf("chaptarr add book: %w", err)
+	}
+	return &book, nil
+}
+
+// SetBookMonitored toggles monitoring for the given books.
+func (c *Client) SetBookMonitored(bookIDs []int, monitored bool) error {
+	body := map[string]any{"bookIds": bookIDs, "monitored": monitored}
+	if err := c.do("POST", "/api/v1/book/monitor", body, nil); err != nil {
+		return fmt.Errorf("chaptarr set book monitored: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) GetQueue() ([]QueueItem, error) {
+	resp, err := c.doRequest("GET", "/api/v1/queue?includeAuthor=true&includeBook=true")
+	if err != nil {
+		return nil, fmt.Errorf("chaptarr queue: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var queueResp struct {
+		Records []QueueItem `json:"records"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&queueResp); err != nil {
+		return nil, fmt.Errorf("decode queue: %w", err)
+	}
+	return queueResp.Records, nil
+}
+
+// queueMaxRecords is a safety cap on the total queue records accumulated across
+// pages of GetQueueDetailed.
+const queueMaxRecords = 1000
+
+// GetQueueDetailed returns the download queue with author and book context,
+// paginating from page until all records are fetched (capped at
+// queueMaxRecords).
+func (c *Client) GetQueueDetailed(page, pageSize int) ([]DetailedQueueItem, error) {
+	var all []DetailedQueueItem
+	for ; ; page++ {
+		var resp struct {
+			TotalRecords int                 `json:"totalRecords"`
+			Records      []DetailedQueueItem `json:"records"`
+		}
+		path := fmt.Sprintf("/api/v1/queue?page=%d&pageSize=%d&includeAuthor=true&includeBook=true", page, pageSize)
+		if err := c.do("GET", path, nil, &resp); err != nil {
+			return nil, fmt.Errorf("chaptarr queue: %w", err)
+		}
+		all = append(all, resp.Records...)
+		if len(resp.Records) == 0 || len(all) >= resp.TotalRecords || len(all) >= queueMaxRecords {
+			break
+		}
+	}
+	if len(all) > queueMaxRecords {
+		all = all[:queueMaxRecords]
+	}
+	return all, nil
+}
+
+// RemoveQueueItem removes an item from the download queue. removeFromClient
+// also deletes the download from the client; blocklist prevents the release
+// from being grabbed again; skipRedownload suppresses the automatic re-search
+// that a blocklist would otherwise trigger; changeCategory hands the download
+// to the client's post-import category instead of removing it.
+func (c *Client) RemoveQueueItem(id int, removeFromClient, blocklist, skipRedownload, changeCategory bool) error {
+	path := fmt.Sprintf("/api/v1/queue/%d?removeFromClient=%t&blocklist=%t&skipRedownload=%t&changeCategory=%t",
+		id, removeFromClient, blocklist, skipRedownload, changeCategory)
+	if err := c.do("DELETE", path, nil, nil); err != nil {
+		return fmt.Errorf("chaptarr remove queue item: %w", err)
+	}
+	return nil
+}
+
+// GetHistory returns a page of history records (grabs, imports, failures),
+// most recent first.
+func (c *Client) GetHistory(page, pageSize int) (*HistoryPage, error) {
+	var hp HistoryPage
+	path := fmt.Sprintf("/api/v1/history?page=%d&pageSize=%d&sortKey=date&sortDirection=descending", page, pageSize)
+	if err := c.do("GET", path, nil, &hp); err != nil {
+		return nil, fmt.Errorf("chaptarr history: %w", err)
+	}
+	return &hp, nil
+}
+
+// GetWantedMissing returns a page of monitored books with no file.
+func (c *Client) GetWantedMissing(page, pageSize int) (*WantedPage, error) {
+	var wp WantedPage
+	path := fmt.Sprintf("/api/v1/wanted/missing?page=%d&pageSize=%d&sortKey=releaseDate&sortDirection=descending&includeAuthor=true", page, pageSize)
+	if err := c.do("GET", path, nil, &wp); err != nil {
+		return nil, fmt.Errorf("chaptarr wanted missing: %w", err)
+	}
+	return &wp, nil
+}
+
+// GetWantedCutoff returns a page of monitored books whose file is below the
+// quality cutoff.
+func (c *Client) GetWantedCutoff(page, pageSize int) (*WantedPage, error) {
+	var wp WantedPage
+	path := fmt.Sprintf("/api/v1/wanted/cutoff?page=%d&pageSize=%d&sortKey=releaseDate&sortDirection=descending&includeAuthor=true", page, pageSize)
+	if err := c.do("GET", path, nil, &wp); err != nil {
+		return nil, fmt.Errorf("chaptarr wanted cutoff: %w", err)
+	}
+	return &wp, nil
+}
+
+// releaseSearchClient allows the much longer round-trips of interactive
+// release searches, which query every configured indexer.
+func releaseSearchClient() *http.Client {
+	return &http.Client{Timeout: 120 * time.Second}
+}
+
+// SearchReleases runs an interactive release search for a book.
+func (c *Client) SearchReleases(bookID int) ([]Release, error) {
+	var releases []Release
+	path := fmt.Sprintf("/api/v1/release?bookId=%d", bookID)
+	if err := c.doWith(releaseSearchClient(), "GET", path, nil, &releases); err != nil {
+		return nil, fmt.Errorf("chaptarr release search: %w", err)
+	}
+	return releases, nil
+}
+
+// GrabRelease tells Chaptarr to send a previously searched release to the
+// download client.
+func (c *Client) GrabRelease(guid string, indexerID int) error {
+	body := map[string]any{"guid": guid, "indexerId": indexerID}
+	if err := c.do("POST", "/api/v1/release", body, nil); err != nil {
+		return fmt.Errorf("chaptarr grab release: %w", err)
+	}
+	return nil
+}
+
+// triggerCommand posts a command payload to Chaptarr's command endpoint.
+func (c *Client) triggerCommand(payload map[string]any) error {
+	if err := c.do("POST", "/api/v1/command", payload, nil); err != nil {
+		return fmt.Errorf("chaptarr command: %w", err)
+	}
+	return nil
+}
+
+// TriggerAuthorSearch starts an automatic search for all monitored books of an
+// author.
+func (c *Client) TriggerAuthorSearch(authorID int) error {
+	return c.triggerCommand(map[string]any{"name": "AuthorSearch", "authorId": authorID})
+}
+
+// TriggerBookSearch starts an automatic search for specific books.
+func (c *Client) TriggerBookSearch(bookIDs []int) error {
+	return c.triggerCommand(map[string]any{"name": "BookSearch", "bookIds": bookIDs})
+}
+
+// TriggerMissingBookSearch starts a search for all monitored, missing books.
+func (c *Client) TriggerMissingBookSearch() error {
+	return c.triggerCommand(map[string]any{"name": "MissingBookSearch"})
+}
+
+// TriggerRefreshAuthor refreshes metadata and rescans files for an author.
+func (c *Client) TriggerRefreshAuthor(authorID int) error {
+	return c.triggerCommand(map[string]any{"name": "RefreshAuthor", "authorId": authorID})
+}
+
+// ProcessMonitoredDownloads asks Chaptarr to run its import pass over the
+// download client now (the pass that normally runs on a timer).
+func (c *Client) ProcessMonitoredDownloads() error {
+	return c.triggerCommand(map[string]any{"name": "ProcessMonitoredDownloads"})
+}
+
+// RescanAuthor rescans the files on disk for an author.
+func (c *Client) RescanAuthor(authorID int) error {
+	return c.triggerCommand(map[string]any{"name": "RescanFolders", "authorId": authorID})
+}
+
+// GetDiskSpace reports disk usage for Chaptarr's mounted volumes.
+func (c *Client) GetDiskSpace() ([]DiskSpace, error) {
+	var disks []DiskSpace
+	if err := c.do("GET", "/api/v1/diskspace", nil, &disks); err != nil {
+		return nil, fmt.Errorf("chaptarr diskspace: %w", err)
+	}
+	return disks, nil
+}
+
+// GetHealth returns Chaptarr's current system health checks. These surface
+// config-level root causes (download client down, remote path mapping wrong,
+// indexers unavailable) that per-item queue diagnosis can only guess at.
+func (c *Client) GetHealth() ([]HealthCheck, error) {
+	var checks []HealthCheck
+	if err := c.do("GET", "/api/v1/health", nil, &checks); err != nil {
+		return nil, fmt.Errorf("chaptarr health: %w", err)
+	}
+	return checks, nil
+}
+
+// GetManualImportCandidates lists the files Chaptarr found for a download,
+// including any rejection reasons, without importing existing files.
+func (c *Client) GetManualImportCandidates(downloadID string) ([]ManualImportCandidate, error) {
+	var candidates []ManualImportCandidate
+	path := fmt.Sprintf("/api/v1/manualimport?downloadId=%s&filterExistingFiles=false", url.QueryEscape(downloadID))
+	if err := c.doWith(releaseSearchClient(), "GET", path, nil, &candidates); err != nil {
+		return nil, fmt.Errorf("chaptarr manual import candidates: %w", err)
+	}
+	return candidates, nil
+}
+
+// ExecuteManualImport tells Chaptarr to import the given files. importMode must
+// be lowercase (move/copy/auto); the PascalCase form is silently ignored by the
+// ManualImport command.
+func (c *Client) ExecuteManualImport(files []ManualImportFile) error {
+	payload := map[string]any{
+		"name":       "ManualImport",
+		"importMode": "auto",
+		"files":      files,
+	}
+	return c.triggerCommand(payload)
+}
+
+// ebookTokens and audiobookTokens are uppercase substrings matched against a
+// quality name to classify a book file's format.
+var (
+	ebookTokens     = []string{"EPUB", "MOBI", "AZW3", "AZW", "PDF", "CBZ", "CBR", "KEPUB"}
+	audiobookTokens = []string{"MP3", "M4B", "M4A", "FLAC", "AAC", "OGG", "OPUS", "AUDIOBOOK", "AUDIO"}
+)
+
+// FormatOf classifies a Chaptarr quality name as "ebook", "audiobook", or
+// "unknown" via a case-insensitive substring match. Ebook tokens are checked
+// first so an ambiguous name leans toward the text format.
+func FormatOf(qualityName string) string {
+	upper := strings.ToUpper(qualityName)
+	for _, tok := range ebookTokens {
+		if strings.Contains(upper, tok) {
+			return "ebook"
+		}
+	}
+	for _, tok := range audiobookTokens {
+		if strings.Contains(upper, tok) {
+			return "audiobook"
+		}
+	}
+	return "unknown"
+}

--- a/server/internal/chaptarr/client_test.go
+++ b/server/internal/chaptarr/client_test.go
@@ -1,0 +1,167 @@
+package chaptarr
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+// TestSetBookMonitored asserts SetBookMonitored posts the {bookIds, monitored}
+// body Chaptarr's book/monitor endpoint expects.
+func TestSetBookMonitored(t *testing.T) {
+	var gotPath, gotMethod string
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		data, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(data, &body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "key")
+	if err := c.SetBookMonitored([]int{7, 9, 11}, true); err != nil {
+		t.Fatalf("SetBookMonitored: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %s, want POST", gotMethod)
+	}
+	if gotPath != "/api/v1/book/monitor" {
+		t.Errorf("path = %s, want /api/v1/book/monitor", gotPath)
+	}
+	if body["monitored"] != true {
+		t.Errorf("monitored = %v, want true", body["monitored"])
+	}
+	ids, ok := body["bookIds"].([]any)
+	if !ok || len(ids) != 3 {
+		t.Fatalf("bookIds = %v, want 3 entries", body["bookIds"])
+	}
+	want := []int{7, 9, 11}
+	for i, v := range ids {
+		if int(v.(float64)) != want[i] {
+			t.Errorf("bookIds[%d] = %v, want %d", i, v, want[i])
+		}
+	}
+}
+
+// TestExecuteManualImport asserts ExecuteManualImport posts a ManualImport
+// command with a lowercase importMode and a files array whose bookId is set and
+// whose Quality is preserved verbatim.
+func TestExecuteManualImport(t *testing.T) {
+	var gotPath string
+	var body map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		data, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(data, &body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	quality := json.RawMessage(`{"quality":{"id":3,"name":"EPUB"},"revision":{"version":1}}`)
+	files := []ManualImportFile{{
+		Path:     "/downloads/book.epub",
+		AuthorID: 4,
+		BookID:   42,
+		Quality:  quality,
+	}}
+
+	c := NewClient(srv.URL, "key")
+	if err := c.ExecuteManualImport(files); err != nil {
+		t.Fatalf("ExecuteManualImport: %v", err)
+	}
+
+	if gotPath != "/api/v1/command" {
+		t.Errorf("path = %s, want /api/v1/command", gotPath)
+	}
+	if body["name"] != "ManualImport" {
+		t.Errorf("name = %v, want ManualImport", body["name"])
+	}
+	if body["importMode"] != "auto" {
+		t.Errorf("importMode = %v, want lowercase \"auto\"", body["importMode"])
+	}
+
+	gotFiles, ok := body["files"].([]any)
+	if !ok || len(gotFiles) != 1 {
+		t.Fatalf("files = %v, want a single-element array", body["files"])
+	}
+	file0 := gotFiles[0].(map[string]any)
+	if int(file0["bookId"].(float64)) != 42 {
+		t.Errorf("files[0].bookId = %v, want 42", file0["bookId"])
+	}
+	if int(file0["authorId"].(float64)) != 4 {
+		t.Errorf("files[0].authorId = %v, want 4", file0["authorId"])
+	}
+	// Quality must round-trip verbatim: the nested name survives re-marshaling.
+	q, ok := file0["quality"].(map[string]any)
+	if !ok {
+		t.Fatalf("files[0].quality = %v, want an object", file0["quality"])
+	}
+	inner, ok := q["quality"].(map[string]any)
+	if !ok || inner["name"] != "EPUB" {
+		t.Errorf("files[0].quality.quality.name = %v, want EPUB", q["quality"])
+	}
+}
+
+// TestGetQueue asserts GetQueue hits the queue endpoint with includeAuthor=true
+// and decodes the records array.
+func TestGetQueue(t *testing.T) {
+	var gotPath string
+	var gotQuery url.Values
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"records":[{"id":1,"bookId":42,"title":"Some Book"}]}`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "key")
+	items, err := c.GetQueue()
+	if err != nil {
+		t.Fatalf("GetQueue: %v", err)
+	}
+
+	if gotPath != "/api/v1/queue" {
+		t.Errorf("path = %s, want /api/v1/queue", gotPath)
+	}
+	if gotQuery.Get("includeAuthor") != "true" {
+		t.Errorf("includeAuthor = %q, want true (query %v)", gotQuery.Get("includeAuthor"), gotQuery)
+	}
+	if len(items) != 1 || items[0].BookID != 42 {
+		t.Fatalf("items = %+v, want one item with bookId 42", items)
+	}
+}
+
+// TestFormatOf asserts the quality-name classifier maps representative ebook
+// and audiobook formats and falls back to "unknown".
+func TestFormatOf(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"EPUB", "ebook"},
+		{"epub", "ebook"},
+		{"AZW3", "ebook"},
+		{"PDF", "ebook"},
+		{"MP3-320", "audiobook"},
+		{"M4B", "audiobook"},
+		{"FLAC", "audiobook"},
+		{"AudioBook", "audiobook"},
+		{"Unknown Quality", "unknown"},
+		{"", "unknown"},
+	}
+	for _, tc := range cases {
+		if got := FormatOf(tc.name); got != tc.want {
+			t.Errorf("FormatOf(%q) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -70,6 +70,20 @@ CREATE TABLE IF NOT EXISTS service_instances (
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Per-user default *arr instance override (admin-managed). A row pins which
+-- instance is THIS user's default source for a service type, overriding the
+-- global service_instances.is_default. For service types that have NO global
+-- default (chaptarr), a row is ALSO the per-user access grant: without one the
+-- user can neither see nor proxy to that instance. Absent row = inherit the
+-- global default (or, for chaptarr, no access). At most one row per
+-- (user, service_type). Mirrors user_request_settings (admin-managed per-user).
+CREATE TABLE IF NOT EXISTS user_default_instances (
+    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    service_type TEXT NOT NULL,
+    instance_id TEXT NOT NULL,
+    PRIMARY KEY (user_id, service_type)
+);
+
 CREATE TABLE IF NOT EXISTS devices (
     id TEXT PRIMARY KEY,
     user_id INTEGER NOT NULL REFERENCES users(id),

--- a/server/internal/instance/handler.go
+++ b/server/internal/instance/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 var allowedServiceTypes = map[string]bool{
 	"radarr":       true,
 	"sonarr":       true,
+	"chaptarr":     true,
 	"sabnzbd":      true,
 	"qbittorrent":  true,
 	"nzbget":       true,
@@ -85,7 +87,7 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !allowedServiceTypes[inst.ServiceType] {
-		http.Error(w, `{"error":"service_type must be one of 'radarr', 'sonarr', 'sabnzbd', 'qbittorrent', 'nzbget', 'transmission', 'tautulli'"}`, http.StatusBadRequest)
+		http.Error(w, `{"error":"service_type must be one of 'radarr', 'sonarr', 'chaptarr', 'sabnzbd', 'qbittorrent', 'nzbget', 'transmission', 'tautulli'"}`, http.StatusBadRequest)
 		return
 	}
 	if err := validateRequiredFields(&inst); err != nil {
@@ -183,6 +185,74 @@ func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// GetUserDefaultInstances returns a user's per-user default instance overrides
+// as a {service_type: instance_id} map (admin-only). Service types absent from
+// the map inherit the global default.
+func (h *Handler) GetUserDefaultInstances(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseInt(chi.URLParam(r, "userID"), 10, 64)
+	if err != nil {
+		http.Error(w, `{"error":"invalid user id"}`, http.StatusBadRequest)
+		return
+	}
+	defaults, err := h.store.ListUserDefaults(userID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+		return
+	}
+	if defaults == nil {
+		defaults = map[string]string{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(defaults)
+}
+
+// UpdateUserDefaultInstances sets or clears a user's per-user default instances
+// (admin-only). Body is a {service_type: instance_id|null} map; a null/empty
+// value clears that override (for chaptarr, this revokes access). Each instance
+// id must exist and match its service type. Returns the updated map.
+func (h *Handler) UpdateUserDefaultInstances(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseInt(chi.URLParam(r, "userID"), 10, 64)
+	if err != nil {
+		http.Error(w, `{"error":"invalid user id"}`, http.StatusBadRequest)
+		return
+	}
+	var body map[string]*string
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+	// Reject unknown service types up front so a typo never partially applies.
+	for serviceType := range body {
+		if !allowedServiceTypes[serviceType] {
+			http.Error(w, fmt.Sprintf(`{"error":"unknown service_type: %s"}`, serviceType), http.StatusBadRequest)
+			return
+		}
+	}
+	for serviceType, instanceID := range body {
+		if instanceID == nil || *instanceID == "" {
+			if err := h.store.ClearUserDefault(userID, serviceType); err != nil {
+				http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+				return
+			}
+			continue
+		}
+		if err := h.store.SetUserDefault(userID, serviceType, *instanceID); err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusBadRequest)
+			return
+		}
+	}
+	defaults, err := h.store.ListUserDefaults(userID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+		return
+	}
+	if defaults == nil {
+		defaults = map[string]string{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(defaults)
+}
+
 // validateRequiredFields enforces per-service-type required fields.
 func validateRequiredFields(inst *Instance) error {
 	if inst.Name == "" || inst.URL == "" {
@@ -195,7 +265,7 @@ func validateRequiredFields(inst *Instance) error {
 		}
 	case "transmission":
 		// Username/password are optional: Transmission RPC may run without auth.
-	default: // radarr, sonarr, sabnzbd, tautulli
+	default: // radarr, sonarr, chaptarr, sabnzbd, tautulli
 		if inst.APIKey == "" {
 			return fmt.Errorf("name, url, and api_key are required")
 		}
@@ -207,7 +277,10 @@ func validateRequiredFields(inst *Instance) error {
 func validateConnection(inst *Instance) error {
 	switch inst.ServiceType {
 	case "radarr", "sonarr":
-		return validateArrURL(inst.URL, inst.APIKey)
+		return validateArrURL(inst.URL, inst.APIKey, "v3")
+	case "chaptarr":
+		// Chaptarr is a Readarr fork speaking the Servarr /api/v1 API.
+		return validateArrURL(inst.URL, inst.APIKey, "v1")
 	case "sabnzbd":
 		_, err := sabnzbd.NewClient(inst.URL, inst.APIKey).Version()
 		return err
@@ -232,11 +305,11 @@ func validateConnection(inst *Instance) error {
 	}
 }
 
-// validateArrURL checks that a Radarr/Sonarr instance is reachable by hitting
-// its system/status endpoint.
-func validateArrURL(baseURL, apiKey string) error {
+// validateArrURL checks that a Servarr instance (Radarr/Sonarr on v3, Chaptarr
+// on v1) is reachable by hitting its system/status endpoint.
+func validateArrURL(baseURL, apiKey, apiVersion string) error {
 	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest("GET", baseURL+"/api/v3/system/status", nil)
+	req, err := http.NewRequest("GET", baseURL+"/api/"+apiVersion+"/system/status", nil)
 	if err != nil {
 		return fmt.Errorf("invalid url: %w", err)
 	}

--- a/server/internal/instance/registry.go
+++ b/server/internal/instance/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/nzbget"
 	"github.com/windoze95/cantinarr-server/internal/qbittorrent"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
@@ -19,6 +20,7 @@ type Registry struct {
 	mu                  sync.RWMutex
 	radarrClients       map[string]*radarr.Client
 	sonarrClients       map[string]*sonarr.Client
+	chaptarrClients     map[string]*chaptarr.Client
 	sabnzbdClients      map[string]*sabnzbd.Client
 	qbittorrentClients  map[string]*qbittorrent.Client
 	nzbgetClients       map[string]*nzbget.Client
@@ -32,6 +34,7 @@ func NewRegistry(store *Store) *Registry {
 		store:               store,
 		radarrClients:       make(map[string]*radarr.Client),
 		sonarrClients:       make(map[string]*sonarr.Client),
+		chaptarrClients:     make(map[string]*chaptarr.Client),
 		sabnzbdClients:      make(map[string]*sabnzbd.Client),
 		qbittorrentClients:  make(map[string]*qbittorrent.Client),
 		nzbgetClients:       make(map[string]*nzbget.Client),
@@ -81,6 +84,29 @@ func (r *Registry) GetSonarrClient(instanceID string) (*sonarr.Client, error) {
 
 	r.mu.Lock()
 	r.sonarrClients[instanceID] = client
+	r.mu.Unlock()
+
+	return client, nil
+}
+
+// GetChaptarrClient returns a cached or new Chaptarr client for the given instance ID.
+func (r *Registry) GetChaptarrClient(instanceID string) (*chaptarr.Client, error) {
+	r.mu.RLock()
+	if client, ok := r.chaptarrClients[instanceID]; ok {
+		r.mu.RUnlock()
+		return client, nil
+	}
+	r.mu.RUnlock()
+
+	inst, err := r.getInstanceOfType(instanceID, "chaptarr")
+	if err != nil {
+		return nil, err
+	}
+
+	client := chaptarr.NewClient(inst.URL, inst.APIKey)
+
+	r.mu.Lock()
+	r.chaptarrClients[instanceID] = client
 	r.mu.Unlock()
 
 	return client, nil
@@ -292,11 +318,69 @@ func (r *Registry) GetDefaultTautulliClient() (*tautulli.Client, string, error) 
 	return client, inst.ID, err
 }
 
+// GetUserDefaultRadarrClient returns the Radarr client for a user's per-user
+// default instance, falling back to the global default when the user has no
+// override. The second return is the resolved instance ID.
+func (r *Registry) GetUserDefaultRadarrClient(userID int64) (*radarr.Client, string, error) {
+	if id, ok, err := r.store.GetUserDefault(userID, "radarr"); err != nil {
+		return nil, "", fmt.Errorf("get user default radarr: %w", err)
+	} else if ok {
+		client, err := r.GetRadarrClient(id)
+		return client, id, err
+	}
+	return r.GetDefaultRadarrClient()
+}
+
+// GetUserDefaultSonarrClient returns the Sonarr client for a user's per-user
+// default instance, falling back to the global default when the user has no
+// override. The second return is the resolved instance ID.
+func (r *Registry) GetUserDefaultSonarrClient(userID int64) (*sonarr.Client, string, error) {
+	if id, ok, err := r.store.GetUserDefault(userID, "sonarr"); err != nil {
+		return nil, "", fmt.Errorf("get user default sonarr: %w", err)
+	} else if ok {
+		client, err := r.GetSonarrClient(id)
+		return client, id, err
+	}
+	return r.GetDefaultSonarrClient()
+}
+
+// GetUserChaptarrClient returns the Chaptarr client for a user's granted
+// instance. Chaptarr has NO global default: a user with no grant gets a nil
+// client and an empty ID, which callers surface as "no access / not configured".
+func (r *Registry) GetUserChaptarrClient(userID int64) (*chaptarr.Client, string, error) {
+	id, ok, err := r.store.GetUserDefault(userID, "chaptarr")
+	if err != nil {
+		return nil, "", fmt.Errorf("get user chaptarr: %w", err)
+	}
+	if !ok {
+		return nil, "", nil
+	}
+	client, err := r.GetChaptarrClient(id)
+	return client, id, err
+}
+
+// GetDefaultChaptarrClient returns a client for an arbitrary configured Chaptarr
+// instance (lowest sort_order). Chaptarr has no global default flag; this exists
+// for admin/AI contexts that operate without a specific user identity. Returns a
+// nil client when no Chaptarr instance is configured.
+func (r *Registry) GetDefaultChaptarrClient() (*chaptarr.Client, string, error) {
+	inst, err := r.store.GetDefault("chaptarr")
+	if err != nil {
+		return nil, "", fmt.Errorf("get default chaptarr: %w", err)
+	}
+	if inst == nil {
+		return nil, "", nil
+	}
+	client, err := r.GetChaptarrClient(inst.ID)
+	return client, inst.ID, err
+}
+
 // InvalidateClient removes a cached client, forcing recreation on next access.
 func (r *Registry) InvalidateClient(instanceID string) {
 	r.mu.Lock()
 	delete(r.radarrClients, instanceID)
 	delete(r.sonarrClients, instanceID)
+	delete(r.chaptarrClients, instanceID)
 	delete(r.sabnzbdClients, instanceID)
 	delete(r.qbittorrentClients, instanceID)
 	delete(r.nzbgetClients, instanceID)

--- a/server/internal/instance/store.go
+++ b/server/internal/instance/store.go
@@ -161,6 +161,12 @@ func (s *Store) Delete(id string) error {
 	if rows == 0 {
 		return fmt.Errorf("instance not found: %s", id)
 	}
+	// Drop any per-user defaults/grants that pointed at this instance so a
+	// deleted instance neither lingers as someone's default nor (for chaptarr)
+	// keeps granting access to a now-removed instance.
+	if _, err := s.db.Exec("DELETE FROM user_default_instances WHERE instance_id = ?", id); err != nil {
+		return fmt.Errorf("delete instance user defaults: %w", err)
+	}
 	return nil
 }
 
@@ -188,6 +194,103 @@ func (s *Store) GetDefault(serviceType string) (*Instance, error) {
 		return nil, err
 	}
 	return &inst, nil
+}
+
+// GetUserDefault returns the instance ID a user has pinned as their default for
+// a service type, or ("", false, nil) when the user has no per-user override
+// (the caller should fall back to the global default). For service types with no
+// global default (chaptarr), the returned ID is also the access grant.
+func (s *Store) GetUserDefault(userID int64, serviceType string) (string, bool, error) {
+	var instanceID string
+	err := s.db.QueryRow(
+		"SELECT instance_id FROM user_default_instances WHERE user_id = ? AND service_type = ?",
+		userID, serviceType,
+	).Scan(&instanceID)
+	if err == sql.ErrNoRows {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("get user default instance: %w", err)
+	}
+	return instanceID, true, nil
+}
+
+// ListUserDefaults returns a user's per-user default overrides keyed by service
+// type. Service types absent from the map inherit the global default.
+func (s *Store) ListUserDefaults(userID int64) (map[string]string, error) {
+	rows, err := s.db.Query(
+		"SELECT service_type, instance_id FROM user_default_instances WHERE user_id = ?",
+		userID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list user default instances: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]string)
+	for rows.Next() {
+		var serviceType, instanceID string
+		if err := rows.Scan(&serviceType, &instanceID); err != nil {
+			return nil, fmt.Errorf("scan user default instance: %w", err)
+		}
+		out[serviceType] = instanceID
+	}
+	return out, rows.Err()
+}
+
+// SetUserDefault pins instanceID as userID's default for serviceType. The
+// instance must exist and its stored service type must match serviceType, so a
+// single admin endpoint can accept a {service_type: instance_id} map without
+// risking a mismatched pin.
+func (s *Store) SetUserDefault(userID int64, serviceType, instanceID string) error {
+	inst, err := s.Get(instanceID)
+	if err != nil {
+		return err
+	}
+	if inst == nil {
+		return fmt.Errorf("instance not found: %s", instanceID)
+	}
+	if inst.ServiceType != serviceType {
+		return fmt.Errorf("instance %s is %q, not %q", instanceID, inst.ServiceType, serviceType)
+	}
+	_, err = s.db.Exec(
+		"INSERT INTO user_default_instances (user_id, service_type, instance_id) VALUES (?, ?, ?) "+
+			"ON CONFLICT(user_id, service_type) DO UPDATE SET instance_id = excluded.instance_id",
+		userID, serviceType, instanceID,
+	)
+	if err != nil {
+		return fmt.Errorf("set user default instance: %w", err)
+	}
+	return nil
+}
+
+// ClearUserDefault removes a user's per-user override for a service type, so it
+// reverts to the global default (or, for chaptarr, revokes access).
+func (s *Store) ClearUserDefault(userID int64, serviceType string) error {
+	if _, err := s.db.Exec(
+		"DELETE FROM user_default_instances WHERE user_id = ? AND service_type = ?",
+		userID, serviceType,
+	); err != nil {
+		return fmt.Errorf("clear user default instance: %w", err)
+	}
+	return nil
+}
+
+// UserHasInstanceAccess reports whether a user has been granted a specific
+// instance via a per-user default row. Used to gate access to service types that
+// have no global default (chaptarr); admins bypass this check at the caller.
+func (s *Store) UserHasInstanceAccess(userID int64, instanceID string) (bool, error) {
+	var one int
+	err := s.db.QueryRow(
+		"SELECT 1 FROM user_default_instances WHERE user_id = ? AND instance_id = ? LIMIT 1",
+		userID, instanceID,
+	).Scan(&one)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check user instance access: %w", err)
+	}
+	return true, nil
 }
 
 // Count returns the number of instances for a service type.

--- a/server/internal/instance/store_test.go
+++ b/server/internal/instance/store_test.go
@@ -1,0 +1,123 @@
+package instance
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+func newTestStore(t *testing.T) *Store {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x42}, 32))
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	return NewStore(database, cipher)
+}
+
+// createUser inserts a row directly so the user_default_instances FK is
+// satisfied (foreign_keys is ON). White-box: this test lives in package
+// instance to reach the unexported db handle.
+func createUser(t *testing.T, s *Store, username string) int64 {
+	t.Helper()
+	res, err := s.db.Exec(
+		"INSERT INTO users (username, password_hash, role) VALUES (?, '', 'user')",
+		username,
+	)
+	if err != nil {
+		t.Fatalf("create user %s: %v", username, err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func mkInstance(t *testing.T, s *Store, serviceType, name string) string {
+	t.Helper()
+	inst := &Instance{ServiceType: serviceType, Name: name, URL: "http://localhost", APIKey: "key"}
+	if err := s.Create(inst); err != nil {
+		t.Fatalf("create %s instance: %v", serviceType, err)
+	}
+	return inst.ID
+}
+
+func TestUserDefaultInstances(t *testing.T) {
+	s := newTestStore(t)
+	user := createUser(t, s, "alice")
+	sonarrID := mkInstance(t, s, "sonarr", "Main Sonarr")
+	chaptarrID := mkInstance(t, s, "chaptarr", "Books")
+
+	// No override yet -> not found.
+	if _, ok, err := s.GetUserDefault(user, "sonarr"); err != nil || ok {
+		t.Fatalf("GetUserDefault (empty) = ok=%v err=%v, want false/nil", ok, err)
+	}
+
+	// Set + read back.
+	if err := s.SetUserDefault(user, "sonarr", sonarrID); err != nil {
+		t.Fatalf("SetUserDefault: %v", err)
+	}
+	if id, ok, err := s.GetUserDefault(user, "sonarr"); err != nil || !ok || id != sonarrID {
+		t.Fatalf("GetUserDefault = (%q,%v,%v), want (%q,true,nil)", id, ok, err, sonarrID)
+	}
+
+	// A mismatched service type is rejected (the instance is sonarr).
+	if err := s.SetUserDefault(user, "radarr", sonarrID); err == nil {
+		t.Fatal("SetUserDefault with mismatched service_type should error")
+	}
+	// An unknown instance id is rejected.
+	if err := s.SetUserDefault(user, "sonarr", "nope-12345678"); err == nil {
+		t.Fatal("SetUserDefault with unknown instance should error")
+	}
+
+	// Chaptarr grant: the granted user has access, a different user does not.
+	if err := s.SetUserDefault(user, "chaptarr", chaptarrID); err != nil {
+		t.Fatalf("grant chaptarr: %v", err)
+	}
+	if ok, err := s.UserHasInstanceAccess(user, chaptarrID); err != nil || !ok {
+		t.Fatalf("granted user should have access: ok=%v err=%v", ok, err)
+	}
+	other := createUser(t, s, "bob")
+	if ok, err := s.UserHasInstanceAccess(other, chaptarrID); err != nil || ok {
+		t.Fatalf("non-granted user must NOT have access: ok=%v err=%v", ok, err)
+	}
+
+	// ListUserDefaults returns every override for the user.
+	defs, err := s.ListUserDefaults(user)
+	if err != nil {
+		t.Fatalf("ListUserDefaults: %v", err)
+	}
+	if defs["sonarr"] != sonarrID || defs["chaptarr"] != chaptarrID {
+		t.Fatalf("ListUserDefaults = %v, want sonarr=%s chaptarr=%s", defs, sonarrID, chaptarrID)
+	}
+
+	// Upsert: re-pinning the same service type replaces the instance.
+	sonarr2 := mkInstance(t, s, "sonarr", "Second Sonarr")
+	if err := s.SetUserDefault(user, "sonarr", sonarr2); err != nil {
+		t.Fatalf("re-pin sonarr: %v", err)
+	}
+	if id, _, _ := s.GetUserDefault(user, "sonarr"); id != sonarr2 {
+		t.Fatalf("upsert: GetUserDefault = %q, want %q", id, sonarr2)
+	}
+
+	// Clear reverts to no override.
+	if err := s.ClearUserDefault(user, "sonarr"); err != nil {
+		t.Fatalf("ClearUserDefault: %v", err)
+	}
+	if _, ok, _ := s.GetUserDefault(user, "sonarr"); ok {
+		t.Fatal("ClearUserDefault should remove the override")
+	}
+
+	// Deleting an instance drops the per-user grant (revokes chaptarr access).
+	if err := s.Delete(chaptarrID); err != nil {
+		t.Fatalf("Delete instance: %v", err)
+	}
+	if ok, _ := s.UserHasInstanceAccess(user, chaptarrID); ok {
+		t.Fatal("deleting an instance must revoke its per-user grant")
+	}
+}

--- a/server/internal/mcp/arr_mutations.go
+++ b/server/internal/mcp/arr_mutations.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"fmt"
 
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
 	"github.com/windoze95/cantinarr-server/internal/sonarr"
 	"github.com/windoze95/cantinarr-server/internal/tmdb"
@@ -58,7 +59,7 @@ func seriesByTMDB(bridge *tmdb.Bridge, client *sonarr.Client, tmdbID int) (*sona
 // queueIDToReplace > 0 removes that queue item (deleting the download from the
 // client, no blocklist) before grabbing, so a "grab a different release" fix
 // doesn't leave the old one downloading alongside the new one.
-func GrabReleaseHelper(rc *radarr.Client, sc *sonarr.Client, mediaType, guid string, indexerID, queueIDToReplace int) (string, error) {
+func GrabReleaseHelper(rc *radarr.Client, sc *sonarr.Client, cc *chaptarr.Client, mediaType, guid string, indexerID, queueIDToReplace int) (string, error) {
 	if guid == "" {
 		return "guid is required (from search_releases).", nil
 	}
@@ -87,8 +88,20 @@ func GrabReleaseHelper(rc *radarr.Client, sc *sonarr.Client, mediaType, guid str
 		if err := sc.GrabRelease(guid, indexerID); err != nil {
 			return "", err
 		}
+	case "book":
+		if cc == nil {
+			return "Chaptarr is not configured.", nil
+		}
+		if queueIDToReplace > 0 {
+			if err := cc.RemoveQueueItem(queueIDToReplace, true, false, false, false); err != nil {
+				return "", err
+			}
+		}
+		if err := cc.GrabRelease(guid, indexerID); err != nil {
+			return "", err
+		}
 	default:
-		return "media_type must be \"movie\" or \"tv\".", nil
+		return "media_type must be \"movie\", \"tv\", or \"book\".", nil
 	}
 	msg := "Release sent to the download client. It should show up in get_queue shortly."
 	if queueIDToReplace > 0 {
@@ -100,7 +113,7 @@ func GrabReleaseHelper(rc *radarr.Client, sc *sonarr.Client, mediaType, guid str
 // RemoveQueueItemHelper removes a queue item (deleting the download from the
 // client), optionally blocklisting the release so it is not re-grabbed. Shared
 // body of the remove_queue_item tool.
-func RemoveQueueItemHelper(rc *radarr.Client, sc *sonarr.Client, mediaType string, queueID int, blocklist bool) (string, error) {
+func RemoveQueueItemHelper(rc *radarr.Client, sc *sonarr.Client, cc *chaptarr.Client, mediaType string, queueID int, blocklist bool) (string, error) {
 	switch mediaType {
 	case "movie":
 		if rc == nil {
@@ -116,8 +129,15 @@ func RemoveQueueItemHelper(rc *radarr.Client, sc *sonarr.Client, mediaType strin
 		if err := sc.RemoveQueueItem(queueID, true, blocklist, false, false); err != nil {
 			return "", err
 		}
+	case "book":
+		if cc == nil {
+			return "Chaptarr is not configured.", nil
+		}
+		if err := cc.RemoveQueueItem(queueID, true, blocklist, false, false); err != nil {
+			return "", err
+		}
 	default:
-		return "media_type must be \"movie\" or \"tv\".", nil
+		return "media_type must be \"movie\", \"tv\", or \"book\".", nil
 	}
 	text := fmt.Sprintf("Removed queue item %d and deleted the download from the client.", queueID)
 	if blocklist {
@@ -129,7 +149,7 @@ func RemoveQueueItemHelper(rc *radarr.Client, sc *sonarr.Client, mediaType strin
 // RemediateQueueItemHelper applies one of the structured queue remediations
 // (remove | blocklist_search | change_category) to a queue item. Shared body of
 // the remediate_queue_item tool and the Executor's remediate_queue kind.
-func RemediateQueueItemHelper(rc *radarr.Client, sc *sonarr.Client, mediaType string, queueID int, action string) (string, error) {
+func RemediateQueueItemHelper(rc *radarr.Client, sc *sonarr.Client, cc *chaptarr.Client, mediaType string, queueID int, action string) (string, error) {
 	switch action {
 	case "remove", "blocklist_search", "change_category":
 	default:
@@ -207,8 +227,43 @@ func RemediateQueueItemHelper(rc *radarr.Client, sc *sonarr.Client, mediaType st
 			return fmt.Sprintf("Handed queue item %d (%s) to the download client's post-import category. It stays in the client for tools like Unpackerr.", queueID, sonarrQueueTitle(*item)), nil
 		}
 
+	case "book":
+		if cc == nil {
+			return "Chaptarr is not configured.", nil
+		}
+		item, err := findChaptarrQueueItem(cc, queueID)
+		if err != nil {
+			return "", err
+		}
+		if item == nil {
+			return fmt.Sprintf("No book queue item with id %d.", queueID), nil
+		}
+		switch action {
+		case "remove":
+			if err := cc.RemoveQueueItem(queueID, true, false, false, false); err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Removed queue item %d (%s) and deleted the download.", queueID, chaptarrQueueTitle(*item)), nil
+		case "blocklist_search":
+			if err := cc.RemoveQueueItem(queueID, true, true, false, false); err != nil {
+				return "", err
+			}
+			if item.BookID != 0 {
+				if err := cc.TriggerBookSearch([]int{item.BookID}); err != nil {
+					return "", err
+				}
+				return fmt.Sprintf("Removed and blocklisted queue item %d (%s) and started a fresh search for a different release.", queueID, chaptarrQueueTitle(*item)), nil
+			}
+			return fmt.Sprintf("Removed and blocklisted queue item %d (%s). Could not start a search: no book id on the item.", queueID, chaptarrQueueTitle(*item)), nil
+		case "change_category":
+			if err := cc.RemoveQueueItem(queueID, false, false, false, true); err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Handed queue item %d (%s) to the download client's post-import category. It stays in the client for tools like Unpackerr.", queueID, chaptarrQueueTitle(*item)), nil
+		}
+
 	default:
-		return "media_type must be \"movie\" or \"tv\".", nil
+		return "media_type must be \"movie\", \"tv\", or \"book\".", nil
 	}
 	return "No remediation was applied.", nil
 }
@@ -217,7 +272,7 @@ func RemediateQueueItemHelper(rc *radarr.Client, sc *sonarr.Client, mediaType st
 // item's download, honoring force (force imports despite permanent rejections).
 // Shared body of the execute_manual_import tool and the Executor's manual_import
 // kind.
-func ExecuteManualImportHelper(rc *radarr.Client, sc *sonarr.Client, mediaType string, queueID int, force bool) (string, error) {
+func ExecuteManualImportHelper(rc *radarr.Client, sc *sonarr.Client, cc *chaptarr.Client, mediaType string, queueID int, force bool) (string, error) {
 	switch mediaType {
 	case "movie":
 		if rc == nil {
@@ -327,15 +382,70 @@ func ExecuteManualImportHelper(rc *radarr.Client, sc *sonarr.Client, mediaType s
 		}
 		return importResultMessage(len(files), importMode, skipped), nil
 
+	case "book":
+		if cc == nil {
+			return "Chaptarr is not configured.", nil
+		}
+		item, err := findChaptarrQueueItem(cc, queueID)
+		if err != nil {
+			return "", err
+		}
+		if item == nil {
+			return fmt.Sprintf("No book queue item with id %d.", queueID), nil
+		}
+		if item.DownloadID == "" {
+			return fmt.Sprintf("Queue item %d has no download-client id yet; nothing to import.", queueID), nil
+		}
+		candidates, err := cc.GetManualImportCandidates(item.DownloadID)
+		if err != nil {
+			return "", err
+		}
+		var files []chaptarr.ManualImportFile
+		var skipped []string
+		for _, c := range candidates {
+			rejections := toRejectionViews(c.Rejections)
+			if !force && hasPermanentRejection(rejections) {
+				skipped = append(skipped, fmt.Sprintf("%s (%s)", c.Name, formatRejections(rejections)))
+				continue
+			}
+			if c.BookID == 0 {
+				skipped = append(skipped, fmt.Sprintf("%s (not matched to a book)", c.Name))
+				continue
+			}
+			files = append(files, chaptarr.ManualImportFile{
+				Path:         c.Path,
+				FolderName:   c.FolderName,
+				AuthorID:     c.AuthorID,
+				BookID:       c.BookID,
+				Quality:      c.Quality,
+				ReleaseGroup: c.ReleaseGroup,
+				DownloadID:   c.DownloadID,
+			})
+		}
+		if len(files) == 0 {
+			return importSkippedMessage(skipped, force), nil
+		}
+		// Chaptarr's ManualImport command sets importMode itself (auto); the
+		// helper still reports the protocol-derived mode (copy for torrent, else
+		// move) so the result message matches the movie/TV path.
+		importMode := importModeFor(item.Protocol)
+		if err := cc.ExecuteManualImport(files); err != nil {
+			return "", err
+		}
+		return importResultMessage(len(files), importMode, skipped), nil
+
 	default:
-		return "media_type must be \"movie\" or \"tv\".", nil
+		return "media_type must be \"movie\", \"tv\", or \"book\".", nil
 	}
 }
 
 // TriggerSearchHelper kicks off an automatic search for a movie, a whole series,
-// or a single season (when seasonNumber != nil). Shared body of the
+// or a single season (when seasonNumber != nil). For books the search targets
+// specific bookIDs when present, otherwise every monitored book of authorID;
+// books carry no TMDB id, so tmdbID/seasonNumber are unused on the book path
+// (and authorID/bookIDs are unused on the movie/TV paths). Shared body of the
 // trigger_search tool and the Executor's trigger_search kind.
-func TriggerSearchHelper(bridge *tmdb.Bridge, rc *radarr.Client, sc *sonarr.Client, mediaType string, tmdbID int, seasonNumber *int) (string, error) {
+func TriggerSearchHelper(bridge *tmdb.Bridge, rc *radarr.Client, sc *sonarr.Client, cc *chaptarr.Client, mediaType string, tmdbID int, seasonNumber *int, authorID int, bookIDs []int) (string, error) {
 	switch mediaType {
 	case "movie":
 		if rc == nil {
@@ -375,15 +485,35 @@ func TriggerSearchHelper(bridge *tmdb.Bridge, rc *radarr.Client, sc *sonarr.Clie
 		}
 		return fmt.Sprintf("Search started for all monitored episodes of %s. Check get_queue in a bit to see if releases were grabbed.", series.Title), nil
 
+	case "book":
+		if cc == nil {
+			return "Chaptarr is not configured.", nil
+		}
+		if len(bookIDs) > 0 {
+			if err := cc.TriggerBookSearch(bookIDs); err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("Search started for %d book(s). Check get_queue in a bit to see if releases were grabbed.", len(bookIDs)), nil
+		}
+		if authorID == 0 {
+			return "trigger_search for a book requires author_id or book_id.", nil
+		}
+		if err := cc.TriggerAuthorSearch(authorID); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Search started for all monitored books of author %d. Check get_queue in a bit to see if releases were grabbed.", authorID), nil
+
 	default:
-		return "media_type must be \"movie\" or \"tv\".", nil
+		return "media_type must be \"movie\", \"tv\", or \"book\".", nil
 	}
 }
 
 // RescanMediaHelper rescans a movie or series on disk and runs the import pass
-// (ProcessMonitoredDownloads). Shared body of the rescan_media tool and the
-// Executor's rescan kind.
-func RescanMediaHelper(bridge *tmdb.Bridge, rc *radarr.Client, sc *sonarr.Client, mediaType string, tmdbID int) (string, error) {
+// (ProcessMonitoredDownloads). For books it rescans authorID (books carry no
+// TMDB id, so tmdbID is unused on the book path and authorID is unused on the
+// movie/TV paths). Shared body of the rescan_media tool and the Executor's
+// rescan kind.
+func RescanMediaHelper(bridge *tmdb.Bridge, rc *radarr.Client, sc *sonarr.Client, cc *chaptarr.Client, mediaType string, tmdbID, authorID int) (string, error) {
 	switch mediaType {
 	case "movie":
 		if rc == nil {
@@ -423,7 +553,22 @@ func RescanMediaHelper(bridge *tmdb.Bridge, rc *radarr.Client, sc *sonarr.Client
 		}
 		return fmt.Sprintf("Rescanning %s and running the import pass. Check diagnose_queue shortly.", series.Title), nil
 
+	case "book":
+		if cc == nil {
+			return "Chaptarr is not configured.", nil
+		}
+		if authorID == 0 {
+			return "rescan for a book requires author_id.", nil
+		}
+		if err := cc.RescanAuthor(authorID); err != nil {
+			return "", err
+		}
+		if err := cc.ProcessMonitoredDownloads(); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Rescanning author %d and running the import pass. Check diagnose_queue shortly.", authorID), nil
+
 	default:
-		return "media_type must be \"movie\" or \"tv\".", nil
+		return "media_type must be \"movie\", \"tv\", or \"book\".", nil
 	}
 }

--- a/server/internal/mcp/arr_tools.go
+++ b/server/internal/mcp/arr_tools.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
 	"github.com/windoze95/cantinarr-server/internal/sonarr"
 )
@@ -18,13 +19,13 @@ var arrToolDefinitions = []Tool{
 	{
 		Name:        "get_queue",
 		Permission:  auth.PermissionArrRead,
-		Description: "Get the current download queue from Radarr/Sonarr with progress, time left, protocol, and any errors per item. Admin only",
+		Description: "Get the current download queue from Radarr/Sonarr/Chaptarr with progress, time left, protocol, and any errors per item. Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv", "all"},
+					"enum":        []string{"movie", "tv", "book", "all"},
 					"description": "Which queue to fetch (default: all)",
 				},
 			},
@@ -33,14 +34,14 @@ var arrToolDefinitions = []Tool{
 	{
 		Name:        "get_calendar",
 		Permission:  auth.PermissionArrRead,
-		Description: "Get upcoming movie releases and TV episode air dates, grouped by date. Admin only",
+		Description: "Get upcoming movie releases and TV episode air dates, grouped by date. Books have no calendar in Chaptarr, so media_type=book is not supported. Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv", "all"},
-					"description": "Which calendar to fetch (default: all)",
+					"enum":        []string{"movie", "tv", "book", "all"},
+					"description": "Which calendar to fetch (default: all). Books have no calendar.",
 				},
 				"days": map[string]interface{}{
 					"type":        "integer",
@@ -54,14 +55,14 @@ var arrToolDefinitions = []Tool{
 	{
 		Name:        "get_library",
 		Permission:  auth.PermissionArrRead,
-		Description: "Browse the Radarr/Sonarr library. Filter for missing (monitored but not downloaded) or unmonitored items, optionally narrowed by a title query. Admin only",
+		Description: "Browse the Radarr/Sonarr/Chaptarr library. Filter for missing (monitored but not downloaded) or unmonitored items, optionally narrowed by a title query. Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv"},
-					"description": "Whether to list movies or TV series",
+					"enum":        []string{"movie", "tv", "book"},
+					"description": "Whether to list movies, TV series, or books",
 				},
 				"filter": map[string]interface{}{
 					"type":        "string",
@@ -79,14 +80,14 @@ var arrToolDefinitions = []Tool{
 	{
 		Name:        "get_history",
 		Permission:  auth.PermissionArrRead,
-		Description: "Get recent download activity (grabs, imports, failures) from Radarr/Sonarr. Admin only",
+		Description: "Get recent download activity (grabs, imports, failures) from Radarr/Sonarr/Chaptarr. Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv"},
-					"description": "Whether to fetch movie or TV history",
+					"enum":        []string{"movie", "tv", "book"},
+					"description": "Whether to fetch movie, TV, or book history",
 				},
 				"limit": map[string]interface{}{
 					"type":        "integer",
@@ -99,50 +100,62 @@ var arrToolDefinitions = []Tool{
 	{
 		Name:        "trigger_search",
 		Permission:  auth.PermissionArrSearch,
-		Description: "Trigger an automatic indexer search for a movie or series that is already in the library. For TV, pass season_number to search a single season. Admin only",
+		Description: "Trigger an automatic indexer search for a movie, series, or book that is already in the library. For movies/TV pass tmdb_id (and, for TV, season_number to search a single season). For books pass book_id to search one book or author_id to search all of an author's monitored books (books have no tmdb_id). Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"tmdb_id": map[string]interface{}{
 					"type":        "integer",
-					"description": "The TMDB ID of the movie or TV show",
+					"description": "Movie/TV only: the TMDB ID of the movie or TV show",
 				},
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv"},
-					"description": "Whether this is a movie or TV show",
+					"enum":        []string{"movie", "tv", "book"},
+					"description": "Whether this is a movie, TV show, or book",
 				},
 				"season_number": map[string]interface{}{
 					"type":        "integer",
 					"description": "TV only: limit the search to this season",
 				},
+				"author_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "Book only: search all monitored books of this Chaptarr author id (used when book_id is absent)",
+				},
+				"book_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "Book only: search this single Chaptarr book id",
+				},
 			},
-			"required": []string{"tmdb_id", "media_type"},
+			"required": []string{"media_type"},
 		},
 	},
 	{
 		Name:        "search_releases",
 		AdminOnly:   true,
 		Permission:  auth.PermissionArrSearch,
-		Description: "Interactively search indexers for downloadable releases of a library item and list them with the guid and indexer_id needed to grab one. For TV, season_number is required. Admin only",
+		Description: "Interactively search indexers for downloadable releases of a library item and list them with the guid and indexer_id needed to grab one. For movies/TV pass tmdb_id (TV also requires season_number). For books pass book_id (books have no tmdb_id). Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"tmdb_id": map[string]interface{}{
 					"type":        "integer",
-					"description": "The TMDB ID of the movie or TV show",
+					"description": "Movie/TV only: the TMDB ID of the movie or TV show",
 				},
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv"},
-					"description": "Whether this is a movie or TV show",
+					"enum":        []string{"movie", "tv", "book"},
+					"description": "Whether this is a movie, TV show, or book",
 				},
 				"season_number": map[string]interface{}{
 					"type":        "integer",
 					"description": "TV only: the season to search releases for (required for tv)",
 				},
+				"book_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "Book only: the Chaptarr book id to search releases for (required for book)",
+				},
 			},
-			"required": []string{"tmdb_id", "media_type"},
+			"required": []string{"media_type"},
 		},
 	},
 	{
@@ -163,8 +176,8 @@ var arrToolDefinitions = []Tool{
 				},
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv"},
-					"description": "Whether the release is for a movie or TV show",
+					"enum":        []string{"movie", "tv", "book"},
+					"description": "Whether the release is for a movie, TV show, or book",
 				},
 			},
 			"required": []string{"guid", "indexer_id", "media_type"},
@@ -184,8 +197,8 @@ var arrToolDefinitions = []Tool{
 				},
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv"},
-					"description": "Whether the queue item is a movie or TV download",
+					"enum":        []string{"movie", "tv", "book"},
+					"description": "Whether the queue item is a movie, TV, or book download",
 				},
 				"blocklist": map[string]interface{}{
 					"type":        "boolean",
@@ -199,7 +212,7 @@ var arrToolDefinitions = []Tool{
 		Name:        "get_disk_space",
 		AdminOnly:   true,
 		Permission:  auth.PermissionSystemRead,
-		Description: "Get free and total disk space for the Radarr and Sonarr volumes. Admin only",
+		Description: "Get free and total disk space for the Radarr, Sonarr, and Chaptarr volumes. Admin only",
 		InputSchema: map[string]interface{}{
 			"type":       "object",
 			"properties": map[string]interface{}{},
@@ -208,13 +221,13 @@ var arrToolDefinitions = []Tool{
 	{
 		Name:        "get_arr_health",
 		Permission:  auth.PermissionArrRead,
-		Description: "Check Radarr/Sonarr system health for config-level problems (download client unreachable, remote path mapping, indexers down, disk, no root folder). Use this when diagnose_queue shows path/permission/client errors to confirm the root cause that per-item queue diagnosis can only guess at. Admin only",
+		Description: "Check Radarr/Sonarr/Chaptarr system health for config-level problems (download client unreachable, remote path mapping, indexers down, disk, no root folder). Use this when diagnose_queue shows path/permission/client errors to confirm the root cause that per-item queue diagnosis can only guess at. Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv", "all"},
+					"enum":        []string{"movie", "tv", "book", "all"},
 					"description": "Which service's health to fetch (default: all)",
 				},
 			},
@@ -223,13 +236,13 @@ var arrToolDefinitions = []Tool{
 	{
 		Name:        "diagnose_queue",
 		Permission:  auth.PermissionArrRead,
-		Description: "Import Doctor: scan the Radarr/Sonarr download queue for items that are stuck, failed, or blocked from importing, and explain each problem in plain language with the queue_id and suggested fix actions (process, manual_import, force_import, remove, blocklist_search, change_category, rescan). For each problem it also prints the exact next MCP tool call to run. Use this before the fix tools. Admin only",
+		Description: "Import Doctor: scan the Radarr/Sonarr/Chaptarr download queue for items that are stuck, failed, or blocked from importing, and explain each problem in plain language with the queue_id and suggested fix actions (process, manual_import, force_import, remove, blocklist_search, change_category, rescan). For each problem it also prints the exact next MCP tool call to run. Use this before the fix tools. Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv", "all"},
+					"enum":        []string{"movie", "tv", "book", "all"},
 					"description": "Which queue to diagnose (default: all)",
 				},
 			},
@@ -239,7 +252,7 @@ var arrToolDefinitions = []Tool{
 		Name:        "get_manual_import_candidates",
 		AdminOnly:   true,
 		Permission:  auth.PermissionDownloadsManage,
-		Description: "List the files Radarr/Sonarr found for a stuck download (from its queue_id), including each file's mapped movie/series/episodes and any rejection reasons that blocked an automatic import. Use this to understand why an item won't import before calling execute_manual_import. Admin only",
+		Description: "List the files Radarr/Sonarr/Chaptarr found for a stuck download (from its queue_id), including each file's mapped movie/series/episodes/book and any rejection reasons that blocked an automatic import. Use this to understand why an item won't import before calling execute_manual_import. Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -249,8 +262,8 @@ var arrToolDefinitions = []Tool{
 				},
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv"},
-					"description": "Whether the queue item is a movie or TV download",
+					"enum":        []string{"movie", "tv", "book"},
+					"description": "Whether the queue item is a movie, TV, or book download",
 				},
 			},
 			"required": []string{"queue_id", "media_type"},
@@ -270,8 +283,8 @@ var arrToolDefinitions = []Tool{
 				},
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv"},
-					"description": "Whether the queue item is a movie or TV download",
+					"enum":        []string{"movie", "tv", "book"},
+					"description": "Whether the queue item is a movie, TV, or book download",
 				},
 				"force": map[string]interface{}{
 					"type":        "boolean",
@@ -295,8 +308,8 @@ var arrToolDefinitions = []Tool{
 				},
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv"},
-					"description": "Whether the queue item is a movie or TV download",
+					"enum":        []string{"movie", "tv", "book"},
+					"description": "Whether the queue item is a movie, TV, or book download",
 				},
 				"action": map[string]interface{}{
 					"type":        "string",
@@ -311,21 +324,25 @@ var arrToolDefinitions = []Tool{
 		Name:        "rescan_media",
 		AdminOnly:   true,
 		Permission:  auth.PermissionArrSearch,
-		Description: "Rescan the files on disk for a library movie or series, then run the import pass. Use this after fixing a disk-space, path, or permissions problem so Radarr/Sonarr picks up files that are already there. Admin only",
+		Description: "Rescan the files on disk for a library movie, series, or author, then run the import pass. Use this after fixing a disk-space, path, or permissions problem so the service picks up files that are already there. For movies/TV pass tmdb_id; for books pass author_id (books have no tmdb_id). Admin only",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"tmdb_id": map[string]interface{}{
 					"type":        "integer",
-					"description": "The TMDB ID of the movie or TV show",
+					"description": "Movie/TV only: the TMDB ID of the movie or TV show",
 				},
 				"media_type": map[string]interface{}{
 					"type":        "string",
-					"enum":        []string{"movie", "tv"},
-					"description": "Whether this is a movie or TV show",
+					"enum":        []string{"movie", "tv", "book"},
+					"description": "Whether this is a movie, TV show, or book",
+				},
+				"author_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "Book only: the Chaptarr author id to rescan (required for book)",
 				},
 			},
-			"required": []string{"tmdb_id", "media_type"},
+			"required": []string{"media_type"},
 		},
 	},
 }
@@ -450,6 +467,42 @@ func formatSonarrQueueItem(item sonarr.DetailedQueueItem) string {
 	return sb.String()
 }
 
+func formatChaptarrQueueItem(item chaptarr.DetailedQueueItem) string {
+	title := item.Title
+	if item.Book != nil && item.Book.Title != "" {
+		title = item.Book.Title
+		if item.Author != nil && item.Author.AuthorName != "" {
+			title = fmt.Sprintf("%s — %s", item.Author.AuthorName, item.Book.Title)
+		}
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "- [queue %d] %s — %s", item.ID, title, item.Status)
+	if item.Size > 0 {
+		fmt.Fprintf(&sb, ", %.1f%% done", (item.Size-item.Sizeleft)/item.Size*100)
+	}
+	if item.Timeleft != "" {
+		fmt.Fprintf(&sb, ", %s left", item.Timeleft)
+	}
+	if item.Protocol != "" {
+		fmt.Fprintf(&sb, ", %s", item.Protocol)
+	}
+	if item.DownloadClient != "" {
+		fmt.Fprintf(&sb, " via %s", item.DownloadClient)
+	}
+	if item.TrackedDownloadStatus != "" && !strings.EqualFold(item.TrackedDownloadStatus, "ok") {
+		fmt.Fprintf(&sb, " [%s/%s]", item.TrackedDownloadStatus, item.TrackedDownloadState)
+	}
+	if item.ErrorMessage != "" {
+		fmt.Fprintf(&sb, "\n  error: %s", item.ErrorMessage)
+	}
+	for _, msg := range item.StatusMessages {
+		if len(msg.Messages) > 0 {
+			fmt.Fprintf(&sb, "\n  issue: %s", strings.Join(msg.Messages, "; "))
+		}
+	}
+	return sb.String()
+}
+
 func (s *ToolServer) getQueue(input json.RawMessage) (*ToolResult, error) {
 	var params struct {
 		MediaType string `json:"media_type"`
@@ -517,6 +570,34 @@ func (s *ToolServer) getQueue(input json.RawMessage) (*ToolResult, error) {
 		}
 	}
 
+	if mediaType == "book" || mediaType == "all" {
+		chaptarrClient := s.GetChaptarr()
+		if chaptarrClient == nil {
+			if mediaType == "book" {
+				return &ToolResult{Text: "Chaptarr is not configured."}, nil
+			}
+			sections = append(sections, "Chaptarr is not configured.")
+		} else {
+			items, err := chaptarrClient.GetQueueDetailed(chaptarrQueuePage, chaptarrQueuePageSize)
+			if err != nil {
+				return nil, err
+			}
+			if len(items) == 0 {
+				sections = append(sections, "Book queue: empty.")
+			} else {
+				shown := items
+				if len(shown) > maxQueueItems {
+					shown = shown[:maxQueueItems]
+				}
+				lines := make([]string, 0, len(shown))
+				for _, item := range shown {
+					lines = append(lines, formatChaptarrQueueItem(item))
+				}
+				sections = append(sections, renderQueueSection("Book queue", len(items), lines))
+			}
+		}
+	}
+
 	return &ToolResult{Text: strings.Join(sections, "\n\n")}, nil
 }
 
@@ -536,6 +617,12 @@ func (s *ToolServer) getCalendar(input json.RawMessage) (*ToolResult, error) {
 		return nil, fmt.Errorf("parse input: %w", err)
 	}
 	mediaType := normalizeMediaType(params.MediaType)
+	// Chaptarr has no calendar endpoint (books carry no air/release schedule the
+	// way episodes and theatrical/digital releases do), so book is unsupported
+	// here. Return a graceful explanation rather than an error.
+	if mediaType == "book" {
+		return &ToolResult{Text: "get_calendar is not supported for books — Chaptarr has no calendar. Use get_library (filter=missing) to see monitored books without a file."}, nil
+	}
 	days := params.Days
 	if days < 1 {
 		days = 14
@@ -548,6 +635,10 @@ func (s *ToolServer) getCalendar(input json.RawMessage) (*ToolResult, error) {
 
 	var entries []calendarEntry
 	var notes []string
+	if mediaType == "all" {
+		// The combined view still skips books; note it so the omission is explicit.
+		notes = append(notes, "Books have no calendar.")
+	}
 
 	if mediaType == "movie" || mediaType == "all" {
 		radarrClient := s.GetRadarr()
@@ -768,8 +859,59 @@ func (s *ToolServer) getLibrary(input json.RawMessage) (*ToolResult, error) {
 		}
 		return &ToolResult{Text: sb.String()}, nil
 
+	case "book":
+		chaptarrClient := s.GetChaptarr()
+		if chaptarrClient == nil {
+			return &ToolResult{Text: "Chaptarr is not configured."}, nil
+		}
+		authors, err := chaptarrClient.GetAllAuthors()
+		if err != nil {
+			return nil, err
+		}
+		total := len(authors)
+		var matched []chaptarr.Author
+		for _, a := range authors {
+			switch filter {
+			case "missing":
+				if !a.Monitored {
+					continue
+				}
+				if a.Statistics.PercentOfBooks >= 100 {
+					continue
+				}
+			case "unmonitored":
+				if a.Monitored {
+					continue
+				}
+			}
+			if query != "" && !strings.Contains(strings.ToLower(a.AuthorName), query) {
+				continue
+			}
+			matched = append(matched, a)
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "Book library: %d author(s) total, %d matching (filter: %s", total, len(matched), filter)
+		if query != "" {
+			fmt.Fprintf(&sb, ", query: %q", params.Query)
+		}
+		sb.WriteString(")")
+		shown := matched
+		if len(shown) > maxLibraryItems {
+			shown = shown[:maxLibraryItems]
+			fmt.Fprintf(&sb, ", showing first %d of %d matches for filter %q", maxLibraryItems, len(matched), filter)
+		}
+		for _, a := range shown {
+			fmt.Fprintf(&sb, "\n- %s [author ID %d]", a.AuthorName, a.ID)
+			fmt.Fprintf(&sb, " — %d/%d books", a.Statistics.BookFileCount, a.Statistics.BookCount)
+			if !a.Monitored {
+				sb.WriteString(" — unmonitored")
+			}
+		}
+		sb.WriteString("\n\nUse get_queue, search_releases (book_id), or trigger_search (author_id/book_id) for per-book actions; book ids come from the Chaptarr library, not this summary.")
+		return &ToolResult{Text: sb.String()}, nil
+
 	default:
-		return &ToolResult{Text: "media_type must be \"movie\" or \"tv\"."}, nil
+		return &ToolResult{Text: "media_type must be \"movie\", \"tv\", or \"book\"."}, nil
 	}
 }
 
@@ -851,8 +993,42 @@ func (s *ToolServer) getHistory(input json.RawMessage) (*ToolResult, error) {
 		}
 		return &ToolResult{Text: sb.String()}, nil
 
+	case "book":
+		chaptarrClient := s.GetChaptarr()
+		if chaptarrClient == nil {
+			return &ToolResult{Text: "Chaptarr is not configured."}, nil
+		}
+		page, err := chaptarrClient.GetHistory(1, limit)
+		if err != nil {
+			return nil, err
+		}
+		if page == nil || len(page.Records) == 0 {
+			return &ToolResult{Text: "No book history found."}, nil
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "Recent book history (%d records):", len(page.Records))
+		for _, rec := range page.Records {
+			when := "unknown date"
+			if rec.Date != nil {
+				when = rec.Date.UTC().Format("2006-01-02 15:04")
+			}
+			fmt.Fprintf(&sb, "\n- %s %s", when, rec.EventType)
+			if rec.Author != nil && rec.Author.AuthorName != "" {
+				fmt.Fprintf(&sb, ": %s", rec.Author.AuthorName)
+				if rec.Book != nil && rec.Book.Title != "" {
+					fmt.Fprintf(&sb, " — %s", rec.Book.Title)
+				}
+			} else if rec.Book != nil && rec.Book.Title != "" {
+				fmt.Fprintf(&sb, ": %s", rec.Book.Title)
+			}
+			if rec.SourceTitle != "" {
+				fmt.Fprintf(&sb, " — %s", rec.SourceTitle)
+			}
+		}
+		return &ToolResult{Text: sb.String()}, nil
+
 	default:
-		return &ToolResult{Text: "media_type must be \"movie\" or \"tv\"."}, nil
+		return &ToolResult{Text: "media_type must be \"movie\", \"tv\", or \"book\"."}, nil
 	}
 }
 
@@ -863,12 +1039,18 @@ func (s *ToolServer) triggerSearch(input json.RawMessage) (*ToolResult, error) {
 		TmdbID       int    `json:"tmdb_id"`
 		MediaType    string `json:"media_type"`
 		SeasonNumber *int   `json:"season_number"`
+		AuthorID     int    `json:"author_id"`
+		BookID       int    `json:"book_id"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
 		return nil, fmt.Errorf("parse input: %w", err)
 	}
 
-	text, err := TriggerSearchHelper(s.bridge, s.GetRadarr(), s.GetSonarr(), params.MediaType, params.TmdbID, params.SeasonNumber)
+	var bookIDs []int
+	if params.BookID != 0 {
+		bookIDs = []int{params.BookID}
+	}
+	text, err := TriggerSearchHelper(s.bridge, s.GetRadarr(), s.GetSonarr(), s.GetChaptarr(), params.MediaType, params.TmdbID, params.SeasonNumber, params.AuthorID, bookIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -937,11 +1119,51 @@ func formatSonarrReleases(releases []sonarr.Release) string {
 	return sb.String()
 }
 
+// chaptarrSeeders dereferences a Chaptarr release's optional seeder/leecher
+// count (the API omits them for usenet), returning 0 when absent.
+func chaptarrSeeders(n *int) int {
+	if n == nil {
+		return 0
+	}
+	return *n
+}
+
+func formatChaptarrReleases(releases []chaptarr.Release) string {
+	sort.SliceStable(releases, func(i, j int) bool {
+		if releases[i].Rejected != releases[j].Rejected {
+			return !releases[i].Rejected
+		}
+		si, sj := chaptarrSeeders(releases[i].Seeders), chaptarrSeeders(releases[j].Seeders)
+		if si != sj {
+			return si > sj
+		}
+		return releases[i].Size > releases[j].Size
+	})
+	if len(releases) > maxReleaseResults {
+		releases = releases[:maxReleaseResults]
+	}
+	var sb strings.Builder
+	for i, rel := range releases {
+		fmt.Fprintf(&sb, "%d. %s\n", i+1, rel.Title)
+		fmt.Fprintf(&sb, "   size: %s | %s", humanBytes(float64(rel.Size)), rel.Protocol)
+		if rel.Protocol == "torrent" {
+			fmt.Fprintf(&sb, " (%d seeders / %d leechers)", chaptarrSeeders(rel.Seeders), chaptarrSeeders(rel.Leechers))
+		}
+		fmt.Fprintf(&sb, " | indexer: %s (indexer_id: %d) | age: %.1f days\n", rel.Indexer, rel.IndexerID, rel.AgeHours/24)
+		if rel.Rejected {
+			fmt.Fprintf(&sb, "   rejected: %s\n", strings.Join(rel.Rejections, "; "))
+		}
+		fmt.Fprintf(&sb, "   guid: %s\n", rel.GUID)
+	}
+	return sb.String()
+}
+
 func (s *ToolServer) searchReleases(input json.RawMessage) (*ToolResult, error) {
 	var params struct {
 		TmdbID       int    `json:"tmdb_id"`
 		MediaType    string `json:"media_type"`
 		SeasonNumber *int   `json:"season_number"`
+		BookID       int    `json:"book_id"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
 		return nil, fmt.Errorf("parse input: %w", err)
@@ -997,8 +1219,27 @@ func (s *ToolServer) searchReleases(input json.RawMessage) (*ToolResult, error) 
 			len(releases), series.Title, *params.SeasonNumber, min(len(releases), maxReleaseResults))
 		return &ToolResult{Text: header + formatSonarrReleases(releases)}, nil
 
+	case "book":
+		chaptarrClient := s.GetChaptarr()
+		if chaptarrClient == nil {
+			return &ToolResult{Text: "Chaptarr is not configured."}, nil
+		}
+		if params.BookID == 0 {
+			return &ToolResult{Text: "book_id is required when searching book releases."}, nil
+		}
+		releases, err := chaptarrClient.SearchReleases(params.BookID)
+		if err != nil {
+			return nil, err
+		}
+		if len(releases) == 0 {
+			return &ToolResult{Text: fmt.Sprintf("No releases found for book id %d.", params.BookID)}, nil
+		}
+		header := fmt.Sprintf("Found %d release(s) for book id %d, showing top %d. Use grab_release with a guid and indexer_id to download one.\n",
+			len(releases), params.BookID, min(len(releases), maxReleaseResults))
+		return &ToolResult{Text: header + formatChaptarrReleases(releases)}, nil
+
 	default:
-		return &ToolResult{Text: "media_type must be \"movie\" or \"tv\"."}, nil
+		return &ToolResult{Text: "media_type must be \"movie\", \"tv\", or \"book\"."}, nil
 	}
 }
 
@@ -1013,7 +1254,7 @@ func (s *ToolServer) grabRelease(input json.RawMessage) (*ToolResult, error) {
 	if err := json.Unmarshal(input, &params); err != nil {
 		return nil, fmt.Errorf("parse input: %w", err)
 	}
-	text, err := GrabReleaseHelper(s.GetRadarr(), s.GetSonarr(), params.MediaType, params.GUID, params.IndexerID, 0)
+	text, err := GrabReleaseHelper(s.GetRadarr(), s.GetSonarr(), s.GetChaptarr(), params.MediaType, params.GUID, params.IndexerID, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -1031,7 +1272,7 @@ func (s *ToolServer) removeQueueItem(input json.RawMessage) (*ToolResult, error)
 	if err := json.Unmarshal(input, &params); err != nil {
 		return nil, fmt.Errorf("parse input: %w", err)
 	}
-	text, err := RemoveQueueItemHelper(s.GetRadarr(), s.GetSonarr(), params.MediaType, params.QueueID, params.Blocklist)
+	text, err := RemoveQueueItemHelper(s.GetRadarr(), s.GetSonarr(), s.GetChaptarr(), params.MediaType, params.QueueID, params.Blocklist)
 	if err != nil {
 		return nil, err
 	}
@@ -1055,8 +1296,9 @@ func formatDiskLines(sb *strings.Builder, path, label string, free, total int64)
 func (s *ToolServer) getDiskSpace() (*ToolResult, error) {
 	radarrClient := s.GetRadarr()
 	sonarrClient := s.GetSonarr()
-	if radarrClient == nil && sonarrClient == nil {
-		return &ToolResult{Text: "Radarr/Sonarr is not configured."}, nil
+	chaptarrClient := s.GetChaptarr()
+	if radarrClient == nil && sonarrClient == nil && chaptarrClient == nil {
+		return &ToolResult{Text: "Radarr/Sonarr/Chaptarr is not configured."}, nil
 	}
 
 	var sb strings.Builder
@@ -1086,6 +1328,21 @@ func (s *ToolServer) getDiskSpace() (*ToolResult, error) {
 		}
 	} else {
 		sb.WriteString("Sonarr is not configured.")
+	}
+
+	sb.WriteString("\n\n")
+
+	if chaptarrClient != nil {
+		disks, err := chaptarrClient.GetDiskSpace()
+		if err != nil {
+			return nil, err
+		}
+		sb.WriteString("Chaptarr disk space:")
+		for _, d := range disks {
+			formatDiskLines(&sb, d.Path, d.Label, d.FreeSpace, d.TotalSpace)
+		}
+	} else {
+		sb.WriteString("Chaptarr is not configured.")
 	}
 
 	return &ToolResult{Text: sb.String()}, nil

--- a/server/internal/mcp/import_doctor.go
+++ b/server/internal/mcp/import_doctor.go
@@ -6,8 +6,18 @@ import (
 	"strings"
 
 	"github.com/windoze95/cantinarr-server/internal/arr"
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
 	"github.com/windoze95/cantinarr-server/internal/sonarr"
+)
+
+// chaptarrQueuePage / chaptarrQueuePageSize drive the paginated
+// chaptarr.GetQueueDetailed calls (the client loops from this page until every
+// record is fetched). Radarr/Sonarr expose a non-paginated GetQueueDetailed, so
+// these are book-only.
+const (
+	chaptarrQueuePage     = 1
+	chaptarrQueuePageSize = 100
 )
 
 // --- Import Doctor: shared signal mapping ---
@@ -30,6 +40,24 @@ func sonarrSignal(item sonarr.DetailedQueueItem) arr.QueueSignal {
 
 // radarrSignal projects a Radarr queue item into the neutral classifier input.
 func radarrSignal(item radarr.DetailedQueueItem) arr.QueueSignal {
+	messages := make([]arr.StatusMessage, 0, len(item.StatusMessages))
+	for _, m := range item.StatusMessages {
+		messages = append(messages, arr.StatusMessage{Title: m.Title, Messages: m.Messages})
+	}
+	return arr.QueueSignal{
+		Status:                item.Status,
+		TrackedDownloadStatus: item.TrackedDownloadStatus,
+		TrackedDownloadState:  item.TrackedDownloadState,
+		ErrorMessage:          item.ErrorMessage,
+		StatusMessages:        messages,
+		Protocol:              item.Protocol,
+	}
+}
+
+// chaptarrSignal projects a Chaptarr queue item into the neutral classifier
+// input. Chaptarr's queue item is structurally identical to Sonarr's for the
+// fields the classifier reasons over.
+func chaptarrSignal(item chaptarr.QueueItem) arr.QueueSignal {
 	messages := make([]arr.StatusMessage, 0, len(item.StatusMessages))
 	for _, m := range item.StatusMessages {
 		messages = append(messages, arr.StatusMessage{Title: m.Title, Messages: m.Messages})
@@ -71,6 +99,19 @@ func radarrQueueTitle(item radarr.DetailedQueueItem) string {
 	return fmt.Sprintf("movie %d", item.MovieID)
 }
 
+func chaptarrQueueTitle(item chaptarr.QueueItem) string {
+	if item.Book != nil && item.Book.Title != "" {
+		if item.Author != nil && item.Author.AuthorName != "" {
+			return fmt.Sprintf("%s — %s", item.Author.AuthorName, item.Book.Title)
+		}
+		return item.Book.Title
+	}
+	if item.Title != "" {
+		return item.Title
+	}
+	return fmt.Sprintf("book %d", item.BookID)
+}
+
 // renderDiagnosis appends a problem item's diagnosis to the builder, including
 // the exact next MCP tool call(s) to run for each suggested action so a weak
 // agent can execute verbatim. tmdbID is the resolved TMDB id of the underlying
@@ -104,9 +145,14 @@ func nextCalls(mediaType string, queueID, tmdbID int, verbs []string) string {
 	for _, v := range verbs {
 		switch v {
 		case arr.ActionProcess, arr.ActionRescan:
-			// rescan_media runs Rescan{Series,Movie} then the import pass. It
-			// needs a tmdb_id; the Sonarr queue item only carries a TVDB id, so
-			// fall back to naming the tool when we could not resolve one.
+			// rescan_media runs Rescan{Series,Movie,Author} then the import pass.
+			// For movies/TV it needs a tmdb_id (the Sonarr queue item only carries
+			// a TVDB id, so we fall back to naming the tool when we could not
+			// resolve one). Books carry no TMDB id at all — rescan_media takes an
+			// author_id there — so book always renders a resolve hint.
+			if mediaType == "book" {
+				return "rescan_media (resolve this item's author_id first — get_library media_type=book by author/title — then call it with that author_id)"
+			}
 			if tmdbID != 0 {
 				return toolCall("rescan_media", fmt.Sprintf(`{"tmdb_id": %d, "media_type": %q}`, tmdbID, mediaType))
 			}
@@ -134,7 +180,7 @@ func toolCall(name, args string) string {
 // are skipped so the agent only sees actionable config problems). The generic
 // parameter lets the one renderer serve both sonarr.HealthCheck and
 // radarr.HealthCheck, which are structurally identical but distinct types.
-func renderHealthSection[T sonarr.HealthCheck | radarr.HealthCheck](label string, checks []T) string {
+func renderHealthSection[T sonarr.HealthCheck | radarr.HealthCheck | chaptarr.HealthCheck](label string, checks []T) string {
 	var sb strings.Builder
 	shown := 0
 	for _, c := range checks {
@@ -143,6 +189,8 @@ func renderHealthSection[T sonarr.HealthCheck | radarr.HealthCheck](label string
 		case sonarr.HealthCheck:
 			source, ctype, message, wiki = v.Source, v.Type, v.Message, v.WikiURL
 		case radarr.HealthCheck:
+			source, ctype, message, wiki = v.Source, v.Type, v.Message, v.WikiURL
+		case chaptarr.HealthCheck:
 			source, ctype, message, wiki = v.Source, v.Type, v.Message, v.WikiURL
 		}
 		if strings.EqualFold(ctype, "ok") {
@@ -206,6 +254,22 @@ func (s *ToolServer) getArrHealth(input json.RawMessage) (*ToolResult, error) {
 				return nil, err
 			}
 			sections = append(sections, renderHealthSection("Sonarr", checks))
+		}
+	}
+
+	if mediaType == "book" || mediaType == "all" {
+		client := s.GetChaptarr()
+		if client == nil {
+			if mediaType == "book" {
+				return &ToolResult{Text: "Chaptarr is not configured."}, nil
+			}
+			sections = append(sections, "Chaptarr is not configured.")
+		} else {
+			checks, err := client.GetHealth()
+			if err != nil {
+				return nil, err
+			}
+			sections = append(sections, renderHealthSection("Chaptarr", checks))
 		}
 	}
 
@@ -285,6 +349,33 @@ func (s *ToolServer) diagnoseQueue(input json.RawMessage) (*ToolResult, error) {
 		}
 	}
 
+	if mediaType == "book" || mediaType == "all" {
+		chaptarrClient := s.GetChaptarr()
+		if chaptarrClient == nil {
+			if mediaType == "book" {
+				return &ToolResult{Text: "Chaptarr is not configured."}, nil
+			}
+			notes = append(notes, "Chaptarr is not configured.")
+		} else {
+			items, err := chaptarrClient.GetQueueDetailed(chaptarrQueuePage, chaptarrQueuePageSize)
+			if err != nil {
+				return nil, err
+			}
+			for _, item := range items {
+				d := arr.Diagnose(chaptarrSignal(item))
+				if d.Severity == arr.SeverityOK {
+					healthy++
+					continue
+				}
+				problems++
+				// Chaptarr books carry no TMDB id, so rescan_media can't be
+				// resolved cheaply here; pass 0 and let nextCalls name the tool
+				// with a resolve hint instead.
+				renderDiagnosis(&sb, "book", item.ID, 0, chaptarrQueueTitle(item), d)
+			}
+		}
+	}
+
 	var header strings.Builder
 	if problems == 0 {
 		header.WriteString("Import Doctor: no queue problems found.")
@@ -324,6 +415,20 @@ func findRadarrQueueItem(client *radarr.Client, queueID int) (*radarr.DetailedQu
 // findSonarrQueueItem returns the queue item with the given id, or nil.
 func findSonarrQueueItem(client *sonarr.Client, queueID int) (*sonarr.DetailedQueueItem, error) {
 	items, err := client.GetQueueDetailed()
+	if err != nil {
+		return nil, err
+	}
+	for i := range items {
+		if items[i].ID == queueID {
+			return &items[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// findChaptarrQueueItem returns the queue item with the given id, or nil.
+func findChaptarrQueueItem(client *chaptarr.Client, queueID int) (*chaptarr.DetailedQueueItem, error) {
+	items, err := client.GetQueueDetailed(chaptarrQueuePage, chaptarrQueuePageSize)
 	if err != nil {
 		return nil, err
 	}
@@ -442,18 +547,58 @@ func (s *ToolServer) getManualImportCandidates(input json.RawMessage) (*ToolResu
 		sb.WriteString("\n\nUse execute_manual_import to import these (add force=true to import despite permanent rejections).")
 		return &ToolResult{Text: sb.String()}, nil
 
+	case "book":
+		client := s.GetChaptarr()
+		if client == nil {
+			return &ToolResult{Text: "Chaptarr is not configured."}, nil
+		}
+		item, err := findChaptarrQueueItem(client, params.QueueID)
+		if err != nil {
+			return nil, err
+		}
+		if item == nil {
+			return &ToolResult{Text: fmt.Sprintf("No book queue item with id %d. Run get_queue or diagnose_queue for current ids.", params.QueueID)}, nil
+		}
+		if item.DownloadID == "" {
+			return &ToolResult{Text: fmt.Sprintf("Queue item %d has no download-client id yet, so its files cannot be inspected. Wait until it has been handed to the download client.", params.QueueID)}, nil
+		}
+		candidates, err := client.GetManualImportCandidates(item.DownloadID)
+		if err != nil {
+			return nil, err
+		}
+		if len(candidates) == 0 {
+			return &ToolResult{Text: fmt.Sprintf("No importable files found for %s. The folder may be empty, an unextracted archive, or inaccessible.", chaptarrQueueTitle(*item))}, nil
+		}
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "%d candidate file(s) for %s:", len(candidates), chaptarrQueueTitle(*item))
+		for _, c := range candidates {
+			fmt.Fprintf(&sb, "\n- %s (%s)", c.Name, humanBytes(float64(c.Size)))
+			if c.BookID != 0 {
+				fmt.Fprintf(&sb, "\n  maps to book id %d", c.BookID)
+			} else {
+				sb.WriteString("\n  not matched to a book (cannot be imported without a book mapping)")
+			}
+			if rej := formatRejections(toRejectionViews(c.Rejections)); rej != "" {
+				fmt.Fprintf(&sb, "\n  rejections: %s", rej)
+			}
+		}
+		sb.WriteString("\n\nUse execute_manual_import to import these (add force=true to import despite permanent rejections).")
+		return &ToolResult{Text: sb.String()}, nil
+
 	default:
-		return &ToolResult{Text: "media_type must be \"movie\" or \"tv\"."}, nil
+		return &ToolResult{Text: "media_type must be \"movie\", \"tv\", or \"book\"."}, nil
 	}
 }
 
-func toRejectionViews[T sonarr.ManualImportRejection | radarr.ManualImportRejection](rejections []T) []arr.ManualImportRejectionView {
+func toRejectionViews[T sonarr.ManualImportRejection | radarr.ManualImportRejection | chaptarr.ManualImportRejection](rejections []T) []arr.ManualImportRejectionView {
 	out := make([]arr.ManualImportRejectionView, 0, len(rejections))
 	for _, r := range rejections {
 		switch v := any(r).(type) {
 		case sonarr.ManualImportRejection:
 			out = append(out, arr.ManualImportRejectionView{Reason: v.Reason, Type: v.Type})
 		case radarr.ManualImportRejection:
+			out = append(out, arr.ManualImportRejectionView{Reason: v.Reason, Type: v.Type})
+		case chaptarr.ManualImportRejection:
 			out = append(out, arr.ManualImportRejectionView{Reason: v.Reason, Type: v.Type})
 		}
 	}
@@ -481,7 +626,7 @@ func (s *ToolServer) executeManualImport(input json.RawMessage) (*ToolResult, er
 	if err := json.Unmarshal(input, &params); err != nil {
 		return nil, fmt.Errorf("parse input: %w", err)
 	}
-	text, err := ExecuteManualImportHelper(s.GetRadarr(), s.GetSonarr(), params.MediaType, params.QueueID, params.Force)
+	text, err := ExecuteManualImportHelper(s.GetRadarr(), s.GetSonarr(), s.GetChaptarr(), params.MediaType, params.QueueID, params.Force)
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +672,7 @@ func (s *ToolServer) remediateQueueItem(input json.RawMessage) (*ToolResult, err
 	if err := json.Unmarshal(input, &params); err != nil {
 		return nil, fmt.Errorf("parse input: %w", err)
 	}
-	text, err := RemediateQueueItemHelper(s.GetRadarr(), s.GetSonarr(), params.MediaType, params.QueueID, params.Action)
+	text, err := RemediateQueueItemHelper(s.GetRadarr(), s.GetSonarr(), s.GetChaptarr(), params.MediaType, params.QueueID, params.Action)
 	if err != nil {
 		return nil, err
 	}
@@ -540,11 +685,12 @@ func (s *ToolServer) rescanMedia(input json.RawMessage) (*ToolResult, error) {
 	var params struct {
 		TmdbID    int    `json:"tmdb_id"`
 		MediaType string `json:"media_type"`
+		AuthorID  int    `json:"author_id"`
 	}
 	if err := json.Unmarshal(input, &params); err != nil {
 		return nil, fmt.Errorf("parse input: %w", err)
 	}
-	text, err := RescanMediaHelper(s.bridge, s.GetRadarr(), s.GetSonarr(), params.MediaType, params.TmdbID)
+	text, err := RescanMediaHelper(s.bridge, s.GetRadarr(), s.GetSonarr(), s.GetChaptarr(), params.MediaType, params.TmdbID, params.AuthorID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/mcp/server.go
+++ b/server/internal/mcp/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/credentials"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
@@ -77,6 +78,19 @@ func (s *ToolServer) GetRadarr() *radarr.Client {
 func (s *ToolServer) GetSonarr() *sonarr.Client {
 	if s.registry != nil {
 		client, _, err := s.registry.GetDefaultSonarrClient()
+		if err == nil && client != nil {
+			return client
+		}
+	}
+	return nil
+}
+
+// GetChaptarr returns the default Chaptarr client. Chaptarr has no global
+// default flag, so GetDefaultChaptarrClient resolves an arbitrary configured
+// instance (and returns a nil client, no error, when none is configured).
+func (s *ToolServer) GetChaptarr() *chaptarr.Client {
+	if s.registry != nil {
+		client, _, err := s.registry.GetDefaultChaptarrClient()
 		if err == nil && client != nil {
 			return client
 		}

--- a/server/internal/remediation/actions.go
+++ b/server/internal/remediation/actions.go
@@ -41,21 +41,31 @@ type ManualImportParams struct {
 	Force     bool   `json:"force,omitempty"`
 }
 
-// TriggerSearchParams starts an automatic search.
+// TriggerSearchParams starts an automatic search. Movies/TV target a library
+// item by tmdb_id (TV optionally narrowed to a season); books carry no TMDB id,
+// so they target a single book by book_id or all of an author's monitored books
+// by author_id. The book fields are omitempty so a movie/TV action's canonical
+// JSON (and therefore its fingerprint) is unchanged by their addition.
 type TriggerSearchParams struct {
 	MediaType string `json:"media_type"`
-	TmdbID    int    `json:"tmdb_id"`
+	TmdbID    int    `json:"tmdb_id,omitempty"`
 	Season    *int   `json:"season,omitempty"`
+	AuthorID  int    `json:"author_id,omitempty"`
+	BookID    int    `json:"book_id,omitempty"`
 }
 
-// RescanParams rescans the media on disk and runs the import pass.
+// RescanParams rescans the media on disk and runs the import pass. Movies/TV are
+// addressed by tmdb_id; books carry no TMDB id and are addressed by author_id.
+// author_id is omitempty so a movie/TV action's canonical JSON (and fingerprint)
+// is unchanged by its addition.
 type RescanParams struct {
 	MediaType string `json:"media_type"`
-	TmdbID    int    `json:"tmdb_id"`
+	TmdbID    int    `json:"tmdb_id,omitempty"`
+	AuthorID  int    `json:"author_id,omitempty"`
 }
 
 // validMediaType reports whether m is a supported media type.
-func validMediaType(m string) bool { return m == "movie" || m == "tv" }
+func validMediaType(m string) bool { return m == "movie" || m == "tv" || m == "book" }
 
 // validateActionParams validates params against the kind's schema and returns the
 // CANONICAL JSON form to store + fingerprint. Canonicalization is by struct-field
@@ -71,7 +81,7 @@ func validateActionParams(kind ActionKind, raw json.RawMessage) (canonical json.
 			return nil, err
 		}
 		if !validMediaType(p.MediaType) {
-			return nil, fmt.Errorf("media_type must be \"movie\" or \"tv\"")
+			return nil, fmt.Errorf("media_type must be \"movie\", \"tv\", or \"book\"")
 		}
 		if p.GUID == "" || p.IndexerID == 0 {
 			return nil, fmt.Errorf("grab_release requires guid and indexer_id (from search_releases)")
@@ -87,7 +97,7 @@ func validateActionParams(kind ActionKind, raw json.RawMessage) (canonical json.
 			return nil, err
 		}
 		if !validMediaType(p.MediaType) {
-			return nil, fmt.Errorf("media_type must be \"movie\" or \"tv\"")
+			return nil, fmt.Errorf("media_type must be \"movie\", \"tv\", or \"book\"")
 		}
 		if p.QueueID <= 0 {
 			return nil, fmt.Errorf("remediate_queue requires a positive queue_id")
@@ -105,7 +115,7 @@ func validateActionParams(kind ActionKind, raw json.RawMessage) (canonical json.
 			return nil, err
 		}
 		if !validMediaType(p.MediaType) {
-			return nil, fmt.Errorf("media_type must be \"movie\" or \"tv\"")
+			return nil, fmt.Errorf("media_type must be \"movie\", \"tv\", or \"book\"")
 		}
 		if p.QueueID <= 0 {
 			return nil, fmt.Errorf("manual_import requires a positive queue_id")
@@ -118,10 +128,26 @@ func validateActionParams(kind ActionKind, raw json.RawMessage) (canonical json.
 			return nil, err
 		}
 		if !validMediaType(p.MediaType) {
-			return nil, fmt.Errorf("media_type must be \"movie\" or \"tv\"")
+			return nil, fmt.Errorf("media_type must be \"movie\", \"tv\", or \"book\"")
 		}
-		if p.TmdbID <= 0 {
-			return nil, fmt.Errorf("trigger_search requires a positive tmdb_id")
+		if p.MediaType == "book" {
+			// Books carry no TMDB id: target a single book by book_id or all of
+			// an author's monitored books by author_id. Reject a stray tmdb_id so
+			// only the documented book params are ever stored/fingerprinted.
+			if p.TmdbID != 0 {
+				return nil, fmt.Errorf("trigger_search for a book must not set tmdb_id")
+			}
+			if p.AuthorID <= 0 && p.BookID <= 0 {
+				return nil, fmt.Errorf("trigger_search for a book requires a positive author_id or book_id")
+			}
+		} else {
+			// Movies/TV are addressed by tmdb_id; the book fields don't apply.
+			if p.AuthorID != 0 || p.BookID != 0 {
+				return nil, fmt.Errorf("author_id and book_id apply only to media_type book")
+			}
+			if p.TmdbID <= 0 {
+				return nil, fmt.Errorf("trigger_search requires a positive tmdb_id")
+			}
 		}
 		return canonicalJSON(p)
 
@@ -131,10 +157,23 @@ func validateActionParams(kind ActionKind, raw json.RawMessage) (canonical json.
 			return nil, err
 		}
 		if !validMediaType(p.MediaType) {
-			return nil, fmt.Errorf("media_type must be \"movie\" or \"tv\"")
+			return nil, fmt.Errorf("media_type must be \"movie\", \"tv\", or \"book\"")
 		}
-		if p.TmdbID <= 0 {
-			return nil, fmt.Errorf("rescan requires a positive tmdb_id")
+		if p.MediaType == "book" {
+			// Books carry no TMDB id and are rescanned by author_id.
+			if p.TmdbID != 0 {
+				return nil, fmt.Errorf("rescan for a book must not set tmdb_id")
+			}
+			if p.AuthorID <= 0 {
+				return nil, fmt.Errorf("rescan for a book requires a positive author_id")
+			}
+		} else {
+			if p.AuthorID != 0 {
+				return nil, fmt.Errorf("author_id applies only to media_type book")
+			}
+			if p.TmdbID <= 0 {
+				return nil, fmt.Errorf("rescan requires a positive tmdb_id")
+			}
 		}
 		return canonicalJSON(p)
 

--- a/server/internal/remediation/executor.go
+++ b/server/internal/remediation/executor.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/mcp"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
@@ -32,6 +33,15 @@ func NewExecutor(registry *instance.Registry, bridge *tmdb.Bridge, db *sql.DB) *
 	return &Executor{registry: registry, bridge: bridge, db: db}
 }
 
+// chaptarrQueuePage / chaptarrQueuePageSize drive the paginated
+// chaptarr.GetQueueDetailed call used by the book validation gate (the client
+// loops from this page until every record is fetched). Radarr/Sonarr expose a
+// non-paginated GetQueueDetailed, so these are book-only.
+const (
+	chaptarrQueuePage     = 1
+	chaptarrQueuePageSize = 100
+)
+
 // issueContext is the stable, cheap-to-fetch identity of an issue's media used to
 // resolve the arr client and to validate a queue-targeting action still applies
 // to THIS issue. instance_id/download_id are set for auto issues; for user issues
@@ -52,7 +62,7 @@ func (e *Executor) Execute(ctx context.Context, issueID int64, kind ActionKind, 
 		return "", err
 	}
 
-	rc, sc, err := e.clientsFor(ic)
+	rc, sc, cc, err := e.clientsFor(ic)
 	if err != nil {
 		return "", err
 	}
@@ -70,45 +80,49 @@ func (e *Executor) Execute(ctx context.Context, issueID int64, kind ActionKind, 
 		// release and re-hammer indexers); the arr returns a clean error on a stale
 		// guid, which Execute surfaces as a definitive failure.
 		if p.QueueIDToReplace > 0 {
-			if err := e.validateQueueItem(p.MediaType, p.QueueIDToReplace, ic, rc, sc); err != nil {
+			if err := e.validateQueueItem(p.MediaType, p.QueueIDToReplace, ic, rc, sc, cc); err != nil {
 				return "", err
 			}
 		}
-		return mcp.GrabReleaseHelper(rc, sc, p.MediaType, p.GUID, p.IndexerID, p.QueueIDToReplace)
+		return mcp.GrabReleaseHelper(rc, sc, cc, p.MediaType, p.GUID, p.IndexerID, p.QueueIDToReplace)
 
 	case ActionRemediateQueue:
 		var p RemediateQueueParams
 		if err := json.Unmarshal(params, &p); err != nil {
 			return "", fmt.Errorf("decode remediate_queue params: %w", err)
 		}
-		if err := e.validateQueueItem(p.MediaType, p.QueueID, ic, rc, sc); err != nil {
+		if err := e.validateQueueItem(p.MediaType, p.QueueID, ic, rc, sc, cc); err != nil {
 			return "", err
 		}
-		return mcp.RemediateQueueItemHelper(rc, sc, p.MediaType, p.QueueID, p.Action)
+		return mcp.RemediateQueueItemHelper(rc, sc, cc, p.MediaType, p.QueueID, p.Action)
 
 	case ActionManualImport:
 		var p ManualImportParams
 		if err := json.Unmarshal(params, &p); err != nil {
 			return "", fmt.Errorf("decode manual_import params: %w", err)
 		}
-		if err := e.validateQueueItem(p.MediaType, p.QueueID, ic, rc, sc); err != nil {
+		if err := e.validateQueueItem(p.MediaType, p.QueueID, ic, rc, sc, cc); err != nil {
 			return "", err
 		}
-		return mcp.ExecuteManualImportHelper(rc, sc, p.MediaType, p.QueueID, p.Force)
+		return mcp.ExecuteManualImportHelper(rc, sc, cc, p.MediaType, p.QueueID, p.Force)
 
 	case ActionTriggerSearch:
 		var p TriggerSearchParams
 		if err := json.Unmarshal(params, &p); err != nil {
 			return "", fmt.Errorf("decode trigger_search params: %w", err)
 		}
-		return mcp.TriggerSearchHelper(e.bridge, rc, sc, p.MediaType, p.TmdbID, p.Season)
+		var bookIDs []int
+		if p.BookID != 0 {
+			bookIDs = []int{p.BookID}
+		}
+		return mcp.TriggerSearchHelper(e.bridge, rc, sc, cc, p.MediaType, p.TmdbID, p.Season, p.AuthorID, bookIDs)
 
 	case ActionRescan:
 		var p RescanParams
 		if err := json.Unmarshal(params, &p); err != nil {
 			return "", fmt.Errorf("decode rescan params: %w", err)
 		}
-		return mcp.RescanMediaHelper(e.bridge, rc, sc, p.MediaType, p.TmdbID)
+		return mcp.RescanMediaHelper(e.bridge, rc, sc, cc, p.MediaType, p.TmdbID, p.AuthorID)
 
 	default:
 		return "", fmt.Errorf("unknown action kind: %s", kind)
@@ -130,29 +144,34 @@ func (e *Executor) loadIssueContext(issueID int64) (issueContext, error) {
 	return issueContext{instanceID: instanceID.String, downloadID: downloadID.String}, nil
 }
 
-// clientsFor resolves the Radarr and Sonarr clients for the issue. If the issue
-// carries a specific instance_id, that instance's client is used; otherwise the
-// default instance for each service is resolved. A nil client is fine — the
-// shared helpers return a "<service> is not configured" message for the wrong
-// media_type. An error is only returned when a NAMED instance fails to resolve.
-func (e *Executor) clientsFor(ic issueContext) (*radarr.Client, *sonarr.Client, error) {
+// clientsFor resolves the Radarr, Sonarr, and Chaptarr clients for the issue. If
+// the issue carries a specific instance_id, that instance's client is used;
+// otherwise the default instance for each service is resolved. A nil client is
+// fine — the shared helpers return a "<service> is not configured" message for
+// the wrong media_type. An error is only returned when a NAMED instance fails to
+// resolve as ANY of the three service kinds.
+func (e *Executor) clientsFor(ic issueContext) (*radarr.Client, *sonarr.Client, *chaptarr.Client, error) {
 	if e.registry == nil {
-		return nil, nil, fmt.Errorf("instance registry not configured")
+		return nil, nil, nil, fmt.Errorf("instance registry not configured")
 	}
 	if ic.instanceID != "" {
-		// A specific instance was recorded (auto issue). Try it as both a Radarr and
-		// a Sonarr instance; whichever matches yields a client, the other stays nil.
+		// A specific instance was recorded (auto issue). Try it as a Radarr, a
+		// Sonarr, and a Chaptarr instance; whichever matches yields a client, the
+		// others stay nil.
 		rc, rErr := e.registry.GetRadarrClient(ic.instanceID)
 		sc, sErr := e.registry.GetSonarrClient(ic.instanceID)
-		if rErr != nil && sErr != nil {
-			return nil, nil, fmt.Errorf("resolve instance %q: %v / %v", ic.instanceID, rErr, sErr)
+		cc, cErr := e.registry.GetChaptarrClient(ic.instanceID)
+		if rErr != nil && sErr != nil && cErr != nil {
+			return nil, nil, nil, fmt.Errorf("resolve instance %q: %v / %v / %v", ic.instanceID, rErr, sErr, cErr)
 		}
-		return rc, sc, nil
+		return rc, sc, cc, nil
 	}
-	// User issue with no instance: fall back to the default Radarr + Sonarr.
+	// User issue with no instance: fall back to the default Radarr + Sonarr +
+	// Chaptarr.
 	rc, _, _ := e.registry.GetDefaultRadarrClient()
 	sc, _, _ := e.registry.GetDefaultSonarrClient()
-	return rc, sc, nil
+	cc, _, _ := e.registry.GetDefaultChaptarrClient()
+	return rc, sc, cc, nil
 }
 
 // validateQueueItem is the stable-invariant gate for a queue-targeting action: it
@@ -162,7 +181,7 @@ func (e *Executor) clientsFor(ic issueContext) (*radarr.Client, *sonarr.Client, 
 // to a different download since the proposal. Cheap (one detailed-queue fetch)
 // and stable. A definitive mismatch returns an error so the action is marked
 // failed rather than executing against the wrong item.
-func (e *Executor) validateQueueItem(mediaType string, queueID int, ic issueContext, rc *radarr.Client, sc *sonarr.Client) error {
+func (e *Executor) validateQueueItem(mediaType string, queueID int, ic issueContext, rc *radarr.Client, sc *sonarr.Client, cc *chaptarr.Client) error {
 	switch mediaType {
 	case "movie":
 		if rc == nil {
@@ -200,7 +219,25 @@ func (e *Executor) validateQueueItem(mediaType string, queueID int, ic issueCont
 		}
 		return fmt.Errorf("queue item %d is no longer in the Sonarr queue (already handled or removed); not executing", queueID)
 
+	case "book":
+		if cc == nil {
+			return nil
+		}
+		items, err := cc.GetQueueDetailed(chaptarrQueuePage, chaptarrQueuePageSize)
+		if err != nil {
+			return fmt.Errorf("validate queue item: %w", err)
+		}
+		for i := range items {
+			if items[i].ID == queueID {
+				if ic.downloadID != "" && items[i].DownloadID != "" && items[i].DownloadID != ic.downloadID {
+					return fmt.Errorf("queue item %d no longer matches this issue's download (it was reassigned); not executing", queueID)
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("queue item %d is no longer in the Chaptarr queue (already handled or removed); not executing", queueID)
+
 	default:
-		return fmt.Errorf("media_type must be \"movie\" or \"tv\"")
+		return fmt.Errorf("media_type must be \"movie\", \"tv\", or \"book\"")
 	}
 }

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -59,10 +59,12 @@ func NewService(db *sql.DB, registry *instance.Registry, bridge *tmdb.Bridge, no
 	}
 }
 
-// getRadarr returns the default Radarr client from the registry.
-func (s *Service) getRadarr() *radarr.Client {
+// getRadarr returns the Radarr client to use as a given user's source: their
+// per-user default override when set, else the global default. A userID of 0
+// (no specific user / admin-global context) resolves to the global default.
+func (s *Service) getRadarr(userID int64) *radarr.Client {
 	if s.registry != nil {
-		client, _, err := s.registry.GetDefaultRadarrClient()
+		client, _, err := s.registry.GetUserDefaultRadarrClient(userID)
 		if err == nil && client != nil {
 			return client
 		}
@@ -70,10 +72,12 @@ func (s *Service) getRadarr() *radarr.Client {
 	return nil
 }
 
-// getSonarr returns the default Sonarr client from the registry.
-func (s *Service) getSonarr() *sonarr.Client {
+// getSonarr returns the Sonarr client to use as a given user's source: their
+// per-user default override when set, else the global default. A userID of 0
+// (no specific user / admin-global context) resolves to the global default.
+func (s *Service) getSonarr(userID int64) *sonarr.Client {
 	if s.registry != nil {
-		client, _, err := s.registry.GetDefaultSonarrClient()
+		client, _, err := s.registry.GetUserDefaultSonarrClient(userID)
 		if err == nil && client != nil {
 			return client
 		}
@@ -501,7 +505,7 @@ func (s *Service) addToArr(r *resolvedRequest) (status string, title string, err
 }
 
 func (s *Service) addMovie(r *resolvedRequest) (string, string, error) {
-	radarrClient := s.getRadarr()
+	radarrClient := s.getRadarr(r.userID)
 	if radarrClient == nil {
 		return "", "", fmt.Errorf("radarr is not configured")
 	}
@@ -551,7 +555,7 @@ func (s *Service) addMovie(r *resolvedRequest) (string, string, error) {
 }
 
 func (s *Service) addSeries(r *resolvedRequest) (string, string, error) {
-	sonarrClient := s.getSonarr()
+	sonarrClient := s.getSonarr(r.userID)
 	if sonarrClient == nil {
 		return "", "", fmt.Errorf("sonarr is not configured")
 	}
@@ -710,12 +714,21 @@ func (s *Service) monitorAndSearchSeasons(client *sonarr.Client, series *sonarr.
 	return nil
 }
 
+// GetStatus reports a title's availability against the GLOBAL default instance
+// (userID 0). User-scoped checks go through GetUserStatus, which resolves the
+// requesting user's source instance.
 func (s *Service) GetStatus(tmdbID int, mediaType string) (*StatusResponse, error) {
+	return s.statusFor(0, tmdbID, mediaType)
+}
+
+// statusFor reports a title's availability against userID's source instance
+// (their per-user default override, else the global default).
+func (s *Service) statusFor(userID int64, tmdbID int, mediaType string) (*StatusResponse, error) {
 	switch mediaType {
 	case "movie":
-		return s.getMovieStatus(tmdbID)
+		return s.getMovieStatus(userID, tmdbID)
 	case "tv":
-		return s.getTVStatus(tmdbID)
+		return s.getTVStatus(userID, tmdbID)
 	default:
 		return &StatusResponse{Status: StatusUnavailable}, nil
 	}
@@ -737,17 +750,17 @@ func (s *Service) GetUserStatus(userID int64, tmdbID int, mediaType string) (*St
 		// A denied request shows "denied" only while the title isn't otherwise
 		// available; if it later lands in the arr, prefer the live state.
 		if status == StatusDenied {
-			if live, lerr := s.GetStatus(tmdbID, mediaType); lerr == nil && live != nil && live.Status != StatusUnavailable {
+			if live, lerr := s.statusFor(userID, tmdbID, mediaType); lerr == nil && live != nil && live.Status != StatusUnavailable {
 				return live, nil
 			}
 			return &StatusResponse{Status: StatusDenied}, nil
 		}
 	}
-	return s.GetStatus(tmdbID, mediaType)
+	return s.statusFor(userID, tmdbID, mediaType)
 }
 
-func (s *Service) getMovieStatus(tmdbID int) (*StatusResponse, error) {
-	radarrClient := s.getRadarr()
+func (s *Service) getMovieStatus(userID int64, tmdbID int) (*StatusResponse, error) {
+	radarrClient := s.getRadarr(userID)
 	if radarrClient == nil {
 		return &StatusResponse{Status: StatusUnavailable}, nil
 	}
@@ -781,8 +794,8 @@ func (s *Service) getMovieStatus(tmdbID int) (*StatusResponse, error) {
 	return &StatusResponse{Status: StatusUnavailable}, nil
 }
 
-func (s *Service) getTVStatus(tmdbID int) (*StatusResponse, error) {
-	sonarrClient := s.getSonarr()
+func (s *Service) getTVStatus(userID int64, tmdbID int) (*StatusResponse, error) {
+	sonarrClient := s.getSonarr(userID)
 	if sonarrClient == nil {
 		return &StatusResponse{Status: StatusUnavailable}, nil
 	}
@@ -1032,16 +1045,17 @@ func (s *Service) GetRequestOptions(userID int64, isAdmin bool, mediaType string
 		QualityProfiles:    []QualityProfile{},
 	}
 	if eff.AllowQualityChoice {
-		opts.QualityProfiles = s.qualityProfiles(mediaType)
+		opts.QualityProfiles = s.qualityProfiles(userID, mediaType)
 	}
 	return opts, nil
 }
 
-// qualityProfiles fetches the selectable quality profiles for a media type.
-func (s *Service) qualityProfiles(mediaType string) []QualityProfile {
+// qualityProfiles fetches the selectable quality profiles for a media type from
+// userID's source instance (userID 0 = global default).
+func (s *Service) qualityProfiles(userID int64, mediaType string) []QualityProfile {
 	out := []QualityProfile{}
 	if mediaType == "tv" {
-		if c := s.getSonarr(); c != nil {
+		if c := s.getSonarr(userID); c != nil {
 			if ps, err := c.GetQualityProfiles(); err == nil {
 				for _, p := range ps {
 					out = append(out, QualityProfile{ID: p.ID, Name: p.Name})
@@ -1050,7 +1064,7 @@ func (s *Service) qualityProfiles(mediaType string) []QualityProfile {
 		}
 		return out
 	}
-	if c := s.getRadarr(); c != nil {
+	if c := s.getRadarr(userID); c != nil {
 		if ps, err := c.GetQualityProfiles(); err == nil {
 			for _, p := range ps {
 				out = append(out, QualityProfile{ID: p.ID, Name: p.Name})
@@ -1065,8 +1079,8 @@ func (s *Service) qualityProfiles(mediaType string) []QualityProfile {
 func (s *Service) GetAdminSettings() *AdminSettingsView {
 	return &AdminSettingsView{
 		Settings:       s.GetGlobalSettings(),
-		RadarrProfiles: s.qualityProfiles("movie"),
-		SonarrProfiles: s.qualityProfiles("tv"),
+		RadarrProfiles: s.qualityProfiles(0, "movie"),
+		SonarrProfiles: s.qualityProfiles(0, "tv"),
 	}
 }
 

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/windoze95/cantinarr-server/internal/arr"
 	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/downloads"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
@@ -357,6 +358,7 @@ func (h *Hub) pollLoop(ctx context.Context) {
 		case <-arrTicker.C:
 			h.pollAllRadarr()
 			h.pollAllSonarr()
+			h.pollAllChaptarr()
 		case <-downloadsTicker.C:
 			h.pollAllDownloadClients()
 		}
@@ -647,6 +649,23 @@ func (h *Hub) pollAllSonarr() {
 	}
 }
 
+func (h *Hub) pollAllChaptarr() {
+	if h.store == nil || h.registry == nil {
+		return
+	}
+	instances, err := h.store.List("chaptarr")
+	if err != nil {
+		return
+	}
+	for _, inst := range instances {
+		client, err := h.registry.GetChaptarrClient(inst.ID)
+		if err != nil {
+			continue
+		}
+		h.pollChaptarrInstance(inst.ID, client)
+	}
+}
+
 func (h *Hub) pollRadarrInstance(instanceID string, client *radarr.Client) {
 	queue, err := client.GetQueue()
 	if err != nil {
@@ -790,4 +809,24 @@ func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
 
 	// Auto-dispatch pass (see pollRadarrInstance). No-op when the opener is nil.
 	h.autoDispatchSonarr(instanceID, client)
+}
+
+// pollChaptarrInstance emits an arr_queue_changed invalidation ping whenever the
+// instance's download queue composition changes. Unlike the Radarr/Sonarr
+// pollers it does not emit per-item download_progress events: Chaptarr books
+// carry no TMDB id, which those events key on. There is also no auto-dispatch
+// pass; remediation does not cover chaptarr.
+func (h *Hub) pollChaptarrInstance(instanceID string, client *chaptarr.Client) {
+	queue, err := client.GetQueue()
+	if err != nil {
+		log.Printf("websocket: poll chaptarr queue (%s): %v", instanceID, err)
+		return
+	}
+
+	tuples := make([]string, 0, len(queue))
+	for _, item := range queue {
+		tuples = append(tuples, fmt.Sprintf("%d|%s|%.0f", item.BookID, item.Status, item.Sizeleft))
+	}
+
+	h.noteArrQueueComposition(instanceID, "chaptarr", tuples)
 }


### PR DESCRIPTION
## Summary

Two related capabilities:

1. **Per-user default *arr instance override (admin-managed).** The "default" instance per service type was a single global flag shared by every user; now an admin can pin which instance is a given user's source per kind.
2. **A new Chaptarr (books) module** — ebooks + audiobooks, full depth mirroring Sonarr. Chaptarr has **no global default**: a user sees the Books section only if an admin explicitly grants them an instance, so the per-user assignment doubles as the visibility/access grant.

## Part 1 — per-user default override

- New `user_default_instances(user_id, service_type, instance_id)` table (PK `user_id, service_type`) in `db.go` `initSQL`, with store methods + orphan cleanup on instance delete.
- Admin endpoints `GET|PUT /api/admin/users/{id}/default-instances` (gated `users:manage`).
- **Single delivery chokepoint:** `configHandler` rewrites each instance's *effective* `is_default` per user, so the Flutter client resolves the right source with **zero client-logic change**. Registry `GetUserDefault{Sonarr,Radarr}Client(userID)` (userID `0` = global) is threaded into the request/add flow. MCP + remediation deliberately stay on the global default (admin/AI context).
- Admin UI: extended the existing **User settings** screen (no new screen/route), scoped to source services (radarr/sonarr/chaptarr).

## Part 2 — Chaptarr module

- Readarr fork on **`/api/v1`** (author → book → edition → bookFile; ebook vs audiobook derived from the bookFile quality/format).
- **No global default, server-enforced per-user access:** a Chaptarr instance is visible/reachable only to admins or a user explicitly granted it — enforced in `configHandler` (filters `instances[]` + `services.chaptarr`) **and** `auth.RequireArrProxyAccess` (per-user grant gate + generalized `/api/v1` read allowlist), not just hidden client-side.
- **Backend:** `internal/chaptarr` typed client, registry/kind registration, websocket queue polling (`arr_queue_changed`), MCP tools + remediation executor extended to `media_type: "book"` (the `validateQueueItem` invariant gate is mirrored for books).
- **Flutter:** `features/chaptarr` mirrors Sonarr — 4-tab shell (Library/Queue/History/Wanted, no Calendar), author → book → edition drill-down, interactive release search, queue + Import Doctor, history, wanted — with **ebook/audiobook badges + format handling** first-class.

## Testing

- **Backend:** `go build ./...`, `go vet ./...`, `go test ./...` — all green. New tests: chaptarr client (`httptest`), proxy grant gate (403 non-granted / 200 granted / admin bypass), store per-user-override + grant logic.
- **Flutter:** `flutter analyze` clean for new code; `flutter test` — **111 pass** (incl. format classifier + doctor bridge).

## Notes / limitations

- **One Chaptarr instance per user** in v1 (grant row keyed by user + type).
- `chaptarr.ExecuteManualImport` uses importMode `"auto"` (lets Chaptarr choose copy/move).
- Chaptarr websocket emits `arr_queue_changed` only (no per-item `download_progress` — books have no TMDB id to key on).
- Schema was added to `db.go` `initSQL`; `server/migrations/*.sql` is a stale/unused snapshot and was intentionally left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
