### PR TITLE
feat(chaptarr): Books dashboard tab + book discovery/request flow

### DIFF
--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -232,10 +232,25 @@ class _BookResultTile extends StatelessWidget {
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
               style: const TextStyle(color: AppTheme.textSecondary)),
-      trailing: (fid != null && fid.isNotEmpty)
-          ? _BookRequestButton(
-              foreignId: fid, title: book.title, service: requestService)
-          : null,
+      // A Chaptarr lookup result that is already tracked in the library comes
+      // back with a non-zero id; show that instead of a Request button (which
+      // would otherwise try to re-add it).
+      trailing: book.id != 0
+          ? const Padding(
+              padding: EdgeInsets.only(right: 8),
+              child: Text(
+                'In Library',
+                style: TextStyle(
+                  color: AppTheme.available,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            )
+          : (fid != null && fid.isNotEmpty)
+              ? _BookRequestButton(
+                  foreignId: fid, title: book.title, service: requestService)
+              : null,
     );
   }
 }

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -1,0 +1,337 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../chaptarr/data/chaptarr_api_service.dart';
+import '../../chaptarr/data/chaptarr_models.dart';
+import '../../request/data/request_service.dart';
+
+/// Dashboard Books tab: search Chaptarr's catalog (books/authors) and request a
+/// book. Chaptarr lookup is search-only (no "popular" feed like TMDB), so this
+/// tab is search-first; the full library lives in the Books module.
+class DashboardBooksTab extends ConsumerStatefulWidget {
+  const DashboardBooksTab({super.key});
+
+  @override
+  ConsumerState<DashboardBooksTab> createState() => _DashboardBooksTabState();
+}
+
+class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
+  final _controller = TextEditingController();
+  List<ChaptarrBook> _results = [];
+  bool _isSearching = false;
+  bool _searched = false;
+  String? _error;
+  int _searchGen = 0; // guards against superseded async results
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() => setState(() {})); // refresh the clear button
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  ChaptarrApiService? _chaptarr() {
+    final instance = ref.read(instanceProvider).activeChaptarrInstance;
+    if (instance == null) return null;
+    return ChaptarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: instance.id,
+    );
+  }
+
+  Future<void> _search() async {
+    final term = _controller.text.trim();
+    if (term.isEmpty) {
+      setState(() {
+        _results = [];
+        _searched = false;
+        _error = null;
+      });
+      return;
+    }
+    final service = _chaptarr();
+    if (service == null) {
+      setState(() => _error = 'No Chaptarr instance is available.');
+      return;
+    }
+    final gen = ++_searchGen;
+    setState(() {
+      _isSearching = true;
+      _error = null;
+    });
+    try {
+      final books = await service.lookupBook(term);
+      if (!mounted || gen != _searchGen) return;
+      setState(() {
+        _results = books;
+        _isSearching = false;
+        _searched = true;
+      });
+    } catch (_) {
+      if (!mounted || gen != _searchGen) return;
+      setState(() {
+        _isSearching = false;
+        _searched = true;
+        _error = 'Search failed. Please try again.';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(12),
+          child: TextField(
+            controller: _controller,
+            textInputAction: TextInputAction.search,
+            onSubmitted: (_) => _search(),
+            style: const TextStyle(color: AppTheme.textPrimary),
+            decoration: InputDecoration(
+              hintText: 'Search books or authors…',
+              hintStyle: const TextStyle(color: AppTheme.textSecondary),
+              prefixIcon:
+                  const Icon(Icons.search, color: AppTheme.textSecondary),
+              suffixIcon: _controller.text.isEmpty
+                  ? null
+                  : IconButton(
+                      icon: const Icon(Icons.clear,
+                          color: AppTheme.textSecondary),
+                      onPressed: () {
+                        _controller.clear();
+                        _search();
+                      },
+                    ),
+              filled: true,
+              fillColor: AppTheme.surface,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+                borderSide: BorderSide.none,
+              ),
+            ),
+          ),
+        ),
+        Expanded(child: _buildBody()),
+      ],
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isSearching) {
+      return const Center(
+        child: CircularProgressIndicator(color: AppTheme.accent),
+      );
+    }
+    if (_error != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Text(_error!,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: AppTheme.error)),
+        ),
+      );
+    }
+    if (_results.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(32),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.menu_book,
+                  size: 48, color: AppTheme.textSecondary),
+              const SizedBox(height: 12),
+              Text(
+                _searched
+                    ? 'No books found. Try a different search.'
+                    : 'Search for a book or author to request.\nYour library lives in the Books section.',
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: AppTheme.textSecondary),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+    // One RequestService for the whole result list (requests go through the
+    // backend's /requests endpoint, not the Chaptarr proxy).
+    final requestService =
+        RequestService(backendDio: ref.read(backendClientProvider));
+    return ListView.separated(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      itemCount: _results.length,
+      separatorBuilder: (_, __) =>
+          const Divider(height: 1, color: AppTheme.border),
+      itemBuilder: (_, i) =>
+          _BookResultTile(book: _results[i], requestService: requestService),
+    );
+  }
+}
+
+class _BookResultTile extends StatelessWidget {
+  final ChaptarrBook book;
+  final RequestService requestService;
+
+  const _BookResultTile({required this.book, required this.requestService});
+
+  @override
+  Widget build(BuildContext context) {
+    final year = book.releaseDate?.year;
+    final subtitle = <String>[
+      if (book.author?.authorName.isNotEmpty ?? false) book.author!.authorName,
+      if (year != null) '$year',
+    ].join(' · ');
+    final fid = book.foreignBookId;
+
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      leading: SizedBox(
+        width: 44,
+        height: 66,
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: book.coverUrl != null
+              ? CachedNetworkImage(
+                  imageUrl: book.coverUrl!,
+                  fit: BoxFit.cover,
+                  placeholder: (_, __) =>
+                      Container(color: AppTheme.surfaceVariant),
+                  errorWidget: (_, __, ___) => Container(
+                    color: AppTheme.surfaceVariant,
+                    child: const Icon(Icons.menu_book,
+                        color: AppTheme.textSecondary, size: 20),
+                  ),
+                )
+              : Container(
+                  color: AppTheme.surfaceVariant,
+                  child: const Icon(Icons.menu_book,
+                      color: AppTheme.textSecondary, size: 20),
+                ),
+        ),
+      ),
+      title: Text(
+        book.title,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+        style: const TextStyle(
+            color: AppTheme.textPrimary, fontWeight: FontWeight.w600),
+      ),
+      subtitle: subtitle.isEmpty
+          ? null
+          : Text(subtitle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(color: AppTheme.textSecondary)),
+      trailing: (fid != null && fid.isNotEmpty)
+          ? _BookRequestButton(
+              foreignId: fid, title: book.title, service: requestService)
+          : null,
+    );
+  }
+}
+
+/// Per-book request affordance: loads the user's request state on build, and on
+/// tap submits a request (which may land as pending when approval is required).
+class _BookRequestButton extends StatefulWidget {
+  final String foreignId;
+  final String title;
+  final RequestService service;
+
+  const _BookRequestButton({
+    required this.foreignId,
+    required this.title,
+    required this.service,
+  });
+
+  @override
+  State<_BookRequestButton> createState() => _BookRequestButtonState();
+}
+
+class _BookRequestButtonState extends State<_BookRequestButton> {
+  RequestStatus _status = RequestStatus.unavailable;
+  bool _loading = true;
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _check();
+  }
+
+  Future<void> _check() async {
+    final s = await widget.service.checkBookStatus(widget.foreignId);
+    if (!mounted) return;
+    setState(() {
+      _status = s;
+      _loading = false;
+    });
+  }
+
+  Future<void> _request() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    final s = await widget.service
+        .requestBook(foreignId: widget.foreignId, title: widget.title);
+    if (!mounted) return;
+    setState(() {
+      _busy = false;
+      if (s != null) _status = s;
+    });
+    if (s == null && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Request failed. Please try again.')),
+      );
+    }
+  }
+
+  bool get _requestable =>
+      _status == RequestStatus.unavailable || _status == RequestStatus.denied;
+
+  Color get _color => switch (_status) {
+        RequestStatus.pending ||
+        RequestStatus.requested ||
+        RequestStatus.partial =>
+          AppTheme.requested,
+        RequestStatus.downloading => AppTheme.downloading,
+        RequestStatus.available => AppTheme.available,
+        _ => AppTheme.accent,
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const SizedBox(
+        width: 96,
+        child: Center(
+          child: SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+                strokeWidth: 2, color: AppTheme.accent),
+          ),
+        ),
+      );
+    }
+    return TextButton(
+      onPressed: _requestable && !_busy ? _request : null,
+      style: TextButton.styleFrom(foregroundColor: _color),
+      child: _busy
+          ? const SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Text(_status.buttonLabel),
+    );
+  }
+}

