### PR TITLE
fix(chaptarr): Books search triggers on type + surfaces real errors

### DIFF
--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/network/backend_client.dart';
@@ -20,6 +23,7 @@ class DashboardBooksTab extends ConsumerStatefulWidget {
 
 class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
   final _controller = TextEditingController();
+  Timer? _debounce;
   List<ChaptarrBook> _results = [];
   bool _isSearching = false;
   bool _searched = false;
@@ -27,15 +31,18 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
   int _searchGen = 0; // guards against superseded async results
 
   @override
-  void initState() {
-    super.initState();
-    _controller.addListener(() => setState(() {})); // refresh the clear button
-  }
-
-  @override
   void dispose() {
+    _debounce?.cancel();
     _controller.dispose();
     super.dispose();
+  }
+
+  // Search as the user types (debounced) so results appear without having to
+  // hit the keyboard's submit key; also refreshes the clear-button affordance.
+  void _onChanged() {
+    setState(() {});
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 400), _search);
   }
 
   ChaptarrApiService? _chaptarr() {
@@ -75,12 +82,25 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
         _isSearching = false;
         _searched = true;
       });
-    } catch (_) {
+    } on DioException catch (e) {
+      if (!mounted || gen != _searchGen) return;
+      final code = e.response?.statusCode;
+      setState(() {
+        _isSearching = false;
+        _searched = true;
+        // Surface the real failure: a 404 usually means this Chaptarr build's
+        // search API differs from Readarr's /api/v1/book/lookup; 401/403 is an
+        // access/grant problem.
+        _error = code != null
+            ? 'Search failed (HTTP $code). This Chaptarr instance may not support /api/v1/book/lookup.'
+            : 'Search failed: ${e.message ?? 'network error'}.';
+      });
+    } catch (e) {
       if (!mounted || gen != _searchGen) return;
       setState(() {
         _isSearching = false;
         _searched = true;
-        _error = 'Search failed. Please try again.';
+        _error = 'Search failed: $e';
       });
     }
   }
@@ -94,7 +114,11 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
           child: TextField(
             controller: _controller,
             textInputAction: TextInputAction.search,
-            onSubmitted: (_) => _search(),
+            onChanged: (_) => _onChanged(),
+            onSubmitted: (_) {
+              _debounce?.cancel();
+              _search();
+            },
             style: const TextStyle(color: AppTheme.textPrimary),
             decoration: InputDecoration(
               hintText: 'Search books or authors…',

--- a/server/internal/proxy/handler_test.go
+++ b/server/internal/proxy/handler_test.go
@@ -1,0 +1,78 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+// TestInstanceProxyForwardsChaptarrLookup is a smoke test for the Books-tab
+// search path: GET /api/instances/{id}/api/v1/book/lookup?term=... must reach
+// the Chaptarr upstream verbatim — prefix stripped, query string preserved, and
+// the instance's X-Api-Key injected — with the response passed back unchanged.
+func TestInstanceProxyForwardsChaptarrLookup(t *testing.T) {
+	var gotPath, gotTerm, gotKey string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotTerm = r.URL.Query().Get("term")
+		gotKey = r.Header.Get("X-Api-Key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"title":"Dune","foreignBookId":"gr:234","author":{"id":0,"authorName":"Frank Herbert"}}]`))
+	}))
+	defer upstream.Close()
+
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer database.Close()
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x42}, 32))
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	store := instance.NewStore(database, cipher)
+	inst := &instance.Instance{
+		ServiceType: "chaptarr",
+		Name:        "Books",
+		URL:         upstream.URL,
+		APIKey:      "secret-key",
+	}
+	if err := store.Create(inst); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+
+	r := chi.NewRouter()
+	r.HandleFunc("/api/instances/{instanceID}/*", NewHandler(store).InstanceProxy())
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/instances/" + inst.ID + "/api/v1/book/lookup?term=dune")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	if gotPath != "/api/v1/book/lookup" {
+		t.Errorf("upstream path = %q, want /api/v1/book/lookup", gotPath)
+	}
+	if gotTerm != "dune" {
+		t.Errorf("upstream term = %q, want \"dune\" (query string dropped?)", gotTerm)
+	}
+	if gotKey != "secret-key" {
+		t.Errorf("upstream X-Api-Key = %q, want \"secret-key\"", gotKey)
+	}
+	if !bytes.Contains(body, []byte("Dune")) {
+		t.Errorf("response not passed through verbatim: %s", body)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the Books-tab search "not working", and adds a smoke test for the search path.

## What the smoke test showed

New `internal/proxy/handler_test.go` exercises the exact Books-search path — `GET /api/instances/{id}/api/v1/book/lookup?term=…` — against a mock Chaptarr upstream. It **passes**: the proxy strips the instance prefix, **preserves `?term=`**, injects `X-Api-Key`, and passes the response through. So the backend plumbing is correct — the problem was on the client (and possibly the Chaptarr instance's own search API).

## Fixes

- **Search now triggers on typing.** It previously only fired on the keyboard's submit key, so typing appeared to do nothing. It now runs **debounced (400 ms) on change**; an explicit submit still searches immediately.
- **Real errors are surfaced.** The catch-all "Search failed" hid the cause. Failures now show the **HTTP status** — e.g. `404` ⇒ this Chaptarr build's search API differs from Readarr's `/api/v1/book/lookup`; `401/403` ⇒ an access/grant problem. A Chaptarr-API mismatch is now diagnosable instead of silent.

## If it still fails after this

The banner will read e.g. *"Search failed (HTTP 404)…"*. Chaptarr reportedly modified Readarr's metadata/search API, so a 404 means we just need to point `lookupBook`/`lookupAuthor` at the path your Chaptarr build actually uses — share the status it shows and I'll adjust.

## Testing
- `go test ./internal/proxy/` green (new smoke test).
- `flutter analyze` clean for the changed file; `flutter test` — 111 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
