### PR TITLE
Books dashboard: reflect already-owned formats + owned-aware search

### DIFF
--- a/app/lib/features/dashboard/data/book_library_service.dart
+++ b/app/lib/features/dashboard/data/book_library_service.dart
@@ -1,0 +1,38 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../request/data/book_ownership.dart';
+
+/// Fetches the backend's lean owned-books digest — what the user already has in
+/// their Chaptarr library, reduced per title+format — so the Books search can
+/// mark results as owned and stop re-requesting a format they already have.
+class BookLibraryService {
+  final Dio _dio;
+
+  BookLibraryService({required Dio backendDio}) : _dio = backendDio;
+
+  Future<List<OwnedTitle>> fetchOwnedTitles() async {
+    try {
+      final resp = await _dio.get('/api/requests/book-library');
+      final data = resp.data;
+      final titles = data is Map ? data['titles'] : null;
+      if (titles is! List) return const [];
+      return titles
+          .whereType<Map<String, dynamic>>()
+          .map(OwnedTitle.fromJson)
+          .toList();
+    } catch (_) {
+      // Degrade silently: search still works, just without ownership marks.
+      return const [];
+    }
+  }
+}
+
+/// The user's owned-book digest. Fetched while the Books tab is open; the
+/// backend caches it (~2 min) so refetches are cheap. Degrades to an empty list
+/// on any failure (no ownership info, search unaffected).
+final ownedBooksProvider =
+    FutureProvider.autoDispose<List<OwnedTitle>>((ref) async {
+  final dio = ref.read(backendClientProvider);
+  return BookLibraryService(backendDio: dio).fetchOwnedTitles();
+});

--- a/app/lib/features/dashboard/logic/book_ownership_matcher.dart
+++ b/app/lib/features/dashboard/logic/book_ownership_matcher.dart
@@ -1,0 +1,160 @@
+/// Pure matching logic for the "owned-aware book search" feature.
+///
+/// A book search returns [ChaptarrBook] lookup results, which carry no
+/// ownership information and whose `foreignBookId` does NOT line up with the
+/// user's owned records. So to decide whether the user already owns a result
+/// (per format), we fuzzy-match its normalized title + author against the
+/// ownership digest ([OwnedTitle] rows).
+///
+/// This file is intentionally free of Flutter imports so it can be unit-tested
+/// in isolation.
+library;
+
+import '../../chaptarr/data/chaptarr_models.dart' show ChaptarrBook;
+import '../../request/data/book_ownership.dart';
+
+/// Minimum title similarity (token Jaccard) for a digest row to count as a
+/// match for a lookup result.
+const double kOwnershipTitleThreshold = 0.75;
+
+/// Words dropped from title/author token sets before comparison. Kept small and
+/// generic: articles, conjunctions, and the common "X to Y" connector so series
+/// titles like "Heir to the Empire" reduce to their distinctive words.
+const Set<String> _titleStopwords = {'the', 'a', 'an', 'and', 'of', 'to'};
+
+/// Words dropped from author token sets. Authors rarely contain articles, so we
+/// only strip the connectors that show up in "First and Last"-style joins.
+const Set<String> _authorStopwords = {'the', 'a', 'an', 'and', 'of', '&'};
+
+/// Matches any run of characters that are neither a Unicode letter nor a digit.
+/// Used to split a normalized string into word tokens.
+final RegExp _nonAlnum = RegExp(r'[^\p{L}\p{N}]+', unicode: true);
+
+/// Matches a single trailing parenthetical/bracket group, e.g. " (Part 1)",
+/// "(Book 2)", "(#3)", "[Illustrated]". Anchored to the end of the string.
+final RegExp _trailingBracket = RegExp(r'\s*[\(\[][^\)\]]*[\)\]]\s*$');
+
+/// Matches a trailing ", Book 3" / ", Vol 2" / " #3" style series suffix.
+final RegExp _trailingSeriesSuffix =
+    RegExp(r'[\s,]+(?:book|vol|volume|part|#)\s*\d+\s*$', caseSensitive: false);
+
+/// Tokenizes a title for fuzzy comparison.
+///
+/// Steps: lowercase; (when [stripSeries]) drop a leading "Series: " prefix up to
+/// and including the first ": " as long as a non-empty remainder survives; strip
+/// a single trailing parenthetical/bracket and a trailing ", Book N"/"#N"
+/// suffix; replace every non-alphanumeric run with a space; split on whitespace;
+/// drop stopwords and empties.
+List<String> normalizeTitleTokens(String s, {bool stripSeries = true}) {
+  var text = s.toLowerCase();
+
+  if (stripSeries) {
+    final idx = text.indexOf(': ');
+    if (idx >= 0) {
+      final remainder = text.substring(idx + 2).trim();
+      if (remainder.isNotEmpty) text = remainder;
+    }
+  }
+
+  // Strip trailing series suffix and a trailing bracket group. Run repeatedly so
+  // "Title (Book 2) [Illustrated]" collapses fully.
+  var changed = true;
+  while (changed) {
+    changed = false;
+    final afterBracket = text.replaceFirst(_trailingBracket, '');
+    if (afterBracket != text) {
+      text = afterBracket;
+      changed = true;
+    }
+    final afterSuffix = text.replaceFirst(_trailingSeriesSuffix, '');
+    if (afterSuffix != text) {
+      text = afterSuffix;
+      changed = true;
+    }
+  }
+
+  return text
+      .split(_nonAlnum)
+      .where((t) => t.isNotEmpty && !_titleStopwords.contains(t))
+      .toList();
+}
+
+/// Jaccard similarity of two token sets: |a∩b| / |a∪b|. Defined as 0 when both
+/// sets are empty.
+double jaccard(Set<String> a, Set<String> b) {
+  if (a.isEmpty && b.isEmpty) return 0;
+  final intersection = a.where(b.contains).length;
+  final union = a.length + b.length - intersection;
+  if (union == 0) return 0;
+  return intersection / union;
+}
+
+/// Normalizes an author string into comparison tokens: lowercase, split on
+/// non-alphanumerics, drop author stopwords and empties.
+List<String> _authorTokens(String s) => s
+    .toLowerCase()
+    .split(_nonAlnum)
+    .where((t) => t.isNotEmpty && !_authorStopwords.contains(t))
+    .toList();
+
+/// Whether a lookup result's author plausibly matches a digest row's author.
+///
+/// True when the token-set Jaccard is >= 0.6 OR the surname (last token) is the
+/// same on both sides. The caller is responsible for the empty/absent-author
+/// case (this returns false when either side has no usable tokens).
+bool authorMatches(String? lookupAuthor, String digestAuthor) {
+  if (lookupAuthor == null) return false;
+  final a = _authorTokens(lookupAuthor);
+  final b = _authorTokens(digestAuthor);
+  if (a.isEmpty || b.isEmpty) return false;
+  if (jaccard(a.toSet(), b.toSet()) >= 0.6) return true;
+  return a.last == b.last;
+}
+
+/// The best title-similarity score between a result and a digest row, taking the
+/// max over the series-stripped and series-kept tokenizations (so a result that
+/// keeps its "Series: " prefix can still match a digest row that dropped it, and
+/// vice versa).
+double _titleScore(ChaptarrBook result, OwnedTitle owned) {
+  final stripped = jaccard(
+    normalizeTitleTokens(result.title, stripSeries: true).toSet(),
+    normalizeTitleTokens(owned.title, stripSeries: true).toSet(),
+  );
+  final kept = jaccard(
+    normalizeTitleTokens(result.title, stripSeries: false).toSet(),
+    normalizeTitleTokens(owned.title, stripSeries: false).toSet(),
+  );
+  return stripped > kept ? stripped : kept;
+}
+
+/// Decides whether the user already owns [result], by matching it against the
+/// ownership [digest].
+///
+/// A digest row is a candidate when its [_titleScore] >= [kOwnershipTitleThreshold]
+/// AND either the authors match ([authorMatches]) or — when an author is missing
+/// on either side — the title score is high enough (>= 0.9) to stand on its own.
+/// Returns the [BookOwnership] of the highest-scoring candidate, or null when no
+/// row qualifies.
+BookOwnership? ownershipFor(ChaptarrBook result, List<OwnedTitle> digest) {
+  final lookupAuthor = result.author?.authorName;
+  final lookupAuthorEmpty = lookupAuthor == null || lookupAuthor.isEmpty;
+
+  BookOwnership? best;
+  double bestScore = -1;
+
+  for (final owned in digest) {
+    final score = _titleScore(result, owned);
+    if (score < kOwnershipTitleThreshold) continue;
+
+    final authorOk = authorMatches(lookupAuthor, owned.author) ||
+        ((lookupAuthorEmpty || owned.author.isEmpty) && score >= 0.9);
+    if (!authorOk) continue;
+
+    if (score > bestScore) {
+      bestScore = score;
+      best = owned.ownership;
+    }
+  }
+
+  return best;
+}

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -9,7 +9,10 @@ import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../chaptarr/data/chaptarr_api_service.dart';
 import '../../chaptarr/data/chaptarr_models.dart';