--- a/app/lib/features/dashboard/ui/dashboard_shell.dart
+++ b/app/lib/features/dashboard/ui/dashboard_shell.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../auth/logic/auth_provider.dart';
 
-/// Dashboard module shell with bottom nav: Movies | TV Shows | Releases.
-class DashboardShell extends StatefulWidget {
+/// Dashboard module shell with bottom nav: Movies | TV Shows | Releases, plus a
+/// Books tab when the user has Chaptarr access (services.chaptarr). Books is the
+/// LAST branch so showing/hiding it never shifts the other tabs' indices.
+class DashboardShell extends ConsumerWidget {
   final int currentIndex;
   final ValueChanged<int> onTabChanged;
   final Widget child;
@@ -15,39 +19,47 @@ class DashboardShell extends StatefulWidget {
   });
 
   @override
-  State<DashboardShell> createState() => _DashboardShellState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final showBooks = ref.watch(
+      authProvider.select(
+        (a) => a.valueOrNull?.connection?.services.chaptarr ?? false,
+      ),
+    );
 
-class _DashboardShellState extends State<DashboardShell> {
-  @override
-  Widget build(BuildContext context) {
+    final items = <BottomNavigationBarItem>[
+      const BottomNavigationBarItem(
+        icon: Icon(Icons.movie_outlined),
+        activeIcon: Icon(Icons.movie),
+        label: 'Movies',
+      ),
+      const BottomNavigationBarItem(
+        icon: Icon(Icons.tv_outlined),
+        activeIcon: Icon(Icons.tv),
+        label: 'TV Shows',
+      ),
+      const BottomNavigationBarItem(
+        icon: Icon(Icons.event_outlined),
+        activeIcon: Icon(Icons.event),
+        label: 'Releases',
+      ),
+      if (showBooks)
+        const BottomNavigationBarItem(
+          icon: Icon(Icons.menu_book_outlined),
+          activeIcon: Icon(Icons.menu_book),
+          label: 'Books',
+        ),
+    ];
+
     return Scaffold(
-      body: widget.child,
+      body: child,
       bottomNavigationBar: Container(
         decoration: const BoxDecoration(
-          border:
-              Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
+          border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
         ),
         child: BottomNavigationBar(
-          currentIndex: widget.currentIndex,
-          onTap: widget.onTabChanged,
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.movie_outlined),
-              activeIcon: Icon(Icons.movie),
-              label: 'Movies',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.tv_outlined),
-              activeIcon: Icon(Icons.tv),
-              label: 'TV Shows',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.event_outlined),
-              activeIcon: Icon(Icons.event),
-              label: 'Releases',
-            ),
-          ],
+          currentIndex: currentIndex.clamp(0, items.length - 1),
+          onTap: onTabChanged,
+          items: items,
         ),
       ),
     );

