### PR TITLE
fix(chaptarr): decode lookup responses Dio returns as a raw String (Books search root cause)

### DIFF
--- a/app/lib/features/chaptarr/data/chaptarr_api_service.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_api_service.dart
@@ -1,5 +1,20 @@
+import 'dart:convert';
+
 import 'package:dio/dio.dart';
 import 'chaptarr_models.dart';
+
+/// Coerces a Dio response body into a JSON list. Chaptarr's lookup/metadata
+/// endpoints don't reliably send an `application/json` content-type, so Dio can
+/// hand back the raw String instead of a decoded List — decode it here rather
+/// than blindly casting (which threw "String is not a subtype of List").
+List<dynamic> _jsonList(dynamic data) {
+  if (data is List) return data;
+  if (data is String && data.trim().isNotEmpty) {
+    final decoded = jsonDecode(data);
+    if (decoded is List) return decoded;
+  }
+  return const [];
+}
 
 /// Networking layer for Chaptarr (a Readarr-family books service), proxied
 /// through the Cantinarr backend. Note the Readarr API is v1 (not v3).
@@ -34,7 +49,7 @@ class ChaptarrApiService {
   Future<List<ChaptarrAuthor>> lookupAuthor(String term) async {
     final resp = await _dio
         .get('$_basePath/author/lookup', queryParameters: {'term': term});
-    return (resp.data as List<dynamic>)
+    return _jsonList(resp.data)
         .map((a) => ChaptarrAuthor.fromJson(a as Map<String, dynamic>))
         .toList();
   }
@@ -58,7 +73,7 @@ class ChaptarrApiService {
   Future<List<ChaptarrBook>> lookupBook(String term) async {
     final resp = await _dio
         .get('$_basePath/book/lookup', queryParameters: {'term': term});
-    return (resp.data as List<dynamic>)
+    return _jsonList(resp.data)
         .map((b) => ChaptarrBook.fromJson(b as Map<String, dynamic>))
         .toList();
   }


### PR DESCRIPTION
## Summary

The actual root-cause fix for Books search. It missed the #103 merge (#103 merged the search **diagnostics** — debounce-on-type + surfaced errors — but not this fix). With those diagnostics in place, the real failure was visible: `type 'String' is not a subtype of type 'List<dynamic>'`.

## Root cause

Chaptarr's lookup/metadata endpoints (`/api/v1/book/lookup`, `/api/v1/author/lookup`) don't send an `application/json` content-type, so Dio returns the response as a **raw String** and `resp.data as List<dynamic>` throws. (Library/queue screens work because they hit Chaptarr's main app API, which returns proper JSON.)

## Fix

`lookupBook` / `lookupAuthor` decode the body defensively instead of blind-casting:

```dart
List<dynamic> _jsonList(dynamic data) {
  if (data is List) return data;                  // proper JSON — unchanged
  if (data is String && data.trim().isNotEmpty)   // raw String — decode it
    { final d = jsonDecode(data); if (d is List) return d; }
  return const [];
}
```

`flutter analyze` clean; `flutter test` — 111 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
