### PR TITLE
Chaptarr: one entry per title, per-format monitor/search/request

### DIFF
--- a/app/lib/features/chaptarr/data/chaptarr_models.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_models.dart
@@ -350,6 +350,10 @@ class ChaptarrBook {
   final String? overview;
   final DateTime? releaseDate;
   final bool monitored;
+
+  /// Chaptarr (this fork) tracks a title's ebook and audiobook as separate book
+  /// records distinguished by mediaType ("ebook"/"audiobook").
+  final String? mediaType;
   final bool anyEditionOk;
   final int pageCount;
   final ChaptarrAuthorContext? author;
@@ -367,6 +371,7 @@ class ChaptarrBook {
     this.overview,
     this.releaseDate,
     this.monitored = true,
+    this.mediaType,
     this.anyEditionOk = true,
     this.pageCount = 0,
     this.author,
@@ -385,6 +390,7 @@ class ChaptarrBook {
         overview: json['overview'] as String?,
         releaseDate: DateTime.tryParse(json['releaseDate'] as String? ?? ''),
         monitored: json['monitored'] as bool? ?? true,
+        mediaType: json['mediaType'] as String?,
         anyEditionOk: json['anyEditionOk'] as bool? ?? true,
         pageCount: json['pageCount'] as int? ?? 0,
         author: json['author'] != null
@@ -409,6 +415,7 @@ class ChaptarrBook {
         'overview': overview,
         'releaseDate': releaseDate?.toIso8601String(),
         'monitored': monitored,
+        'mediaType': mediaType,
         'anyEditionOk': anyEditionOk,
         'pageCount': pageCount,
         'editions': editions.map((e) => e.toJson()).toList(),
@@ -434,6 +441,27 @@ class ChaptarrBook {
     }
     return set;
   }
+
+  /// The single format this record represents. Chaptarr stores a title's ebook
+  /// and audiobook as separate records distinguished by [mediaType]; fall back
+  /// to a lone edition's format, else unknown.
+  BookFormat get format {
+    switch (mediaType) {
+      case 'ebook':
+        return BookFormat.ebook;
+      case 'audiobook':
+        return BookFormat.audiobook;
+    }
+    final fs = formats;
+    return fs.length == 1 ? fs.first : BookFormat.unknown;
+  }
+
+  /// Groups the ebook and audiobook records of one title (they share a
+  /// foreignBookId). Falls back to the unique id so records without a
+  /// foreignBookId never merge into one another.
+  String get groupKey => (foreignBookId != null && foreignBookId!.isNotEmpty)
+      ? foreignBookId!
+      : 'id:$id';
 }
 
 /// A downloaded book file: drives the "EPUB — 4.6 MB" status line. The raw

--- a/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
@@ -9,6 +9,7 @@ import '../data/chaptarr_models.dart';
 import 'chaptarr_book_screen.dart';
 import 'widgets/book_status.dart';
 import 'widgets/format_badge.dart';
+import 'widgets/format_picker.dart';
 
 /// Author detail: an author summary plus the author's books, each with its
 /// format badges, availability line and a monitor toggle. Tapping a book drills
@@ -97,16 +98,31 @@ class _ChaptarrAuthorDetailScreenState
     }
   }
 