--- a/app/lib/features/request/data/request_service.dart
+++ b/app/lib/features/request/data/request_service.dart
@@ -47,8 +47,9 @@ class SeasonScope {
     (value: all, label: 'Entire series'),
   ];
 
-  static String labelFor(String value) =>
-      choices.firstWhere((c) => c.value == value, orElse: () => choices.last).label;
+  static String labelFor(String value) => choices
+      .firstWhere((c) => c.value == value, orElse: () => choices.last)
+      .label;
 
   /// True when [value] holds an explicit JSON season list (e.g. "[3,5]")
   /// rather than a coarse scope keyword. The backend stores per-season requests
@@ -170,9 +171,11 @@ class RequestOptions {
   factory RequestOptions.fromJson(Map<String, dynamic> json) => RequestOptions(
         canChooseSeason: json['can_choose_season'] as bool? ?? false,
         canChooseQuality: json['can_choose_quality'] as bool? ?? false,
-        defaultSeasonScope: json['default_season_scope'] as String? ?? SeasonScope.all,
+        defaultSeasonScope:
+            json['default_season_scope'] as String? ?? SeasonScope.all,
         qualityProfiles: ((json['quality_profiles'] as List?) ?? const [])
-            .map((e) => QualityProfileOption.fromJson(e as Map<String, dynamic>))
+            .map(
+                (e) => QualityProfileOption.fromJson(e as Map<String, dynamic>))
             .toList(),
       );
 }