+import '../../request/data/book_ownership.dart';
 import '../../request/data/request_service.dart';
+import '../data/book_library_service.dart';
+import '../logic/book_ownership_matcher.dart';
 
 /// Dashboard Books tab: search Chaptarr's catalog (books/authors) and request a
 /// book. Chaptarr lookup is search-only (no "popular" feed like TMDB), so this
@@ -191,22 +194,43 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
     // backend's /requests endpoint, not the Chaptarr proxy).
     final requestService =
         RequestService(backendDio: ref.read(backendClientProvider));
+    // What the user already owns, to mark results and gate per-format requests.
+    final digest =
+        ref.watch(ownedBooksProvider).valueOrNull ?? const <OwnedTitle>[];
+    // Compute ownership per result and float owned titles to the top, preserving
+    // Chaptarr's relevance order within each bucket (don't collapse versions —
+    // the user wants to see ones they don't own).
+    final owned = <(ChaptarrBook, BookOwnership?)>[];
+    final rest = <(ChaptarrBook, BookOwnership?)>[];
+    for (final book in _results) {
+      final o = digest.isEmpty ? null : ownershipFor(book, digest);
+      ((o?.anyOwned ?? false) ? owned : rest).add((book, o));
+    }
+    final ordered = [...owned, ...rest];
     return ListView.separated(
       padding: const EdgeInsets.symmetric(vertical: 8),
-      itemCount: _results.length,
+      itemCount: ordered.length,
       separatorBuilder: (_, __) =>
           const Divider(height: 1, color: AppTheme.border),
-      itemBuilder: (_, i) =>
-          _BookResultTile(book: _results[i], requestService: requestService),
+      itemBuilder: (_, i) => _BookResultTile(
+        book: ordered[i].$1,
+        ownership: ordered[i].$2,
+        requestService: requestService,
+      ),
     );
   }
 }
 
 class _BookResultTile extends StatelessWidget {
   final ChaptarrBook book;
+  final BookOwnership? ownership;
   final RequestService requestService;
 
-  const _BookResultTile({required this.book, required this.requestService});
+  const _BookResultTile({
+    required this.book,
+    this.ownership,
+    required this.requestService,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -216,6 +240,11 @@ class _BookResultTile extends StatelessWidget {
       if (year != null) '$year',
     ].join(' · ');
     final fid = book.foreignBookId;
+    final o = ownership;
+    // Lookup results never carry a library id (always null), so ownership comes
+    // from the owned-books digest, matched by title+author.
+    final bothOwned = o != null && o.ebook.owned && o.audiobook.owned;
+    final chip = _ownershipChip(o);
 
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -250,34 +279,70 @@ class _BookResultTile extends StatelessWidget {
         style: const TextStyle(
             color: AppTheme.textPrimary, fontWeight: FontWeight.w600),
       ),
-      subtitle: subtitle.isEmpty
+      subtitle: (subtitle.isEmpty && chip == null)
           ? null
-          : Text(subtitle,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(color: AppTheme.textSecondary)),
-      // A Chaptarr lookup result that is already tracked in the library comes
-      // back with a non-zero id; show that instead of a Request button (which
-      // would otherwise try to re-add it).
-      trailing: book.id != 0
-          ? const Padding(
-              padding: EdgeInsets.only(right: 8),
-              child: Text(
-                'In Library',
-                style: TextStyle(
-                  color: AppTheme.available,
-                  fontSize: 12,
-                  fontWeight: FontWeight.w600,
-                ),
+          : Padding(
+              padding: const EdgeInsets.only(top: 3),
+              child: Row(
+                children: [
+                  if (subtitle.isNotEmpty)
+                    Flexible(
+                      child: Text(subtitle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style:
+                              const TextStyle(color: AppTheme.textSecondary)),
+                    ),
+                  if (chip != null) ...[
+                    if (subtitle.isNotEmpty) const SizedBox(width: 8),
+                    chip,
+                  ],
+                ],
               ),
-            )
+            ),
+      // Fully-owned titles show only the chip; otherwise offer a request for the
+      // format(s) the user neither owns nor already requested.
+      trailing: bothOwned
+          ? null
           : (fid != null && fid.isNotEmpty)
               ? _BookRequestButton(
                   foreignId: fid,
                   title: book.title,
                   service: requestService,
+                  ownership: o,
                 )
               : null,
+    );
+  }
+}
+
+Widget? _ownershipChip(BookOwnership? o) {
+  if (o == null || !o.anyOwned) return null;
+  final downloaded = o.anyDownloaded;
+  return _OwnershipChip(
+    label: downloaded ? 'Downloaded' : 'In Library',
+    color: downloaded ? AppTheme.available : AppTheme.requested,
+  );
+}
+
+/// A small colored pill marking that a search result is already in the library.
+class _OwnershipChip extends StatelessWidget {
+  final String label;
+  final Color color;
+
+  const _OwnershipChip({required this.label, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.15),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(label,
+          style: TextStyle(
+              color: color, fontSize: 10.5, fontWeight: FontWeight.w600)),
     );
   }
 }
