### PR TITLE
Fix book request prompt and Chaptarr add payload

### DIFF
--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -276,7 +276,6 @@ class _BookResultTile extends StatelessWidget {
                   foreignId: fid,
                   title: book.title,
                   service: requestService,
-                  availableFormats: book.formats,
                 )
               : null,
     );
@@ -289,13 +288,11 @@ class _BookRequestButton extends StatefulWidget {
   final String foreignId;
   final String title;
   final RequestService service;
-  final Set<BookFormat> availableFormats;
 
   const _BookRequestButton({
     required this.foreignId,
     required this.title,
     required this.service,
-    required this.availableFormats,
   });
 
   @override
@@ -324,21 +321,12 @@ class _BookRequestButtonState extends State<_BookRequestButton> {
 
   Future<void> _request() async {
     if (_busy) return;
-    final choices = _formatChoices(widget.availableFormats);
-    BookRequestFormat format =
-        choices.length == 1 ? choices.first : BookRequestFormat.both;
-    if (choices.length > 1) {
-      final selected = await showModalBottomSheet<BookRequestFormat>(
-        context: context,
-        backgroundColor: Colors.transparent,
-        builder: (_) => _BookFormatSheet(
-          title: widget.title,
-          choices: choices,
-        ),
-      );
-      if (selected == null) return;
-      format = selected;
-    }
+    final selected = await showModalBottomSheet<BookRequestFormat>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (_) => _BookFormatSheet(title: widget.title),
+    );
+    if (selected == null) return;
     if (!mounted) return;
     setState(() => _busy = true);
     RequestStatus? s;
@@ -347,7 +335,7 @@ class _BookRequestButtonState extends State<_BookRequestButton> {
       s = await widget.service.requestBook(
         foreignId: widget.foreignId,
         title: widget.title,
-        format: format,
+        format: selected,
       );
     } on RequestSubmissionException catch (e) {
       failureMessage = e.message;
@@ -408,33 +396,10 @@ class _BookRequestButtonState extends State<_BookRequestButton> {
   }
 }
 
-List<BookRequestFormat> _formatChoices(Set<BookFormat> available) {
-  final hasEbook = available.contains(BookFormat.ebook);
-  final hasAudiobook = available.contains(BookFormat.audiobook);
-  if (hasEbook && hasAudiobook) {
-    return const [
-      BookRequestFormat.ebook,
-      BookRequestFormat.audiobook,
-      BookRequestFormat.both,
-    ];
-  }
-  if (hasEbook) return const [BookRequestFormat.ebook];
-  if (hasAudiobook) return const [BookRequestFormat.audiobook];
-  return const [
-    BookRequestFormat.ebook,
-    BookRequestFormat.audiobook,
-    BookRequestFormat.both,
-  ];
-}
-
 class _BookFormatSheet extends StatelessWidget {
   final String title;
-  final List<BookRequestFormat> choices;
 
-  const _BookFormatSheet({
-    required this.title,
-    required this.choices,
-  });
+  const _BookFormatSheet({required this.title});
 
   @override
   Widget build(BuildContext context) {
@@ -471,7 +436,7 @@ class _BookFormatSheet extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 14),
-            for (final choice in choices)
+            for (final choice in BookRequestFormat.values)
               Padding(
                 padding: const EdgeInsets.only(bottom: 8),
                 child: _FormatChoiceTile(choice: choice),

--- a/server/internal/chaptarr/client.go
+++ b/server/internal/chaptarr/client.go
@@ -145,6 +145,7 @@ type RootFolder struct {
 // and (for book lookups) the nested author the book belongs to.
 type LookupResult struct {
 	Title           string    `json:"title"`
+	TitleSlug       string    `json:"titleSlug,omitempty"`
 	AuthorName      string    `json:"authorName"`
 	ForeignAuthorID string    `json:"foreignAuthorId"`
 	ForeignBookID   string    `json:"foreignBookId"`
@@ -177,6 +178,8 @@ type AddAuthorRequest struct {
 // book-add payload, so an author ref is required for authors not yet tracked.
 type AddBookRequest struct {
 	ForeignBookID string           `json:"foreignBookId"`
+	Title         string           `json:"title"`
+	TitleSlug     string           `json:"titleSlug,omitempty"`
 	Monitored     bool             `json:"monitored"`
 	AnyEditionOk  bool             `json:"anyEditionOk"`
 	Author        AddAuthorRequest `json:"author"`

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
+	"unicode"
 
 	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/instance"
@@ -605,8 +607,18 @@ func (s *Service) addToChaptarr(r *resolvedRequest) (string, string, error) {
 		return "", "", fmt.Errorf("no root folders available")
 	}
 
+	title := match.Title
+	if title == "" {
+		title = r.title
+	}
+	titleSlug := match.TitleSlug
+	if titleSlug == "" {
+		titleSlug = fallbackTitleSlug(title)
+	}
 	addReq := chaptarr.AddBookRequest{
 		ForeignBookID: match.ForeignBookID,
+		Title:         title,
+		TitleSlug:     titleSlug,
 		Monitored:     true,
 		AnyEditionOk:  normalizeBookFormat(r.bookFormat) == BookFormatBoth,
 	}
@@ -644,10 +656,6 @@ func (s *Service) addToChaptarr(r *resolvedRequest) (string, string, error) {
 		}
 	}
 
-	title := match.Title
-	if title == "" {
-		title = r.title
-	}
 	if _, err := client.AddBook(addReq); err != nil {
 		return "", "", fmt.Errorf("add book failed: %w", err)
 	}
@@ -1389,6 +1397,23 @@ func chaptarrEditionFormat(edition chaptarr.Edition) string {
 		return BookFormatAudiobook
 	}
 	return "unknown"
+}
+
+func fallbackTitleSlug(title string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(title) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if b.Len() > 0 && !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 // sonarrMonitor maps a season scope to Sonarr's addOptions.monitor enum.

--- a/server/internal/request/service_book_test.go
+++ b/server/internal/request/service_book_test.go
@@ -112,6 +112,7 @@ func TestBookRequestFormatMonitorsRequestedEditions(t *testing.T) {
 			_, _ = w.Write([]byte(`[
 				{
 					"title":"Star Wars: Heir to the Empire",
+					"titleSlug":"star-wars-heir-to-the-empire",
 					"foreignBookId":"book-123",
 					"author":{
 						"authorName":"Timothy Zahn",
@@ -158,6 +159,12 @@ func TestBookRequestFormatMonitorsRequestedEditions(t *testing.T) {
 	}
 	if got := addBody["anyEditionOk"]; got != false {
 		t.Fatalf("anyEditionOk = %v, want false for audiobook-only", got)
+	}
+	if addBody["title"] != "Star Wars: Heir to the Empire" {
+		t.Fatalf("title = %v, want Star Wars: Heir to the Empire", addBody["title"])
+	}
+	if addBody["titleSlug"] != "star-wars-heir-to-the-empire" {
+		t.Fatalf("titleSlug = %v, want star-wars-heir-to-the-empire", addBody["titleSlug"])
 	}
 	author := addBody["author"].(map[string]any)
 	if author["authorName"] != "Timothy Zahn" || author["foreignAuthorId"] != "author-456" {
@@ -228,6 +235,12 @@ func TestAdminBookRequestsUseDefaultChaptarrWithoutUserGrant(t *testing.T) {
 	svc := NewService(database, instance.NewRegistry(store), nil, nil)
 	if client := svc.getChaptarr(uid); client == nil {
 		t.Fatal("admin getChaptarr returned nil without per-user grant; want default Chaptarr client")
+	}
+}
+
+func TestFallbackTitleSlug(t *testing.T) {
+	if got := fallbackTitleSlug("Ahsoka (Star Wars)"); got != "ahsoka-star-wars" {
+		t.Fatalf("fallbackTitleSlug = %q, want ahsoka-star-wars", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- always show the book format picker before submitting a dashboard book request
- include `title` and `titleSlug` in the Chaptarr add-book payload so the book POST does not fail after adding only the author
- add a fallback title slug for thinner Chaptarr lookup responses
- extend book request tests to assert title/titleSlug and monitored edition payloads

## Verification
- `go test ./internal/request ./internal/chaptarr` from `server/`
- `go test ./...` from `server/`
- `flutter test test/request/book_request_format_test.dart test/chaptarr/chaptarr_logic_test.dart` from `app/`
- `flutter analyze --no-fatal-infos` from `app/` (plain analyze still reports existing info-level lints)
- `git diff --check`
