### PR TITLE
Books: keep Request/Request more until both files are present

### DIFF
--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -256,8 +256,11 @@ class _BookResultTile extends StatelessWidget {
     final fid = book.foreignBookId;
     final o = ownership;
     // Lookup results never carry a library id (always null), so ownership comes
-    // from the owned-books digest, matched by title+author.
-    final bothOwned = o != null && o.ebook.owned && o.audiobook.owned;
+    // from the owned-books digest, matched by title+author. Only hide the request
+    // affordance when BOTH files are present — a format that's missing or merely
+    // monitored can still be requested.
+    final bothDownloaded =
+        o != null && o.ebook.downloaded && o.audiobook.downloaded;
     final chip = _ownershipChip(o);
 
     return ListTile(
@@ -314,9 +317,9 @@ class _BookResultTile extends StatelessWidget {
                 ],
               ),
             ),
-      // Fully-owned titles show only the chip; otherwise offer a request for the
-      // format(s) the user neither owns nor already requested.
-      trailing: bothOwned
+      // Both files present → just the chip; otherwise offer Request / Request
+      // more for the format(s) without a file (the button gates per format).
+      trailing: bothDownloaded
           ? null
           : (fid != null && fid.isNotEmpty)
               ? _BookRequestButton(

--- a/app/lib/features/request/data/request_service.dart
+++ b/app/lib/features/request/data/request_service.dart
@@ -52,9 +52,10 @@ enum BookRequestFormat {
 /// A user's per-format request state for a book. [status] is the collapsed
 /// (latest) state; [formats] maps each already-requested concrete format to its
 /// status (a stored "both" request fills both ebook and audiobook); [ownership]
-/// is what the user already has in the Chaptarr library. A format is covered
-/// (no longer requestable) when it's already requested OR already owned, so the
-/// dashboard keeps offering only the formats the user neither requested nor owns.
+/// is what the user already has in the Chaptarr library. A format is covered (no
+/// longer requestable) when it's already requested OR its file is already
+/// present (downloaded). A format that's only *monitored* (tracked but no file
+/// yet) stays requestable, so the user can still pull the missing file.
 class BookRequestStatusDetail {
   final RequestStatus status;
   final Map<BookRequestFormat, RequestStatus> formats;
@@ -71,17 +72,18 @@ class BookRequestStatusDetail {
       BookRequestStatusDetail(
           status: status, formats: formats, ownership: ownership);
 
-  /// Covered = already requested (non-denied) OR already owned in the library.
-  /// "both" is covered only when each concrete format is covered (possibly from
-  /// different sources — e.g. ebook owned + audiobook requested). The backend
-  /// expands a stored "both" request into ebook+audiobook, so [formats] never
-  /// carries a literal "both" key.
+  /// Covered = already requested (non-denied) OR its file is downloaded. A
+  /// merely-monitored format (no file) is NOT covered — the user should still be
+  /// able to request the missing file. "both" is covered only when each concrete
+  /// format is covered (possibly from different sources — e.g. ebook downloaded +
+  /// audiobook requested). The backend expands a stored "both" request into
+  /// ebook+audiobook, so [formats] never carries a literal "both" key.
   bool isCovered(BookRequestFormat format) {
     if (format == BookRequestFormat.both) {
       return isCovered(BookRequestFormat.ebook) &&
           isCovered(BookRequestFormat.audiobook);
     }
-    return _requestCovered(format) || _ownershipCovers(format);
+    return _requestCovered(format) || _downloaded(format);
   }
 
   bool _requestCovered(BookRequestFormat format) {
@@ -91,18 +93,18 @@ class BookRequestStatusDetail {
         s != RequestStatus.unavailable;
   }
 
-  bool _ownershipCovers(BookRequestFormat format) {
+  bool _downloaded(BookRequestFormat format) {
     final o = ownership;
     if (o == null) return false;
     return switch (format) {
-      BookRequestFormat.ebook => o.ebook.owned,
-      BookRequestFormat.audiobook => o.audiobook.owned,
-      BookRequestFormat.both => o.ebook.owned && o.audiobook.owned,
+      BookRequestFormat.ebook => o.ebook.downloaded,
+      BookRequestFormat.audiobook => o.audiobook.downloaded,
+      BookRequestFormat.both => o.ebook.downloaded && o.audiobook.downloaded,
     };
   }
 
   /// Short reason a [format] is covered, for the request sheet: a request status
-  /// label, else "Downloaded"/"In Library" from library ownership, else null.
+  /// label, else "Downloaded" when the file is present, else null.
   String? coverageLabel(BookRequestFormat format) {
     if (!isCovered(format)) return null;
     final reqKey =
@@ -113,13 +115,7 @@ class BookRequestStatusDetail {
         s != RequestStatus.unavailable) {
       return s.label;
     }
-    final o = ownership;
-    if (o != null) {
-      final fo = format == BookRequestFormat.audiobook ? o.audiobook : o.ebook;
-      if (fo.downloaded) return 'Downloaded';
-      if (fo.monitored) return 'In Library';
-    }
-    return null;
+    return _downloaded(format) ? 'Downloaded' : null;
   }
 }
 

--- a/app/test/request/book_ownership_gating_test.dart
+++ b/app/test/request/book_ownership_gating_test.dart
@@ -13,12 +13,25 @@ void main() {
       expect(d.coverageLabel(BookRequestFormat.ebook), 'Downloaded');
     });
 
-    test('a monitored-only ebook is covered, labeled "In Library"', () {
+    test('a monitored-only ebook (no file) stays requestable', () {
       const d = BookRequestStatusDetail(
         ownership: BookOwnership(ebook: FormatOwnership(monitored: true)),
       );
-      expect(d.isCovered(BookRequestFormat.ebook), isTrue);
-      expect(d.coverageLabel(BookRequestFormat.ebook), 'In Library');
+      expect(d.isCovered(BookRequestFormat.ebook), isFalse);
+      expect(d.coverageLabel(BookRequestFormat.ebook), isNull);
+    });
+
+    test('downloaded ebook + monitored-only audiobook keeps audiobook open', () {
+      const d = BookRequestStatusDetail(
+        ownership: BookOwnership(
+          ebook: FormatOwnership(downloaded: true),
+          audiobook: FormatOwnership(monitored: true),
+        ),
+      );
+      expect(d.isCovered(BookRequestFormat.ebook), isTrue); // file present
+      expect(d.isCovered(BookRequestFormat.audiobook), isFalse); // no file yet
+      expect(d.isCovered(BookRequestFormat.both), isFalse);
+      expect(d.coverageLabel(BookRequestFormat.ebook), 'Downloaded');
     });
 
     test('owned ebook + requested audiobook → both covered, labels distinct',
@@ -38,7 +51,7 @@ void main() {
     test('withOwnership attaches ownership without mutating the original', () {
       const base = BookRequestStatusDetail();
       final withOwn = base.withOwnership(
-          const BookOwnership(audiobook: FormatOwnership(monitored: true)));
+          const BookOwnership(audiobook: FormatOwnership(downloaded: true)));
       expect(withOwn.isCovered(BookRequestFormat.audiobook), isTrue);
       expect(base.isCovered(BookRequestFormat.audiobook), isFalse);
     });


### PR DESCRIPTION
Follow-up to #117/#118. On a title where the user has the **ebook file** but not the audiobook (e.g. *Ahsoka* — ebook downloaded, audiobook only monitored), the search row showed a "Downloaded" chip and **no way to pull the audiobook**. The gating counted a merely-*monitored* format (tracked in Chaptarr but no file yet) as "covered".

Per the report: *"unless both ebook and audiobook files are present for a title, there should be a request or request more still."*

## Fix — coverage is about files, not monitoring
- `request_service`: `isCovered` now uses **downloaded** (not `monitored || downloaded`). A format is covered only when its file is present or a request is already in flight; a monitored-without-a-file format stays requestable. `coverageLabel` drops the now-unreachable "In Library" branch.
- `dashboard_books_tab`: hide the request affordance only on **bothDownloaded** (both files present) instead of "both owned" — otherwise the row offers **Request / Request more** for the missing format(s).

Net: *Ahsoka* now shows the "Downloaded" chip **and** "Request more", and the format sheet greys the ebook ("Downloaded") while offering the audiobook.

## Verification
New/updated gating tests (monitored-only stays requestable; downloaded ebook + monitored audiobook keeps the audiobook open); **164 Flutter tests pass**, analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)