@@ -288,11 +353,13 @@ class _BookRequestButton extends StatefulWidget {
   final String foreignId;
   final String title;
   final RequestService service;
+  final BookOwnership? ownership;
 
   const _BookRequestButton({
     required this.foreignId,
     required this.title,
     required this.service,
+    this.ownership,
   });
 
   @override
@@ -315,7 +382,9 @@ class _BookRequestButtonState extends State<_BookRequestButton> {
     final detail = await widget.service.checkBookStatusDetail(widget.foreignId);
     if (!mounted) return;
     setState(() {
-      _detail = detail;
+      // Union request state with library ownership so an owned format is also
+      // treated as covered (unrequestable).
+      _detail = detail.withOwnership(widget.ownership);
       _status = detail.status;
       _loading = false;
     });
@@ -428,12 +497,8 @@ class _BookFormatSheet extends StatelessWidget {
     };
   }
 
-  String? _statusLabelFor(BookRequestFormat choice) {
-    if (!_coveredFor(choice)) return null;
-    final key =
-        choice == BookRequestFormat.both ? BookRequestFormat.ebook : choice;
-    return (detail.formats[key] ?? RequestStatus.requested).label;
-  }
+  String? _statusLabelFor(BookRequestFormat choice) =>
+      detail.coverageLabel(choice);
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/features/request/data/book_ownership.dart
+++ b/app/lib/features/request/data/book_ownership.dart
@@ -1,0 +1,82 @@
+/// Ownership model for the "owned-aware book search" feature.
+///
+/// The backend serves an ownership digest of the form
+/// `{"titles":[{"title","author","year","ebook":{...},"audiobook":{...}}]}`.
+/// Each format object carries `monitored`/`downloaded` flags. We model these as
+/// neutral value types here, deliberately free of any dependency on
+/// `request_service.dart` (in particular `BookRequestFormat`) so this file can
+/// be imported by the request service without creating an import cycle.
+library;
+
+/// Whether the user already has a given format (ebook or audiobook) of a title.
+///
+/// A format counts as [owned] — and therefore unrequestable — once it is
+/// monitored or downloaded.
+class FormatOwnership {
+  final bool monitored;
+  final bool downloaded;
+
+  const FormatOwnership({this.monitored = false, this.downloaded = false});
+
+  /// Owned means the user already has (or is tracking) this format, so it
+  /// should not be offered as a new request.
+  bool get owned => monitored || downloaded;
+
+  /// Null-safe parse of a `{"monitored":bool,"downloaded":bool}` object. A null
+  /// or malformed map yields a default (un-owned) [FormatOwnership].
+  factory FormatOwnership.fromJson(Map<String, dynamic>? json) {
+    if (json == null) return const FormatOwnership();
+    return FormatOwnership(
+      monitored: json['monitored'] as bool? ?? false,
+      downloaded: json['downloaded'] as bool? ?? false,
+    );
+  }
+}
+
+/// Per-format ownership of a single title (its ebook and audiobook).
+class BookOwnership {
+  final FormatOwnership ebook;
+  final FormatOwnership audiobook;
+
+  const BookOwnership({
+    this.ebook = const FormatOwnership(),
+    this.audiobook = const FormatOwnership(),
+  });
+
+  /// True when either format is owned (monitored or downloaded).
+  bool get anyOwned => ebook.owned || audiobook.owned;
+
+  /// True when either format has a downloaded file on disk.
+  bool get anyDownloaded => ebook.downloaded || audiobook.downloaded;
+}
+
+/// One parsed row of the ownership digest: a title the user already has in some
+/// form, with the normalized fields used for fuzzy matching against search
+/// lookup results.
+class OwnedTitle {
+  final String title;
+  final String author;
+  final int year;
+  final BookOwnership ownership;
+
+  const OwnedTitle({
+    required this.title,
+    required this.author,
+    this.year = 0,
+    required this.ownership,
+  });
+
+  /// Parses one digest entry: `title`/`author`/`year` plus the `ebook` and
+  /// `audiobook` format objects.
+  factory OwnedTitle.fromJson(Map<String, dynamic> json) => OwnedTitle(
+        title: json['title'] as String? ?? '',
+        author: json['author'] as String? ?? '',
+        year: json['year'] as int? ?? 0,
+        ownership: BookOwnership(
+          ebook: FormatOwnership.fromJson(
+              json['ebook'] as Map<String, dynamic>?),
+          audiobook: FormatOwnership.fromJson(
+              json['audiobook'] as Map<String, dynamic>?),
+        ),
+      );
+}

--- a/app/lib/features/request/data/request_service.dart
+++ b/app/lib/features/request/data/request_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:dio/dio.dart';
 import '../../discover/data/tmdb_models.dart';
+import 'book_ownership.dart';
 
 /// Status of a media request from the user's perspective.
 enum RequestStatus {
@@ -50,24 +51,75 @@ enum BookRequestFormat {
 
 /// A user's per-format request state for a book. [status] is the collapsed
 /// (latest) state; [formats] maps each already-requested concrete format to its
-/// status (a stored "both" request fills both ebook and audiobook). Lets the
-/// dashboard keep offering a format that hasn't been requested yet.
+/// status (a stored "both" request fills both ebook and audiobook); [ownership]
+/// is what the user already has in the Chaptarr library. A format is covered
+/// (no longer requestable) when it's already requested OR already owned, so the
+/// dashboard keeps offering only the formats the user neither requested nor owns.
 class BookRequestStatusDetail {
   final RequestStatus status;
   final Map<BookRequestFormat, RequestStatus> formats;
+  final BookOwnership? ownership;
 
   const BookRequestStatusDetail({
     this.status = RequestStatus.unavailable,
     this.formats = const {},
+    this.ownership,
   });
 
-  /// A format is "covered" (no longer requestable) when it has a non-denied
-  /// row. Denied and never-requested formats stay requestable.
+  /// Returns a copy carrying library [ownership] (from the owned-books digest).
+  BookRequestStatusDetail withOwnership(BookOwnership? ownership) =>
+      BookRequestStatusDetail(
+          status: status, formats: formats, ownership: ownership);
+
+  /// Covered = already requested (non-denied) OR already owned in the library.
+  /// "both" is covered only when each concrete format is covered (possibly from
+  /// different sources — e.g. ebook owned + audiobook requested). The backend
+  /// expands a stored "both" request into ebook+audiobook, so [formats] never
+  /// carries a literal "both" key.
   bool isCovered(BookRequestFormat format) {
+    if (format == BookRequestFormat.both) {
+      return isCovered(BookRequestFormat.ebook) &&
+          isCovered(BookRequestFormat.audiobook);
+    }
+    return _requestCovered(format) || _ownershipCovers(format);
+  }
+
+  bool _requestCovered(BookRequestFormat format) {
     final s = formats[format];
     return s != null &&
         s != RequestStatus.denied &&
         s != RequestStatus.unavailable;
+  }
+
+  bool _ownershipCovers(BookRequestFormat format) {
+    final o = ownership;
+    if (o == null) return false;
+    return switch (format) {
+      BookRequestFormat.ebook => o.ebook.owned,
+      BookRequestFormat.audiobook => o.audiobook.owned,
+      BookRequestFormat.both => o.ebook.owned && o.audiobook.owned,
+    };
+  }
+
+  /// Short reason a [format] is covered, for the request sheet: a request status
+  /// label, else "Downloaded"/"In Library" from library ownership, else null.
+  String? coverageLabel(BookRequestFormat format) {
+    if (!isCovered(format)) return null;
+    final reqKey =
+        format == BookRequestFormat.both ? BookRequestFormat.ebook : format;
+    final s = formats[reqKey];
+    if (s != null &&
+        s != RequestStatus.denied &&
+        s != RequestStatus.unavailable) {
+      return s.label;
+    }
+    final o = ownership;
+    if (o != null) {
+      final fo = format == BookRequestFormat.audiobook ? o.audiobook : o.ebook;
+      if (fo.downloaded) return 'Downloaded';
+      if (fo.monitored) return 'In Library';
+    }
+    return null;
   }
 }
 

--- a/app/test/dashboard/book_ownership_matcher_test.dart
+++ b/app/test/dashboard/book_ownership_matcher_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:cantinarr/features/chaptarr/data/chaptarr_models.dart';
+import 'package:cantinarr/features/dashboard/logic/book_ownership_matcher.dart';
+import 'package:cantinarr/features/request/data/book_ownership.dart';
+
+/// Builds a lookup result. [author] becomes `author.authorName`; pass null for a
+/// result with no author context.
+ChaptarrBook _result(String title, {String? author}) =>
+    ChaptarrBook.fromJson({
+      'id': 1,
+      'title': title,
+      if (author != null) 'author': {'authorName': author},
+    });
+
+OwnedTitle _owned(
+  String title,
+  String author, {
+  bool ebookMonitored = false,
+  bool ebookDownloaded = false,
+  bool audiobookMonitored = false,
+  bool audiobookDownloaded = false,
+}) =>
+    OwnedTitle.fromJson({
+      'title': title,
+      'author': author,
+      'ebook': {'monitored': ebookMonitored, 'downloaded': ebookDownloaded},
+      'audiobook': {
+        'monitored': audiobookMonitored,
+        'downloaded': audiobookDownloaded,
+      },
+    });
+
+void main() {
+  group('normalizeTitleTokens', () {
+    test('strips series prefix, trailing parenthetical, and stopwords', () {
+      final tokens =
+          normalizeTitleTokens('Star Wars: Heir to the Empire (Part 1)');
+      expect(tokens.toSet(), {'heir', 'empire'});
+      // Series prefix, parenthetical, and stopwords are all gone.
+      for (final dropped in ['star', 'wars', 'part', '1', 'the', 'to']) {
+        expect(tokens, isNot(contains(dropped)));
+      }
+    });
+
+    test('keeps the series prefix when stripSeries is false', () {
+      final tokens = normalizeTitleTokens(
+        'Star Wars: Heir to the Empire',
+        stripSeries: false,
+      );
+      expect(tokens, contains('star'));
+      expect(tokens, contains('wars'));
+      expect(tokens, contains('heir'));
+    });
+
+    test('does not strip the series prefix when nothing follows it', () {
+      // Remainder after ": " would be empty, so the whole string is kept.
+      final tokens = normalizeTitleTokens('Dune: ');
+      expect(tokens, contains('dune'));
+    });
+
+    test('strips a trailing ", Book N" suffix', () {
+      final tokens = normalizeTitleTokens('Mistborn, Book 2');
+      expect(tokens, contains('mistborn'));
+      expect(tokens, isNot(contains('book')));
+      expect(tokens, isNot(contains('2')));
+    });
+  });
+
+  group('jaccard', () {
+    test('identical sets score 1.0', () {
+      expect(jaccard({'art', 'war'}, {'art', 'war'}), 1.0);
+    });
+
+    test('two empty sets score 0', () {
+      expect(jaccard(<String>{}, <String>{}), 0);
+    });
+
+    test('"The Art of War" vs "Art of War" is at least the threshold', () {
+      final a = normalizeTitleTokens('The Art of War').toSet();
+      final b = normalizeTitleTokens('Art of War').toSet();
+      // Both reduce to {art, war} after stopword removal -> 1.0.
+      expect(jaccard(a, b), greaterThanOrEqualTo(0.75));
+    });
+  });
+
+  group('authorMatches', () {
+    test('exact author matches', () {
+      expect(authorMatches('Timothy Zahn', 'Timothy Zahn'), isTrue);
+    });
+
+    test('surname-only lookup matches a full digest author', () {
+      expect(authorMatches('Zahn', 'Timothy Zahn'), isTrue);
+    });
+
+    test('different authors do not match', () {
+      expect(authorMatches('Marcus Aurelius', 'Sun Tzu'), isFalse);
+    });
+
+    test('null author does not match', () {
+      expect(authorMatches(null, 'Timothy Zahn'), isFalse);
+    });
+  });
+
+  group('ownershipFor', () {
+    test('matches a series-prefixed result to a bare owned title', () {
+      final digest = [
+        _owned('Heir to the Empire', 'Timothy Zahn', ebookDownloaded: true),
+      ];
+      final result =
+          _result('Star Wars: Heir to the Empire', author: 'Timothy Zahn');
+
+      final ownership = ownershipFor(result, digest);
+      expect(ownership, isNotNull);
+      expect(ownership!.ebook.downloaded, isTrue);
+      expect(ownership.anyDownloaded, isTrue);
+    });
+
+    test('false-positive guard: same title, wrong author returns null', () {
+      final digest = [
+        _owned('Meditations and The Art of War', 'Sun Tzu',
+            ebookDownloaded: true),
+      ];
+      final result = _result('Meditations and The Art of War',
+          author: 'Marcus Aurelius');
+
+      expect(ownershipFor(result, digest), isNull);
+    });
+
+    test('surname-only author still resolves ownership', () {
+      final digest = [
+        _owned('Heir to the Empire', 'Timothy Zahn',
+            audiobookMonitored: true),
+      ];
+      final result = _result('Heir to the Empire', author: 'Zahn');
+
+      final ownership = ownershipFor(result, digest);
+      expect(ownership, isNotNull);
+      expect(ownership!.audiobook.monitored, isTrue);
+      expect(ownership.anyOwned, isTrue);
+    });
+
+    test('below-threshold title with same author returns null', () {
+      final digest = [
+        _owned('The Final Empire', 'Brandon Sanderson', ebookDownloaded: true),
+      ];
+      final result =
+          _result('The Way of Kings', author: 'Brandon Sanderson');
+
+      expect(ownershipFor(result, digest), isNull);
+    });
+
+    test('empty digest returns null', () {
+      final result = _result('Heir to the Empire', author: 'Timothy Zahn');
+      expect(ownershipFor(result, const []), isNull);
+    });
+  });
+}

--- a/app/test/request/book_ownership_gating_test.dart
+++ b/app/test/request/book_ownership_gating_test.dart
@@ -1,0 +1,54 @@
+import 'package:cantinarr/features/request/data/book_ownership.dart';
+import 'package:cantinarr/features/request/data/request_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('BookRequestStatusDetail unions library ownership into isCovered', () {
+    test('a downloaded ebook is covered even with no request rows', () {
+      const d = BookRequestStatusDetail(
+        ownership: BookOwnership(ebook: FormatOwnership(downloaded: true)),
+      );
+      expect(d.isCovered(BookRequestFormat.ebook), isTrue);
+      expect(d.isCovered(BookRequestFormat.audiobook), isFalse);
+      expect(d.coverageLabel(BookRequestFormat.ebook), 'Downloaded');
+    });
+
+    test('a monitored-only ebook is covered, labeled "In Library"', () {
+      const d = BookRequestStatusDetail(
+        ownership: BookOwnership(ebook: FormatOwnership(monitored: true)),
+      );
+      expect(d.isCovered(BookRequestFormat.ebook), isTrue);
+      expect(d.coverageLabel(BookRequestFormat.ebook), 'In Library');
+    });
+
+    test('owned ebook + requested audiobook → both covered, labels distinct',
+        () {
+      const d = BookRequestStatusDetail(
+        formats: {BookRequestFormat.audiobook: RequestStatus.requested},
+        ownership: BookOwnership(ebook: FormatOwnership(downloaded: true)),
+      );
+      expect(d.isCovered(BookRequestFormat.ebook), isTrue); // owned
+      expect(d.isCovered(BookRequestFormat.audiobook), isTrue); // requested
+      expect(d.isCovered(BookRequestFormat.both), isTrue);
+      expect(d.coverageLabel(BookRequestFormat.ebook), 'Downloaded');
+      expect(d.coverageLabel(BookRequestFormat.audiobook),
+          RequestStatus.requested.label);
+    });
+
+    test('withOwnership attaches ownership without mutating the original', () {
+      const base = BookRequestStatusDetail();
+      final withOwn = base.withOwnership(
+          const BookOwnership(audiobook: FormatOwnership(monitored: true)));
+      expect(withOwn.isCovered(BookRequestFormat.audiobook), isTrue);
+      expect(base.isCovered(BookRequestFormat.audiobook), isFalse);
+    });
+
+    test('without ownership, a denied request stays requestable', () {
+      const d = BookRequestStatusDetail(
+        formats: {BookRequestFormat.ebook: RequestStatus.denied},
+      );
+      expect(d.isCovered(BookRequestFormat.ebook), isFalse);
+      expect(d.coverageLabel(BookRequestFormat.ebook), isNull);
+    });
+  });
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -207,6 +207,7 @@ func NewRouter(
 			r.Get("/requests", requestHandler.List)
 			r.Get("/requests/options", requestHandler.Options)
 			r.Get("/requests/book-status", requestHandler.GetBookStatus)
+			r.Get("/requests/book-library", requestHandler.GetBookLibrary)
 			r.Get("/requests/{tmdb_id}/status", requestHandler.GetStatus)
 		})
 

