### PR TITLE
Chaptarr: add the missing format (ebook/audiobook) from the author card

### DIFF
--- a/app/lib/features/chaptarr/data/chaptarr_add_payload.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_add_payload.dart
@@ -1,0 +1,52 @@
+import 'chaptarr_models.dart';
+
+/// Builds the Chaptarr add-book body for adding a single missing format of a
+/// title that's already in the library. The title's other format already exists
+/// (so the author is tracked); a monitored record added under an existing author
+/// stays monitored without needing editions, and searchForNewBook starts a
+/// download search. mediaType is the single source of format truth on this fork;
+/// the matching ebook/audiobook flag is set to agree with it.
+Map<String, dynamic> chaptarrAddFormatBody({
+  required String foreignBookId,
+  required String title,
+  String? titleSlug,
+  required BookFormat format,
+  required String authorName,
+  String? foreignAuthorId,
+  required int qualityProfileId,
+  required int metadataProfileId,
+  required String rootFolderPath,
+}) {
+  final isAudiobook = format == BookFormat.audiobook;
+  return {
+    'foreignBookId': foreignBookId,
+    'title': title,
+    'titleSlug': titleSlug,
+    'monitored': true,
+    'mediaType': isAudiobook ? 'audiobook' : 'ebook',
+    'ebookMonitored': !isAudiobook,
+    'audiobookMonitored': isAudiobook,
+    'anyEditionOk': false,
+    'author': {
+      'authorName': authorName,
+      'foreignAuthorId': foreignAuthorId,
+      'qualityProfileId': qualityProfileId,
+      'metadataProfileId': metadataProfileId,
+      'rootFolderPath': rootFolderPath,
+      'monitored': true,
+      'addOptions': {'monitor': 'all', 'searchForMissingBooks': false},
+    },
+    'addOptions': {'searchForNewBook': true},
+  };
+}
+
+/// Picks the root folder matching the format (…/audiobooks vs …/ebooks), falling
+/// back to the first folder when no path matches.
+String chaptarrRootFolderFor(
+    BookFormat format, List<ChaptarrRootFolder> folders) {
+  final needle = format == BookFormat.audiobook ? 'audiobook' : 'ebook';
+  for (final f in folders) {
+    if (f.path.toLowerCase().contains(needle)) return f.path;
+  }
+  return folders.first.path;
+}

--- a/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
+import '../data/chaptarr_add_payload.dart';
 import '../data/chaptarr_api_service.dart';
 import '../data/chaptarr_models.dart';
 import 'chaptarr_book_screen.dart';
@@ -39,6 +40,8 @@ class _ChaptarrAuthorDetailScreenState
   bool _isLoading = true;
   String? _error;
   final Set<int> _togglingBooks = {};
+  // Keys ("<groupKey>:<format index>") of format records currently being added.
+  final Set<String> _addingFormats = {};
 
   @override
   void initState() {
@@ -125,6 +128,76 @@ class _ChaptarrAuthorDetailScreenState
     return groups.values.toList();
   }
 
