### PR TITLE
Books search: surface owned/monitored library books the lookup missed

### DIFF
--- a/app/lib/features/dashboard/logic/book_ownership_matcher.dart
+++ b/app/lib/features/dashboard/logic/book_ownership_matcher.dart
@@ -127,34 +127,90 @@ double _titleScore(ChaptarrBook result, OwnedTitle owned) {
   return stripped > kept ? stripped : kept;
 }
 
-/// Decides whether the user already owns [result], by matching it against the
-/// ownership [digest].
-///
-/// A digest row is a candidate when its [_titleScore] >= [kOwnershipTitleThreshold]
-/// AND either the authors match ([authorMatches]) or — when an author is missing
-/// on either side — the title score is high enough (>= 0.9) to stand on its own.
-/// Returns the [BookOwnership] of the highest-scoring candidate, or null when no
-/// row qualifies.
-BookOwnership? ownershipFor(ChaptarrBook result, List<OwnedTitle> digest) {
+/// Digest rows that match [result]: title score >= [kOwnershipTitleThreshold]
+/// AND the authors match (or, when an author is missing on either side, the
+/// title score stands alone at >= 0.9). A title can have more than one matching
+/// row when its ebook and audiobook records didn't share a foreignBookId.
+List<OwnedTitle> _matchingTitles(ChaptarrBook result, List<OwnedTitle> digest) {
   final lookupAuthor = result.author?.authorName;
   final lookupAuthorEmpty = lookupAuthor == null || lookupAuthor.isEmpty;
-
-  BookOwnership? best;
-  double bestScore = -1;
-
+  final out = <OwnedTitle>[];
   for (final owned in digest) {
     final score = _titleScore(result, owned);
     if (score < kOwnershipTitleThreshold) continue;
-
     final authorOk = authorMatches(lookupAuthor, owned.author) ||
         ((lookupAuthorEmpty || owned.author.isEmpty) && score >= 0.9);
-    if (!authorOk) continue;
+    if (authorOk) out.add(owned);
+  }
+  return out;
+}
 
-    if (score > bestScore) {
-      bestScore = score;
-      best = owned.ownership;
+/// Combines several rows' ownership: a format is owned/downloaded if it is in
+/// any of them (so split ebook/audiobook records merge into one truth).
+BookOwnership _mergeOwnership(Iterable<BookOwnership> owns) {
+  var em = false, ed = false, am = false, ad = false;
+  for (final o in owns) {
+    em = em || o.ebook.monitored;
+    ed = ed || o.ebook.downloaded;
+    am = am || o.audiobook.monitored;
+    ad = ad || o.audiobook.downloaded;
+  }
+  return BookOwnership(
+    ebook: FormatOwnership(monitored: em, downloaded: ed),
+    audiobook: FormatOwnership(monitored: am, downloaded: ad),
+  );
+}
+
+/// Decides whether the user already owns [result], by matching it against the
+/// ownership [digest]. Returns the merged ownership across every matching digest
+/// row (so a title split into separate ebook/audiobook rows still reports both),
+/// or null when no row qualifies.
+BookOwnership? ownershipFor(ChaptarrBook result, List<OwnedTitle> digest) {
+  final matches = _matchingTitles(result, digest);
+  if (matches.isEmpty) return null;
+  return _mergeOwnership(matches.map((t) => t.ownership));
+}
+
+/// Owned digest titles matching the search [query] (every query token appears in
+/// the title) that the [lookupResults] didn't already return — deduped by
+/// normalized title+author with ownership merged. These are injected at the top
+/// of the results so a book the user owns/monitors surfaces even when Chaptarr's
+/// metadata search doesn't rank it.
+List<OwnedTitle> ownedTitlesForQuery(
+  String query,
+  List<OwnedTitle> digest,
+  List<ChaptarrBook> lookupResults,
+) {
+  final queryTokens = normalizeTitleTokens(query).toSet();
+  if (queryTokens.isEmpty) return const [];
+
+  final byKey = <String, List<OwnedTitle>>{};
+  final keyOrder = <String>[];
+  for (final owned in digest) {
+    final titleTokens = normalizeTitleTokens(owned.title).toSet();
+    if (titleTokens.isEmpty) continue;
+    // The query must be contained in the title (a partial-name match).
+    if (!queryTokens.every(titleTokens.contains)) continue;
+    // Skip when a lookup result already represents this owned title.
+    if (lookupResults.any((r) => _matchingTitles(r, [owned]).isNotEmpty)) {
+      continue;
     }
+    final key =
+        '${titleTokens.join(' ')}|${_authorTokens(owned.author).join(' ')}';
+    if (byKey[key] == null) {
+      byKey[key] = [];
+      keyOrder.add(key);
+    }
+    byKey[key]!.add(owned);
   }
 
-  return best;
+  return [
+    for (final key in keyOrder)
+      OwnedTitle(
+        title: byKey[key]!.first.title,
+        author: byKey[key]!.first.author,
+        year: byKey[key]!.first.year,
+        ownership: _mergeOwnership(byKey[key]!.map((o) => o.ownership)),
+      ),
+  ];
 }

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -32,6 +32,7 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
   bool _searched = false;
   String? _error;
   int _searchGen = 0; // guards against superseded async results
+  String _searchedTerm = ''; // term the current _results belong to
 
   @override
   void dispose() {
@@ -82,6 +83,7 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
       if (!mounted || gen != _searchGen) return;
       setState(() {
         _results = books;
+        _searchedTerm = term;
         _isSearching = false;
         _searched = true;
       });
@@ -168,7 +170,32 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
         ),
       );
     }