@@ -257,6 +260,52 @@ class RequestService {
       final statusName = data?['status'] as String? ?? 'requested';
       return RequestStatus.values.firstWhere(
         (s) => s.name == statusName,
+        orElse: () => RequestStatus.requested,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Check the current user's request state for a book, keyed by the Chaptarr/
+  /// Readarr foreignBookId (books have no tmdb_id). Returns one of
+  /// unavailable / pending / requested / denied.
+  Future<RequestStatus> checkBookStatus(String foreignId) async {
+    try {
+      final resp = await _backendDio.get(
+        '/api/requests/book-status',
+        queryParameters: {'foreign_id': foreignId},
+      );
+      final name = (resp.data as Map<String, dynamic>)['status'] as String? ??
+          'unavailable';
+      return RequestStatus.values.firstWhere(
+        (s) => s.name == name,
+        orElse: () => RequestStatus.unavailable,
+      );
+    } catch (_) {
+      return RequestStatus.unavailable;
+    }
+  }
+
+  /// Submit a book request. Books are keyed by the foreignBookId, not a tmdb_id;
+  /// the backend adds the book to the user's granted Chaptarr instance (after
+  /// approval when the user's policy requires it). Returns the resulting status
+  /// (e.g. [RequestStatus.pending]) or null on failure.
+  Future<RequestStatus?> requestBook({
+    required String foreignId,
+    required String title,
+  }) async {
+    try {
+      final resp = await _backendDio.post('/api/requests', data: {
+        'media_type': 'book',
+        'foreign_id': foreignId,
+        'title': title,
+      });
+      if (resp.statusCode != 200 && resp.statusCode != 201) return null;
+      final data = resp.data as Map<String, dynamic>?;
+      final name = data?['status'] as String? ?? 'requested';
+      return RequestStatus.values.firstWhere(
+        (s) => s.name == name,
         orElse: () => RequestStatus.requested,
       );
     } catch (_) {

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -12,6 +12,7 @@ import '../features/chaptarr/ui/chaptarr_home_screen.dart';
 import '../features/chaptarr/ui/chaptarr_module_shell.dart';
 import '../features/chaptarr/ui/chaptarr_queue_screen.dart';
 import '../features/chaptarr/ui/chaptarr_wanted_screen.dart';
+import '../features/dashboard/ui/dashboard_books_tab.dart';
 import '../features/dashboard/ui/dashboard_movies_tab.dart';
 import '../features/dashboard/ui/dashboard_releases_tab.dart';
 import '../features/dashboard/ui/dashboard_shell.dart';
@@ -133,6 +134,18 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   GoRoute(
                     path: '/dashboard/releases',
                     builder: (_, __) => const DashboardReleasesTab(),
+                  ),
+                ],
+              ),
+              // Books (Chaptarr) — last branch so the Books tab can be shown or
+              // hidden (per the user's chaptarr grant) without shifting the
+              // Movies/TV/Releases tab indices. The DashboardShell only surfaces
+              // the Books tab when services.chaptarr is true.
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/dashboard/books',
+                    builder: (_, __) => const DashboardBooksTab(),
                   ),
                 ],
               ),

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -206,6 +206,7 @@ func NewRouter(
 			r.Post("/requests", requestHandler.Create)
 			r.Get("/requests", requestHandler.List)
 			r.Get("/requests/options", requestHandler.Options)
+			r.Get("/requests/book-status", requestHandler.GetBookStatus)
 			r.Get("/requests/{tmdb_id}/status", requestHandler.GetStatus)
 		})
 

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS request_log (
     user_id INTEGER REFERENCES users(id),
     tmdb_id INTEGER NOT NULL,
     tvdb_id INTEGER,
+    foreign_id TEXT,
     media_type TEXT NOT NULL,
     title TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'requested',
@@ -362,6 +363,9 @@ func Open(dbPath string) (*sql.DB, error) {
 		{alter: "ALTER TABLE request_log ADD COLUMN approved_by INTEGER REFERENCES users(id)"},
 		{alter: "ALTER TABLE request_log ADD COLUMN decided_at DATETIME"},
 		{alter: "ALTER TABLE request_log ADD COLUMN deny_reason TEXT"},
+		// Books (Chaptarr) have no TMDB id; they are keyed by the Readarr
+		// foreignBookId stored here (tmdb_id is left 0 for book rows).
+		{alter: "ALTER TABLE request_log ADD COLUMN foreign_id TEXT"},
 		// Stable per-device hardware id (e.g. iOS identifierForVendor) so a
 		// reconnect from the same physical device updates its existing row
 		// instead of creating a duplicate. Empty for rows created before this

--- a/server/internal/request/handler.go
+++ b/server/internal/request/handler.go
@@ -32,8 +32,19 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.TmdbID == 0 || req.MediaType == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "tmdb_id and media_type required"})
+	if req.MediaType == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "media_type required"})
+		return
+	}
+	// Books are keyed by the Readarr foreignBookId (no tmdb_id); everything else
+	// is keyed by tmdb_id.
+	if req.MediaType == "book" {
+		if req.ForeignID == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "foreign_id required for book requests"})
+			return
+		}
+	} else if req.TmdbID == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "tmdb_id required"})
 		return
 	}
 
@@ -71,6 +82,27 @@ func (h *Handler) GetStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// GetBookStatus reports the current user's request state for a book, keyed by
+// the Readarr foreignBookId (books have no tmdb_id).
+func (h *Handler) GetBookStatus(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	foreignID := r.URL.Query().Get("foreign_id")
+	if foreignID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "foreign_id required"})
+		return
+	}
+	resp, err := h.service.GetUserBookStatus(claims.UserID, foreignID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
 	writeJSON(w, http.StatusOK, resp)
 }
 

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
 	"github.com/windoze95/cantinarr-server/internal/sonarr"
@@ -85,11 +86,27 @@ func (s *Service) getSonarr(userID int64) *sonarr.Client {
 	return nil
 }
 
