### PR TITLE
Let admins use default Chaptarr for book requests

### DIFF
--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -93,14 +93,21 @@ func (s *Service) getSonarr(userID int64) *sonarr.Client {
 	return nil
 }
 
-// getChaptarr returns the Chaptarr client for the user's granted instance, or
-// nil when the user has no grant (Chaptarr has no global default — access is
-// admin-granted per user).
+// getChaptarr returns the Chaptarr client for the user's granted instance. A
+// user grant is still required for non-admins; admins fall back to the configured
+// default/first Chaptarr instance so they can request books without assigning
+// themselves a per-user grant.
 func (s *Service) getChaptarr(userID int64) *chaptarr.Client {
 	if s.registry != nil {
 		client, _, err := s.registry.GetUserChaptarrClient(userID)
 		if err == nil && client != nil {
 			return client
+		}
+		if s.userIsAdmin(userID) {
+			client, _, err := s.registry.GetDefaultChaptarrClient()
+			if err == nil && client != nil {
+				return client
+			}
 		}
 	}
 	return nil

--- a/server/internal/request/service_book_test.go
+++ b/server/internal/request/service_book_test.go
@@ -195,6 +195,42 @@ func TestBookRequestFormatMonitorsRequestedEditions(t *testing.T) {
 	}
 }
 
+func TestAdminBookRequestsUseDefaultChaptarrWithoutUserGrant(t *testing.T) {
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	res, err := database.Exec(
+		"INSERT INTO users (username, password_hash, role) VALUES ('admin', '', 'admin')",
+	)
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	uid, _ := res.LastInsertId()
+
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x24}, 32))
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	store := instance.NewStore(database, cipher)
+	if err := store.Create(&instance.Instance{
+		ServiceType: "chaptarr",
+		Name:        "Books",
+		URL:         "http://chaptarr.local:8787",
+		APIKey:      "key",
+		IsDefault:   true,
+	}); err != nil {
+		t.Fatalf("create chaptarr instance: %v", err)
+	}
+
+	svc := NewService(database, instance.NewRegistry(store), nil, nil)
+	if client := svc.getChaptarr(uid); client == nil {
+		t.Fatal("admin getChaptarr returned nil without per-user grant; want default Chaptarr client")
+	}
+}
+
 func newChaptarrBookTestService(t *testing.T, chaptarrURL string) (*Service, int64) {
 	t.Helper()
 	database, err := db.Open(":memory:")


### PR DESCRIPTION
## Summary
- keep Chaptarr per-user grants required for non-admins
- let admins fall back to the configured default/first Chaptarr instance when they have no per-user Chaptarr grant
- add regression coverage for admin book-request Chaptarr resolution without a user grant

## Notes
The Chaptarr instance global default/first instance is meaningful for admin/global contexts. Non-admins still need an explicit per-user Chaptarr assignment; that assignment controls both access/visibility and their request target.

## Verification
- `go test ./...` from `server/`
- `git diff --check`
