### PR TITLE
Fix Chaptarr book add failing on string genres in response

### DIFF
--- a/server/internal/chaptarr/client.go
+++ b/server/internal/chaptarr/client.go
@@ -38,6 +38,42 @@ type Image struct {
 	RemoteURL string `json:"remoteUrl"`
 }
 
+// genreList unmarshals a genres value that may be either a JSON array of strings
+// (stock Servarr) or a single, possibly comma-separated, string. This Chaptarr
+// fork returns genres as a string (e.g. "" or "Science Fiction, Fantasy"), which
+// would otherwise fail to decode into a []string and abort the whole response —
+// e.g. a successful book add reported as "cannot unmarshal string into Go struct
+// field Book.genres of type []string".
+type genreList []string
+
+func (g *genreList) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || string(trimmed) == "null" {
+		*g = nil
+		return nil
+	}
+	if trimmed[0] == '[' {
+		var arr []string
+		if err := json.Unmarshal(trimmed, &arr); err != nil {
+			return err
+		}
+		*g = arr
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(trimmed, &s); err != nil {
+		return err
+	}
+	out := make([]string, 0)
+	for _, part := range strings.Split(s, ",") {
+		if p := strings.TrimSpace(part); p != "" {
+			out = append(out, p)
+		}
+	}
+	*g = out
+	return nil
+}
+
 // AuthorStatistics is the per-author book rollup Chaptarr returns on an author.
 type AuthorStatistics struct {
 	BookCount          int     `json:"bookCount"`
@@ -61,7 +97,7 @@ type Author struct {
 	MetadataProfileID int              `json:"metadataProfileId"`
 	Statistics        AuthorStatistics `json:"statistics"`
 	Images            []Image          `json:"images"`
-	Genres            []string         `json:"genres"`
+	Genres            genreList        `json:"genres"`
 }
 
 // BookStatistics is the per-book file rollup Chaptarr returns on a book.
@@ -107,7 +143,7 @@ type Book struct {
 	Statistics    BookStatistics `json:"statistics"`
 	Editions      []Edition      `json:"editions"`
 	Images        []Image        `json:"images"`
-	Genres        []string       `json:"genres"`
+	Genres        genreList      `json:"genres"`
 }
 
 type BookFile struct {

--- a/server/internal/chaptarr/client_test.go
+++ b/server/internal/chaptarr/client_test.go
@@ -173,6 +173,63 @@ func TestSearchReleasesEnvelope(t *testing.T) {
 	}
 }
 
+// TestGenreListUnmarshal asserts genres decode from both a comma-separated
+// string (this Chaptarr fork) and a JSON array (stock Servarr).
+func TestGenreListUnmarshal(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty string", `""`, []string{}},
+		{"comma string", `"Science Fiction, Fantasy"`, []string{"Science Fiction", "Fantasy"}},
+		{"single string", `"Fiction"`, []string{"Fiction"}},
+		{"array", `["A","B"]`, []string{"A", "B"}},
+		{"null", `null`, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var g genreList
+			if err := json.Unmarshal([]byte(tc.in), &g); err != nil {
+				t.Fatalf("unmarshal %q: %v", tc.in, err)
+			}
+			if len(g) != len(tc.want) {
+				t.Fatalf("got %#v, want %#v", []string(g), tc.want)
+			}
+			for i := range tc.want {
+				if g[i] != tc.want[i] {
+					t.Fatalf("got %#v, want %#v", []string(g), tc.want)
+				}
+			}
+		})
+	}
+}
+
+// TestAddBookToleratesStringGenres guards the add-book response decode: Chaptarr
+// returns the created book with genres as a string, which previously surfaced a
+// successful add as "cannot unmarshal string into Go struct field Book.genres of
+// type []string".
+func TestAddBookToleratesStringGenres(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"id":51,"title":"Dune Messiah","foreignBookId":"x","monitored":true,`+
+			`"genres":"Science Fiction, Fantasy","releaseDate":null,"editions":null,`+
+			`"author":{"id":9,"authorName":"Frank Herbert"},"statistics":{"bookCount":1}}`)
+	}))
+	defer srv.Close()
+
+	book, err := NewClient(srv.URL, "key").AddBook(AddBookRequest{ForeignBookID: "x"})
+	if err != nil {
+		t.Fatalf("AddBook: %v", err)
+	}
+	if book.ID != 51 || !book.Monitored {
+		t.Fatalf("book = id %d monitored %v, want id 51 monitored true", book.ID, book.Monitored)
+	}
+	if len(book.Genres) != 2 || book.Genres[0] != "Science Fiction" {
+		t.Fatalf("genres = %#v, want [Science Fiction, Fantasy]", []string(book.Genres))
+	}
+}
+
 // TestFormatOf asserts the quality-name classifier maps representative ebook
 // and audiobook formats and falls back to "unknown".
 func TestFormatOf(t *testing.T) {


### PR DESCRIPTION
Follow-up to #112. With the 409 fixed, book adds now reach the response-decode step — and hit the next fork quirk.

## Problem
This Chaptarr fork returns a book's `genres` as a **string** (`""` or `"Science Fiction, Fantasy"`), not a JSON array. The Go `Book`/`Author` structs typed `genres` as `[]string`, so decoding the add-book response failed:

```
add book failed: chaptarr add book: decode response: json: cannot unmarshal string into Go struct field Book.genres of type []string
```

The book is actually **created** on Chaptarr's side — only reading the response back failed, so a successful add was reported as a failure. It went uncaught because the test mocks omitted `genres`.

## Fix
Add a `genreList` type that unmarshals from either a string (comma-split, trimmed) or a `[]string` array, mirroring what the Flutter client already does, and use it for `Book.Genres` and `Author.Genres`.

## Verification
- Confirmed against the live instance: all 2164 library books return `genres` as a string; `releaseDate` is null or a valid date (never the empty-string that would be the next landmine).
- Decoded the **real** captured book response into the Go `Book` struct — clean, `genres:""` → `[]`, no other field mismatch.
- New tests: `genreList` table (string/comma/array/null) + an `AddBook` decode against a string-`genres` response. Full Go suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)