+// getChaptarr returns the Chaptarr client for the user's granted instance, or
+// nil when the user has no grant (Chaptarr has no global default — access is
+// admin-granted per user).
+func (s *Service) getChaptarr(userID int64) *chaptarr.Client {
+	if s.registry != nil {
+		client, _, err := s.registry.GetUserChaptarrClient(userID)
+		if err == nil && client != nil {
+			return client
+		}
+	}
+	return nil
+}
+
 type CreateRequest struct {
-	TmdbID           int    `json:"tmdb_id"`
-	MediaType        string `json:"media_type"`
-	Title            string `json:"title"`
-	TvdbID           int    `json:"tvdb_id"`
+	TmdbID    int    `json:"tmdb_id"`
+	MediaType string `json:"media_type"`
+	Title     string `json:"title"`
+	TvdbID    int    `json:"tvdb_id"`
+	// ForeignID is the Chaptarr/Readarr foreignBookId for book requests, which
+	// have no TMDB id. Required when media_type == "book"; ignored otherwise.
+	ForeignID        string `json:"foreign_id"`
 	SeasonScope      string `json:"season_scope"`
 	QualityProfileID int    `json:"quality_profile_id"`
 	// Seasons is an optional explicit list of season numbers (TV only). When
@@ -221,6 +238,7 @@ type resolvedRequest struct {
 	userID           int64
 	tmdbID           int
 	tvdbID           int
+	foreignID        string // Chaptarr foreignBookId (book requests)
 	mediaType        string
 	title            string
 	seasonScope      string
@@ -384,8 +402,11 @@ func (s *Service) effectiveSettings(userID int64, isAdmin bool) (effective, erro
 }
 
 func (s *Service) CreateMediaRequest(userID int64, req *CreateRequest) (*CreateResponse, error) {
-	if req.MediaType != "movie" && req.MediaType != "tv" {
+	if req.MediaType != "movie" && req.MediaType != "tv" && req.MediaType != "book" {
 		return nil, fmt.Errorf("unsupported media type: %s", req.MediaType)
+	}
+	if req.MediaType == "book" && req.ForeignID == "" {
+		return nil, fmt.Errorf("foreign_id is required for book requests")
 	}
 
 	isAdmin := s.userIsAdmin(userID)
@@ -398,6 +419,7 @@ func (s *Service) CreateMediaRequest(userID int64, req *CreateRequest) (*CreateR
 		userID:    userID,
 		tmdbID:    req.TmdbID,
 		tvdbID:    req.TvdbID,
+		foreignID: req.ForeignID,
 		mediaType: req.MediaType,
 		title:     req.Title,
 	}
@@ -426,12 +448,15 @@ func (s *Service) CreateMediaRequest(userID int64, req *CreateRequest) (*CreateR
 
 	// Quality profile. Default per service; honor the client's choice only
 	// when allowed (out of the box non-admins cannot choose).
-	if req.MediaType == "tv" {
+	switch req.MediaType {
+	case "tv":
 		resolved.qualityProfileID = eff.QualitySonarr
-	} else {
+	case "movie":
 		resolved.qualityProfileID = eff.QualityRadarr
 	}
-	if req.QualityProfileID != 0 && eff.AllowQualityChoice {
+	// Books pick the Chaptarr instance's first quality/metadata profile at add
+	// time (addToChaptarr), so they carry no per-user quality profile here.
+	if req.QualityProfileID != 0 && eff.AllowQualityChoice && req.MediaType != "book" {
 		resolved.qualityProfileID = req.QualityProfileID
 	}
 
@@ -451,18 +476,33 @@ func (s *Service) CreateMediaRequest(userID int64, req *CreateRequest) (*CreateR
 // createPending records a request awaiting admin approval without touching the
 // arr services. The stored options are replayed verbatim on approval.
 func (s *Service) createPending(r *resolvedRequest) (*CreateResponse, error) {
-	// Insert atomically only when no pending row already exists for this
-	// user+title, so a double-submit can't create duplicate queue entries
-	// (the check + insert is one statement under the single-writer DB).
-	res, err := s.db.Exec(
-		`INSERT INTO request_log (user_id, tmdb_id, tvdb_id, media_type, title, status, season_scope, quality_profile_id)
-		 SELECT ?, ?, ?, ?, ?, ?, ?, ?
-		 WHERE NOT EXISTS (
-		     SELECT 1 FROM request_log WHERE user_id = ? AND tmdb_id = ? AND media_type = ? AND status = ?
-		 )`,
-		r.userID, r.tmdbID, sqlNullInt(r.tvdbID), r.mediaType, r.title, StatusPending, sqlNullStr(r.seasonScope), sqlNullInt(r.qualityProfileID),
-		r.userID, r.tmdbID, r.mediaType, StatusPending,
-	)
+	// Insert atomically only when no pending row already exists for this user +
+	// title, so a double-submit can't create duplicate queue entries (the check +
+	// insert is one statement under the single-writer DB). Books have no tmdb_id,
+	// so they dedupe/key on the Readarr foreignBookId instead.
+	var res sql.Result
+	var err error
+	if r.mediaType == "book" {
+		res, err = s.db.Exec(
+			`INSERT INTO request_log (user_id, tmdb_id, foreign_id, media_type, title, status)
+			 SELECT ?, 0, ?, ?, ?, ?
+			 WHERE NOT EXISTS (
+			     SELECT 1 FROM request_log WHERE user_id = ? AND foreign_id = ? AND media_type = ? AND status = ?
+			 )`,
+			r.userID, r.foreignID, r.mediaType, r.title, StatusPending,
+			r.userID, r.foreignID, r.mediaType, StatusPending,
+		)
+	} else {
+		res, err = s.db.Exec(
+			`INSERT INTO request_log (user_id, tmdb_id, tvdb_id, media_type, title, status, season_scope, quality_profile_id)
+			 SELECT ?, ?, ?, ?, ?, ?, ?, ?
+			 WHERE NOT EXISTS (
+			     SELECT 1 FROM request_log WHERE user_id = ? AND tmdb_id = ? AND media_type = ? AND status = ?
+			 )`,
+			r.userID, r.tmdbID, sqlNullInt(r.tvdbID), r.mediaType, r.title, StatusPending, sqlNullStr(r.seasonScope), sqlNullInt(r.qualityProfileID),
+			r.userID, r.tmdbID, r.mediaType, StatusPending,
+		)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("save pending request: %w", err)
 	}
@@ -499,9 +539,74 @@ func (s *Service) addToArr(r *resolvedRequest) (status string, title string, err
 		return s.addMovie(r)
 	case "tv":
 		return s.addSeries(r)
+	case "book":
+		return s.addToChaptarr(r)
 	default:
 		return "", "", fmt.Errorf("unsupported media type: %s", r.mediaType)
 	}
+}
+
+// addToChaptarr adds a book to the requesting user's granted Chaptarr instance.
+// Books have no TMDB id, so the request carries the Readarr foreignBookId; we
+// resolve it through Chaptarr's lookup (by title, matched on foreignBookId) and
+// add the book with the instance's first quality/metadata profile + root folder,
+// mirroring the addSeries flow. Verify the exact add payload against a live
+// Chaptarr instance — the lookup/add field shapes are the Readarr v1 convention.
+func (s *Service) addToChaptarr(r *resolvedRequest) (string, string, error) {
+	client := s.getChaptarr(r.userID)
+	if client == nil {
+		return "", "", fmt.Errorf("chaptarr is not configured for you")
+	}
+
+	results, err := client.LookupBook(r.title)
+	if err != nil {
+		return "", "", fmt.Errorf("book lookup failed: %w", err)
+	}
+	var match *chaptarr.LookupResult
+	for i := range results {
+		if results[i].ForeignBookID == r.foreignID {
+			match = &results[i]
+			break
+		}
+	}
+	if match == nil {
+		return "", "", fmt.Errorf("book not found for foreign id %s", r.foreignID)
+	}
+
+	qps, err := client.GetQualityProfiles()
+	if err != nil || len(qps) == 0 {
+		return "", "", fmt.Errorf("no quality profiles available")
+	}
+	mps, err := client.GetMetadataProfiles()
+	if err != nil || len(mps) == 0 {
+		return "", "", fmt.Errorf("no metadata profiles available")
+	}
+	folders, err := client.GetRootFolders()
+	if err != nil || len(folders) == 0 {
+		return "", "", fmt.Errorf("no root folders available")
+	}
+
+	addReq := chaptarr.AddBookRequest{
+		ForeignBookID: match.ForeignBookID,
+		Monitored:     true,
+	}
+	addReq.Author.AuthorName = match.AuthorName
+	addReq.Author.ForeignAuthorID = match.ForeignAuthorID
+	addReq.Author.QualityProfileID = qps[0].ID
+	addReq.Author.MetadataProfileID = mps[0].ID
+	addReq.Author.RootFolderPath = folders[0].Path
+	addReq.Author.Monitored = true
+	addReq.Author.AddOptions.Monitor = "all"
+	addReq.AddOptions.SearchForNewBook = true
+
+	title := match.Title
+	if title == "" {
+		title = r.title
+	}
+	if _, err := client.AddBook(addReq); err != nil {
+		return "", "", fmt.Errorf("add book failed: %w", err)
+	}
+	return StatusRequested, title, nil
 }
 
 func (s *Service) addMovie(r *resolvedRequest) (string, string, error) {
@@ -759,6 +864,29 @@ func (s *Service) GetUserStatus(userID int64, tmdbID int, mediaType string) (*St
 	return s.statusFor(userID, tmdbID, mediaType)
 }
 
+// GetUserBookStatus reports a user's request state for a book, keyed by the
+// Readarr foreignBookId (books have no tmdb_id). It reflects the request_log
+// row (pending / denied / requested); deeper library availability + download
+// progress are shown in the Books module itself.
+func (s *Service) GetUserBookStatus(userID int64, foreignID string) (*StatusResponse, error) {
+	var status string
+	err := s.db.QueryRow(
+		"SELECT status FROM request_log WHERE user_id = ? AND foreign_id = ? AND media_type = 'book' ORDER BY requested_at DESC, id DESC LIMIT 1",
+		userID, foreignID,
+	).Scan(&status)
+	if err != nil {
+		return &StatusResponse{Status: StatusUnavailable}, nil
+	}
+	switch status {
+	case StatusPending:
+		return &StatusResponse{Status: StatusPending}, nil
+	case StatusDenied:
+		return &StatusResponse{Status: StatusDenied}, nil
+	default:
+		return &StatusResponse{Status: StatusRequested}, nil
+	}
+}
+
 func (s *Service) getMovieStatus(userID int64, tmdbID int) (*StatusResponse, error) {
 	radarrClient := s.getRadarr(userID)
 	if radarrClient == nil {
@@ -932,9 +1060,9 @@ func (s *Service) loadRequest(requestID int64) (*resolvedRequest, string, error)
 	var r resolvedRequest
 	var status string
 	err := s.db.QueryRow(
-		"SELECT user_id, tmdb_id, COALESCE(tvdb_id, 0), media_type, title, status, COALESCE(season_scope, ''), COALESCE(quality_profile_id, 0) FROM request_log WHERE id = ?",
+		"SELECT user_id, tmdb_id, COALESCE(tvdb_id, 0), COALESCE(foreign_id, ''), media_type, title, status, COALESCE(season_scope, ''), COALESCE(quality_profile_id, 0) FROM request_log WHERE id = ?",
 		requestID,
-	).Scan(&r.userID, &r.tmdbID, &r.tvdbID, &r.mediaType, &r.title, &status, &r.seasonScope, &r.qualityProfileID)
+	).Scan(&r.userID, &r.tmdbID, &r.tvdbID, &r.foreignID, &r.mediaType, &r.title, &status, &r.seasonScope, &r.qualityProfileID)
 	if err == sql.ErrNoRows {
 		return nil, "", fmt.Errorf("request not found")
 	}
@@ -1087,8 +1215,8 @@ func (s *Service) GetAdminSettings() *AdminSettingsView {
 // insertRequest writes a request_log row and returns its id.
 func (s *Service) insertRequest(r *resolvedRequest, title, status string) (int64, error) {
 	res, err := s.db.Exec(
-		"INSERT INTO request_log (user_id, tmdb_id, tvdb_id, media_type, title, status, season_scope, quality_profile_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-		r.userID, r.tmdbID, sqlNullInt(r.tvdbID), r.mediaType, title, status, sqlNullStr(r.seasonScope), sqlNullInt(r.qualityProfileID),
+		"INSERT INTO request_log (user_id, tmdb_id, tvdb_id, foreign_id, media_type, title, status, season_scope, quality_profile_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		r.userID, r.tmdbID, sqlNullInt(r.tvdbID), sqlNullStr(r.foreignID), r.mediaType, title, status, sqlNullStr(r.seasonScope), sqlNullInt(r.qualityProfileID),
 	)
 	if err != nil {
 		return 0, err

--- a/server/internal/request/service_book_test.go
+++ b/server/internal/request/service_book_test.go
@@ -1,0 +1,83 @@
+package request
+
+import (
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/db"
+)
+
+// newBookTestService builds a Service backed by an in-memory DB with one user
+// row (so request_log's user_id FK is satisfied). The book request_log path
+// (createPending / insertRequest / GetUserBookStatus) needs only the DB, so the
+// registry/bridge/notifier are nil.
+func newBookTestService(t *testing.T) (*Service, int64) {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	res, err := database.Exec(
+		"INSERT INTO users (username, password_hash, role) VALUES ('reader', '', 'user')",
+	)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	uid, _ := res.LastInsertId()
+	return NewService(database, nil, nil, nil), uid
+}
+
+// TestBookRequestStatusAndDedup covers the request_log book path: status is
+// keyed by foreignBookId, a duplicate pending request does not create a second
+// row, distinct books are independent, and a directly-logged book reads back as
+// requested.
+func TestBookRequestStatusAndDedup(t *testing.T) {
+	s, uid := newBookTestService(t)
+	const fid = "goodreads:12345"
+
+	if st, err := s.GetUserBookStatus(uid, fid); err != nil || st.Status != StatusUnavailable {
+		t.Fatalf("empty status = %+v err=%v, want unavailable", st, err)
+	}
+
+	r := &resolvedRequest{userID: uid, mediaType: "book", foreignID: fid, title: "Some Book"}
+	if _, err := s.createPending(r); err != nil {
+		t.Fatalf("createPending: %v", err)
+	}
+	if st, _ := s.GetUserBookStatus(uid, fid); st.Status != StatusPending {
+		t.Fatalf("status after pending = %s, want pending", st.Status)
+	}
+
+	// A duplicate pending request must NOT create a second row.
+	if _, err := s.createPending(r); err != nil {
+		t.Fatalf("createPending dup: %v", err)
+	}
+	var count int
+	if err := s.db.QueryRow(
+		"SELECT COUNT(*) FROM request_log WHERE user_id=? AND foreign_id=? AND media_type='book' AND status='pending'",
+		uid, fid,
+	).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("pending book rows = %d, want 1 (dedup by foreign_id)", count)
+	}
+
+	// A different book is independent of the first.
+	other := &resolvedRequest{userID: uid, mediaType: "book", foreignID: "goodreads:999", title: "Other"}
+	if _, err := s.createPending(other); err != nil {
+		t.Fatalf("createPending other: %v", err)
+	}
+	if st, _ := s.GetUserBookStatus(uid, "goodreads:999"); st.Status != StatusPending {
+		t.Fatalf("other book status = %s, want pending", st.Status)
+	}
+
+	// A directly-logged (auto-approved) book reads back as requested — proves
+	// insertRequest persists foreign_id so the status lookup finds it.
+	direct := &resolvedRequest{userID: uid, mediaType: "book", foreignID: "goodreads:777", title: "Direct"}
+	if _, err := s.insertRequest(direct, "Direct", StatusRequested); err != nil {
+		t.Fatalf("insertRequest: %v", err)
+	}
+	if st, _ := s.GetUserBookStatus(uid, "goodreads:777"); st.Status != StatusRequested {
+		t.Fatalf("direct book status = %s, want requested", st.Status)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a **Books** entry to the dashboard alongside Movies and TV Shows, closing the asymmetry where Radarr/Sonarr had request front-ends but Chaptarr did not. Books are **discovered by search** (Chaptarr's `/book/lookup`) and **requested through the existing request/approval system**. The Books tab is gated on the user's Chaptarr grant (`services.chaptarr`), consistent with the Books module.

## Discovery

Chaptarr lookup has no "popular" feed (unlike TMDB), so the Books tab is **search-first**. Book/author lookup is already reachable for granted users via the instance proxy (`/api/v1/book/lookup` is allowlisted), so **no new discovery backend was needed** — `DashboardBooksTab` calls `ChaptarrApiService.lookupBook` directly.

## Request flow (books have no TMDB id)

- `request_log` gains a nullable **`foreign_id`** column (the Readarr `foreignBookId`); `tmdb_id` stays `0` for book rows.
- `request/service.go`: `media_type: "book"` flows through the same path as movies/TV — `effectiveSettings` (per-user approval still applies) → `createPending` (deduped by `foreign_id`) or `addToChaptarr`. `addToChaptarr` looks the book up by title, matches the `foreignBookId`, and adds it to the user's **granted** Chaptarr instance using that instance's first quality/metadata profile + root folder (a server-side add, so a non-admin's approved request goes through even though in-module adds are admin-only).
- New `GetUserBookStatus` + `GET /api/requests/book-status?foreign_id=`; `Create` accepts a book with `foreign_id` instead of `tmdb_id`.

## UI

- `RequestService.requestBook(...)` / `checkBookStatus(...)`.
- `DashboardBooksTab`: a search field + result list; each result has a Request button that reflects status (Request → Pending/Requested) and handles failures.
- `DashboardShell` appends the **Books** tab when `services.chaptarr` — it's the **last** branch, so showing/hiding it never shifts the Movies/TV/Releases tab indices. New `/dashboard/books` router branch.

## Testing

- **Backend:** `go build ./...` + `go vet` + `go test ./...` green, incl. a new test covering book status + `foreign_id` dedup (`service_book_test.go`).
- **Flutter:** `flutter analyze` clean for new code; `flutter test` — 111 pass.

## Notes / limitations

- Book status reflects the **request state** (unavailable / pending / requested); deeper library availability + download progress live in the Books module (this avoids expensive per-book library scans on the discovery surface).
- `addToChaptarr` builds the Readarr v1 add-book payload (lookup → match → add); worth a smoke test against a live Chaptarr instance to confirm the exact add fields.
- Builds on the per-user Chaptarr grant from #101 — the grant gates both the Books module and this tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