--- a/server/internal/chaptarr/client.go
+++ b/server/internal/chaptarr/client.go
@@ -129,21 +129,25 @@ type Edition struct {
 }
 
 type Book struct {
-	ID            int            `json:"id"`
-	Title         string         `json:"title"`
-	AuthorID      int            `json:"authorId"`
-	ForeignBookID string         `json:"foreignBookId"`
-	TitleSlug     string         `json:"titleSlug"`
-	Overview      string         `json:"overview"`
-	ReleaseDate   *time.Time     `json:"releaseDate,omitempty"`
-	Monitored     bool           `json:"monitored"`
-	AnyEditionOk  bool           `json:"anyEditionOk"`
-	PageCount     int            `json:"pageCount"`
-	Author        *AuthorContext `json:"author,omitempty"`
-	Statistics    BookStatistics `json:"statistics"`
-	Editions      []Edition      `json:"editions"`
-	Images        []Image        `json:"images"`
-	Genres        genreList      `json:"genres"`
+	ID            int        `json:"id"`
+	Title         string     `json:"title"`
+	AuthorID      int        `json:"authorId"`
+	ForeignBookID string     `json:"foreignBookId"`
+	TitleSlug     string     `json:"titleSlug"`
+	Overview      string     `json:"overview"`
+	ReleaseDate   *time.Time `json:"releaseDate,omitempty"`
+	Monitored     bool       `json:"monitored"`
+	// MediaType is the book-level format Chaptarr returns on library books
+	// ("ebook"/"audiobook"); this fork tracks a title's ebook and audiobook as
+	// separate records sharing a foreignBookId, distinguished by this field.
+	MediaType    string         `json:"mediaType"`
+	AnyEditionOk bool           `json:"anyEditionOk"`
+	PageCount    int            `json:"pageCount"`
+	Author       *AuthorContext `json:"author,omitempty"`
+	Statistics   BookStatistics `json:"statistics"`
+	Editions     []Edition      `json:"editions"`
+	Images       []Image        `json:"images"`
+	Genres       genreList      `json:"genres"`
 }
 
 type BookFile struct {
@@ -224,15 +228,15 @@ type AddAuthorRequest struct {
 // fields. Editions is raw JSON round-tripped from the lookup result so the
 // add satisfies Chaptarr's NOT NULL edition columns (links, images).
 type AddBookRequest struct {
-	ForeignBookID      string            `json:"foreignBookId"`
-	Title              string            `json:"title"`
-	TitleSlug          string            `json:"titleSlug,omitempty"`
-	Monitored          bool              `json:"monitored"`
-	AnyEditionOk       bool              `json:"anyEditionOk"`
-	MediaType          string            `json:"mediaType,omitempty"`
-	EbookMonitored     *bool             `json:"ebookMonitored,omitempty"`
-	AudiobookMonitored *bool             `json:"audiobookMonitored,omitempty"`
-	Author             AddAuthorRequest  `json:"author"`
+	ForeignBookID      string           `json:"foreignBookId"`
+	Title              string           `json:"title"`
+	TitleSlug          string           `json:"titleSlug,omitempty"`
+	Monitored          bool             `json:"monitored"`
+	AnyEditionOk       bool             `json:"anyEditionOk"`
+	MediaType          string           `json:"mediaType,omitempty"`
+	EbookMonitored     *bool            `json:"ebookMonitored,omitempty"`
+	AudiobookMonitored *bool            `json:"audiobookMonitored,omitempty"`
+	Author             AddAuthorRequest `json:"author"`
 	AddOptions         struct {
 		SearchForNewBook bool `json:"searchForNewBook"`
 	} `json:"addOptions"`
@@ -532,6 +536,16 @@ func (c *Client) GetBooks(authorID int) ([]Book, error) {
 	var books []Book
 	path := fmt.Sprintf("/api/v1/book?authorId=%d", authorID)
 	if err := c.do("GET", path, nil, &books); err != nil {
+		return nil, fmt.Errorf("chaptarr books: %w", err)
+	}
+	return books, nil
+}
+
+// GetAllBooks lists every book in the Chaptarr library (all authors). Chaptarr
+// returns the same book shape as GetBooks; omitting authorId widens the scope.
+func (c *Client) GetAllBooks() ([]Book, error) {
+	var books []Book
+	if err := c.do("GET", "/api/v1/book", nil, &books); err != nil {
 		return nil, fmt.Errorf("chaptarr books: %w", err)
 	}
 	return books, nil
@@ -875,6 +889,14 @@ var (
 	}
 )
 
+// Format classifications returned by FormatOf and used to route a book record
+// to its ebook/audiobook slot.
+const (
+	FormatEbook     = "ebook"
+	FormatAudiobook = "audiobook"
+	FormatUnknown   = "unknown"
+)
+
 // FormatOf classifies a Chaptarr quality name as "ebook", "audiobook", or
 // "unknown" via a case-insensitive substring match. Ebook tokens are checked
 // first so an ambiguous name leans toward the text format.
@@ -882,13 +904,13 @@ func FormatOf(qualityName string) string {
 	upper := strings.ToUpper(qualityName)
 	for _, tok := range ebookTokens {
 		if strings.Contains(upper, tok) {
-			return "ebook"
+			return FormatEbook
 		}
 	}
 	for _, tok := range audiobookTokens {
 		if strings.Contains(upper, tok) {
-			return "audiobook"
+			return FormatAudiobook
 		}
 	}
-	return "unknown"
+	return FormatUnknown
 }

--- a/server/internal/chaptarr/client_test.go
+++ b/server/internal/chaptarr/client_test.go
@@ -111,6 +111,37 @@ func TestExecuteManualImport(t *testing.T) {
 	}
 }
 
+// TestGetAllBooks asserts GetAllBooks hits /api/v1/book with no authorId filter
+// and decodes the library books (including the book-level mediaType).
+func TestGetAllBooks(t *testing.T) {
+	var gotPath string
+	var gotQuery url.Values
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `[{"id":1,"title":"Heir to the Empire","foreignBookId":"fb-1","mediaType":"ebook","monitored":true,"statistics":{"bookFileCount":1}}]`)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "key")
+	books, err := c.GetAllBooks()
+	if err != nil {
+		t.Fatalf("GetAllBooks: %v", err)
+	}
+
+	if gotPath != "/api/v1/book" {
+		t.Errorf("path = %s, want /api/v1/book", gotPath)
+	}
+	if gotQuery.Get("authorId") != "" {
+		t.Errorf("authorId = %q, want empty (no per-author filter)", gotQuery.Get("authorId"))
+	}
+	if len(books) != 1 || books[0].MediaType != "ebook" || books[0].Statistics.BookFileCount != 1 {
+		t.Fatalf("books = %+v, want one ebook with bookFileCount 1", books)
+	}
+}
+
 // TestGetQueue asserts GetQueue hits the queue endpoint with includeAuthor=true
 // and decodes the records array.
 func TestGetQueue(t *testing.T) {

--- a/server/internal/request/handler.go
+++ b/server/internal/request/handler.go
@@ -106,6 +106,24 @@ func (h *Handler) GetBookStatus(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// GetBookLibrary returns the current user's reduced, cached Chaptarr library
+// digest (one entry per title with per-format ownership), so the app can mark
+// search results as already-owned. A user with no Chaptarr access gets an empty
+// digest, not an error.
+func (h *Handler) GetBookLibrary(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	digest, err := h.service.GetBookLibraryDigest(claims.UserID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, digest)
+}
+
 func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	claims := auth.GetClaims(r.Context())
 	if claims == nil {

--- a/server/internal/request/library.go
+++ b/server/internal/request/library.go
@@ -1,0 +1,185 @@
+package request
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
+)
+
+// bookLibraryCacheTTL bounds how long a user's reduced Chaptarr library digest
+// is served from cache before a fresh GetAllBooks. Short enough that a just-added
+// book shows as owned soon, long enough to spare Chaptarr a full library fetch on
+// every search keystroke.
+const bookLibraryCacheTTL = 120 * time.Second
+
+// FormatOwnership is one format's (ebook or audiobook) ownership state for a
+// title: whether Chaptarr is monitoring that format and whether a file is on
+// disk for it.
+type FormatOwnership struct {
+	Monitored  bool `json:"monitored"`
+	Downloaded bool `json:"downloaded"`
+}
+
+// LibraryTitle is one title in the owned-books digest, reduced from the (up to
+// two) Chaptarr records that share a foreignBookId. Both Ebook and Audiobook are
+// always present; a format with no record is the zero {false,false}.
+type LibraryTitle struct {
+	Title     string          `json:"title"`
+	Author    string          `json:"author"`
+	Year      int             `json:"year"`
+	Ebook     FormatOwnership `json:"ebook"`
+	Audiobook FormatOwnership `json:"audiobook"`
+}
+
+// BookLibraryDigest is the lean per-title ownership digest the app uses to mark
+// search results as already-owned. Titles is always a non-nil slice.
+type BookLibraryDigest struct {
+	Titles []LibraryTitle `json:"titles"`
+}
+
+// reduceLibrary collapses a flat Chaptarr library into one entry per title.
+// Chaptarr stores a title's ebook and audiobook as separate records sharing a
+// foreignBookId, so records are grouped by groupKey (foreignBookId, else the
+// record id) — mirroring the Dart ChaptarrBook.groupKey — and each record is
+// routed to the ebook or audiobook slot by its format. A record's format is its
+// book-level mediaType when set, else the format of its lone edition (else
+// unknown), matching the Dart ChaptarrBook.format fallback. Downloaded is keyed
+// off Statistics.BookFileCount (the hasFiles field is unreliable here).
+func reduceLibrary(books []chaptarr.Book) BookLibraryDigest {
+	type group struct {
+		title    *LibraryTitle
+		haveMeta bool // title/author/year already filled from a record with an author
+	}
+	groups := make(map[string]*group)
+	order := make([]string, 0, len(books))
+
+	for i := range books {
+		book := books[i]
+		key := groupKey(book)
+		g, ok := groups[key]
+		if !ok {
+			g = &group{title: &LibraryTitle{}}
+			groups[key] = g
+			order = append(order, key)
+		}
+
+		// Fill the title/author/year from the first record in the group that
+		// carries an author name, mirroring the Dart "first record with metadata"
+		// behavior.
+		if !g.haveMeta && book.Author != nil && book.Author.AuthorName != "" {
+			g.title.Title = book.Title
+			g.title.Author = book.Author.AuthorName
+			if book.ReleaseDate != nil {
+				g.title.Year = book.ReleaseDate.Year()
+			}
+			g.haveMeta = true
+		}
+		// Always keep a title even if no record had an author, so the digest never
+		// emits a blank title for a group that has records.
+		if g.title.Title == "" {
+			g.title.Title = book.Title
+		}
+
+		own := FormatOwnership{
+			Monitored:  book.Monitored,
+			Downloaded: book.Statistics.BookFileCount > 0,
+		}
+		switch recordFormat(book) {
+		case chaptarr.FormatEbook:
+			g.title.Ebook = own
+		case chaptarr.FormatAudiobook:
+			g.title.Audiobook = own
+		}
+	}
+
+	titles := make([]LibraryTitle, 0, len(order))
+	for _, key := range order {
+		titles = append(titles, *groups[key].title)
+	}
+	return BookLibraryDigest{Titles: titles}
+}
+
+// groupKey keys the records of one title: its foreignBookId when present, else a
+// per-record id key so records without a foreignBookId never merge. Mirrors the
+// Dart ChaptarrBook.groupKey.
+func groupKey(book chaptarr.Book) string {
+	if book.ForeignBookID != "" {
+		return book.ForeignBookID
+	}
+	return fmt.Sprintf("id:%d", book.ID)
+}
+
+// recordFormat resolves the single format a Chaptarr book record represents: its
+// book-level mediaType when "ebook"/"audiobook", else the format of its lone
+// edition via chaptarr.FormatOf (a book with anything other than exactly one
+// edition is "unknown"). Mirrors the Dart ChaptarrBook.format fallback.
+func recordFormat(book chaptarr.Book) string {
+	switch book.MediaType {
+	case chaptarr.FormatEbook:
+		return chaptarr.FormatEbook
+	case chaptarr.FormatAudiobook:
+		return chaptarr.FormatAudiobook
+	}
+	if len(book.Editions) == 1 {
+		return chaptarr.FormatOf(book.Editions[0].Format)
+	}
+	return chaptarr.FormatUnknown
+}
+
+// GetBookLibraryDigest returns the requesting user's reduced, cached Chaptarr
+// library digest. A user with no Chaptarr access gets an empty (non-nil) digest
+// rather than an error, so the app can degrade gracefully to "nothing owned".
+// The digest is cached per resolved Chaptarr instance for bookLibraryCacheTTL.
+func (s *Service) GetBookLibraryDigest(userID int64) (*BookLibraryDigest, error) {
+	client, instanceID := s.getChaptarrWithID(userID)
+	if client == nil {
+		return &BookLibraryDigest{Titles: []LibraryTitle{}}, nil
+	}
+
+	cacheKey := "book-library:" + instanceID
+	if s.libraryCache != nil {
+		if data, ok := s.libraryCache.Get(cacheKey); ok {
+			var digest BookLibraryDigest
+			if err := json.Unmarshal(data, &digest); err == nil {
+				if digest.Titles == nil {
+					digest.Titles = []LibraryTitle{}
+				}
+				return &digest, nil
+			}
+		}
+	}
+
+	books, err := client.GetAllBooks()
+	if err != nil {
+		return nil, err
+	}
+	digest := reduceLibrary(books)
+
+	if s.libraryCache != nil {
+		if data, err := json.Marshal(digest); err == nil {
+			s.libraryCache.Set(cacheKey, data, bookLibraryCacheTTL)
+		}
+	}
+	return &digest, nil
+}
+
+// getChaptarrWithID resolves the same Chaptarr client as getChaptarr but also
+// returns the instance id it resolved to, for cache keying. The id mirrors
+// getChaptarr's resolution: the user's granted instance, else (for admins) the
+// default Chaptarr instance.
+func (s *Service) getChaptarrWithID(userID int64) (*chaptarr.Client, string) {
+	if s.registry == nil {
+		return nil, ""
+	}
+	if client, id, err := s.registry.GetUserChaptarrClient(userID); err == nil && client != nil {
+		return client, id
+	}
+	if s.userIsAdmin(userID) {
+		if client, id, err := s.registry.GetDefaultChaptarrClient(); err == nil && client != nil {
+			return client, id
+		}
+	}
+	return nil, ""
+}

--- a/server/internal/request/library_test.go
+++ b/server/internal/request/library_test.go
@@ -1,0 +1,143 @@
+package request
+
+import (
+	"testing"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
+)
+
+// findTitle returns the digest title whose Title matches, or fails.
+func findTitle(t *testing.T, d BookLibraryDigest, title string) LibraryTitle {
+	t.Helper()
+	for _, lt := range d.Titles {
+		if lt.Title == title {
+			return lt
+		}
+	}
+	t.Fatalf("title %q not found in digest %+v", title, d.Titles)
+	return LibraryTitle{}
+}
+
+// TestReduceLibraryMergesFormatsByForeignBookID asserts the two records of one
+// title (same foreignBookId, distinct mediaType) collapse into a single title
+// with each format routed to its slot, and that downloaded comes from
+// Statistics.BookFileCount.
+func TestReduceLibraryMergesFormatsByForeignBookID(t *testing.T) {
+	rel := time.Date(1991, 5, 1, 0, 0, 0, 0, time.UTC)
+	books := []chaptarr.Book{
+		{
+			ID:            1,
+			Title:         "Heir to the Empire",
+			ForeignBookID: "fb-1",
+			MediaType:     "ebook",
+			Monitored:     true,
+			ReleaseDate:   &rel,
+			Author:        &chaptarr.AuthorContext{AuthorName: "Timothy Zahn"},
+			Statistics:    chaptarr.BookStatistics{BookFileCount: 1},
+		},
+		{
+			ID:            2,
+			Title:         "Heir to the Empire",
+			ForeignBookID: "fb-1",
+			MediaType:     "audiobook",
+			Monitored:     true,
+			Author:        &chaptarr.AuthorContext{AuthorName: "Timothy Zahn"},
+			Statistics:    chaptarr.BookStatistics{BookFileCount: 0},
+		},
+	}
+
+	digest := reduceLibrary(books)
+	if len(digest.Titles) != 1 {
+		t.Fatalf("len(titles) = %d, want 1 (digest %+v)", len(digest.Titles), digest.Titles)
+	}
+	lt := digest.Titles[0]
+	if lt.Title != "Heir to the Empire" || lt.Author != "Timothy Zahn" || lt.Year != 1991 {
+		t.Fatalf("title meta = %+v, want Heir to the Empire / Timothy Zahn / 1991", lt)
+	}
+	if !lt.Ebook.Monitored || !lt.Ebook.Downloaded {
+		t.Errorf("ebook = %+v, want monitored && downloaded", lt.Ebook)
+	}
+	if !lt.Audiobook.Monitored || lt.Audiobook.Downloaded {
+		t.Errorf("audiobook = %+v, want monitored && !downloaded", lt.Audiobook)
+	}
+}
+
+// TestReduceLibraryRoutesByLoneEditionFormat asserts a record with no mediaType
+// is routed by the format of its single edition (EPUB -> ebook).
+func TestReduceLibraryRoutesByLoneEditionFormat(t *testing.T) {
+	books := []chaptarr.Book{
+		{
+			ID:            5,
+			Title:         "Some Ebook",
+			ForeignBookID: "fb-5",
+			MediaType:     "", // no book-level format
+			Monitored:     true,
+			Author:        &chaptarr.AuthorContext{AuthorName: "An Author"},
+			Statistics:    chaptarr.BookStatistics{BookFileCount: 1},
+			Editions:      []chaptarr.Edition{{Format: "EPUB"}},
+		},
+	}
+
+	digest := reduceLibrary(books)
+	lt := findTitle(t, digest, "Some Ebook")
+	if !lt.Ebook.Monitored || !lt.Ebook.Downloaded {
+		t.Errorf("ebook = %+v, want monitored && downloaded (routed from lone EPUB edition)", lt.Ebook)
+	}
+	if lt.Audiobook != (FormatOwnership{}) {
+		t.Errorf("audiobook = %+v, want zero (no audiobook record)", lt.Audiobook)
+	}
+}
+
+// TestReduceLibraryDoesNotMergeWithoutForeignBookID asserts two records that
+// both lack a foreignBookId stay distinct (keyed by their record id), so
+// unrelated records never collapse into one title.
+func TestReduceLibraryDoesNotMergeWithoutForeignBookID(t *testing.T) {
+	books := []chaptarr.Book{
+		{ID: 10, Title: "Book Ten", MediaType: "ebook", Author: &chaptarr.AuthorContext{AuthorName: "A"}},
+		{ID: 11, Title: "Book Eleven", MediaType: "ebook", Author: &chaptarr.AuthorContext{AuthorName: "B"}},
+	}
+
+	digest := reduceLibrary(books)
+	if len(digest.Titles) != 2 {
+		t.Fatalf("len(titles) = %d, want 2 (digest %+v)", len(digest.Titles), digest.Titles)
+	}
+}
+
+// TestReduceLibraryEmptyInputNonNilSlice asserts an empty library reduces to a
+// non-nil empty Titles slice (so it serializes as [] not null).
+func TestReduceLibraryEmptyInputNonNilSlice(t *testing.T) {
+	digest := reduceLibrary(nil)
+	if digest.Titles == nil {
+		t.Fatalf("Titles is nil, want non-nil empty slice")
+	}
+	if len(digest.Titles) != 0 {
+		t.Fatalf("len(Titles) = %d, want 0", len(digest.Titles))
+	}
+}
+
+// TestReduceLibraryDownloadedUsesBookFileCount asserts downloaded is derived
+// from Statistics.BookFileCount, not from any hasFiles-style flag: a record with
+// BookFileCount == 0 is not downloaded even though it is monitored.
+func TestReduceLibraryDownloadedUsesBookFileCount(t *testing.T) {
+	books := []chaptarr.Book{
+		{
+			ID:            20,
+			Title:         "Monitored Not Downloaded",
+			ForeignBookID: "fb-20",
+			MediaType:     "ebook",
+			Monitored:     true,
+			Author:        &chaptarr.AuthorContext{AuthorName: "A"},
+			Statistics:    chaptarr.BookStatistics{BookFileCount: 0, BookCount: 1},
+		},
+	}
+
+	digest := reduceLibrary(books)
+	lt := findTitle(t, digest, "Monitored Not Downloaded")
+	if !lt.Ebook.Monitored {
+		t.Errorf("ebook.monitored = false, want true")
+	}
+	if lt.Ebook.Downloaded {
+		t.Errorf("ebook.downloaded = true, want false (BookFileCount is 0)")
+	}
+}

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/windoze95/cantinarr-server/internal/cache"
 	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
@@ -58,14 +59,18 @@ type Service struct {
 	registry *instance.Registry
 	bridge   *tmdb.Bridge
 	notifier Notifier
+	// libraryCache holds reduced Chaptarr library digests keyed by instance id,
+	// so the owned-books digest doesn't refetch the whole library on every call.
+	libraryCache *cache.Cache
 }
 
 func NewService(db *sql.DB, registry *instance.Registry, bridge *tmdb.Bridge, notifier Notifier) *Service {
 	return &Service{
-		db:       db,
-		registry: registry,
-		bridge:   bridge,
-		notifier: notifier,
+		db:           db,
+		registry:     registry,
+		bridge:       bridge,
+		notifier:     notifier,
+		libraryCache: cache.New(),
 	}
 }
 


### PR DESCRIPTION
When searching a book to request, the dashboard didn't know what the user already **owns** in their Chaptarr library — so it offered "Request" for a title they'd already downloaded (e.g. *Heir to the Empire* eBook) and let them re-request a format they have.

## The hard constraint
Chaptarr's `/book/lookup` is metadata-only: results carry **no** library id (always null), and their foreignBookIds **don't** match owned records (owned *Heir to the Empire* is `340125`, lookup says `40604754`). So ownership must be matched by **normalized title + author** (fuzzy). The full library is ~11 MB and the app's 15 s client timeout + no-compression proxy can't pull it → the **backend serves a lean cached digest**.

## Backend
- `chaptarr.Client`: parse the dropped `mediaType`; add `GetAllBooks()`.
- New `request/library.go`: `reduceLibrary()` collapses the library into one entry per title (grouped by foreignBookId, mirroring the Dart `groupKey`), with per-format `{monitored, downloaded}` where `downloaded = Statistics.BookFileCount > 0` (the `hasFiles` field is buggy). `GET /api/requests/book-library` returns the digest, cached **120 s per resolved instance**; no Chaptarr grant → empty digest (never errors).

## App
- New `BookOwnership` model + a **dependency-free fuzzy matcher** (token-set Jaccard over normalized titles — strips "Star Wars:" prefixes, part numbers, punctuation — gated by an author check to avoid the real two-author "Meditations & The Art of War" collision).
- **Single seam:** `BookRequestStatusDetail.isCovered` now unions request state with library ownership (and "both" = each concrete format covered), so the chip, the request gating, and "hide both when one remains" all flow from one place. The request sheet greys out a format you already own; `coverageLabel` shows "Downloaded"/"In Library".
- Dashboard marks results with an ownership chip, **floats owned titles to the top** (without collapsing distinct versions you might still want), and removes the dead `id != 0` gate.

## Verification
- Go reducer tests + Dart matcher/gating tests; full Go suite + 157 Flutter tests pass; analyze clean.
- **End-to-end against the live library**: the reducer turned 1,972 records → 1,027 titles and *Heir to the Empire* came out `ebook={monitored,downloaded}, audiobook={false,false}` — exactly what marks its search row "Downloaded", sorts it up, and disables eBook while keeping Audiobook offerable.

Known limitation (by design): matching is fuzzy/approximate; "owned" counts monitored-but-not-downloaded as covered (the chip distinguishes "In Library" vs "Downloaded"). Built with a swarm: backend digest + app matcher in parallel, integration + verification here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)