### PR TITLE
Simplify instance navigation

### DIFF
--- a/app/lib/core/providers/module_provider.dart
+++ b/app/lib/core/providers/module_provider.dart
@@ -33,7 +33,8 @@ class ModuleState {
   int get activeIndex {
     for (int i = 0; i < modules.length; i++) {
       final m = modules[i];
-      if (m.type == activeModuleType && m.instanceId == activeInstanceId) {
+      if (m.type == activeModuleType &&
+          (m.instanceId == null || m.instanceId == activeInstanceId)) {
         return i;
       }
     }
@@ -64,66 +65,44 @@ class ModuleNotifier extends Notifier<ModuleState> {
     ));
 
     if (connection != null) {
-      // Radarr instances
-      for (final inst in connection.radarrInstances) {
-        modules.add(AppModule(
+      if (isAdmin && connection.radarrInstances.isNotEmpty) {
+        modules.add(const AppModule(
           type: ModuleType.radarr,
-          label: inst.name,
+          label: 'Radarr',
           icon: Icons.movie,
-          instanceId: inst.id,
-          instanceName: inst.name,
         ));
       }
 
-      // Sonarr instances
-      for (final inst in connection.sonarrInstances) {
-        modules.add(AppModule(
+      if (isAdmin && connection.sonarrInstances.isNotEmpty) {
+        modules.add(const AppModule(
           type: ModuleType.sonarr,
-          label: inst.name,
+          label: 'Sonarr',
           icon: Icons.tv,
-          instanceId: inst.id,
-          instanceName: inst.name,
         ));
       }
 
-      // Chaptarr (books) instances. NOT admin-gated here: the backend only
-      // surfaces a chaptarr instance to users an admin has explicitly granted,
-      // so any chaptarr instance present in the connection is one this user may
-      // see (admins see all). Visibility is enforced server-side.
-      for (final inst in connection.chaptarrInstances) {
-        modules.add(AppModule(
+      if (isAdmin && connection.chaptarrInstances.isNotEmpty) {
+        modules.add(const AppModule(
           type: ModuleType.chaptarr,
-          label: inst.name,
+          label: 'Chaptarr',
           icon: Icons.menu_book,
-          instanceId: inst.id,
-          instanceName: inst.name,
         ));
       }
 
-      // Download client instances (admin only)
-      if (isAdmin) {
-        for (final inst in connection.downloadInstances) {
-          modules.add(AppModule(
-            type: ModuleType.downloads,
-            label: inst.name,
-            icon: Icons.download,
-            instanceId: inst.id,
-            instanceName: inst.name,
-          ));
-        }
+      if (isAdmin && connection.downloadInstances.isNotEmpty) {
+        modules.add(const AppModule(
+          type: ModuleType.downloads,
+          label: 'Downloads',
+          icon: Icons.download,
+        ));
       }
 
-      // Tautulli instances (admin only)
-      if (isAdmin) {
-        for (final inst in connection.tautulliInstances) {
-          modules.add(AppModule(
-            type: ModuleType.tautulli,
-            label: inst.name,
-            icon: Icons.monitor_heart,
-            instanceId: inst.id,
-            instanceName: inst.name,
-          ));
-        }
+      if (isAdmin && connection.tautulliInstances.isNotEmpty) {
+        modules.add(const AppModule(
+          type: ModuleType.tautulli,
+          label: 'Tautulli',
+          icon: Icons.monitor_heart,
+        ));
       }
 
       // AI Assistant

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/models/app_module.dart';
+import '../../../core/models/backend_connection.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/providers/module_provider.dart';
@@ -745,8 +746,8 @@ class _AppShellState extends ConsumerState<AppShell>
 
   Widget _buildDrawerContent(BuildContext context, {required bool isOverlay}) {
     final moduleState = ref.watch(moduleProvider);
-    final isAdmin =
-        ref.watch(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    final instanceState = ref.watch(instanceProvider);
+    final isAdmin = ref.watch(authProvider).valueOrNull?.user?.isAdmin ?? false;
     final pendingApprovals = ref.watch(pendingApprovalsProvider);
     final openIssues = ref.watch(openIssuesProvider);
     final pendingAgentActions = ref.watch(pendingAgentActionsProvider);
@@ -828,18 +829,49 @@ class _AppShellState extends ConsumerState<AppShell>
               children: moduleState.modules.asMap().entries.map((entry) {
                 final module = entry.value;
                 final isActive = entry.key == moduleState.activeIndex;
+                final selectorInstances = isAdmin
+                    ? _instancesForModule(instanceState, module.type)
+                    : const <ServiceInstance>[];
+                final activeInstance =
+                    _activeInstanceForModule(instanceState, module.type);
 
                 return _DrawerItem(
                   icon: module.icon,
                   title: module.label,
                   selected: isActive,
+                  trailing: selectorInstances.length > 1
+                      ? _InstanceSelector(
+                          appName: module.label,
+                          instances: selectorInstances,
+                          activeInstanceId: activeInstance?.id,
+                          onSelected: (instanceId) {
+                            if (isOverlay) Navigator.pop(context);
+                            _navigateToModule(
+                              context,
+                              module,
+                              instanceId: instanceId,
+                            );
+                            if (module.type != ModuleType.assistant) {
+                              ref
+                                  .read(moduleProvider.notifier)
+                                  .setActiveModule(module.type);
+                            }
+                          },
+                        )
+                      : null,
                   onTap: () {
                     if (isOverlay) Navigator.pop(context);
-                    _navigateToModule(context, module);
+                    _navigateToModule(
+                      context,
+                      module,
+                      instanceId: _defaultInstanceForModule(
+                        instanceState,
+                        module.type,
+                      )?.id,
+                    );
                     if (module.type != ModuleType.assistant) {
                       ref.read(moduleProvider.notifier).setActiveModule(
                             module.type,
-                            instanceId: module.instanceId,
                           );
                     }
                   },
@@ -872,11 +904,63 @@ class _AppShellState extends ConsumerState<AppShell>
     );
   }
 
-  void _navigateToModule(BuildContext context, AppModule module) {
-    // Drawer entries are per-instance for multi-instance services; make the
-    // tapped instance active so the module opens on it rather than on
-    // whatever instance the in-module dropdown was last set to.
-    final instanceId = module.instanceId;
+  List<ServiceInstance> _instancesForModule(
+    InstanceState state,
+    ModuleType type,
+  ) {
+    switch (type) {
+      case ModuleType.radarr:
+        return state.radarrInstances;
+      case ModuleType.sonarr:
+        return state.sonarrInstances;
+      case ModuleType.downloads:
+        return state.downloadInstances;
+      case ModuleType.tautulli:
+        return state.tautulliInstances;
+      case ModuleType.chaptarr:
+        return state.chaptarrInstances;
+      default:
+        return const [];
+    }
+  }
+
+  ServiceInstance? _activeInstanceForModule(
+    InstanceState state,
+    ModuleType type,
+  ) {
+    switch (type) {
+      case ModuleType.radarr:
+        return state.activeRadarrInstance;
+      case ModuleType.sonarr:
+        return state.activeSonarrInstance;
+      case ModuleType.downloads:
+        return state.activeDownloadInstance;
+      case ModuleType.tautulli:
+        return state.activeTautulliInstance;
+      case ModuleType.chaptarr:
+        return state.activeChaptarrInstance;
+      default:
+        return null;
+    }
+  }
+
+  ServiceInstance? _defaultInstanceForModule(
+    InstanceState state,
+    ModuleType type,
+  ) {
+    final instances = _instancesForModule(state, type);
+    if (instances.isEmpty) return null;
+    return instances.firstWhere(
+      (instance) => instance.isDefault,
+      orElse: () => instances.first,
+    );
+  }
+
+  void _navigateToModule(
+    BuildContext context,
+    AppModule module, {
+    String? instanceId,
+  }) {
     if (instanceId != null) {
       final instances = ref.read(instanceProvider.notifier);
       switch (module.type) {
@@ -918,6 +1002,7 @@ class _DrawerItem extends StatelessWidget {
   final String title;
   final bool selected;
   final VoidCallback onTap;
+  final Widget? trailing;
 
   /// When > 0, renders a trailing count pill (e.g. the pending-approvals count).
   final int badgeCount;
@@ -927,6 +1012,7 @@ class _DrawerItem extends StatelessWidget {
     required this.title,
     this.selected = false,
     required this.onTap,
+    this.trailing,
     this.badgeCount = 0,
   });
 
@@ -942,11 +1028,96 @@ class _DrawerItem extends StatelessWidget {
           fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
         ),
       ),
-      trailing: badgeCount > 0 ? _CountPill(count: badgeCount) : null,
+      trailing: badgeCount > 0 ? _CountPill(count: badgeCount) : trailing,
       selected: selected,
       selectedTileColor: AppTheme.accent.withValues(alpha: 0.08),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
       onTap: onTap,
+    );
+  }
+}
+
+class _InstanceSelector extends StatelessWidget {
+  final String appName;
+  final List<ServiceInstance> instances;
+  final String? activeInstanceId;
+  final ValueChanged<String> onSelected;
+
+  const _InstanceSelector({
+    required this.appName,
+    required this.instances,
+    required this.activeInstanceId,
+    required this.onSelected,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final activeInstance = instances.firstWhere(
+      (instance) => instance.id == activeInstanceId,
+      orElse: () => instances.firstWhere(
+        (instance) => instance.isDefault,
+        orElse: () => instances.first,
+      ),
+    );
+
+    return PopupMenuButton<String>(
+      tooltip: 'Choose $appName instance',
+      color: AppTheme.surface,
+      onSelected: onSelected,
+      itemBuilder: (context) => [
+        for (final instance in instances)
+          PopupMenuItem<String>(
+            value: instance.id,
+            child: Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    instance.name,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                if (instance.id == activeInstance.id)
+                  const Icon(
+                    Icons.check,
+                    size: 18,
+                    color: AppTheme.accent,
+                  ),
+              ],
+            ),
+          ),
+      ],
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 128),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          decoration: BoxDecoration(
+            border: Border.all(color: AppTheme.border),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                child: Text(
+                  activeInstance.name,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(
+                    color: AppTheme.textSecondary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 4),
+              const Icon(
+                Icons.arrow_drop_down,
+                color: AppTheme.textSecondary,
+                size: 18,
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -87,6 +87,12 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         return isAuthRoute ? null : '/login';
       }
       if (isAuthenticated && isAuthRoute) return '/dashboard/movies';
+      final isAdmin = auth?.user?.isAdmin ?? false;
+      if (isAuthenticated &&
+          !isAdmin &&
+          _isInstanceModuleRoute(state.uri.path)) {
+        return '/dashboard/movies';
+      }
       return null;
     },
     routes: [
@@ -523,3 +529,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
     ],
   );
 });
+
+bool _isInstanceModuleRoute(String path) {
+  return path.startsWith('/radarr/') ||
+      path.startsWith('/sonarr/') ||
+      path.startsWith('/chaptarr/') ||
+      path.startsWith('/downloads/') ||
+      path.startsWith('/tautulli/');
+}

--- a/app/test/core/providers/module_provider_test.dart
+++ b/app/test/core/providers/module_provider_test.dart
@@ -1,0 +1,131 @@
+import 'package:cantinarr/core/models/app_module.dart';
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/providers/module_provider.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('non-admin module navigation is app-level and hides admin modules',
+      () async {
+    final container = ProviderContainer(
+      overrides: [
+        authProvider.overrideWith(
+          () => _FakeAuthNotifier(_authState(isAdmin: false)),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(authProvider.future);
+    await container.pump();
+
+    final modules = container.read(moduleProvider).modules;
+    expect(_labels(modules), ['Dashboard']);
+    expect(_labels(modules), isNot(contains('Main Radarr')));
+    expect(_labels(modules), isNot(contains('4K Radarr')));
+    expect(_labels(modules), isNot(contains('Radarr')));
+    expect(_labels(modules), isNot(contains('Sonarr')));
+    expect(_labels(modules), isNot(contains('Chaptarr')));
+    expect(_labels(modules), isNot(contains('Downloads')));
+    expect(_labels(modules), isNot(contains('Tautulli')));
+  });
+
+  test('admin module navigation is one row per app type', () async {
+    final container = ProviderContainer(
+      overrides: [
+        authProvider.overrideWith(
+          () => _FakeAuthNotifier(_authState(isAdmin: true)),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(authProvider.future);
+    await container.pump();
+
+    final modules = container.read(moduleProvider).modules;
+    expect(
+      _labels(modules),
+      containsAll([
+        'Dashboard',
+        'Radarr',
+        'Sonarr',
+        'Chaptarr',
+        'Downloads',
+        'Tautulli',
+      ]),
+    );
+    expect(
+      modules.where((module) => module.type == ModuleType.radarr),
+      hasLength(1),
+    );
+    expect(
+      modules.where((module) => module.type == ModuleType.downloads),
+      hasLength(1),
+    );
+  });
+}
+
+List<String> _labels(List<AppModule> modules) =>
+    modules.map((module) => module.label).toList();
+
+AuthState _authState({required bool isAdmin}) {
+  return AuthState(
+    connection: const BackendConnection(
+      serverUrl: 'http://localhost',
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      instances: [
+        ServiceInstance(
+          id: 'radarr-main',
+          serviceType: 'radarr',
+          name: 'Main Radarr',
+          isDefault: true,
+        ),
+        ServiceInstance(
+          id: 'radarr-4k',
+          serviceType: 'radarr',
+          name: '4K Radarr',
+        ),
+        ServiceInstance(
+          id: 'sonarr-main',
+          serviceType: 'sonarr',
+          name: 'Main Sonarr',
+          isDefault: true,
+        ),
+        ServiceInstance(
+          id: 'chaptarr-main',
+          serviceType: 'chaptarr',
+          name: 'Books',
+          isDefault: true,
+        ),
+        ServiceInstance(
+          id: 'sab-main',
+          serviceType: 'sabnzbd',
+          name: 'Downloads',
+        ),
+        ServiceInstance(
+          id: 'tautulli-main',
+          serviceType: 'tautulli',
+          name: 'Tautulli',
+        ),
+      ],
+    ),
+    user: UserProfile(
+      id: 1,
+      username: isAdmin ? 'admin' : 'viewer',
+      role: isAdmin ? 'admin' : 'user',
+    ),
+  );
+}
+
+class _FakeAuthNotifier extends AuthNotifier {
+  final AuthState authState;
+
+  _FakeAuthNotifier(this.authState);
+
+  @override
+  Future<AuthState> build() async => authState;
+}

--- a/app/test/navigation/app_router_test.dart
+++ b/app/test/navigation/app_router_test.dart
@@ -1,7 +1,13 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
 import 'package:cantinarr/core/models/user_profile.dart';
 import 'package:cantinarr/features/auth/logic/auth_provider.dart';
 import 'package:cantinarr/navigation/app_router.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
@@ -30,7 +36,38 @@ void main() {
 
     final second = container.read(appRouterProvider);
     expect(identical(first, second), isTrue,
-        reason: 'auth changes should refresh redirects, not rebuild the router');
+        reason:
+            'auth changes should refresh redirects, not rebuild the router');
+  });
+
+  testWidgets('non-admin instance module routes redirect to dashboard',
+      (tester) async {
+    final container = ProviderContainer(
+      overrides: [
+        authProvider.overrideWith(() => _FakeAuthNotifier(_authedState)),
+        backendClientProvider.overrideWithValue(_fakeDio()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(authProvider.future);
+    await container.pump();
+    final router = container.read(appRouterProvider);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    router.go('/radarr/library');
+    await tester.pumpAndSettle();
+
+    expect(
+      router.routeInformationProvider.value.uri.path,
+      '/dashboard/movies',
+    );
   });
 }
 
@@ -53,4 +90,39 @@ class _FakeAuthNotifier extends AuthNotifier {
   Future<AuthState> build() async => _initial;
 
   void push(AuthState next) => state = AsyncData(next);
+}
+
+Dio _fakeDio() {
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+  dio.httpClientAdapter = _JsonAdapter();
+  return dio;
+}
+
+class _JsonAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final Object body = switch (options.path) {
+      '/api/trakt/anticipated' => [],
+      _ => {
+          'page': 1,
+          'results': [],
+          'total_pages': 0,
+          'total_results': 0,
+        },
+    };
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
 }

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -1,4 +1,11 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/network/websocket_client.dart';
+import 'package:cantinarr/core/providers/instance_provider.dart';
+import 'package:cantinarr/core/providers/realtime_provider.dart';
 import 'package:cantinarr/core/models/user_profile.dart';
 import 'package:cantinarr/features/ai_assistant/data/ai_chat_service.dart';
 import 'package:cantinarr/features/ai_assistant/logic/ai_chat_provider.dart';
@@ -76,6 +83,118 @@ void main() {
     expect(find.byType(AiChatScreen), findsNothing);
     expect(find.text('What should I watch tonight?'), findsNothing);
   });
+
+  testWidgets('non-admin drawer hides instance app modules', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final router = GoRouter(
+      initialLocation: '/dashboard/movies',
+      routes: [
+        ShellRoute(
+          builder: (context, state, child) => AppShell(child: child),
+          routes: [
+            GoRoute(
+              path: '/dashboard/movies',
+              builder: (_, __) => const Scaffold(body: Text('Dashboard home')),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith(
+            () => _FakeAuthNotifier(_multiRadarrState(isAdmin: false)),
+          ),
+          backendClientProvider.overrideWithValue(_fakeDio()),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.menu));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.text('Radarr'), findsNothing);
+    expect(find.text('Main Radarr'), findsNothing);
+    expect(find.text('4K Radarr'), findsNothing);
+    expect(find.byTooltip('Choose Radarr instance'), findsNothing);
+  });
+
+  testWidgets('admin drawer selector switches the active app instance',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final container = ProviderContainer(
+      overrides: [
+        authProvider.overrideWith(
+          () => _FakeAuthNotifier(_multiRadarrState(isAdmin: true)),
+        ),
+        backendClientProvider.overrideWithValue(_fakeDio()),
+        realtimeEventsProvider.overrideWithValue(const Stream<WsEvent>.empty()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final router = GoRouter(
+      initialLocation: '/dashboard/movies',
+      routes: [
+        ShellRoute(
+          builder: (context, state, child) => AppShell(child: child),
+          routes: [
+            GoRoute(
+              path: '/dashboard/movies',
+              builder: (_, __) => const Scaffold(body: Text('Dashboard home')),
+            ),
+            GoRoute(
+              path: '/radarr/library',
+              builder: (_, __) => const Scaffold(body: Text('Radarr library')),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.menu));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Radarr'), findsOneWidget);
+    expect(find.text('Main Radarr'), findsOneWidget);
+    expect(find.text('4K Radarr'), findsNothing);
+
+    await tester.tap(find.byTooltip('Choose Radarr instance'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('4K Radarr'));
+    await tester.pumpAndSettle();
+
+    expect(
+      container.read(instanceProvider).activeRadarrInstanceId,
+      'radarr-4k',
+    );
+    expect(find.text('Radarr library'), findsOneWidget);
+  });
 }
 
 const _authenticatedAiState = AuthState(
@@ -87,6 +206,34 @@ const _authenticatedAiState = AuthState(
   ),
   user: UserProfile(id: 1, username: 'tester', role: 'admin'),
 );
+
+AuthState _multiRadarrState({required bool isAdmin}) {
+  return AuthState(
+    connection: const BackendConnection(
+      serverUrl: 'http://localhost',
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      instances: [
+        ServiceInstance(
+          id: 'radarr-main',
+          serviceType: 'radarr',
+          name: 'Main Radarr',
+          isDefault: true,
+        ),
+        ServiceInstance(
+          id: 'radarr-4k',
+          serviceType: 'radarr',
+          name: '4K Radarr',
+        ),
+      ],
+    ),
+    user: UserProfile(
+      id: 1,
+      username: isAdmin ? 'admin' : 'viewer',
+      role: isAdmin ? 'admin' : 'user',
+    ),
+  );
+}
 
 class _FakeAuthNotifier extends AuthNotifier {
   final AuthState authState;
@@ -106,4 +253,41 @@ class _FakeAiChatNotifier extends AiChatNotifier {
   Future<void> sendMessage(String text) async {
     sentMessage = text;
   }
+}
+
+Dio _fakeDio() {
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+  dio.httpClientAdapter = _JsonAdapter();
+  return dio;
+}
+
+class _JsonAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final path = options.path;
+    final Object body;
+    if (path.endsWith('/movie') || path.endsWith('/series')) {
+      body = [];
+    } else if (path == '/api/admin/issues') {
+      body = {'issues': []};
+    } else if (path == '/api/admin/agent-actions') {
+      body = {'actions': []};
+    } else {
+      body = [];
+    }
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
 }

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -386,10 +386,10 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 			IsDefault   bool   `json:"is_default"`
 		}
 
-		// The config payload is per-user: the default instance for a service
-		// type can be overridden per user (admin-managed), and service types
-		// with no global default (chaptarr) are visible only to users an admin
-		// has explicitly granted an instance. Admins see every instance.
+		// The config payload is per-user: admins see every instance, while
+		// regular users only see the effective default Radarr/Sonarr instances
+		// selected for them and any Chaptarr instance explicitly granted by an
+		// admin.
 		claims := auth.GetClaims(r.Context())
 		var userID int64
 		isAdmin := false
@@ -407,11 +407,12 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 		instances := []instanceInfo{}
 		allInstances, err := store.ListAll()
 		if err == nil {
+			visibleDefaults := map[string]string{}
+			if !isAdmin {
+				visibleDefaults = effectiveUserInstanceIDs(allInstances, overrides)
+			}
 			for _, inst := range allInstances {
-				// Access gate for service types without a global default: a
-				// chaptarr instance is visible only to admins or the specific
-				// user granted THAT instance.
-				if inst.ServiceType == "chaptarr" && !isAdmin && overrides["chaptarr"] != inst.ID {
+				if !isAdmin && visibleDefaults[inst.ServiceType] != inst.ID {
 					continue
 				}
 				// Effective default: a per-user override wins over the global
@@ -464,4 +465,41 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 			"allow_reporting": remSettings.AllowReporting,
 		})
 	}
+}
+
+func effectiveUserInstanceIDs(instances []instance.Instance, overrides map[string]string) map[string]string {
+	first := map[string]string{}
+	globalDefault := map[string]string{}
+	for _, inst := range instances {
+		switch inst.ServiceType {
+		case "radarr", "sonarr":
+			if _, ok := first[inst.ServiceType]; !ok {
+				first[inst.ServiceType] = inst.ID
+			}
+			if inst.IsDefault {
+				if _, ok := globalDefault[inst.ServiceType]; !ok {
+					globalDefault[inst.ServiceType] = inst.ID
+				}
+			}
+		}
+	}
+
+	visible := map[string]string{}
+	for _, serviceType := range []string{"radarr", "sonarr"} {
+		if override, ok := overrides[serviceType]; ok {
+			visible[serviceType] = override
+			continue
+		}
+		if id, ok := globalDefault[serviceType]; ok {
+			visible[serviceType] = id
+			continue
+		}
+		if id, ok := first[serviceType]; ok {
+			visible[serviceType] = id
+		}
+	}
+	if chaptarrID, ok := overrides["chaptarr"]; ok {
+		visible["chaptarr"] = chaptarrID
+	}
+	return visible
 }

--- a/server/internal/api/router_test.go
+++ b/server/internal/api/router_test.go
@@ -1,12 +1,20 @@
 package api
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/windoze95/cantinarr-server/internal/auth"
 	"github.com/windoze95/cantinarr-server/internal/config"
+	"github.com/windoze95/cantinarr-server/internal/credentials"
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+	"github.com/windoze95/cantinarr-server/internal/remediation"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
 )
 
 func TestAppleAppSiteAssociationHandler(t *testing.T) {
@@ -80,4 +88,151 @@ func TestAndroidAssetLinksHandler(t *testing.T) {
 		body[0].Target.SHA256CertFingerprints[0] != "AA:BB" {
 		t.Fatalf("fingerprints = %#v", body[0].Target.SHA256CertFingerprints)
 	}
+}
+
+func TestConfigHandlerFiltersInstancesForNonAdmin(t *testing.T) {
+	store, creds, remediationSvc, userID := newConfigHandlerTestState(t)
+	mainRadarr := createConfigInstance(t, store, "radarr", "Main Radarr", true)
+	fourKRadarr := createConfigInstance(t, store, "radarr", "4K Radarr", false)
+	mainSonarr := createConfigInstance(t, store, "sonarr", "Main Sonarr", true)
+	createConfigInstance(t, store, "sonarr", "Anime Sonarr", false)
+	books := createConfigInstance(t, store, "chaptarr", "Books", false)
+	createConfigInstance(t, store, "chaptarr", "Private Books", false)
+	createConfigInstance(t, store, "sabnzbd", "Downloads", false)
+	createConfigInstance(t, store, "tautulli", "Tautulli", false)
+
+	if err := store.SetUserDefault(userID, "radarr", fourKRadarr.ID); err != nil {
+		t.Fatalf("pin radarr: %v", err)
+	}
+	if err := store.SetUserDefault(userID, "chaptarr", books.ID); err != nil {
+		t.Fatalf("grant chaptarr: %v", err)
+	}
+
+	resp := requestConfig(t, store, creds, remediationSvc, &auth.Claims{
+		UserID:   userID,
+		Username: "alice",
+		Role:     auth.RoleUser,
+	})
+
+	want := map[string]string{
+		fourKRadarr.ID: "radarr",
+		mainSonarr.ID:  "sonarr",
+		books.ID:       "chaptarr",
+	}
+	if len(resp.Instances) != len(want) {
+		t.Fatalf("instances = %#v, want %d visible instances", resp.Instances, len(want))
+	}
+	for _, inst := range resp.Instances {
+		if want[inst.ID] != inst.ServiceType {
+			t.Fatalf("unexpected visible instance: %#v", inst)
+		}
+		if inst.ID == mainRadarr.ID {
+			t.Fatal("non-admin should not see the non-pinned Radarr instance")
+		}
+		if (inst.ServiceType == "radarr" || inst.ServiceType == "sonarr" || inst.ServiceType == "chaptarr") && !inst.IsDefault {
+			t.Fatalf("visible user instance should be marked default: %#v", inst)
+		}
+	}
+	if !resp.Services["radarr"] || !resp.Services["sonarr"] || !resp.Services["chaptarr"] {
+		t.Fatalf("services = %#v, want radarr/sonarr/chaptarr visible", resp.Services)
+	}
+}
+
+func TestConfigHandlerShowsAllInstancesForAdmin(t *testing.T) {
+	store, creds, remediationSvc, userID := newConfigHandlerTestState(t)
+	createConfigInstance(t, store, "radarr", "Main Radarr", true)
+	createConfigInstance(t, store, "radarr", "4K Radarr", false)
+	createConfigInstance(t, store, "sonarr", "Main Sonarr", true)
+	createConfigInstance(t, store, "chaptarr", "Books", false)
+	createConfigInstance(t, store, "sabnzbd", "Downloads", false)
+	createConfigInstance(t, store, "tautulli", "Tautulli", false)
+
+	resp := requestConfig(t, store, creds, remediationSvc, &auth.Claims{
+		UserID:   userID,
+		Username: "admin",
+		Role:     auth.RoleAdmin,
+	})
+
+	if len(resp.Instances) != 6 {
+		t.Fatalf("instances = %#v, want all 6 instances", resp.Instances)
+	}
+}
+
+type configHandlerResponse struct {
+	Services  map[string]bool `json:"services"`
+	Instances []struct {
+		ID          string `json:"id"`
+		ServiceType string `json:"service_type"`
+		Name        string `json:"name"`
+		IsDefault   bool   `json:"is_default"`
+	} `json:"instances"`
+}
+
+func newConfigHandlerTestState(t *testing.T) (*instance.Store, *credentials.Registry, *remediation.Service, int64) {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x42}, 32))
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	store := instance.NewStore(database, cipher)
+	creds := credentials.NewRegistry(database, cipher)
+	remediationSvc := remediation.NewService(database, nil, nil, nil)
+
+	res, err := database.Exec(
+		"INSERT INTO users (username, password_hash, role) VALUES (?, '', ?)",
+		"alice",
+		auth.RoleUser,
+	)
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	userID, err := res.LastInsertId()
+	if err != nil {
+		t.Fatalf("LastInsertId: %v", err)
+	}
+	return store, creds, remediationSvc, userID
+}
+
+func createConfigInstance(t *testing.T, store *instance.Store, serviceType, name string, isDefault bool) instance.Instance {
+	t.Helper()
+	inst := instance.Instance{
+		ServiceType: serviceType,
+		Name:        name,
+		URL:         "http://localhost",
+		APIKey:      "key",
+		IsDefault:   isDefault,
+	}
+	if err := store.Create(&inst); err != nil {
+		t.Fatalf("create %s instance: %v", serviceType, err)
+	}
+	return inst
+}
+
+func requestConfig(
+	t *testing.T,
+	store *instance.Store,
+	creds *credentials.Registry,
+	remediationSvc *remediation.Service,
+	claims *auth.Claims,
+) configHandlerResponse {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, claims))
+	rec := httptest.NewRecorder()
+
+	configHandler(&config.Config{}, store, creds, remediationSvc)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var resp configHandlerResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	return resp
 }


### PR DESCRIPTION
Summary
- Limit `/api/config` for non-admins to effective default Radarr/Sonarr instances plus granted Chaptarr access for dashboard/request flows.
- Hide Radarr, Sonarr, Chaptarr, Downloads, and Tautulli module navigation from non-admins.
- Redirect non-admin direct instance-module routes back to `/dashboard/movies`.
- Collapse admin drawer modules to one app-level row per service type with an instance selector for multi-instance apps.
- Cover server config filtering, module list derivation, drawer selector behavior, and non-admin route redirects with tests.

Tests
- `go test ./internal/api`
- `go test ./...` from `server/`
- `flutter test test/core/providers/module_provider_test.dart test/shell/app_shell_test.dart test/navigation/app_router_test.dart`
- `flutter analyze` exits non-zero because of 20 existing info-level lints in unrelated files.
- `flutter analyze --no-fatal-infos` passes.