-  void _openBook(ChaptarrBook book) {
+  void _openBookGroup(List<ChaptarrBook> records) {
     Navigator.of(context, rootNavigator: true).push(
       MaterialPageRoute(
         builder: (_) => ChaptarrBookScreen(
           instanceId: widget.instanceId,
-          bookId: book.id,
-          bookTitle: book.title,
+          records: records,
+          bookTitle: records.first.title,
         ),
       ),
     );
+  }
+
+  /// Groups the flat book list into one entry per title: Chaptarr stores a
+  /// title's ebook and audiobook as separate records sharing a foreignBookId.
+  /// Insertion order (already release-date sorted) is preserved; within a group
+  /// ebook is ordered before audiobook.
+  List<List<ChaptarrBook>> _groupedBooks() {
+    final groups = <String, List<ChaptarrBook>>{};
+    for (final b in _books) {
+      (groups[b.groupKey] ??= []).add(b);
+    }
+    for (final records in groups.values) {
+      records.sort((a, b) => a.format.index.compareTo(b.format.index));
+    }
+    return groups.values.toList();
   }
 
   @override
@@ -138,11 +154,11 @@ class _ChaptarrAuthorDetailScreenState
                     ErrorBanner(message: _error!, onRetry: _load),
                   if (_author != null) _AuthorSummaryCard(author: _author!),
                   const SizedBox(height: 4),
-                  ..._books.map((b) => _BookCard(
-                        book: b,
-                        busy: _togglingBooks.contains(b.id),
-                        onTap: () => _openBook(b),
-                        onToggleMonitored: () => _toggleBookMonitored(b),
+                  ..._groupedBooks().map((records) => _BookCard(
+                        records: records,
+                        togglingIds: _togglingBooks,
+                        onTap: () => _openBookGroup(records),
+                        onToggleRecord: _toggleBookMonitored,
                       )),
                   if (_books.isEmpty && !_isLoading)
                     const Padding(
@@ -170,6 +186,7 @@ ChaptarrBook _withMonitored(ChaptarrBook b, bool monitored) => ChaptarrBook(
       overview: b.overview,
       releaseDate: b.releaseDate,
       monitored: monitored,
+      mediaType: b.mediaType,
       anyEditionOk: b.anyEditionOk,
       pageCount: b.pageCount,
       author: b.author,
@@ -247,23 +264,34 @@ class _AuthorSummaryCard extends StatelessWidget {
   }
 }
 
+/// One card per title. Chaptarr stores a title's ebook and audiobook as
+/// separate records (same foreignBookId); [records] holds the 1–2 records so the
+/// card shows a single entry with a format badge and monitor toggle per format.
 class _BookCard extends StatelessWidget {
-  final ChaptarrBook book;
-  final bool busy;
+  final List<ChaptarrBook> records;
+  final Set<int> togglingIds;
   final VoidCallback onTap;
-  final VoidCallback onToggleMonitored;
+  final void Function(ChaptarrBook record) onToggleRecord;
 
   const _BookCard({
-    required this.book,
-    required this.busy,
+    required this.records,
+    required this.togglingIds,
     required this.onTap,
-    required this.onToggleMonitored,
+    required this.onToggleRecord,
   });
 
   @override
   Widget build(BuildContext context) {
-    final status = bookFileStatusLine(book);
-    final formats = book.formats.toList()..sort((a, b) => a.index - b.index);
+    final primary = records.first;
+    // Prefer a downloaded record for the status line, else the first record.
+    final fileRecord =
+        records.firstWhere((r) => r.hasFile, orElse: () => primary);
+    final status = bookFileStatusLine(fileRecord);
+    final anyMonitored = records.any((r) => r.monitored);
+    final formats = records
+        .map((r) => r.format)
+        .where((f) => f != BookFormat.unknown)
+        .toList();
     return InkWell(
       onTap: onTap,
       child: Container(
@@ -281,14 +309,14 @@ class _BookCard extends StatelessWidget {
               child: SizedBox(
                 width: 44,
                 height: 60,
-                child: book.coverUrl != null
+                child: primary.coverUrl != null
                     ? CachedNetworkImage(
-                        imageUrl: book.coverUrl!, fit: BoxFit.cover)
+                        imageUrl: primary.coverUrl!, fit: BoxFit.cover)
                     : Container(
                         color: AppTheme.surfaceVariant,
                         child: Icon(
                           Icons.menu_book_outlined,
-                          color: book.monitored
+                          color: anyMonitored
                               ? AppTheme.available
                               : AppTheme.unavailable,
                           size: 22,
@@ -301,7 +329,7 @@ class _BookCard extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(book.title,
+                  Text(primary.title,
                       style: const TextStyle(
                           color: AppTheme.textPrimary,
                           fontSize: 16,
@@ -331,23 +359,71 @@ class _BookCard extends StatelessWidget {
                 ],
               ),
             ),
-            IconButton(
-              onPressed: busy ? null : onToggleMonitored,
-              tooltip: book.monitored ? 'Stop monitoring' : 'Monitor',
-              icon: busy
+            const SizedBox(width: 8),
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                for (final r in records)
+                  _MonitorToggle(
+                    record: r,
+                    busy: togglingIds.contains(r.id),
+                    onTap: () => onToggleRecord(r),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// A compact per-format monitor toggle: the format icon plus a bookmark that
+/// fills when that record is monitored, so a "both" title can monitor its ebook
+/// and audiobook independently.
+class _MonitorToggle extends StatelessWidget {
+  final ChaptarrBook record;
+  final bool busy;
+  final VoidCallback onTap;
+
+  const _MonitorToggle({
+    required this.record,
+    required this.busy,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final monitored = record.monitored;
+    final label = chaptarrFormatLabel(record.format);
+    return Tooltip(
+      message: monitored ? 'Stop monitoring $label' : 'Monitor $label',
+      child: InkWell(
+        onTap: busy ? null : onTap,
+        borderRadius: BorderRadius.circular(8),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 6),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(chaptarrFormatIcon(record.format),
+                  size: 14, color: AppTheme.textSecondary),
+              const SizedBox(width: 4),
+              busy
                   ? const SizedBox(
                       width: 18,
                       height: 18,
                       child: CircularProgressIndicator(
-                          strokeWidth: 2, color: AppTheme.accent))
+                          strokeWidth: 2, color: AppTheme.accent),
+                    )
                   : Icon(
-                      book.monitored ? Icons.bookmark : Icons.bookmark_border,
-                      color: book.monitored
-                          ? AppTheme.accent
-                          : AppTheme.textSecondary,
+                      monitored ? Icons.bookmark : Icons.bookmark_border,
+                      size: 20,
+                      color:
+                          monitored ? AppTheme.accent : AppTheme.textSecondary,
                     ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/app/lib/features/chaptarr/ui/chaptarr_book_detail_sheet.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_book_detail_sheet.dart
@@ -9,14 +9,16 @@ import '../data/chaptarr_models.dart';
 import 'chaptarr_releases_screen.dart';
 import 'widgets/book_status.dart';
 import 'widgets/format_badge.dart';
+import 'widgets/format_picker.dart';
 
-/// Opens the book detail bottom sheet for one book. Returns `true` when the
-/// caller should refresh (an Automatic/Interactive search was started from the
-/// sheet). Mirrors [showModalBottomSheet] usage around the Sonarr episode sheet.
+/// Opens the book detail bottom sheet for a title. Chaptarr stores a title's
+/// ebook and audiobook as separate records (same foreignBookId); [records] holds
+/// the 1–2 records. Returns `true` when the caller should refresh (an
+/// Automatic/Interactive search was started). Mirrors the Sonarr episode sheet.
 Future<bool?> showChaptarrBookDetailSheet(
   BuildContext context, {
   required String instanceId,
-  required int bookId,
+  required List<ChaptarrBook> records,
   String? bookTitle,
 }) {
   return showModalBottomSheet<bool>(
@@ -25,23 +27,23 @@ Future<bool?> showChaptarrBookDetailSheet(
     isScrollControlled: true,
     builder: (_) => _ChaptarrBookDetailSheet(
       instanceId: instanceId,
-      bookId: bookId,
+      records: records,
       bookTitle: bookTitle,
     ),
   );
 }
 
-/// Bottom sheet for a single book: status, overview and recent history, with
-/// Automatic/Interactive search actions. Mirrors [EpisodeDetailSheet], but
-/// fetches the book + history itself (the caller passes only ids).
+/// Bottom sheet for one title: status, formats, overview and recent history,
+/// with Automatic/Interactive search actions that prompt for a format when the
+/// title has both an ebook and an audiobook record.
 class _ChaptarrBookDetailSheet extends ConsumerStatefulWidget {
   final String instanceId;
-  final int bookId;
+  final List<ChaptarrBook> records;
   final String? bookTitle;
 
   const _ChaptarrBookDetailSheet({
     required this.instanceId,
-    required this.bookId,
+    required this.records,
     this.bookTitle,
   });
 
@@ -53,10 +55,11 @@ class _ChaptarrBookDetailSheet extends ConsumerStatefulWidget {
 class _ChaptarrBookDetailSheetState
     extends ConsumerState<_ChaptarrBookDetailSheet> {
   late final ChaptarrApiService _service;
-  ChaptarrBook? _book;
   List<ChaptarrHistoryRecord> _history = [];
-  bool _historyLoading = true; // history load (independent of the book)
-  String? _error; // book-load failure, if any
+  bool _historyLoading = true;
+
+  // The records are passed in already loaded; the primary drives the header.
+  ChaptarrBook get _primary => widget.records.first;
 
   @override
   void initState() {
@@ -65,92 +68,73 @@ class _ChaptarrBookDetailSheetState
       backendDio: ref.read(backendClientProvider),
       instanceId: widget.instanceId,
     );
-    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
-  }
-
-  // Book and history load independently: a history failure must never blank out
-  // the book the sheet is for (a single try/catch around both previously left
-  // the sheet stuck on "Loading…" when the history call errored).
-  void _load() {
-    _loadBook();
-    _loadHistory();
-  }
-
-  Future<void> _loadBook() async {
-    try {
-      final book = await _service.getBookById(widget.bookId);
-      if (!mounted) return;
-      setState(() {
-        _book = book;
-        _error = null;
-      });
-    } catch (e) {
-      if (!mounted) return;
-      setState(() => _error = '$e');
-    }
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadHistory());
   }
 
   Future<void> _loadHistory() async {
     try {
-      final history = await _service.getBookHistory(widget.bookId);
+      final history = await _service.getBookHistory(_primary.id);
       if (!mounted) return;
       setState(() {
         _history = history.take(8).toList();
         _historyLoading = false;
       });
     } catch (_) {
-      // History is best-effort: the book is already shown, so a history
-      // failure just drops to "No history yet." rather than surfacing an error.
+      // History is best-effort; the book is already shown.
       if (!mounted) return;
       setState(() => _historyLoading = false);
     }
   }
 
+  // Pick the format (when the title has both), close the sheet, then search.
   Future<void> _automaticSearch() async {
+    final chosen = await pickFormatRecord(context, widget.records);
+    if (chosen == null || !mounted) return;
+    final messenger = ScaffoldMessenger.of(context);
     try {
-      await _service.searchBook([widget.bookId]);
-      if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(const SnackBar(content: Text('Book search started')));
+      await _service.searchBook([chosen.id]);
+      messenger.showSnackBar(SnackBar(
+          content: Text(
+              'Searching for ${chaptarrFormatLabel(chosen.format)} — ${chosen.title}…')));
     } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context)
+      messenger
           .showSnackBar(SnackBar(content: Text('Failed to start search: $e')));
     }
+    if (mounted) Navigator.of(context).pop(true);
   }
 
-  void _interactiveSearch() {
-    Navigator.of(context, rootNavigator: true).push(
+  Future<void> _interactiveSearch() async {
+    final chosen = await pickFormatRecord(context, widget.records);
+    if (chosen == null || !mounted) return;
+    final nav = Navigator.of(context, rootNavigator: true);
+    Navigator.of(context).pop(true);
+    nav.push(
       MaterialPageRoute(
         builder: (_) => ChaptarrReleasesScreen(
           instanceId: widget.instanceId,
-          bookId: widget.bookId,
-          bookTitle: _book?.title ?? widget.bookTitle,
+          bookId: chosen.id,
+          bookTitle: chosen.title,
         ),
       ),
     );
   }
 
   ({String label, Color color}) get _shortStatus {
-    final book = _book;
-    if (book == null) {
-      if (_error != null) {
-        return (label: 'Unavailable', color: AppTheme.error);
-      }
-      return (label: 'Loading…', color: AppTheme.textSecondary);
-    }
-    final line = bookFileStatusLine(book);
+    final line = bookFileStatusLine(_primary);
     return (label: line.text, color: line.color);
   }
 
   @override
   Widget build(BuildContext context) {
-    final book = _book;
-    final title = book?.title ?? widget.bookTitle ?? 'Book';
+    final title = _primary.title.isNotEmpty
+        ? _primary.title
+        : (widget.bookTitle ?? 'Book');
     final status = _shortStatus;
-    final release = book?.releaseDate;
-    final formats = book?.formats.toList() ?? [];
-    formats.sort((a, b) => a.index - b.index);
+    final release = _primary.releaseDate;
+    final formats = widget.records
+        .map((r) => r.format)
+        .where((f) => f != BookFormat.unknown)
+        .toList();
 
     return Padding(
       padding:
@@ -186,9 +170,9 @@ class _ChaptarrBookDetailSheetState
                     fontSize: 20,
                     fontWeight: FontWeight.bold),
               ),
-              if (book?.author?.authorName.isNotEmpty ?? false) ...[
+              if (_primary.author?.authorName.isNotEmpty ?? false) ...[
                 const SizedBox(height: 4),
-                Text(book!.author!.authorName,
+                Text(_primary.author!.authorName,
                     style: const TextStyle(
                         color: AppTheme.textSecondary, fontSize: 14)),
               ],
@@ -207,16 +191,10 @@ class _ChaptarrBookDetailSheetState
                   ...formats.map((f) => ChaptarrFormatBadge(format: f)),
                 ],
               ),
-              if (book == null && _error != null) ...[
-                const SizedBox(height: 12),
-                Text(
-                  "Couldn't load this book.\n$_error",
-                  style: const TextStyle(color: AppTheme.error, fontSize: 12),
-                ),
-              ],
-              if (book?.overview != null && book!.overview!.isNotEmpty) ...[
+              if (_primary.overview != null &&
+                  _primary.overview!.isNotEmpty) ...[
                 const SizedBox(height: 14),
-                Text(book.overview!,
+                Text(_primary.overview!,
                     style: const TextStyle(
                         color: AppTheme.textPrimary,
                         fontSize: 14,
@@ -235,10 +213,7 @@ class _ChaptarrBookDetailSheetState
                 children: [
                   Expanded(
                     child: OutlinedButton.icon(
-                      onPressed: () {
-                        Navigator.of(context).pop(true);
-                        _automaticSearch();
-                      },
+                      onPressed: _automaticSearch,
                       icon: const Icon(Icons.search,
                           size: 18, color: AppTheme.available),
                       label: const Text('Automatic',
@@ -254,10 +229,7 @@ class _ChaptarrBookDetailSheetState
                   const SizedBox(width: 10),
                   Expanded(
                     child: OutlinedButton.icon(
-                      onPressed: () {
-                        Navigator.of(context).pop(true);
-                        _interactiveSearch();
-                      },
+                      onPressed: _interactiveSearch,
                       icon: const Icon(Icons.manage_search,
                           size: 18, color: AppTheme.available),
                       label: const Text('Interactive',

--- a/app/lib/features/chaptarr/ui/chaptarr_book_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_book_screen.dart
@@ -10,20 +10,22 @@ import 'chaptarr_book_detail_sheet.dart';
 import 'chaptarr_releases_screen.dart';
 import 'widgets/book_status.dart';
 import 'widgets/format_badge.dart';
+import 'widgets/format_picker.dart';
 
-/// Editions/files for one book: each edition's title, format badge and the
-/// matched file's quality+size (or a Missing/Unreleased line). Tapping the book
-/// header opens its detail sheet; the action bar runs a per-book search.
-/// Mirrors [SonarrSeasonScreen].
+/// One title's formats. Chaptarr stores a title's ebook and audiobook as
+/// separate book records (same foreignBookId); [records] holds the 1–2 records.
+/// Shows a section per format with its availability + matched file, and an
+/// action bar whose Automatic/Interactive searches prompt for the format when
+/// the title has both. Mirrors [SonarrSeasonScreen].
 class ChaptarrBookScreen extends ConsumerStatefulWidget {
   final String instanceId;
-  final int bookId;
+  final List<ChaptarrBook> records;
   final String? bookTitle;
 
   const ChaptarrBookScreen({
     super.key,
     required this.instanceId,
-    required this.bookId,
+    required this.records,
     this.bookTitle,
   });
 
@@ -33,10 +35,12 @@ class ChaptarrBookScreen extends ConsumerStatefulWidget {
 
 class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
   late final ChaptarrApiService _service;
-  ChaptarrBook? _book;
-  List<ChaptarrBookFile> _files = [];
+  // Downloaded files keyed by record (book) id.
+  Map<int, List<ChaptarrBookFile>> _filesByBook = {};
   bool _isLoading = true;
   String? _error;
+
+  List<ChaptarrBook> get _records => widget.records;
 
   @override
   void initState() {
@@ -51,16 +55,16 @@ class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
   Future<void> _load() async {
     setState(() => _isLoading = true);
     try {
-      // Kick off both requests, then await — effectively parallel without the
-      // heterogeneous Future.wait cast.
-      final bookFuture = _service.getBookById(widget.bookId);
-      final filesFuture = _service.getBookFiles(bookId: widget.bookId);
-      final book = await bookFuture;
-      final files = await filesFuture;
+      final results = await Future.wait(
+        _records.map((r) => _service.getBookFiles(bookId: r.id)),
+      );
       if (!mounted) return;
+      final map = <int, List<ChaptarrBookFile>>{};
+      for (var i = 0; i < _records.length; i++) {
+        map[_records[i].id] = results[i];
+      }
       setState(() {
-        _book = book;
-        _files = files;
+        _filesByBook = map;
         _isLoading = false;
         _error = null;
       });
@@ -74,11 +78,14 @@ class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
   }
 
   Future<void> _automaticSearch() async {
+    final chosen = await pickFormatRecord(context, _records);
+    if (chosen == null || !mounted) return;
     try {
-      await _service.searchBook([widget.bookId]);
+      await _service.searchBook([chosen.id]);
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Searching for ${_book?.title ?? 'book'}…')));
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(
+              'Searching for ${chaptarrFormatLabel(chosen.format)} — ${chosen.title}…')));
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context)
@@ -86,13 +93,15 @@ class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
     }
   }
 
-  void _interactiveSearch() {
+  Future<void> _interactiveSearch() async {
+    final chosen = await pickFormatRecord(context, _records);
+    if (chosen == null || !mounted) return;
     Navigator.of(context, rootNavigator: true).push(
       MaterialPageRoute(
         builder: (_) => ChaptarrReleasesScreen(
           instanceId: widget.instanceId,
-          bookId: widget.bookId,
-          bookTitle: _book?.title ?? widget.bookTitle,
+          bookId: chosen.id,
+          bookTitle: chosen.title,
         ),
       ),
     );
@@ -102,17 +111,19 @@ class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
     final changed = await showChaptarrBookDetailSheet(
       context,
       instanceId: widget.instanceId,
-      bookId: widget.bookId,
-      bookTitle: _book?.title ?? widget.bookTitle,
+      records: _records,
+      bookTitle: widget.bookTitle,
     );
-    // The book sheet returns true after an Automatic/Interactive search.
+    // The sheet returns true after an Automatic/Interactive search.
     if (changed == true && mounted) _load();
   }
 
   @override
   Widget build(BuildContext context) {
-    final title = _book?.title ?? widget.bookTitle ?? 'Book';
-    final author = _book?.author?.authorName;
+    final primary = _records.first;
+    final title =
+        primary.title.isNotEmpty ? primary.title : (widget.bookTitle ?? 'Book');
+    final author = primary.author?.authorName;
 
     return Scaffold(
       backgroundColor: AppTheme.background,
@@ -148,54 +159,31 @@ class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
   }
 
   Widget _buildBody() {
-    if (_isLoading && _book == null) {
-      return const Center(
-          child: CircularProgressIndicator(color: AppTheme.accent));
-    }
-    if (_error != null && _book == null) {
+    if (_error != null) {
       return FullScreenError(message: _error!, onRetry: _load);
     }
-    final book = _book;
-    if (book == null) {
-      return const Center(
-        child: Text('No book',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 16)),
-      );
-    }
-    final fileByEdition = {
-      for (final f in _files) f.editionId: f,
-    };
-    final editions = [...book.editions];
     return RefreshIndicator(
       onRefresh: _load,
       color: AppTheme.accent,
       child: ListView(
         padding: const EdgeInsets.symmetric(vertical: 8),
         children: [
-          if (_error != null) ErrorBanner(message: _error!, onRetry: _load),
-          _BookHeader(book: book, onTap: _openDetail),
+          _BookHeader(book: _records.first, onTap: _openDetail),
           const Divider(color: AppTheme.border, height: 1),
-          if (editions.isEmpty)
-            const Padding(
-              padding: EdgeInsets.all(24),
-              child: Center(
-                child: Text('No editions',
-                    style: TextStyle(color: AppTheme.textSecondary)),
-              ),
-            )
-          else
-            ...editions.map((e) => _EditionTile(
-                  edition: e,
-                  file: fileByEdition[e.id],
-                  onTap: _openDetail,
-                )),
+          for (final r in _records)
+            _FormatSection(
+              record: r,
+              files: _filesByBook[r.id] ?? const [],
+              loading: _isLoading,
+              onTap: _openDetail,
+            ),
         ],
       ),
     );
   }
 }
 
-/// The book summary header — cover icon, title, availability line. Tapping it
+/// The book summary header — title, release date, availability line. Tapping it
 /// opens the detail sheet.
 class _BookHeader extends StatelessWidget {
   final ChaptarrBook book;
@@ -248,25 +236,30 @@ class _BookHeader extends StatelessWidget {
   }
 }
 
-/// One edition row: format badge, edition title and the matched file's
-/// quality+size (when downloaded).
-class _EditionTile extends StatelessWidget {
-  final ChaptarrEdition edition;
-  final ChaptarrBookFile? file;
+/// One format (ebook or audiobook) of a title: a format badge, this record's
+/// availability/file line, and a read-only monitor indicator (the toggle lives
+/// on the author screen's card).
+class _FormatSection extends StatelessWidget {
+  final ChaptarrBook record;
+  final List<ChaptarrBookFile> files;
+  final bool loading;
   final VoidCallback onTap;
 
-  const _EditionTile({
-    required this.edition,
-    required this.file,
+  const _FormatSection({
+    required this.record,
+    required this.files,
+    required this.loading,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    final f = file;
-    final fileLine = f != null
-        ? '${f.qualityName ?? 'Downloaded'} — ${f.sizeFormatted}'
-        : 'Not downloaded';
+    final status = bookFileStatusLine(record);
+    final file = files.isNotEmpty ? files.first : null;
+    final hasFile = file != null;
+    final line = hasFile
+        ? '${file.qualityName ?? 'Downloaded'} — ${file.sizeFormatted}'
+        : (loading ? 'Checking…' : status.text);
     return InkWell(
       onTap: onTap,
       child: Padding(
@@ -280,37 +273,35 @@ class _EditionTile extends StatelessWidget {
                 children: [
                   Row(
                     children: [
-                      ChaptarrFormatBadge(format: edition.bookFormat),
-                      if (edition.title != null &&
-                          edition.title!.isNotEmpty) ...[
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            edition.title!,
-                            style: const TextStyle(
+                      ChaptarrFormatBadge(format: record.format),
+                      if (record.format == BookFormat.unknown)
+                        const Text('Book',
+                            style: TextStyle(
                                 color: AppTheme.textPrimary,
                                 fontSize: 14,
-                                fontWeight: FontWeight.w500),
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                        ),
-                      ],
+                                fontWeight: FontWeight.w500)),
                     ],
                   ),
                   const SizedBox(height: 4),
                   Text(
-                    fileLine,
+                    line,
                     style: TextStyle(
-                        color: f != null
-                            ? AppTheme.available
-                            : AppTheme.textSecondary,
+                        color: hasFile ? AppTheme.available : status.color,
                         fontSize: 13,
                         fontWeight: FontWeight.w500),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
                 ],
+              ),
+            ),
+            Tooltip(
+              message: record.monitored ? 'Monitored' : 'Not monitored',
+              child: Icon(
+                record.monitored ? Icons.bookmark : Icons.bookmark_border,
+                size: 18,
+                color:
+                    record.monitored ? AppTheme.accent : AppTheme.textSecondary,
               ),
             ),
           ],

--- a/app/lib/features/chaptarr/ui/widgets/format_picker.dart
+++ b/app/lib/features/chaptarr/ui/widgets/format_picker.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_theme.dart';
+import '../../data/chaptarr_models.dart';
+
+/// Prompts the user to choose which format record (ebook vs audiobook) to act on
+/// for a title Chaptarr stores as two records. Returns the chosen record, the
+/// sole record when there's only one (no prompt), or null if dismissed.
+Future<ChaptarrBook?> pickFormatRecord(
+  BuildContext context,
+  List<ChaptarrBook> records,
+) async {
+  if (records.isEmpty) return null;
+  if (records.length == 1) return records.first;
+  return showModalBottomSheet<ChaptarrBook>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    builder: (_) => _FormatPickerSheet(records: records),
+  );
+}
+
+IconData chaptarrFormatIcon(BookFormat f) => switch (f) {
+      BookFormat.audiobook => Icons.headphones,
+      BookFormat.ebook => Icons.menu_book,
+      BookFormat.unknown => Icons.help_outline,
+    };
+
+String chaptarrFormatLabel(BookFormat f) => switch (f) {
+      BookFormat.audiobook => 'Audiobook',
+      BookFormat.ebook => 'eBook',
+      BookFormat.unknown => 'Unknown format',
+    };
+
+class _FormatPickerSheet extends StatelessWidget {
+  final List<ChaptarrBook> records;
+  const _FormatPickerSheet({required this.records});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
+        decoration: const BoxDecoration(
+          color: AppTheme.surface,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: AppTheme.textSecondary,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+            const SizedBox(height: 18),
+            const Text(
+              'Which format?',
+              style: TextStyle(
+                color: AppTheme.textPrimary,
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 14),
+            for (final record in records)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: ListTile(
+                  contentPadding: const EdgeInsets.symmetric(horizontal: 12),
+                  leading: Icon(chaptarrFormatIcon(record.format),
+                      color: AppTheme.accent),
+                  title: Text(
+                    chaptarrFormatLabel(record.format),
+                    style: const TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(8),
+                    side: const BorderSide(color: AppTheme.border),
+                  ),
+                  onTap: () => Navigator.of(context).pop(record),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -300,6 +300,7 @@ class _BookRequestButton extends StatefulWidget {
 }
 
 class _BookRequestButtonState extends State<_BookRequestButton> {
+  BookRequestStatusDetail _detail = const BookRequestStatusDetail();
   RequestStatus _status = RequestStatus.unavailable;
   bool _loading = true;
   bool _busy = false;
@@ -311,10 +312,11 @@ class _BookRequestButtonState extends State<_BookRequestButton> {
   }
 
   Future<void> _check() async {
-    final s = await widget.service.checkBookStatus(widget.foreignId);
+    final detail = await widget.service.checkBookStatusDetail(widget.foreignId);
     if (!mounted) return;
     setState(() {
-      _status = s;
+      _detail = detail;
+      _status = detail.status;
       _loading = false;
     });
   }
@@ -324,7 +326,7 @@ class _BookRequestButtonState extends State<_BookRequestButton> {
     final selected = await showModalBottomSheet<BookRequestFormat>(
       context: context,
       backgroundColor: Colors.transparent,
-      builder: (_) => _BookFormatSheet(title: widget.title),
+      builder: (_) => _BookFormatSheet(title: widget.title, detail: _detail),
     );
     if (selected == null) return;
     if (!mounted) return;
@@ -341,31 +343,45 @@ class _BookRequestButtonState extends State<_BookRequestButton> {
       failureMessage = e.message;
     }
     if (!mounted) return;
-    setState(() {
-      _busy = false;
-      if (s != null) _status = s;
-    });
-    if (s == null && mounted) {
+    setState(() => _busy = false);
+    if (s == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(failureMessage ?? 'Request failed. Please try again.'),
         ),
       );
+      return;
     }
+    // Re-pull per-format coverage so the button reflects the still-open format.
+    await _check();
   }
 
-  bool get _requestable =>
-      _status == RequestStatus.unavailable || _status == RequestStatus.denied;
+  bool _isCovered(BookRequestFormat f) => _detail.isCovered(f);
 
-  Color get _color => switch (_status) {
-        RequestStatus.pending ||
-        RequestStatus.requested ||
-        RequestStatus.partial =>
-          AppTheme.requested,
-        RequestStatus.downloading => AppTheme.downloading,
-        RequestStatus.available => AppTheme.available,
-        _ => AppTheme.accent,
-      };
+  /// Requestable while at least one of ebook/audiobook hasn't been requested.
+  bool get _requestable =>
+      !(_isCovered(BookRequestFormat.ebook) &&
+          _isCovered(BookRequestFormat.audiobook));
+
+  String get _buttonText {
+    if (!_requestable) return _status.buttonLabel; // both formats covered
+    final anyCovered = _isCovered(BookRequestFormat.ebook) ||
+        _isCovered(BookRequestFormat.audiobook);
+    return anyCovered ? 'Request more' : _status.buttonLabel;
+  }
+
+  Color get _color {
+    if (_requestable) return AppTheme.accent;
+    return switch (_status) {
+      RequestStatus.pending ||
+      RequestStatus.requested ||
+      RequestStatus.partial =>
+        AppTheme.requested,
+      RequestStatus.downloading => AppTheme.downloading,
+      RequestStatus.available => AppTheme.available,
+      _ => AppTheme.accent,
+    };
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -391,18 +407,39 @@ class _BookRequestButtonState extends State<_BookRequestButton> {
               height: 16,
               child: CircularProgressIndicator(strokeWidth: 2),
             )
-          : Text(_status.buttonLabel),
+          : Text(_buttonText),
     );
   }
 }
 
 class _BookFormatSheet extends StatelessWidget {
   final String title;
+  final BookRequestStatusDetail detail;
 
-  const _BookFormatSheet({required this.title});
+  const _BookFormatSheet({required this.title, required this.detail});
+
+  bool _coveredFor(BookRequestFormat choice) {
+    final eb = detail.isCovered(BookRequestFormat.ebook);
+    final ab = detail.isCovered(BookRequestFormat.audiobook);
+    return switch (choice) {
+      BookRequestFormat.ebook => eb,
+      BookRequestFormat.audiobook => ab,
+      BookRequestFormat.both => eb && ab,
+    };
+  }
+
+  String? _statusLabelFor(BookRequestFormat choice) {
+    if (!_coveredFor(choice)) return null;
+    final key =
+        choice == BookRequestFormat.both ? BookRequestFormat.ebook : choice;
+    return (detail.formats[key] ?? RequestStatus.requested).label;
+  }
 
   @override
   Widget build(BuildContext context) {
+    final eb = detail.isCovered(BookRequestFormat.ebook);
+    final ab = detail.isCovered(BookRequestFormat.audiobook);
+    final exactlyOneCovered = eb != ab;
     return SafeArea(
       child: Container(
         padding: const EdgeInsets.fromLTRB(20, 12, 20, 20),
@@ -437,10 +474,17 @@ class _BookFormatSheet extends StatelessWidget {
             ),
             const SizedBox(height: 14),
             for (final choice in BookRequestFormat.values)
-              Padding(
-                padding: const EdgeInsets.only(bottom: 8),
-                child: _FormatChoiceTile(choice: choice),
-              ),
+              // Hide "both" when exactly one format is already requested — only
+              // the remaining single format is worth offering.
+              if (!(choice == BookRequestFormat.both && exactlyOneCovered))
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: _FormatChoiceTile(
+                    choice: choice,
+                    covered: _coveredFor(choice),
+                    statusLabel: _statusLabelFor(choice),
+                  ),
+                ),
           ],
         ),
       ),
@@ -450,8 +494,14 @@ class _BookFormatSheet extends StatelessWidget {
 
 class _FormatChoiceTile extends StatelessWidget {
   final BookRequestFormat choice;
+  final bool covered;
+  final String? statusLabel;
 
-  const _FormatChoiceTile({required this.choice});
+  const _FormatChoiceTile({
+    required this.choice,
+    this.covered = false,
+    this.statusLabel,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -461,20 +511,29 @@ class _FormatChoiceTile extends StatelessWidget {
       BookRequestFormat.both => Icons.library_books,
     };
     return ListTile(
+      enabled: !covered,
       contentPadding: const EdgeInsets.symmetric(horizontal: 12),
-      leading: Icon(icon, color: AppTheme.accent),
+      leading: Icon(icon, color: covered ? AppTheme.textSecondary : AppTheme.accent),
       title: Text(
         choice.label,
-        style: const TextStyle(
-          color: AppTheme.textPrimary,
+        style: TextStyle(
+          color: covered ? AppTheme.textSecondary : AppTheme.textPrimary,
           fontWeight: FontWeight.w600,
         ),
       ),
+      subtitle: covered && statusLabel != null
+          ? Text(statusLabel!,
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 12))
+          : null,
+      trailing: covered
+          ? const Icon(Icons.check, color: AppTheme.available, size: 18)
+          : null,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(8),
         side: const BorderSide(color: AppTheme.border),
       ),
-      onTap: () => Navigator.of(context).pop(choice),
+      onTap: covered ? null : () => Navigator.of(context).pop(choice),
     );
   }
 }

--- a/app/lib/features/request/data/request_service.dart
+++ b/app/lib/features/request/data/request_service.dart
@@ -48,6 +48,29 @@ enum BookRequestFormat {
       );
 }
 
+/// A user's per-format request state for a book. [status] is the collapsed
+/// (latest) state; [formats] maps each already-requested concrete format to its
+/// status (a stored "both" request fills both ebook and audiobook). Lets the
+/// dashboard keep offering a format that hasn't been requested yet.
+class BookRequestStatusDetail {
+  final RequestStatus status;
+  final Map<BookRequestFormat, RequestStatus> formats;
+
+  const BookRequestStatusDetail({
+    this.status = RequestStatus.unavailable,
+    this.formats = const {},
+  });
+
+  /// A format is "covered" (no longer requestable) when it has a non-denied
+  /// row. Denied and never-requested formats stay requestable.
+  bool isCovered(BookRequestFormat format) {
+    final s = formats[format];
+    return s != null &&
+        s != RequestStatus.denied &&
+        s != RequestStatus.unavailable;
+  }
+}
+
 class RequestSubmissionException implements Exception {
   final String message;
 
@@ -306,20 +329,45 @@ class RequestService {
   /// Check the current user's request state for a book, keyed by the Chaptarr/
   /// Readarr foreignBookId (books have no tmdb_id). Returns one of
   /// unavailable / pending / requested / denied.
-  Future<RequestStatus> checkBookStatus(String foreignId) async {
+  Future<RequestStatus> checkBookStatus(String foreignId) async =>
+      (await checkBookStatusDetail(foreignId)).status;
+
+  /// Like [checkBookStatus] but also returns the per-format breakdown so the
+  /// caller can still offer a not-yet-requested format. Falls back to an
+  /// unavailable/empty detail on any failure.
+  Future<BookRequestStatusDetail> checkBookStatusDetail(
+      String foreignId) async {
     try {
       final resp = await _backendDio.get(
         '/api/requests/book-status',
         queryParameters: {'foreign_id': foreignId},
       );
-      final name = (resp.data as Map<String, dynamic>)['status'] as String? ??
-          'unavailable';
-      return RequestStatus.values.firstWhere(
-        (s) => s.name == name,
+      final data = resp.data as Map<String, dynamic>;
+      final status = RequestStatus.values.firstWhere(
+        (s) => s.name == (data['status'] as String? ?? 'unavailable'),
         orElse: () => RequestStatus.unavailable,
       );
+      final formats = <BookRequestFormat, RequestStatus>{};
+      final raw = data['book_formats'];
+      if (raw is Map) {
+        raw.forEach((key, value) {
+          BookRequestFormat? fmt;
+          for (final f in BookRequestFormat.values) {
+            if (f.value == key.toString()) {
+              fmt = f;
+              break;
+            }
+          }
+          if (fmt == null) return;
+          formats[fmt] = RequestStatus.values.firstWhere(
+            (s) => s.name == value.toString(),
+            orElse: () => RequestStatus.requested,
+          );
+        });
+      }
+      return BookRequestStatusDetail(status: status, formats: formats);
     } catch (_) {
-      return RequestStatus.unavailable;
+      return const BookRequestStatusDetail();
     }
   }
 

--- a/app/test/chaptarr/chaptarr_logic_test.dart
+++ b/app/test/chaptarr/chaptarr_logic_test.dart
@@ -107,6 +107,31 @@ void main() {
 
       expect(book.formats, isEmpty);
     });
+
+    test('format derives from mediaType', () {
+      ChaptarrBook book(String? mediaType) =>
+          ChaptarrBook.fromJson({'title': 'T', 'mediaType': mediaType});
+      expect(book('ebook').format, BookFormat.ebook);
+      expect(book('audiobook').format, BookFormat.audiobook);
+      expect(book(null).format, BookFormat.unknown);
+    });
+
+    test('groupKey groups records by foreignBookId, else falls back to id', () {
+      final ebook = ChaptarrBook.fromJson(
+          {'id': 1, 'title': 'T', 'foreignBookId': 'fb-1', 'mediaType': 'ebook'});
+      final audio = ChaptarrBook.fromJson({
+        'id': 2,
+        'title': 'T',
+        'foreignBookId': 'fb-1',
+        'mediaType': 'audiobook'
+      });
+      final noForeign = ChaptarrBook.fromJson({'id': 3, 'title': 'T'});
+      // The two formats of one title share a key; a foreignId-less record gets
+      // its own (id-based) key so unrelated books never merge.
+      expect(ebook.groupKey, audio.groupKey);
+      expect(noForeign.groupKey, 'id:3');
+      expect(noForeign.groupKey, isNot(ebook.groupKey));
+    });
   });
 
   // diagnoseChaptarrQueueItem bridges ChaptarrStatusMessage -> the shared neutral

--- a/app/test/request/book_status_detail_test.dart
+++ b/app/test/request/book_status_detail_test.dart
@@ -1,0 +1,79 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/features/request/data/request_service.dart'
+    hide RequestOptions;
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Minimal GET adapter returning a canned book-status JSON body.
+class _GetAdapter implements HttpClientAdapter {
+  _GetAdapter(this.responseJson);
+  final Map<String, dynamic> responseJson;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    return ResponseBody.fromString(
+      jsonEncode(responseJson),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+RequestService _service(Map<String, dynamic> resp) {
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+    ..httpClientAdapter = _GetAdapter(resp);
+  return RequestService(backendDio: dio);
+}
+
+void main() {
+  group('checkBookStatusDetail', () {
+    test('one requested format leaves the other requestable', () async {
+      final d = await _service({
+        'status': 'requested',
+        'book_formats': {'ebook': 'requested'},
+      }).checkBookStatusDetail('fb');
+
+      expect(d.status, RequestStatus.requested);
+      expect(d.isCovered(BookRequestFormat.ebook), isTrue);
+      expect(d.isCovered(BookRequestFormat.audiobook), isFalse);
+    });
+
+    test('both formats covered', () async {
+      final d = await _service({
+        'status': 'requested',
+        'book_formats': {'ebook': 'requested', 'audiobook': 'pending'},
+      }).checkBookStatusDetail('fb');
+
+      expect(d.isCovered(BookRequestFormat.ebook), isTrue);
+      expect(d.isCovered(BookRequestFormat.audiobook), isTrue);
+    });
+
+    test('denied stays requestable (not covered)', () async {
+      final d = await _service({
+        'status': 'denied',
+        'book_formats': {'ebook': 'denied'},
+      }).checkBookStatusDetail('fb');
+
+      expect(d.isCovered(BookRequestFormat.ebook), isFalse);
+    });
+
+    test('no book_formats means nothing is covered', () async {
+      final d = await _service({'status': 'unavailable'})
+          .checkBookStatusDetail('fb');
+
+      expect(d.isCovered(BookRequestFormat.ebook), isFalse);
+      expect(d.isCovered(BookRequestFormat.audiobook), isFalse);
+    });
+  });
+}

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -146,6 +146,11 @@ type StatusResponse struct {
 	// movies and for series not yet in the library). Season 0 / Specials are
 	// excluded, matching the rest of the app's season handling.
 	Seasons []SeasonStatus `json:"seasons,omitempty"`
+	// BookFormats maps each already-requested book format ("ebook"/"audiobook")
+	// to its request status, so the dashboard can still offer the other format
+	// after one is requested. Only populated for book status; nil (omitted) for
+	// movies/TV. A stored "both" request covers both formats.
+	BookFormats map[string]string `json:"book_formats,omitempty"`
 }
 
 // SeasonStatus is one season's availability, mirroring the title-level status
@@ -959,25 +964,65 @@ func (s *Service) GetUserStatus(userID int64, tmdbID int, mediaType string) (*St
 }
 
 // GetUserBookStatus reports a user's request state for a book, keyed by the
-// Readarr foreignBookId (books have no tmdb_id). It reflects the request_log
-// row (pending / denied / requested); deeper library availability + download
-// progress are shown in the Books module itself.
+// Readarr foreignBookId (books have no tmdb_id). Status is the collapsed
+// (latest) request_log state (pending / denied / requested); BookFormats breaks
+// it down per format so the dashboard can still offer the other format after one
+// is requested. A stored "both" request covers both ebook and audiobook. Deeper
+// library availability + download progress are shown in the Books module itself.
 func (s *Service) GetUserBookStatus(userID int64, foreignID string) (*StatusResponse, error) {
-	var status string
-	err := s.db.QueryRow(
-		"SELECT status FROM request_log WHERE user_id = ? AND foreign_id = ? AND media_type = 'book' ORDER BY requested_at DESC, id DESC LIMIT 1",
+	rows, err := s.db.Query(
+		"SELECT COALESCE(book_format, 'both'), status FROM request_log WHERE user_id = ? AND foreign_id = ? AND media_type = 'book' ORDER BY requested_at DESC, id DESC",
 		userID, foreignID,
-	).Scan(&status)
+	)
 	if err != nil {
 		return &StatusResponse{Status: StatusUnavailable}, nil
 	}
-	switch status {
+	defer rows.Close()
+
+	formats := map[string]string{}
+	collapsed := ""
+	for rows.Next() {
+		var format, status string
+		if err := rows.Scan(&format, &status); err != nil {
+			return &StatusResponse{Status: StatusUnavailable}, nil
+		}
+		if collapsed == "" {
+			collapsed = status // first row is the latest overall
+		}
+		// Rows are newest-first, so only record a format's status the first
+		// (latest) time it appears. A "both" row fills both concrete formats.
+		for _, f := range expandBookFormat(format) {
+			if _, ok := formats[f]; !ok {
+				formats[f] = status
+			}
+		}
+	}
+	if collapsed == "" {
+		return &StatusResponse{Status: StatusUnavailable}, nil
+	}
+
+	resp := &StatusResponse{BookFormats: formats}
+	switch collapsed {
 	case StatusPending:
-		return &StatusResponse{Status: StatusPending}, nil
+		resp.Status = StatusPending
 	case StatusDenied:
-		return &StatusResponse{Status: StatusDenied}, nil
+		resp.Status = StatusDenied
 	default:
-		return &StatusResponse{Status: StatusRequested}, nil
+		resp.Status = StatusRequested
+	}
+	return resp, nil
+}
+
+// expandBookFormat maps a stored book_format to the concrete formats it covers:
+// "both" (and any unrecognized value) covers both ebook and audiobook.
+func expandBookFormat(format string) []string {
+	switch normalizeBookFormat(format) {
+	case BookFormatEbook:
+		return []string{BookFormatEbook}
+	case BookFormatAudiobook:
+		return []string{BookFormatAudiobook}
+	default:
+		return []string{BookFormatEbook, BookFormatAudiobook}
 	}
 }
 

--- a/server/internal/request/service_book_test.go
+++ b/server/internal/request/service_book_test.go
@@ -103,6 +103,69 @@ func TestBookRequestStatusAndDedup(t *testing.T) {
 	}
 }
 
+// TestGetUserBookStatusPerFormat covers the per-format breakdown that lets the
+// dashboard offer the other format after one is requested: a format-specific row
+// covers only that format, a "both" row covers both, denied stays re-requestable,
+// and the collapsed Status is preserved for back-compat.
+func TestGetUserBookStatusPerFormat(t *testing.T) {
+	svc, uid := newBookTestService(t)
+	insert := func(fid, format, status string) {
+		t.Helper()
+		if _, err := svc.db.Exec(
+			"INSERT INTO request_log (user_id, tmdb_id, foreign_id, book_format, media_type, title, status) VALUES (?, 0, ?, ?, 'book', 'T', ?)",
+			uid, fid, format, status,
+		); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	// Ebook requested only: ebook covered, audiobook still open (absent).
+	insert("b-ebook", BookFormatEbook, StatusRequested)
+	st, _ := svc.GetUserBookStatus(uid, "b-ebook")
+	if st.BookFormats[BookFormatEbook] != StatusRequested {
+		t.Fatalf("ebook = %v, want requested", st.BookFormats[BookFormatEbook])
+	}
+	if _, ok := st.BookFormats[BookFormatAudiobook]; ok {
+		t.Fatalf("audiobook should be absent (still requestable), got %v", st.BookFormats)
+	}
+
+	// Two separate format rows.
+	insert("b-two", BookFormatEbook, StatusRequested)
+	insert("b-two", BookFormatAudiobook, StatusPending)
+	st, _ = svc.GetUserBookStatus(uid, "b-two")
+	if st.BookFormats[BookFormatEbook] != StatusRequested ||
+		st.BookFormats[BookFormatAudiobook] != StatusPending {
+		t.Fatalf("two-format = %#v, want ebook requested + audiobook pending", st.BookFormats)
+	}
+
+	// A single "both" row expands to both concrete formats.
+	insert("b-both", BookFormatBoth, StatusRequested)
+	st, _ = svc.GetUserBookStatus(uid, "b-both")
+	if st.BookFormats[BookFormatEbook] != StatusRequested ||
+		st.BookFormats[BookFormatAudiobook] != StatusRequested {
+		t.Fatalf("both = %#v, want ebook+audiobook requested", st.BookFormats)
+	}
+
+	// Denied ebook, no audiobook: collapsed Status preserved; audiobook still open.
+	insert("b-denied", BookFormatEbook, StatusDenied)
+	st, _ = svc.GetUserBookStatus(uid, "b-denied")
+	if st.BookFormats[BookFormatEbook] != StatusDenied {
+		t.Fatalf("denied ebook = %#v, want ebook denied", st.BookFormats)
+	}
+	if _, ok := st.BookFormats[BookFormatAudiobook]; ok {
+		t.Fatalf("audiobook should be absent for denied-ebook book, got %#v", st.BookFormats)
+	}
+	if st.Status != StatusDenied {
+		t.Fatalf("collapsed status = %v, want denied (back-compat)", st.Status)
+	}
+
+	// Unknown foreign id: unavailable, no per-format map.
+	st, _ = svc.GetUserBookStatus(uid, "nope")
+	if st.Status != StatusUnavailable || len(st.BookFormats) != 0 {
+		t.Fatalf("unknown = %#v, want unavailable + no formats", st)
+	}
+}
+
 func TestBookRequestFormatMonitorsRequestedEditions(t *testing.T) {
 	var addBody map[string]any
 	chaptarrServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Chaptarr stores a title's ebook and audiobook as **two separate book records** (same `foreignBookId`, different `mediaType`). The UI treated each record independently, causing the four reported issues — all fixed here.

| # | Issue | Fix |
|---|---|---|
| 1 | A "both" title showed as **two identical entries** in the author | Group records by `foreignBookId` (`ChaptarrBook.groupKey`) → one card per title |
| 2 | Monitor button couldn't express **both formats** | Grouped card shows **one monitor toggle per format**, each toggling that record independently |
| 3 | Searches didn't let you **pick a format** | Book screen + detail sheet take the group; Automatic/Interactive call `pickFormatRecord` to prompt for the format when a title has both (release search stays per-record) |
| 4 | Requesting one format **greyed out** the dashboard button | `GetUserBookStatus` now also returns a per-format breakdown (`book_formats`); the button stays enabled while a format is open, and the format sheet disables/annotates already-requested formats (hides "both" when exactly one is covered) |

## Notes
- New `ChaptarrBook.mediaType` + `format`/`groupKey` getters drive the grouping. No Go model change needed for 1–3 (the proxy is a pass-through).
- Issue 4 is **additive**: `StatusResponse.book_formats` is `omitempty` (movie/TV payloads unchanged); the collapsed `status` is preserved, so `checkBookStatus` and existing callers are untouched. A stored "both" row covers both formats; `denied` stays re-requestable.

## Verification
- Backend: `go build/vet/test ./...` green; new `TestGetUserBookStatusPerFormat` covers ebook-only / two-format / `both` / denied / unknown.
- App: `flutter analyze` clean (0 errors in changed files); full suite passes (132 tests) incl. new model `format`/`groupKey` tests and a `checkBookStatusDetail` parsing test.
- Live (read-only): confirmed `/book?authorId=` returns `mediaType` + shared `foreignBookId`, so the two formats of a title group into one entry.
- Manual (TestFlight): one entry per title, per-format monitor toggles, search prompts for format, and the second format is requestable after the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)