+  String _addKey(List<ChaptarrBook> records, BookFormat format) =>
+      '${records.first.groupKey}:${format.index}';
+
+  /// Adds the missing format (ebook or audiobook) for a title as a new monitored
+  /// Chaptarr record sharing the title's foreignBookId. The author already
+  /// exists here, so a record added monitored stays monitored (no editions
+  /// needed); searchForNewBook then kicks off a download search.
+  Future<void> _addFormat(List<ChaptarrBook> records, BookFormat format) async {
+    final primary = records.first;
+    final foreignBookId = primary.foreignBookId;
+    if (foreignBookId == null || foreignBookId.isEmpty) return;
+    final label = chaptarrFormatLabel(format);
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppTheme.surface,
+        title: Text('Add $label?',
+            style: const TextStyle(color: AppTheme.textPrimary)),
+        content: Text(
+          'Add the $label of “${primary.title}”? It will be monitored '
+          'and a download search will start.',
+          style: const TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Add')),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    final key = _addKey(records, format);
+    setState(() => _addingFormats.add(key));
+    try {
+      final qps = await _service.getQualityProfiles();
+      final mps = await _service.getMetadataProfiles();
+      final folders = await _service.getRootFolders();
+      if (qps.isEmpty || mps.isEmpty || folders.isEmpty) {
+        throw Exception('a quality/metadata profile or root folder is missing');
+      }
+      await _service.addBook(chaptarrAddFormatBody(
+        foreignBookId: foreignBookId,
+        title: primary.title,
+        titleSlug: primary.titleSlug,
+        format: format,
+        authorName: _author?.authorName ?? primary.author?.authorName ?? '',
+        foreignAuthorId:
+            _author?.foreignAuthorId ?? primary.author?.foreignAuthorId,
+        qualityProfileId: qps.first.id,
+        metadataProfileId: mps.first.id,
+        rootFolderPath: chaptarrRootFolderFor(format, folders),
+      ));
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Added $label — searching for ${primary.title}…')));
+      await _load();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Could not add $label: $e')));
+    } finally {
+      if (mounted) setState(() => _addingFormats.remove(key));
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final title = _author?.authorName ?? widget.authorName ?? 'Author';
@@ -157,8 +230,10 @@ class _ChaptarrAuthorDetailScreenState
                   ..._groupedBooks().map((records) => _BookCard(
                         records: records,
                         togglingIds: _togglingBooks,
+                        addingKeys: _addingFormats,
                         onTap: () => _openBookGroup(records),
                         onToggleRecord: _toggleBookMonitored,
+                        onAddFormat: (format) => _addFormat(records, format),
                       )),
                   if (_books.isEmpty && !_isLoading)
                     const Padding(
@@ -266,18 +341,23 @@ class _AuthorSummaryCard extends StatelessWidget {
 
 /// One card per title. Chaptarr stores a title's ebook and audiobook as
 /// separate records (same foreignBookId); [records] holds the 1–2 records so the
-/// card shows a single entry with a format badge and monitor toggle per format.
+/// card shows a single entry with, per format, a monitor toggle (when that
+/// format exists) or an add button (when it doesn't).
 class _BookCard extends StatelessWidget {
   final List<ChaptarrBook> records;
   final Set<int> togglingIds;
+  final Set<String> addingKeys;
   final VoidCallback onTap;
   final void Function(ChaptarrBook record) onToggleRecord;
+  final void Function(BookFormat format) onAddFormat;
 
   const _BookCard({
     required this.records,
     required this.togglingIds,
+    required this.addingKeys,
     required this.onTap,
     required this.onToggleRecord,
+    required this.onAddFormat,
   });
 
   @override
@@ -363,12 +443,8 @@ class _BookCard extends StatelessWidget {
             Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                for (final r in records)
-                  _MonitorToggle(
-                    record: r,
-                    busy: togglingIds.contains(r.id),
-                    onTap: () => onToggleRecord(r),
-                  ),
+                _formatControl(BookFormat.ebook),
+                _formatControl(BookFormat.audiobook),
               ],
             ),
           ],
@@ -376,52 +452,86 @@ class _BookCard extends StatelessWidget {
       ),
     );
   }
+
+  Widget _formatControl(BookFormat format) {
+    final record = _recordForFormat(records, format);
+    final busy = (record != null && togglingIds.contains(record.id)) ||
+        addingKeys.contains('${records.first.groupKey}:${format.index}');
+    return _FormatControl(
+      format: format,
+      record: record,
+      busy: busy,
+      onToggle: onToggleRecord,
+      onAdd: () => onAddFormat(format),
+    );
+  }
 }
 
-/// A compact per-format monitor toggle: the format icon plus a bookmark that
-/// fills when that record is monitored, so a "both" title can monitor its ebook
-/// and audiobook independently.
-class _MonitorToggle extends StatelessWidget {
-  final ChaptarrBook record;
-  final bool busy;
-  final VoidCallback onTap;
+/// Finds a title's record for a format, or null when that format hasn't been
+/// added yet.
+ChaptarrBook? _recordForFormat(List<ChaptarrBook> records, BookFormat format) {
+  for (final r in records) {
+    if (r.format == format) return r;
+  }
+  return null;
+}
 
-  const _MonitorToggle({
+/// A compact per-format control on the right of a book card: a monitor toggle
+/// when the format's record exists (the bookmark fills when monitored), or an
+/// "add" button when the title doesn't have that format yet.
+class _FormatControl extends StatelessWidget {
+  final BookFormat format;
+  final ChaptarrBook? record;
+  final bool busy;
+  final void Function(ChaptarrBook record) onToggle;
+  final VoidCallback onAdd;
+
+  const _FormatControl({
+    required this.format,
     required this.record,
     required this.busy,
-    required this.onTap,
+    required this.onToggle,
+    required this.onAdd,
   });
 
   @override
   Widget build(BuildContext context) {
-    final monitored = record.monitored;
-    final label = chaptarrFormatLabel(record.format);
+    final label = chaptarrFormatLabel(format);
+    final r = record;
+    final exists = r != null;
+    final monitored = r?.monitored ?? false;
+    final tooltip = exists
+        ? (monitored ? 'Stop monitoring $label' : 'Monitor $label')
+        : 'Add $label';
     return Tooltip(
-      message: monitored ? 'Stop monitoring $label' : 'Monitor $label',
+      message: tooltip,
       child: InkWell(
-        onTap: busy ? null : onTap,
+        onTap: busy ? null : (r != null ? () => onToggle(r) : onAdd),
         borderRadius: BorderRadius.circular(8),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 6),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              Icon(chaptarrFormatIcon(record.format),
+              Icon(chaptarrFormatIcon(format),
                   size: 14, color: AppTheme.textSecondary),
               const SizedBox(width: 4),
-              busy
-                  ? const SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(
-                          strokeWidth: 2, color: AppTheme.accent),
-                    )
-                  : Icon(
-                      monitored ? Icons.bookmark : Icons.bookmark_border,
-                      size: 20,
-                      color:
-                          monitored ? AppTheme.accent : AppTheme.textSecondary,
-                    ),
+              if (busy)
+                const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(
+                      strokeWidth: 2, color: AppTheme.accent),
+                )
+              else if (exists)
+                Icon(
+                  monitored ? Icons.bookmark : Icons.bookmark_border,
+                  size: 20,
+                  color: monitored ? AppTheme.accent : AppTheme.textSecondary,
+                )
+              else
+                const Icon(Icons.add_circle_outline,
+                    size: 20, color: AppTheme.textSecondary),
             ],
           ),
         ),

--- a/app/test/chaptarr/chaptarr_add_payload_test.dart
+++ b/app/test/chaptarr/chaptarr_add_payload_test.dart
@@ -1,0 +1,67 @@
+import 'package:cantinarr/features/chaptarr/data/chaptarr_add_payload.dart';
+import 'package:cantinarr/features/chaptarr/data/chaptarr_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('chaptarrAddFormatBody', () {
+    test('audiobook pins mediaType + flags and the author block', () {
+      final body = chaptarrAddFormatBody(
+        foreignBookId: 'fb-1',
+        title: 'Pretty Furious',
+        titleSlug: 'pretty-furious',
+        format: BookFormat.audiobook,
+        authorName: 'E.K. Johnston',
+        foreignAuthorId: 'hc:240647',
+        qualityProfileId: 1,
+        metadataProfileId: 2,
+        rootFolderPath: '/media-server/media/audiobooks',
+      );
+
+      expect(body['foreignBookId'], 'fb-1');
+      expect(body['mediaType'], 'audiobook');
+      expect(body['audiobookMonitored'], isTrue);
+      expect(body['ebookMonitored'], isFalse);
+      expect(body['monitored'], isTrue);
+      final author = body['author'] as Map<String, dynamic>;
+      expect(author['foreignAuthorId'], 'hc:240647');
+      expect(author['qualityProfileId'], 1);
+      expect(author['rootFolderPath'], '/media-server/media/audiobooks');
+      expect(author['addOptions'], {'monitor': 'all', 'searchForMissingBooks': false});
+      expect(body['addOptions'], {'searchForNewBook': true});
+    });
+
+    test('ebook pins the opposite flags', () {
+      final body = chaptarrAddFormatBody(
+        foreignBookId: 'fb-2',
+        title: 'T',
+        format: BookFormat.ebook,
+        authorName: 'A',
+        qualityProfileId: 1,
+        metadataProfileId: 1,
+        rootFolderPath: '/x',
+      );
+      expect(body['mediaType'], 'ebook');
+      expect(body['ebookMonitored'], isTrue);
+      expect(body['audiobookMonitored'], isFalse);
+    });
+  });
+
+  group('chaptarrRootFolderFor', () {
+    final folders = [
+      const ChaptarrRootFolder(id: 1, path: '/media-server/media/ebooks'),
+      const ChaptarrRootFolder(id: 2, path: '/media-server/media/audiobooks'),
+    ];
+
+    test('routes each format to its matching folder', () {
+      expect(chaptarrRootFolderFor(BookFormat.audiobook, folders),
+          '/media-server/media/audiobooks');
+      expect(chaptarrRootFolderFor(BookFormat.ebook, folders),
+          '/media-server/media/ebooks');
+    });
+
+    test('falls back to the first folder when nothing matches', () {
+      final only = [const ChaptarrRootFolder(id: 1, path: '/books')];
+      expect(chaptarrRootFolderFor(BookFormat.audiobook, only), '/books');
+    });
+  });
+}