-    if (_results.isEmpty) {
+    // What the user already owns, used to mark results, gate per-format
+    // requests, and surface owned/monitored books the metadata search missed.
+    final digest =
+        ref.watch(ownedBooksProvider).valueOrNull ?? const <OwnedTitle>[];
+    // Owned library titles matching the query that lookup didn't return — shown
+    // first as "you already have this" rows. They carry no foreignBookId, so
+    // they're informational (no Request button).
+    final injected = digest.isEmpty
+        ? const <OwnedTitle>[]
+        : ownedTitlesForQuery(_searchedTerm, digest, _results);
+    // Mark each lookup result with its ownership and float owned titles to the
+    // top, preserving Chaptarr's relevance order within each bucket (don't
+    // collapse versions — the user wants to see ones they don't own).
+    final owned = <(ChaptarrBook, BookOwnership?)>[];
+    final rest = <(ChaptarrBook, BookOwnership?)>[];
+    for (final book in _results) {
+      final o = digest.isEmpty ? null : ownershipFor(book, digest);
+      ((o?.anyOwned ?? false) ? owned : rest).add((book, o));
+    }
+    final ordered = <(ChaptarrBook, BookOwnership?)>[
+      for (final t in injected) (_ownedTitleAsBook(t), t.ownership),
+      ...owned,
+      ...rest,
+    ];
+
+    if (ordered.isEmpty) {
       return Center(
         child: Padding(
           padding: const EdgeInsets.all(32),
@@ -194,19 +221,6 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
     // backend's /requests endpoint, not the Chaptarr proxy).
     final requestService =
         RequestService(backendDio: ref.read(backendClientProvider));
-    // What the user already owns, to mark results and gate per-format requests.
-    final digest =
-        ref.watch(ownedBooksProvider).valueOrNull ?? const <OwnedTitle>[];
-    // Compute ownership per result and float owned titles to the top, preserving
-    // Chaptarr's relevance order within each bucket (don't collapse versions —
-    // the user wants to see ones they don't own).
-    final owned = <(ChaptarrBook, BookOwnership?)>[];
-    final rest = <(ChaptarrBook, BookOwnership?)>[];
-    for (final book in _results) {
-      final o = digest.isEmpty ? null : ownershipFor(book, digest);
-      ((o?.anyOwned ?? false) ? owned : rest).add((book, o));
-    }
-    final ordered = [...owned, ...rest];
     return ListView.separated(
       padding: const EdgeInsets.symmetric(vertical: 8),
       itemCount: ordered.length,
@@ -324,6 +338,16 @@ Widget? _ownershipChip(BookOwnership? o) {
     color: downloaded ? AppTheme.available : AppTheme.requested,
   );
 }
+
+/// A synthetic, non-requestable result for an owned library title the metadata
+/// search didn't return. The digest carries no foreignBookId, so the tile shows
+/// the ownership chip with no Request button.
+ChaptarrBook _ownedTitleAsBook(OwnedTitle t) => ChaptarrBook(
+      id: 0,
+      title: t.title,
+      author: ChaptarrAuthorContext(id: 0, authorName: t.author),
+      releaseDate: t.year > 0 ? DateTime(t.year) : null,
+    );
 
 /// A small colored pill marking that a search result is already in the library.
 class _OwnershipChip extends StatelessWidget {

--- a/app/test/dashboard/book_ownership_matcher_test.dart
+++ b/app/test/dashboard/book_ownership_matcher_test.dart
@@ -154,5 +154,62 @@ void main() {
       final result = _result('Heir to the Empire', author: 'Timothy Zahn');
       expect(ownershipFor(result, const []), isNull);
     });
+
+    test('merges ownership across split ebook/audiobook rows', () {
+      final digest = [
+        _owned('Heir to the Empire', 'Timothy Zahn', ebookDownloaded: true),
+        _owned('Heir to the Empire', 'Timothy Zahn', audiobookMonitored: true),
+      ];
+      final o = ownershipFor(
+        _result('Star Wars: Heir to the Empire', author: 'Timothy Zahn'),
+        digest,
+      );
+      expect(o, isNotNull);
+      expect(o!.ebook.downloaded, isTrue);
+      expect(o.audiobook.monitored, isTrue);
+    });
+  });
+
+  group('ownedTitlesForQuery surfaces owned books lookup missed', () {
+    final digest = [
+      _owned('Heir to the Empire', 'Timothy Zahn', ebookDownloaded: true),
+      _owned('Dune', 'Frank Herbert', ebookMonitored: true),
+    ];
+
+    test('injects an owned title matching the query but absent from lookup', () {
+      final lookup = [
+        _result('Heir of Fire', author: 'Sarah J. Maas'),
+        _result('The Heir', author: 'Kiera Cass'),
+      ];
+      final injected = ownedTitlesForQuery('heir', digest, lookup);
+      expect(injected.map((t) => t.title), ['Heir to the Empire']);
+      expect(injected.single.ownership.ebook.downloaded, isTrue);
+    });
+
+    test('does not inject a title a lookup result already represents', () {
+      final lookup = [
+        _result('Star Wars: Heir to the Empire', author: 'Timothy Zahn'),
+      ];
+      expect(ownedTitlesForQuery('heir', digest, lookup), isEmpty);
+    });
+
+    test('merges split rows into one injected entry', () {
+      final split = [
+        _owned('Heir to the Empire', 'Timothy Zahn', ebookDownloaded: true),
+        _owned('Heir to the Empire', 'Timothy Zahn', audiobookMonitored: true),
+      ];
+      final injected = ownedTitlesForQuery('heir', split, const []);
+      expect(injected.length, 1);
+      expect(injected.single.ownership.ebook.downloaded, isTrue);
+      expect(injected.single.ownership.audiobook.monitored, isTrue);
+    });
+
+    test('an empty query injects nothing', () {
+      expect(ownedTitlesForQuery('', digest, const []), isEmpty);
+    });
+
+    test('a query matching no owned title injects nothing', () {
+      expect(ownedTitlesForQuery('foundation', digest, const []), isEmpty);
+    });
   });
 }


### PR DESCRIPTION
Follow-up to #117. Searching e.g. **"heir"** returned only metadata results, so *Heir to the Empire* — which the user owns — never appeared: Chaptarr's lookup doesn't rank it for that term, and ownership can only be matched against results that come back. Now **owned/monitored library titles matching the query are injected at the top**, even when lookup doesn't return them ("it searches books we have or are monitoring first").

## Changes
- `book_ownership_matcher`: new `ownedTitlesForQuery()` — digest titles whose normalized tokens contain every query token, excluding any a lookup row already represents, deduped by title+author with ownership merged. Also made `ownershipFor()` **aggregate** ownership across all matching digest rows (so a title whose ebook/audiobook records didn't share a `foreignBookId` still reports both formats).
- `dashboard_books_tab`: compute injection from the searched term and prepend the matches as synthetic, non-requestable "you already have this" rows (the digest has no `foreignBookId`, so they're informational — chip, no Request button); the empty state is now based on the combined list.

## Verification
- New matcher tests: injects a missed owned title, skips one a lookup result already covers, merges split rows, empty/no-match → empty; plus merged `ownershipFor`. Full suite: **163 Flutter tests pass**, analyze clean.
- Matches the live scenario exactly: digest *Heir to the Empire* (Zahn, ebook downloaded) + lookup `["Heir of Fire", "The Heir", …]` → injects *Heir to the Empire* at the top.

Known limitation (by design): injected rows are informational — to request the *other* format of an owned title, use a search term that lookup returns it for (it then shows "Request more").

🤖 Generated with [Claude Code](https://claude.com/claude-code)