### PR TITLE
Fix Chaptarr book requests and interactive search

### DIFF
--- a/app/lib/features/chaptarr/data/chaptarr_api_service.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_api_service.dart
@@ -16,6 +16,25 @@ List<dynamic> _jsonList(dynamic data) {
   return const [];
 }
 
+/// Extracts the releases array from an interactive-search response. This
+/// Chaptarr fork wraps results as `{"releases": [...]}` (alongside
+/// `hiddenReleases`/`filterSummary`), whereas stock Servarr returns a bare
+/// array. A String body (no `application/json` content-type) is decoded first.
+/// Anything unexpected yields an empty list, so a stray object can no longer
+/// throw the `_Map is not a subtype of List` cast error a bare cast did.
+List<dynamic> _releaseList(dynamic data) {
+  dynamic decoded = data;
+  if (decoded is String && decoded.trim().isNotEmpty) {
+    decoded = jsonDecode(decoded);
+  }
+  if (decoded is List) return decoded;
+  if (decoded is Map) {
+    final releases = decoded['releases'];
+    if (releases is List) return releases;
+  }
+  return const [];
+}
+
 /// Networking layer for Chaptarr (a Readarr-family books service), proxied
 /// through the Cantinarr backend. Note the Readarr API is v1 (not v3).
 class ChaptarrApiService {
@@ -243,13 +262,26 @@ class ChaptarrApiService {
     return records;
   }
 
-  /// History for a single book, newest first. Uses the non-paged
-  /// /history/author endpoint filtered by bookId.
+  /// History for a single book, newest first. Uses the paged /history endpoint
+  /// filtered by bookId: the author-scoped /history/author requires an authorId
+  /// and 404s ("Author with ID 0 does not exist") when called with only a
+  /// bookId on this Chaptarr build, which left the book sheet stuck on
+  /// "Loading…".
   Future<List<ChaptarrHistoryRecord>> getBookHistory(int bookId) async {
-    final resp = await _dio
-        .get('$_basePath/history/author', queryParameters: {'bookId': bookId});
-    final records = (resp.data as List<dynamic>)
-        .map((r) => ChaptarrHistoryRecord.fromJson(r as Map<String, dynamic>))
+    final resp = await _dio.get('$_basePath/history', queryParameters: {
+      'bookId': bookId,
+      'pageSize': 50,
+      'sortKey': 'date',
+      'sortDirection': 'descending',
+    });
+    var data = resp.data;
+    // Decode a raw String body first (some Chaptarr endpoints omit the JSON
+    // content-type), mirroring _jsonList/_releaseList.
+    if (data is String && data.trim().isNotEmpty) data = jsonDecode(data);
+    final raw = data is Map ? data['records'] : data;
+    final records = (raw is List ? raw : const [])
+        .whereType<Map<String, dynamic>>()
+        .map(ChaptarrHistoryRecord.fromJson)
         .toList();
     records.sort(
         (a, b) => (b.date ?? DateTime(0)).compareTo(a.date ?? DateTime(0)));
@@ -298,8 +330,9 @@ class ChaptarrApiService {
       queryParameters: {'bookId': bookId},
       options: Options(receiveTimeout: const Duration(seconds: 120)),
     );
-    return (resp.data as List<dynamic>)
-        .map((r) => ChaptarrRelease.fromJson(r as Map<String, dynamic>))
+    return _releaseList(resp.data)
+        .whereType<Map<String, dynamic>>()
+        .map(ChaptarrRelease.fromJson)
         .toList();
   }
 

--- a/app/lib/features/chaptarr/ui/chaptarr_book_detail_sheet.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_book_detail_sheet.dart
@@ -55,7 +55,8 @@ class _ChaptarrBookDetailSheetState
   late final ChaptarrApiService _service;
   ChaptarrBook? _book;
   List<ChaptarrHistoryRecord> _history = [];
-  bool _loading = true;
+  bool _historyLoading = true; // history load (independent of the book)
+  String? _error; // book-load failure, if any
 
   @override
   void initState() {
@@ -67,23 +68,41 @@ class _ChaptarrBookDetailSheetState
     WidgetsBinding.instance.addPostFrameCallback((_) => _load());
   }
 
-  Future<void> _load() async {
+  // Book and history load independently: a history failure must never blank out
+  // the book the sheet is for (a single try/catch around both previously left
+  // the sheet stuck on "Loading…" when the history call errored).
+  void _load() {
+    _loadBook();
+    _loadHistory();
+  }
+
+  Future<void> _loadBook() async {
     try {
-      // Kick off both requests, then await — effectively parallel without the
-      // heterogeneous Future.wait cast.
-      final bookFuture = _service.getBookById(widget.bookId);
-      final historyFuture = _service.getBookHistory(widget.bookId);
-      final book = await bookFuture;
-      final history = await historyFuture;
+      final book = await _service.getBookById(widget.bookId);
       if (!mounted) return;
       setState(() {
         _book = book;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _error = '$e');
+    }
+  }
+
+  Future<void> _loadHistory() async {
+    try {
+      final history = await _service.getBookHistory(widget.bookId);
+      if (!mounted) return;
+      setState(() {
         _history = history.take(8).toList();
-        _loading = false;
+        _historyLoading = false;
       });
     } catch (_) {
+      // History is best-effort: the book is already shown, so a history
+      // failure just drops to "No history yet." rather than surfacing an error.
       if (!mounted) return;
-      setState(() => _loading = false);
+      setState(() => _historyLoading = false);
     }
   }
 
@@ -115,6 +134,9 @@ class _ChaptarrBookDetailSheetState
   ({String label, Color color}) get _shortStatus {
     final book = _book;
     if (book == null) {
+      if (_error != null) {
+        return (label: 'Unavailable', color: AppTheme.error);
+      }
       return (label: 'Loading…', color: AppTheme.textSecondary);
     }
     final line = bookFileStatusLine(book);
@@ -185,6 +207,13 @@ class _ChaptarrBookDetailSheetState
                   ...formats.map((f) => ChaptarrFormatBadge(format: f)),
                 ],
               ),
+              if (book == null && _error != null) ...[
+                const SizedBox(height: 12),
+                Text(
+                  "Couldn't load this book.\n$_error",
+                  style: const TextStyle(color: AppTheme.error, fontSize: 12),
+                ),
+              ],
               if (book?.overview != null && book!.overview!.isNotEmpty) ...[
                 const SizedBox(height: 14),
                 Text(book.overview!,
@@ -251,7 +280,7 @@ class _ChaptarrBookDetailSheetState
   }
 
   Widget _buildHistory() {
-    if (_loading) {
+    if (_historyLoading) {
       return const Padding(
         padding: EdgeInsets.symmetric(vertical: 12),
         child: Center(

--- a/app/test/chaptarr/chaptarr_api_service_test.dart
+++ b/app/test/chaptarr/chaptarr_api_service_test.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/features/chaptarr/data/chaptarr_api_service.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fake Dio adapter: records the request path/query and returns a canned JSON
+/// body (Map or List). Tolerates empty GET bodies (unlike the request-service
+/// test's adapter, which assumes a JSON request body).
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(this.responseJson);
+
+  final dynamic responseJson;
+  String? lastPath;
+  Map<String, dynamic> lastQuery = {};
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastPath = options.uri.path;
+    lastQuery = options.uri.queryParameters;
+    return ResponseBody.fromString(
+      jsonEncode(responseJson),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+ChaptarrApiService _service(_FakeAdapter adapter) {
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+    ..httpClientAdapter = adapter;
+  return ChaptarrApiService(backendDio: dio, instanceId: 'inst1');
+}
+
+void main() {
+  group('getReleases', () {
+    // The exact envelope this Chaptarr fork returns (captured from a live
+    // instance): releases live under "releases", with hiddenReleases and
+    // filterSummary alongside. A bare `as List` cast on this threw
+    // "_Map<String, dynamic> is not a subtype of type 'List<dynamic>'".
+    test('parses the {releases:[...]} envelope from the live fork', () async {
+      final adapter = _FakeAdapter({
+        'releases': [
+          {
+            'guid': 'https://audiobookbay.lu/abss/dark-force-rising/',
+            'indexerId': 2,
+            'indexer': 'AudioBook Bay (Prowlarr)',
+            'protocol': 'torrent',
+            'title': 'Dark Force Rising - Timothy Zahn',
+            'size': 1728724352,
+            'age': 5110,
+            'ageHours': 122657.83,
+            'seeders': 1,
+            'leechers': 0,
+            'rejected': false,
+            'rejections': <dynamic>[],
+            'quality': {
+              'quality': {'id': 10, 'name': 'MP3'},
+            },
+          },
+        ],
+        'hiddenReleases': <dynamic>[],
+        'filterSummary': <String, dynamic>{},
+      });
+
+      final releases = await _service(adapter).getReleases(359);
+
+      expect(adapter.lastPath, '/api/instances/inst1/api/v1/release');
+      expect(adapter.lastQuery['bookId'], '359');
+      expect(releases, hasLength(1));
+      expect(releases.first.guid,
+          'https://audiobookbay.lu/abss/dark-force-rising/');
+      expect(releases.first.indexerId, 2);
+      expect(releases.first.quality, 'MP3');
+      expect(releases.first.seeders, 1);
+      expect(releases.first.isTorrent, isTrue);
+    });
+
+    test('still parses a bare array (stock Servarr shape)', () async {
+      final adapter = _FakeAdapter([
+        {'guid': 'a', 'indexerId': 7, 'title': 'R', 'protocol': 'usenet'},
+      ]);
+
+      final releases = await _service(adapter).getReleases(1);
+
+      expect(releases, hasLength(1));
+      expect(releases.first.guid, 'a');
+      expect(releases.first.isTorrent, isFalse);
+    });
+
+    test('an unexpected object yields no releases instead of throwing',
+        () async {
+      final adapter = _FakeAdapter({'message': 'something broke'});
+      final releases = await _service(adapter).getReleases(1);
+      expect(releases, isEmpty);
+    });
+  });
+
+  group('getBookHistory', () {
+    test('uses the paged /history endpoint (not author-scoped) by bookId',
+        () async {
+      final adapter = _FakeAdapter({
+        'page': 1,
+        'pageSize': 50,
+        'totalRecords': 1,
+        'records': [
+          {
+            'id': 9,
+            'eventType': 'grabbed',
+            'sourceTitle': 'Some Release',
+            'date': '2026-01-02T03:04:05Z',
+            'bookId': 5247,
+          },
+        ],
+      });
+
+      final history = await _service(adapter).getBookHistory(5247);
+
+      // The author-scoped /history/author 404s on this fork when called with
+      // only a bookId, which previously stranded the book sheet on "Loading…".
+      expect(adapter.lastPath, '/api/instances/inst1/api/v1/history');
+      expect(adapter.lastPath, isNot(contains('/history/author')));
+      expect(adapter.lastQuery['bookId'], '5247');
+      expect(history, hasLength(1));
+      expect(history.first.eventType, 'grabbed');
+    });
+  });
+}

--- a/server/internal/chaptarr/client.go
+++ b/server/internal/chaptarr/client.go
@@ -143,18 +143,23 @@ type RootFolder struct {
 // LookupResult is one entry from author/lookup or book/lookup. It carries the
 // fields needed to render a lookup row and seed an add: identifiers, a cover,
 // and (for book lookups) the nested author the book belongs to.
+//
+// Editions is kept as raw JSON, not a typed []Edition, so it can be round-tripped
+// verbatim into the book-add payload. Chaptarr's Editions table has NOT NULL
+// constraints on columns the typed struct would drop (notably links and images),
+// so a lossy re-encode fails the add with a SQLite constraint error.
 type LookupResult struct {
-	Title           string    `json:"title"`
-	TitleSlug       string    `json:"titleSlug,omitempty"`
-	AuthorName      string    `json:"authorName"`
-	ForeignAuthorID string    `json:"foreignAuthorId"`
-	ForeignBookID   string    `json:"foreignBookId"`
-	Overview        string    `json:"overview"`
-	Year            int       `json:"year"`
-	Images          []Image   `json:"images"`
-	Author          *Author   `json:"author,omitempty"`
-	RemoteCover     string    `json:"remoteCover,omitempty"`
-	Editions        []Edition `json:"editions,omitempty"`
+	Title           string            `json:"title"`
+	TitleSlug       string            `json:"titleSlug,omitempty"`
+	AuthorName      string            `json:"authorName"`
+	ForeignAuthorID string            `json:"foreignAuthorId"`
+	ForeignBookID   string            `json:"foreignBookId"`
+	Overview        string            `json:"overview"`
+	Year            int               `json:"year"`
+	Images          []Image           `json:"images"`
+	Author          *Author           `json:"author,omitempty"`
+	RemoteCover     string            `json:"remoteCover,omitempty"`
+	Editions        []json.RawMessage `json:"editions,omitempty"`
 }
 
 // AddAuthorRequest mirrors Sonarr's AddSeriesRequest shape for adding an author
@@ -176,17 +181,26 @@ type AddAuthorRequest struct {
 
 // AddBookRequest adds a single book. Readarr nests the author inside the
 // book-add payload, so an author ref is required for authors not yet tracked.
+//
+// This Chaptarr fork tracks ebook vs audiobook at the book level via
+// MediaType + EbookMonitored/AudiobookMonitored (not per edition — lookup
+// editions carry no format), so requested-format intent is set through those
+// fields. Editions is raw JSON round-tripped from the lookup result so the
+// add satisfies Chaptarr's NOT NULL edition columns (links, images).
 type AddBookRequest struct {
-	ForeignBookID string           `json:"foreignBookId"`
-	Title         string           `json:"title"`
-	TitleSlug     string           `json:"titleSlug,omitempty"`
-	Monitored     bool             `json:"monitored"`
-	AnyEditionOk  bool             `json:"anyEditionOk"`
-	Author        AddAuthorRequest `json:"author"`
-	AddOptions    struct {
+	ForeignBookID      string            `json:"foreignBookId"`
+	Title              string            `json:"title"`
+	TitleSlug          string            `json:"titleSlug,omitempty"`
+	Monitored          bool              `json:"monitored"`
+	AnyEditionOk       bool              `json:"anyEditionOk"`
+	MediaType          string            `json:"mediaType,omitempty"`
+	EbookMonitored     *bool             `json:"ebookMonitored,omitempty"`
+	AudiobookMonitored *bool             `json:"audiobookMonitored,omitempty"`
+	Author             AddAuthorRequest  `json:"author"`
+	AddOptions         struct {
 		SearchForNewBook bool `json:"searchForNewBook"`
 	} `json:"addOptions"`
-	Editions []Edition `json:"editions,omitempty"`
+	Editions []json.RawMessage `json:"editions,omitempty"`
 }
 
 // AuthorContext is the lean author object embedded in queue/history/book records.
@@ -572,10 +586,13 @@ func (c *Client) AddBook(req AddBookRequest) (*Book, error) {
 	return &book, nil
 }
 
-// SetBookMonitored toggles monitoring for the given books.
+// SetBookMonitored toggles monitoring for the given books. Chaptarr's
+// book/monitor endpoint is a PUT (a POST returns 405); it also re-derives a
+// book's ebook/audiobook monitor flags from its mediaType, so monitoring a book
+// whose mediaType was set on add applies the requested format.
 func (c *Client) SetBookMonitored(bookIDs []int, monitored bool) error {
 	body := map[string]any{"bookIds": bookIDs, "monitored": monitored}
-	if err := c.do("POST", "/api/v1/book/monitor", body, nil); err != nil {
+	if err := c.do("PUT", "/api/v1/book/monitor", body, nil); err != nil {
 		return fmt.Errorf("chaptarr set book monitored: %w", err)
 	}
 	return nil
@@ -680,10 +697,38 @@ func releaseSearchClient() *http.Client {
 
 // SearchReleases runs an interactive release search for a book.
 func (c *Client) SearchReleases(bookID int) ([]Release, error) {
-	var releases []Release
+	var raw json.RawMessage
 	path := fmt.Sprintf("/api/v1/release?bookId=%d", bookID)
-	if err := c.doWith(releaseSearchClient(), "GET", path, nil, &releases); err != nil {
+	if err := c.doWith(releaseSearchClient(), "GET", path, nil, &raw); err != nil {
 		return nil, fmt.Errorf("chaptarr release search: %w", err)
+	}
+	releases, err := decodeReleases(raw)
+	if err != nil {
+		return nil, fmt.Errorf("chaptarr release search: %w", err)
+	}
+	return releases, nil
+}
+
+// decodeReleases parses Chaptarr's interactive-search response. This fork wraps
+// results in a {"releases": [...]} envelope (alongside hiddenReleases /
+// filterSummary), while stock Servarr returns a bare array — accept either.
+func decodeReleases(raw json.RawMessage) ([]Release, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	if trimmed[0] == '{' {
+		var env struct {
+			Releases []Release `json:"releases"`
+		}
+		if err := json.Unmarshal(trimmed, &env); err != nil {
+			return nil, fmt.Errorf("decode release envelope: %w", err)
+		}
+		return env.Releases, nil
+	}
+	var releases []Release
+	if err := json.Unmarshal(trimmed, &releases); err != nil {
+		return nil, fmt.Errorf("decode releases: %w", err)
 	}
 	return releases, nil
 }

--- a/server/internal/chaptarr/client_test.go
+++ b/server/internal/chaptarr/client_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 )
 
-// TestSetBookMonitored asserts SetBookMonitored posts the {bookIds, monitored}
-// body Chaptarr's book/monitor endpoint expects.
+// TestSetBookMonitored asserts SetBookMonitored PUTs the {bookIds, monitored}
+// body Chaptarr's book/monitor endpoint expects (a POST returns 405 on the
+// fork).
 func TestSetBookMonitored(t *testing.T) {
 	var gotPath, gotMethod string
 	var body map[string]any
@@ -29,8 +30,8 @@ func TestSetBookMonitored(t *testing.T) {
 		t.Fatalf("SetBookMonitored: %v", err)
 	}
 
-	if gotMethod != http.MethodPost {
-		t.Errorf("method = %s, want POST", gotMethod)
+	if gotMethod != http.MethodPut {
+		t.Errorf("method = %s, want PUT", gotMethod)
 	}
 	if gotPath != "/api/v1/book/monitor" {
 		t.Errorf("path = %s, want /api/v1/book/monitor", gotPath)
@@ -138,6 +139,37 @@ func TestGetQueue(t *testing.T) {
 	}
 	if len(items) != 1 || items[0].BookID != 42 {
 		t.Fatalf("items = %+v, want one item with bookId 42", items)
+	}
+}
+
+// TestSearchReleasesEnvelope asserts the interactive-search response is parsed
+// whether Chaptarr returns its {"releases":[...]} envelope (this fork) or a
+// bare array (stock Servarr). A bare-array assumption here surfaced in the app
+// as "type '_Map<String, dynamic>' is not a subtype of type 'List<dynamic>'".
+func TestSearchReleasesEnvelope(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"envelope", `{"releases":[{"guid":"a","indexerId":2,"title":"R","protocol":"torrent"}],"hiddenReleases":[],"filterSummary":{}}`},
+		{"bare array", `[{"guid":"a","indexerId":2,"title":"R","protocol":"torrent"}]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			defer srv.Close()
+
+			releases, err := NewClient(srv.URL, "key").SearchReleases(42)
+			if err != nil {
+				t.Fatalf("SearchReleases: %v", err)
+			}
+			if len(releases) != 1 || releases[0].GUID != "a" || releases[0].IndexerID != 2 {
+				t.Fatalf("releases = %+v, want one release guid=a indexerId=2", releases)
+			}
+		})
 	}
 }
 

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -615,13 +615,39 @@ func (s *Service) addToChaptarr(r *resolvedRequest) (string, string, error) {
 	if titleSlug == "" {
 		titleSlug = fallbackTitleSlug(title)
 	}
+
+	// Chaptarr stores a title's ebook and audiobook as separate book records
+	// (same foreignBookId, different mediaType), so a "both" request adds the
+	// book once per format. Adding at least one record counts as requested; the
+	// last error is surfaced only if every requested format failed.
+	formats := chaptarrRequestFormats(r.bookFormat)
+	var lastErr error
+	added := 0
+	for _, mediaType := range formats {
+		if err := s.addChaptarrBookRecord(client, match, qps[0].ID, mps[0].ID, folders[0].Path, title, titleSlug, mediaType); err != nil {
+			lastErr = err
+			continue
+		}
+		added++
+	}
+	if added == 0 {
+		return "", "", fmt.Errorf("add book failed: %w", lastErr)
+	}
+	return StatusRequested, title, nil
+}
+
+// addChaptarrBookRecord adds one format record (ebook or audiobook) of a book and
+// ensures it ends up monitored and searched. Chaptarr tracks format at the book
+// level via mediaType, so each requested format is its own record.
+func (s *Service) addChaptarrBookRecord(client *chaptarr.Client, match *chaptarr.LookupResult, qualityProfileID, metadataProfileID int, rootFolderPath, title, titleSlug, mediaType string) error {
 	addReq := chaptarr.AddBookRequest{
 		ForeignBookID: match.ForeignBookID,
 		Title:         title,
 		TitleSlug:     titleSlug,
 		Monitored:     true,
-		AnyEditionOk:  normalizeBookFormat(r.bookFormat) == BookFormatBoth,
 	}
+	setChaptarrMediaType(&addReq, mediaType)
+
 	authorName := match.AuthorName
 	foreignAuthorID := match.ForeignAuthorID
 	if match.Author != nil {
@@ -634,32 +660,47 @@ func (s *Service) addToChaptarr(r *resolvedRequest) (string, string, error) {
 	}
 	addReq.Author.AuthorName = authorName
 	addReq.Author.ForeignAuthorID = foreignAuthorID
-	addReq.Author.QualityProfileID = qps[0].ID
-	addReq.Author.MetadataProfileID = mps[0].ID
-	addReq.Author.RootFolderPath = folders[0].Path
+	addReq.Author.QualityProfileID = qualityProfileID
+	addReq.Author.MetadataProfileID = metadataProfileID
+	addReq.Author.RootFolderPath = rootFolderPath
 	addReq.Author.Monitored = true
 	addReq.Author.AddOptions.Monitor = "all"
 	addReq.AddOptions.SearchForNewBook = true
+
+	// Round-trip the lookup's editions verbatim, marking them monitored so
+	// Chaptarr tracks the book (an add with no editions stays unmonitored).
+	// patchEditionForAdd also guards Chaptarr's NOT NULL links/images columns so
+	// the add can't fail a SQLite constraint.
 	if len(match.Editions) > 0 {
-		addReq.Editions = make([]chaptarr.Edition, 0, len(match.Editions))
-		matchedFormat := false
-		for _, edition := range match.Editions {
-			edition.Monitored = editionMatchesBookFormat(edition, r.bookFormat)
-			edition.ManualAdd = edition.Monitored
-			if edition.Monitored {
-				matchedFormat = true
+		addReq.Editions = make([]json.RawMessage, 0, len(match.Editions))
+		for _, raw := range match.Editions {
+			patched, ok, err := patchEditionForAdd(raw)
+			if err != nil {
+				return fmt.Errorf("prepare edition: %w", err)
 			}
-			addReq.Editions = append(addReq.Editions, edition)
-		}
-		if !matchedFormat {
-			return "", "", fmt.Errorf("no %s edition available for %s", normalizeBookFormat(r.bookFormat), match.Title)
+			if !ok {
+				continue // skip a non-object edition element rather than emit junk
+			}
+			addReq.Editions = append(addReq.Editions, patched)
 		}
 	}
 
-	if _, err := client.AddBook(addReq); err != nil {
-		return "", "", fmt.Errorf("add book failed: %w", err)
+	book, err := client.AddBook(addReq)
+	if err != nil {
+		return err
 	}
-	return StatusRequested, title, nil
+	// A book added under an author created by this same request comes back
+	// unmonitored (Chaptarr's async author refresh hasn't applied monitoring),
+	// so the format flags and searchForNewBook never take effect. Monitor +
+	// search it explicitly; SetBookMonitored re-derives the format from the
+	// mediaType set above. Books under an already-tracked author come back
+	// monitored and need nothing further. Best-effort: the add already succeeded.
+	if book != nil && book.ID != 0 && !book.Monitored {
+		if err := client.SetBookMonitored([]int{book.ID}, true); err == nil {
+			_ = client.TriggerBookSearch([]int{book.ID})
+		}
+	}
+	return nil
 }
 
 func (s *Service) addMovie(r *resolvedRequest) (string, string, error) {
@@ -1372,31 +1413,63 @@ func validBookFormat(format string) bool {
 		format == BookFormatBoth
 }
 
-func editionMatchesBookFormat(edition chaptarr.Edition, format string) bool {
+// chaptarrRequestFormats expands a requested book format into the concrete
+// Chaptarr media types to add. Chaptarr stores a title's ebook and audiobook as
+// separate book records (same foreignBookId, different mediaType), so "both"
+// expands to two adds rather than one record flagged for both.
+func chaptarrRequestFormats(format string) []string {
 	switch normalizeBookFormat(format) {
-	case BookFormatBoth:
-		return true
+	case BookFormatEbook:
+		return []string{"ebook"}
 	case BookFormatAudiobook:
-		return chaptarrEditionFormat(edition) == BookFormatAudiobook
-	default:
-		return chaptarrEditionFormat(edition) == BookFormatEbook
+		return []string{"audiobook"}
+	default: // both
+		return []string{"ebook", "audiobook"}
 	}
 }
 
-func chaptarrEditionFormat(edition chaptarr.Edition) string {
-	if format := chaptarr.FormatOf(edition.Format); format != "unknown" {
-		return format
+// setChaptarrMediaType pins one add-book payload to a single Chaptarr media type
+// (ebook or audiobook) and its matching monitor flag. This fork tracks format at
+// the book level via mediaType — its lookup editions carry no format — so format
+// intent is expressed here, not by selecting an edition. A book record holds one
+// format; the flag that doesn't match mediaType is ignored by Chaptarr.
+func setChaptarrMediaType(req *chaptarr.AddBookRequest, mediaType string) {
+	req.MediaType = mediaType
+	ebook := mediaType == "ebook"
+	audiobook := mediaType == "audiobook"
+	req.EbookMonitored = &ebook
+	req.AudiobookMonitored = &audiobook
+}
+
+// patchEditionForAdd prepares one lookup edition for the add payload: it marks
+// the edition monitored/manualAdd and guarantees the NOT NULL links and images
+// arrays survive. The edition is otherwise passed through verbatim — Chaptarr's
+// Editions table rejects a null links or images, and the lookup result already
+// carries both. ok is false when the element is a JSON null (which decodes to a
+// nil map) — Chaptarr never sends that, but guarding it avoids a nil-map-write
+// panic; the caller skips such elements.
+func patchEditionForAdd(raw json.RawMessage) (out json.RawMessage, ok bool, err error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, false, err
 	}
-	if format := chaptarr.FormatOf(edition.Title); format != "unknown" {
-		return format
+	if obj == nil {
+		return nil, false, nil
 	}
-	if edition.IsEbook != nil {
-		if *edition.IsEbook {
-			return BookFormatEbook
-		}
-		return BookFormatAudiobook
+	t := json.RawMessage("true")
+	obj["monitored"] = t
+	obj["manualAdd"] = t
+	if v, ok := obj["links"]; !ok || string(v) == "null" {
+		obj["links"] = json.RawMessage("[]")
 	}
-	return "unknown"
+	if v, ok := obj["images"]; !ok || string(v) == "null" {
+		obj["images"] = json.RawMessage("[]")
+	}
+	out, err = json.Marshal(obj)
+	if err != nil {
+		return nil, false, err
+	}
+	return out, true, nil
 }
 
 func fallbackTitleSlug(title string) string {

--- a/server/internal/request/service_book_test.go
+++ b/server/internal/request/service_book_test.go
@@ -119,8 +119,8 @@ func TestBookRequestFormatMonitorsRequestedEditions(t *testing.T) {
 						"foreignAuthorId":"author-456"
 					},
 					"editions":[
-						{"id":1,"foreignEditionId":"edition-ebook","titleSlug":"ebook","title":"Kindle Edition","format":"Kindle Edition"},
-						{"id":2,"foreignEditionId":"edition-audio","titleSlug":"audio","title":"Audiobook","format":"Audible Audio"}
+						{"id":1,"foreignEditionId":"edition-ebook","titleSlug":"ebook","title":"Kindle Edition","format":"Kindle Edition","links":[{"url":"https://example.com","name":"Goodreads"}],"images":[{"url":"/cover.jpg","coverType":"cover"}]},
+						{"id":2,"foreignEditionId":"edition-audio","titleSlug":"audio","title":"Audiobook","format":"Audible Audio","links":null}
 					]
 				}
 			]`))
@@ -134,7 +134,7 @@ func TestBookRequestFormatMonitorsRequestedEditions(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&addBody); err != nil {
 				t.Errorf("decode add book body: %v", err)
 			}
-			_, _ = w.Write([]byte(`{"id":9,"title":"Star Wars: Heir to the Empire","foreignBookId":"book-123"}`))
+			_, _ = w.Write([]byte(`{"id":9,"title":"Star Wars: Heir to the Empire","foreignBookId":"book-123","monitored":true}`))
 		default:
 			http.Error(w, "unexpected route", http.StatusNotFound)
 		}
@@ -157,8 +157,19 @@ func TestBookRequestFormatMonitorsRequestedEditions(t *testing.T) {
 	if addBody == nil {
 		t.Fatal("AddBook was not called")
 	}
+	// Format intent is carried by Chaptarr's book-level flags (this fork tracks
+	// ebook vs audiobook per book, not per edition).
 	if got := addBody["anyEditionOk"]; got != false {
 		t.Fatalf("anyEditionOk = %v, want false for audiobook-only", got)
+	}
+	if got := addBody["mediaType"]; got != "audiobook" {
+		t.Fatalf("mediaType = %v, want audiobook", got)
+	}
+	if got := addBody["audiobookMonitored"]; got != true {
+		t.Fatalf("audiobookMonitored = %v, want true for audiobook request", got)
+	}
+	if got := addBody["ebookMonitored"]; got != false {
+		t.Fatalf("ebookMonitored = %v, want false for audiobook request", got)
 	}
 	if addBody["title"] != "Star Wars: Heir to the Empire" {
 		t.Fatalf("title = %v, want Star Wars: Heir to the Empire", addBody["title"])
@@ -170,23 +181,40 @@ func TestBookRequestFormatMonitorsRequestedEditions(t *testing.T) {
 	if author["authorName"] != "Timothy Zahn" || author["foreignAuthorId"] != "author-456" {
 		t.Fatalf("author = %#v, want nested lookup author carried into add payload", author)
 	}
+	// Editions are round-tripped verbatim (all monitored) so Chaptarr's NOT NULL
+	// links/images columns are satisfied; format is no longer chosen per edition.
 	editions, ok := addBody["editions"].([]any)
 	if !ok || len(editions) != 2 {
 		t.Fatalf("editions = %#v, want 2 editions", addBody["editions"])
 	}
 	ebook := editions[0].(map[string]any)
 	audio := editions[1].(map[string]any)
-	if ebook["monitored"] != false {
-		t.Fatalf("ebook monitored = %v, want false", ebook["monitored"])
-	}
-	if audio["monitored"] != true {
-		t.Fatalf("audiobook monitored = %v, want true", audio["monitored"])
-	}
-	if audio["manualAdd"] != true {
-		t.Fatalf("audiobook manualAdd = %v, want true", audio["manualAdd"])
+	for i, ed := range []map[string]any{ebook, audio} {
+		if ed["monitored"] != true {
+			t.Fatalf("edition[%d] monitored = %v, want true (monitor all editions)", i, ed["monitored"])
+		}
+		if ed["manualAdd"] != true {
+			t.Fatalf("edition[%d] manualAdd = %v, want true", i, ed["manualAdd"])
+		}
 	}
 	if audio["foreignEditionId"] != "edition-audio" || audio["titleSlug"] != "audio" {
 		t.Fatalf("audiobook edition = %#v, want foreignEditionId/titleSlug preserved", audio)
+	}
+	// Regression guard for the SQLite "NOT NULL constraint failed: Editions.Links/Images"
+	// add failure: links/images must survive the round-trip, and be defaulted to
+	// [] (never null/absent) for editions the lookup omitted them on.
+	ebookLinks, ok := ebook["links"].([]any)
+	if !ok || len(ebookLinks) != 1 {
+		t.Fatalf("ebook links = %#v, want the lookup's 1 link preserved", ebook["links"])
+	}
+	if ebookImages, ok := ebook["images"].([]any); !ok || len(ebookImages) != 1 {
+		t.Fatalf("ebook images = %#v, want the lookup's 1 image preserved", ebook["images"])
+	}
+	if audioLinks, ok := audio["links"].([]any); !ok || len(audioLinks) != 0 {
+		t.Fatalf("audio links = %#v, want [] coerced (lookup sent links:null)", audio["links"])
+	}
+	if audioImages, ok := audio["images"].([]any); !ok || len(audioImages) != 0 {
+		t.Fatalf("audio images = %#v, want [] injected (lookup omitted images)", audio["images"])
 	}
 
 	var stored string
@@ -199,6 +227,235 @@ func TestBookRequestFormatMonitorsRequestedEditions(t *testing.T) {
 	}
 	if stored != BookFormatAudiobook {
 		t.Fatalf("stored book_format = %q, want %q", stored, BookFormatAudiobook)
+	}
+}
+
+// TestBookRequestEbookFormatAddsRealisticEdition guards the "no ebook edition
+// available" regression: Chaptarr's real lookup editions all report
+// isEbook=false / format=null, so the old per-edition format gate rejected every
+// ebook request. An ebook request must now add the book and set ebook-format
+// book-level flags instead of erroring.
+func TestBookRequestEbookFormatAddsRealisticEdition(t *testing.T) {
+	var addBody map[string]any
+	chaptarrServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/book/lookup":
+			// Mirrors real Chaptarr metadata: a single edition with no format,
+			// isEbook=false, and a present-but-empty links array.
+			_, _ = w.Write([]byte(`[
+				{
+					"title":"Ahsoka (Star Wars)",
+					"titleSlug":"ahsoka-star-wars",
+					"foreignBookId":"29749107",
+					"author":{"authorName":"E.K. Johnston","foreignAuthorId":"gr:7418796"},
+					"editions":[
+						{"foreignEditionId":"29749107","title":"Ahsoka (Star Wars)","format":null,"isEbook":false,"links":[],"images":[{"url":"/c.jpg","coverType":"cover"}]}
+					]
+				}
+			]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/qualityprofile":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"E-Book"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/metadataprofile":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"Standard"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/rootfolder":
+			_, _ = w.Write([]byte(`[{"id":1,"path":"/books","accessible":true}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/book":
+			if err := json.NewDecoder(r.Body).Decode(&addBody); err != nil {
+				t.Errorf("decode add book body: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"id":42,"title":"Ahsoka (Star Wars)","foreignBookId":"29749107","monitored":true}`))
+		default:
+			http.Error(w, "unexpected route", http.StatusNotFound)
+		}
+	}))
+	defer chaptarrServer.Close()
+
+	svc, uid := newChaptarrBookTestService(t, chaptarrServer.URL)
+	resp, err := svc.CreateMediaRequest(uid, &CreateRequest{
+		MediaType:  "book",
+		ForeignID:  "29749107",
+		Title:      "Ahsoka (Star Wars)",
+		BookFormat: BookFormatEbook,
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest (ebook): %v", err)
+	}
+	if resp.Status != StatusRequested {
+		t.Fatalf("status = %s, want requested (ebook must not be rejected)", resp.Status)
+	}
+	if addBody == nil {
+		t.Fatal("AddBook was not called for ebook request")
+	}
+	if got := addBody["mediaType"]; got != "ebook" {
+		t.Fatalf("mediaType = %v, want ebook", got)
+	}
+	if got := addBody["ebookMonitored"]; got != true {
+		t.Fatalf("ebookMonitored = %v, want true", got)
+	}
+	if got := addBody["audiobookMonitored"]; got != false {
+		t.Fatalf("audiobookMonitored = %v, want false", got)
+	}
+	editions, ok := addBody["editions"].([]any)
+	if !ok || len(editions) != 1 {
+		t.Fatalf("editions = %#v, want 1 edition round-tripped", addBody["editions"])
+	}
+	ed := editions[0].(map[string]any)
+	if ed["monitored"] != true {
+		t.Fatalf("edition monitored = %v, want true", ed["monitored"])
+	}
+	if links, ok := ed["links"].([]any); !ok {
+		t.Fatalf("edition links = %#v, want an array (never null)", ed["links"])
+	} else if len(links) != 0 {
+		t.Fatalf("edition links = %#v, want the lookup's empty array preserved", links)
+	}
+	if images, ok := ed["images"].([]any); !ok || len(images) != 1 {
+		t.Fatalf("edition images = %#v, want the lookup's image preserved", ed["images"])
+	}
+}
+
+// TestBookRequestBothFormatAddsEbookAndAudiobookRecords covers the "both" path.
+// Chaptarr stores a title's ebook and audiobook as separate records (same
+// foreignBookId, different mediaType), so a "both" request must POST the book
+// twice — once as ebook, once as audiobook — each pinned to its own mediaType.
+func TestBookRequestBothFormatAddsEbookAndAudiobookRecords(t *testing.T) {
+	var addBodies []map[string]any
+	chaptarrServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/book/lookup":
+			_, _ = w.Write([]byte(`[
+				{
+					"title":"Ahsoka (Star Wars)",
+					"titleSlug":"ahsoka-star-wars",
+					"foreignBookId":"29749107",
+					"author":{"authorName":"E.K. Johnston","foreignAuthorId":"gr:7418796"},
+					"editions":[
+						{"foreignEditionId":"29749107","title":"Ahsoka (Star Wars)","format":null,"isEbook":false,"links":[],"images":[]}
+					]
+				}
+			]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/qualityprofile":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"E-Book"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/metadataprofile":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"Standard"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/rootfolder":
+			_, _ = w.Write([]byte(`[{"id":1,"path":"/books","accessible":true}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/book":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode add book body: %v", err)
+			}
+			addBodies = append(addBodies, body)
+			_, _ = w.Write([]byte(`{"id":50,"title":"Ahsoka (Star Wars)","foreignBookId":"29749107","monitored":true}`))
+		default:
+			http.Error(w, "unexpected route", http.StatusNotFound)
+		}
+	}))
+	defer chaptarrServer.Close()
+
+	svc, uid := newChaptarrBookTestService(t, chaptarrServer.URL)
+	resp, err := svc.CreateMediaRequest(uid, &CreateRequest{
+		MediaType:  "book",
+		ForeignID:  "29749107",
+		Title:      "Ahsoka (Star Wars)",
+		BookFormat: BookFormatBoth,
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest (both): %v", err)
+	}
+	if resp.Status != StatusRequested {
+		t.Fatalf("status = %s, want requested", resp.Status)
+	}
+	if len(addBodies) != 2 {
+		t.Fatalf("AddBook called %d times, want 2 (one ebook record + one audiobook record)", len(addBodies))
+	}
+	byFormat := map[string]map[string]any{}
+	for _, b := range addBodies {
+		mt, _ := b["mediaType"].(string)
+		byFormat[mt] = b
+	}
+	ebook, ok := byFormat["ebook"]
+	if !ok {
+		t.Fatalf("no ebook record added; bodies = %#v", addBodies)
+	}
+	audio, ok := byFormat["audiobook"]
+	if !ok {
+		t.Fatalf("no audiobook record added; bodies = %#v", addBodies)
+	}
+	// Each record is pinned to its own format and shares the foreignBookId.
+	if ebook["ebookMonitored"] != true || ebook["audiobookMonitored"] != false {
+		t.Fatalf("ebook record flags = %#v, want ebookMonitored only", ebook)
+	}
+	if audio["audiobookMonitored"] != true || audio["ebookMonitored"] != false {
+		t.Fatalf("audiobook record flags = %#v, want audiobookMonitored only", audio)
+	}
+	if ebook["foreignBookId"] != "29749107" || audio["foreignBookId"] != "29749107" {
+		t.Fatalf("records must share foreignBookId 29749107; got ebook=%v audio=%v", ebook["foreignBookId"], audio["foreignBookId"])
+	}
+}
+
+// TestBookRequestMonitorsAndSearchesNewAuthorBook covers the new-author case:
+// Chaptarr returns the freshly added book unmonitored (its author's async
+// refresh hasn't applied monitoring), so the request must monitor it (PUT
+// /book/monitor) and kick off a search (BookSearch command) explicitly, or the
+// request would silently fetch nothing.
+func TestBookRequestMonitorsAndSearchesNewAuthorBook(t *testing.T) {
+	var monitorIDs []any
+	var searchCmd map[string]any
+	chaptarrServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/book/lookup":
+			_, _ = w.Write([]byte(`[
+				{
+					"title":"Ahsoka (Star Wars)","titleSlug":"ahsoka","foreignBookId":"29749107",
+					"author":{"authorName":"E.K. Johnston","foreignAuthorId":"gr:7418796"},
+					"editions":[{"foreignEditionId":"29749107","title":"Ahsoka (Star Wars)","links":[],"images":[]}]
+				}
+			]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/qualityprofile":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"E-Book"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/metadataprofile":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"Standard"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/rootfolder":
+			_, _ = w.Write([]byte(`[{"id":1,"path":"/books","accessible":true}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/book":
+			// New-author add: Chaptarr returns the book unmonitored.
+			_, _ = w.Write([]byte(`{"id":44,"title":"Ahsoka (Star Wars)","foreignBookId":"29749107","monitored":false}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v1/book/monitor":
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			monitorIDs, _ = body["bookIds"].([]any)
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/command":
+			_ = json.NewDecoder(r.Body).Decode(&searchCmd)
+			w.WriteHeader(http.StatusCreated)
+		default:
+			http.Error(w, "unexpected route", http.StatusNotFound)
+		}
+	}))
+	defer chaptarrServer.Close()
+
+	svc, uid := newChaptarrBookTestService(t, chaptarrServer.URL)
+	resp, err := svc.CreateMediaRequest(uid, &CreateRequest{
+		MediaType: "book", ForeignID: "29749107", Title: "Ahsoka (Star Wars)", BookFormat: BookFormatEbook,
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if resp.Status != StatusRequested {
+		t.Fatalf("status = %s, want requested", resp.Status)
+	}
+	if len(monitorIDs) != 1 || int(monitorIDs[0].(float64)) != 44 {
+		t.Fatalf("monitor bookIds = %v, want [44] (unmonitored add must be monitored)", monitorIDs)
+	}
+	if searchCmd["name"] != "BookSearch" {
+		t.Fatalf("command = %v, want a BookSearch", searchCmd["name"])
+	}
+	ids, _ := searchCmd["bookIds"].([]any)
+	if len(ids) != 1 || int(ids[0].(float64)) != 44 {
+		t.Fatalf("BookSearch bookIds = %v, want [44]", searchCmd["bookIds"])
 	}
 }
 


### PR DESCRIPTION
Diagnosed live against a real Chaptarr (Readarr fork, v0.9.169) instance. All four user-reported failures are fixed and verified end-to-end.

## Issues fixed
| Symptom | Cause | Fix |
|---|---|---|
| Add **409** `NOT NULL constraint failed: Editions.Links` (and `.Images`) | Lossy `Edition` struct dropped fields the lookup provides | Round-trip lookup editions verbatim (`json.RawMessage`), patch only `monitored`/`manualAdd`, guarantee `links`/`images` are non-null arrays |
| **"no ebook edition available"** for every book | Lookup editions all report `isEbook=false`/`format=null`, so the per-edition format gate rejected every ebook request | Format is book-level on this fork (`mediaType` + `ebookMonitored`/`audiobookMonitored`); set those instead. "Both" adds the title once per format (two records sharing a `foreignBookId`) |
| Request "succeeds" but nothing downloads | New-author books come back **unmonitored** (async author refresh) | Monitor + search the book explicitly when unmonitored; fix `SetBookMonitored` to **PUT** (`POST` → 405) |
| Interactive search **`_Map is not a subtype of List`** | Fork returns `{"releases":[...]}` (object), not a bare array | Unwrap the envelope in the Flutter client and the Go client (`decodeReleases`) |
| Book detail stuck on **"Loading…"** | `getBookHistory` hit `/history/author?bookId` (404 without `authorId`); one try/catch discarded the loaded book | Use paged `/history?bookId`; load book/history independently and surface errors |

## Verification
- Diagnosed and validated against the live instance: reproduced the 409, confirmed the fixed add returns 201, confirmed format/monitoring stick, confirmed the two-record "both" flow, confirmed `/release` is an object and `/history/author?bookId` 404s. All test data cleaned up.
- Adversarial multi-agent review of the diff (caught a nil-map panic + test gaps, all addressed).
- Go: all packages pass. Flutter: analyze clean, full suite passes. New/updated tests guard each regression with realistic fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)