### PR DESCRIPTION
A title that exists in only one format (e.g. all of E.K. Johnston's ebook-only books) showed a single monitor control, with no way to also get the audiobook. Now each book card shows a control for **both** formats:
- **monitor toggle** where the record exists (bookmark fills when monitored), and
- **"add" button** (＋) where the title doesn't have that format yet.

Tapping "add audiobook" (or ebook) confirms, then creates a new **monitored** Chaptarr record sharing the title's `foreignBookId`. The author is already tracked, so a no-editions add stays monitored and `searchForNewBook` kicks off a download search; the record then groups into the same card as a second format badge. The audiobook goes to the `…/audiobooks` root folder (chosen by path).

## Why this shape
- Routed through the module's **own instance proxy** (not the request backend), so it adds to the instance you're viewing.
- **No editions** in the payload → none of the `links`/`images` NOT-NULL complexity; the Dart response decode is already robust.
- Verified live: the exact payload returns **201** with `{mediaType: audiobook, monitored: true, audiobookMonitored: true}`, and the title then shows both formats. (Test record cleaned up.)

## Tests
- Payload + root-folder logic extracted to `chaptarr_add_payload.dart` with unit tests guarding the field names (`mediaType`/`ebookMonitored`/`audiobookMonitored`, author block, folder routing).
- `flutter analyze` clean; full suite passes (136 tests).

Note: this control is admin-level (adding/monitoring already requires `instances:manage` through the proxy), matching the existing monitor toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)