### PR TITLE
Books/authors: load cover + author art, and share one tuned image cache

### DIFF
--- a/app/lib/core/network/app_image_cache.dart
+++ b/app/lib/core/network/app_image_cache.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+/// One shared image cache for the whole app. Posters, covers, author and person
+/// photos all live here so a poster fetched on the dashboard is reused on a
+/// detail screen, and the cache is bounded sensibly for an image-heavy media app
+/// (the per-widget default cache manager only holds ~200 objects).
+///
+/// Disk cache: up to [_maxObjects] files, evicted after [_stalePeriod].
+final BaseCacheManager appImageCache = CacheManager(
+  Config(
+    'cantinarrImageCache',
+    stalePeriod: _stalePeriod,
+    maxNrOfCacheObjects: _maxObjects,
+  ),
+);
+
+const Duration _stalePeriod = Duration(days: 30);
+const int _maxObjects = 1000;

--- a/app/lib/core/widgets/cached_image.dart
+++ b/app/lib/core/widgets/cached_image.dart
@@ -1,0 +1,66 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../network/app_image_cache.dart';
+import '../theme/app_theme.dart';
+
+/// The app's one network-image widget. Every poster/cover/photo goes through it
+/// so they share [appImageCache] and render a consistent placeholder, error
+/// fallback, and fade-in. Pass [headers] for images behind the authenticated
+/// instance proxy (e.g. Chaptarr `/MediaCover`).
+class CachedImage extends StatelessWidget {
+  /// Absolute image URL. A null/empty url renders the [icon] fallback.
+  final String? url;
+
+  /// Optional request headers (e.g. a bearer token for the backend proxy).
+  final Map<String, String>? headers;
+
+  final BoxFit fit;
+
+  /// Icon shown for an empty url or a load failure.
+  final IconData icon;
+  final double iconSize;
+
+  final double? width;
+  final double? height;
+
+  const CachedImage({
+    super.key,
+    required this.url,
+    this.headers,
+    this.fit = BoxFit.cover,
+    this.icon = Icons.image_outlined,
+    this.iconSize = 20,
+    this.width,
+    this.height,
+  });
+
+  Widget _fallback() => Container(
+        width: width,
+        height: height,
+        color: AppTheme.surfaceVariant,
+        alignment: Alignment.center,
+        child: Icon(icon, color: AppTheme.textSecondary, size: iconSize),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final src = url;
+    if (src == null || src.isEmpty) return _fallback();
+    return CachedNetworkImage(
+      imageUrl: src,
+      httpHeaders: headers,
+      cacheManager: appImageCache,
+      fit: fit,
+      width: width,
+      height: height,
+      fadeInDuration: const Duration(milliseconds: 200),
+      placeholder: (_, __) => Container(
+        width: width,
+        height: height,
+        color: AppTheme.surfaceVariant,
+      ),
+      errorWidget: (_, __, ___) => _fallback(),
+    );
+  }
+}

--- a/app/lib/core/widgets/media_card.dart
+++ b/app/lib/core/widgets/media_card.dart
@@ -1,7 +1,7 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import '../config/app_config.dart';
 import '../theme/app_theme.dart';
+import 'cached_image.dart';
 
 /// A poster card for movies/TV shows with optional status badge.
 class MediaCard extends StatelessWidget {
@@ -49,33 +49,12 @@ class MediaCard extends StatelessWidget {
                 child: Stack(
                   fit: StackFit.expand,
                   children: [
-                    if (posterPath != null)
-                      CachedNetworkImage(
-                        imageUrl: imageUrl,
-                        fit: BoxFit.cover,
-                        placeholder: (_, __) => Container(
-                          color: AppTheme.surfaceVariant,
-                          child: const Center(
-                            child: Icon(Icons.movie_outlined,
-                                color: AppTheme.textSecondary, size: 32),
-                          ),
-                        ),
-                        errorWidget: (_, __, ___) => Container(
-                          color: AppTheme.surfaceVariant,
-                          child: const Center(
-                            child: Icon(Icons.broken_image_outlined,
-                                color: AppTheme.textSecondary, size: 32),
-                          ),
-                        ),
-                      )
-                    else
-                      Container(
-                        color: AppTheme.surfaceVariant,
-                        child: const Center(
-                          child: Icon(Icons.movie_outlined,
-                              color: AppTheme.textSecondary, size: 32),
-                        ),
-                      ),
+                    CachedImage(
+                      url: posterPath == null ? null : imageUrl,
+                      fit: BoxFit.cover,
+                      icon: Icons.movie_outlined,
+                      iconSize: 32,
+                    ),
 
                     // Status badge
                     if (statusLabel != null)

--- a/app/lib/core/widgets/media_header.dart
+++ b/app/lib/core/widgets/media_header.dart
@@ -1,7 +1,9 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import '../config/app_config.dart';
+import '../network/app_image_cache.dart';
 import '../theme/app_theme.dart';
+import 'cached_image.dart';
 
 /// A hero-style header with backdrop, poster, title, and status.
 class MediaHeader extends StatelessWidget {
@@ -45,6 +47,7 @@ class MediaHeader extends StatelessWidget {
               child: CachedNetworkImage(
                 imageUrl: AppConfig.tmdbBackdrop(backdropPath, width: 1280),
                 fit: BoxFit.cover,
+                cacheManager: appImageCache,
               ),
             ),
           ),
@@ -65,16 +68,14 @@ class MediaHeader extends StatelessWidget {
                 child: SizedBox(
                   width: 110,
                   height: 165,
-                  child: posterPath != null
-                      ? CachedNetworkImage(
-                          imageUrl: AppConfig.tmdbPoster(posterPath),
-                          fit: BoxFit.cover,
-                        )
-                      : Container(
-                          color: AppTheme.surfaceVariant,
-                          child: const Icon(Icons.movie_outlined,
-                              color: AppTheme.textSecondary, size: 40),
-                        ),
+                  child: CachedImage(
+                    url: posterPath == null
+                        ? null
+                        : AppConfig.tmdbPoster(posterPath),
+                    fit: BoxFit.cover,
+                    icon: Icons.movie_outlined,
+                    iconSize: 40,
+                  ),
                 ),
               ),
               const SizedBox(width: 16),

--- a/app/lib/features/ai_assistant/ui/chat_bubble.dart
+++ b/app/lib/features/ai_assistant/ui/chat_bubble.dart
@@ -1,8 +1,8 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/config/app_config.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../data/ai_models.dart';
 
 /// A single chat message bubble with optional media result cards.
@@ -358,33 +358,12 @@ class _MediaResultCard extends StatelessWidget {
                 child: Stack(
                   fit: StackFit.expand,
                   children: [
-                    if (item.posterPath != null)
-                      CachedNetworkImage(
-                        imageUrl: imageUrl,
-                        fit: BoxFit.cover,
-                        placeholder: (_, __) => Container(
-                          color: AppTheme.surfaceVariant,
-                          child: const Center(
-                            child: Icon(Icons.movie_outlined,
-                                color: AppTheme.textSecondary, size: 28),
-                          ),
-                        ),
-                        errorWidget: (_, __, ___) => Container(
-                          color: AppTheme.surfaceVariant,
-                          child: const Center(
-                            child: Icon(Icons.broken_image_outlined,
-                                color: AppTheme.textSecondary, size: 28),
-                          ),
-                        ),
-                      )
-                    else
-                      Container(
-                        color: AppTheme.surfaceVariant,
-                        child: const Center(
-                          child: Icon(Icons.movie_outlined,
-                              color: AppTheme.textSecondary, size: 28),
-                        ),
-                      ),
+                    CachedImage(
+                      url: item.posterPath == null ? null : imageUrl,
+                      fit: BoxFit.cover,
+                      icon: Icons.movie_outlined,
+                      iconSize: 28,
+                    ),
                     // Rating badge
                     if (item.voteAverage != null && item.voteAverage! > 0)
                       Positioned(

--- a/app/lib/features/chaptarr/data/chaptarr_image.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_image.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../auth/logic/auth_provider.dart';
+
+/// A resolved image URL plus any headers needed to fetch it.
+typedef ChaptarrImageSource = ({String url, Map<String, String>? headers});
+
+/// Resolves a Chaptarr image `url` field into something loadable.
+///
+/// Author art comes back as an absolute metadata-provider URL (hardcover, etc.)
+/// and loads directly. Book covers come back relative (`/MediaCover/...`), which
+/// the Chaptarr web layer gates behind a login session — but prefixing the path
+/// with `/api/v1` makes it API-key authed, so we route it through the backend's
+/// authenticated instance proxy and attach the user's bearer token.
+///
+/// Returns null when there's no usable url or the connection isn't ready.
+ChaptarrImageSource? chaptarrImageSource(
+  WidgetRef ref,
+  String? rawUrl,
+  String instanceId,
+) {
+  if (rawUrl == null || rawUrl.isEmpty) return null;
+  if (rawUrl.startsWith('http')) return (url: rawUrl, headers: null);
+
+  final conn = ref.read(authProvider).valueOrNull?.connection;
+  final serverUrl = conn?.serverUrl;
+  if (serverUrl == null || serverUrl.isEmpty) return null;
+
+  final base =
+      serverUrl.endsWith('/') ? serverUrl.substring(0, serverUrl.length - 1) : serverUrl;
+  final path = rawUrl.startsWith('/') ? rawUrl : '/$rawUrl';
+  final url = '$base/api/instances/$instanceId/api/v1$path';
+
+  final token = conn?.accessToken ?? '';
+  final headers = token.isEmpty ? null : {'Authorization': 'Bearer $token'};
+  return (url: url, headers: headers);
+}

--- a/app/lib/features/chaptarr/data/chaptarr_models.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_models.dart
@@ -194,16 +194,18 @@ class ChaptarrImage {
 }
 
 /// Picks a remote cover URL from a list of images, preferring `cover`/`poster`
-/// art and falling back to the first image with any remote URL.
+/// art and falling back to the first image with a URL. Returns the raw `url`
+/// field (this fork populates `url`, not `remoteUrl`) — absolute for author art,
+/// relative (`/MediaCover/...`) for book covers, which the UI resolves through
+/// the backend proxy via `chaptarrImageSource`.
 String? _pickCoverUrl(List<ChaptarrImage> images) {
+  bool hasUrl(ChaptarrImage i) => i.url != null && i.url!.isNotEmpty;
   for (final type in ['cover', 'poster']) {
-    final match = images.where((i) => i.coverType == type);
-    if (match.isNotEmpty && match.first.remoteUrl != null) {
-      return match.first.remoteUrl;
-    }
+    final match = images.where((i) => i.coverType == type && hasUrl(i));
+    if (match.isNotEmpty) return match.first.url;
   }
-  final withUrl = images.where((i) => i.remoteUrl != null);
-  return withUrl.isNotEmpty ? withUrl.first.remoteUrl : null;
+  final withUrl = images.where(hasUrl);
+  return withUrl.isNotEmpty ? withUrl.first.url : null;
 }
 
 class ChaptarrAuthorStatistics {

--- a/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
@@ -1,11 +1,12 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../data/chaptarr_add_payload.dart';
 import '../data/chaptarr_api_service.dart';
+import '../data/chaptarr_image.dart';
 import '../data/chaptarr_models.dart';
 import 'chaptarr_book_screen.dart';
 import 'widgets/book_status.dart';
@@ -207,6 +208,8 @@ class _ChaptarrAuthorDetailScreenState
                   const SizedBox(height: 4),
                   ..._groupedBooks().map((records) => _BookCard(
                         records: records,
+                        cover: chaptarrImageSource(
+                            ref, records.first.coverUrl, widget.instanceId),
                         togglingIds: _togglingBooks,
                         addingKeys: _addingFormats,
                         onTap: () => _openBookGroup(records),
@@ -323,6 +326,7 @@ class _AuthorSummaryCard extends StatelessWidget {
 /// format exists) or an add button (when it doesn't).
 class _BookCard extends StatelessWidget {
   final List<ChaptarrBook> records;
+  final ChaptarrImageSource? cover;
   final Set<int> togglingIds;
   final Set<String> addingKeys;
   final VoidCallback onTap;
@@ -331,6 +335,7 @@ class _BookCard extends StatelessWidget {
 
   const _BookCard({
     required this.records,
+    required this.cover,
     required this.togglingIds,
     required this.addingKeys,
     required this.onTap,
@@ -345,7 +350,6 @@ class _BookCard extends StatelessWidget {
     final fileRecord =
         records.firstWhere((r) => r.hasFile, orElse: () => primary);
     final status = bookFileStatusLine(fileRecord);
-    final anyMonitored = records.any((r) => r.monitored);
     return InkWell(
       onTap: onTap,
       child: Container(
@@ -363,19 +367,13 @@ class _BookCard extends StatelessWidget {
               child: SizedBox(
                 width: 44,
                 height: 60,
-                child: primary.coverUrl != null
-                    ? CachedNetworkImage(
-                        imageUrl: primary.coverUrl!, fit: BoxFit.cover)
-                    : Container(
-                        color: AppTheme.surfaceVariant,
-                        child: Icon(
-                          Icons.menu_book_outlined,
-                          color: anyMonitored
-                              ? AppTheme.available
-                              : AppTheme.unavailable,
-                          size: 22,
-                        ),
-                      ),
+                child: CachedImage(
+                  url: cover?.url,
+                  headers: cover?.headers,
+                  fit: BoxFit.cover,
+                  icon: Icons.menu_book_outlined,
+                  iconSize: 22,
+                ),
               ),
             ),
             const SizedBox(width: 14),

--- a/app/lib/features/chaptarr/ui/chaptarr_author_list.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_list.dart
@@ -1,6 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../data/chaptarr_models.dart';
 
 /// List of Chaptarr authors with swipe-to-delete and progress indicators.
@@ -107,16 +107,11 @@ class _AuthorTile extends StatelessWidget {
         child: SizedBox(
           width: 45,
           height: 67,
-          child: author.coverUrl != null
-              ? CachedNetworkImage(
-                  imageUrl: author.coverUrl!,
-                  fit: BoxFit.cover,
-                )
-              : Container(
-                  color: AppTheme.surfaceVariant,
-                  child: const Icon(Icons.person,
-                      color: AppTheme.textSecondary, size: 20),
-                ),
+          child: CachedImage(
+            url: author.coverUrl,
+            fit: BoxFit.cover,
+            icon: Icons.person,
+          ),
         ),
       ),
       title: Text(

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -1,13 +1,14 @@
 import 'dart:async';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../../chaptarr/data/chaptarr_api_service.dart';
+import '../../chaptarr/data/chaptarr_image.dart';
 import '../../chaptarr/data/chaptarr_models.dart';
 import '../../request/data/book_ownership.dart';
 import '../../request/data/request_service.dart';
@@ -221,6 +222,7 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
     // backend's /requests endpoint, not the Chaptarr proxy).
     final requestService =
         RequestService(backendDio: ref.read(backendClientProvider));
+    final instanceId = ref.read(instanceProvider).activeChaptarrInstance?.id;
     return ListView.separated(
       padding: const EdgeInsets.symmetric(vertical: 8),
       itemCount: ordered.length,
@@ -229,6 +231,9 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
       itemBuilder: (_, i) => _BookResultTile(
         book: ordered[i].$1,
         ownership: ordered[i].$2,
+        cover: instanceId == null
+            ? null
+            : chaptarrImageSource(ref, ordered[i].$1.coverUrl, instanceId),
         requestService: requestService,
       ),
     );
@@ -238,11 +243,13 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
 class _BookResultTile extends StatelessWidget {
   final ChaptarrBook book;
   final BookOwnership? ownership;
+  final ChaptarrImageSource? cover;
   final RequestService requestService;
 
   const _BookResultTile({
     required this.book,
     this.ownership,
+    this.cover,
     required this.requestService,
   });
 
@@ -265,28 +272,14 @@ class _BookResultTile extends StatelessWidget {
 
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      leading: SizedBox(
-        width: 44,
-        height: 66,
-        child: ClipRRect(
-          borderRadius: BorderRadius.circular(4),
-          child: book.coverUrl != null
-              ? CachedNetworkImage(
-                  imageUrl: book.coverUrl!,
-                  fit: BoxFit.cover,
-                  placeholder: (_, __) =>
-                      Container(color: AppTheme.surfaceVariant),
-                  errorWidget: (_, __, ___) => Container(
-                    color: AppTheme.surfaceVariant,
-                    child: const Icon(Icons.menu_book,
-                        color: AppTheme.textSecondary, size: 20),
-                  ),
-                )
-              : Container(
-                  color: AppTheme.surfaceVariant,
-                  child: const Icon(Icons.menu_book,
-                      color: AppTheme.textSecondary, size: 20),
-                ),
+      leading: ClipRRect(
+        borderRadius: BorderRadius.circular(4),
+        child: CachedImage(
+          url: cover?.url,
+          headers: cover?.headers,
+          width: 44,
+          height: 66,
+          icon: Icons.menu_book,
         ),
       ),
       title: Text(

--- a/app/lib/features/dashboard/ui/dashboard_releases_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_releases_tab.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
+import '../../../core/network/app_image_cache.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -508,6 +509,7 @@ class _ReleaseTile extends StatelessWidget {
             ? CachedNetworkImage(
                 imageUrl: event.posterUrl!,
                 fit: BoxFit.cover,
+                cacheManager: appImageCache,
                 placeholder: (_, __) => placeholder,
                 errorWidget: (_, __, ___) => placeholder,
               )

--- a/app/lib/features/discover/ui/search_results_view.dart
+++ b/app/lib/features/discover/ui/search_results_view.dart
@@ -1,9 +1,9 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shimmer/shimmer.dart';
 import '../../../core/config/app_config.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../../person/ui/person_detail_sheet.dart';
 import '../data/tmdb_models.dart';
 
@@ -208,32 +208,12 @@ class _SearchResultTile extends StatelessWidget {
               child: SizedBox(
                 width: 50,
                 height: 50,
-                child: item.posterPath != null
-                    ? CachedNetworkImage(
-                        imageUrl: imageUrl,
-                        fit: BoxFit.cover,
-                        placeholder: (_, __) => Container(
-                          color: AppTheme.surfaceVariant,
-                          child: const Center(
-                            child: Icon(Icons.person,
-                                color: AppTheme.textSecondary, size: 18),
-                          ),
-                        ),
-                        errorWidget: (_, __, ___) => Container(
-                          color: AppTheme.surfaceVariant,
-                          child: const Center(
-                            child: Icon(Icons.person,
-                                color: AppTheme.textSecondary, size: 18),
-                          ),
-                        ),
-                      )
-                    : Container(
-                        color: AppTheme.surfaceVariant,
-                        child: const Center(
-                          child: Icon(Icons.person,
-                              color: AppTheme.textSecondary, size: 18),
-                        ),
-                      ),
+                child: CachedImage(
+                  url: item.posterPath == null ? null : imageUrl,
+                  fit: BoxFit.cover,
+                  icon: Icons.person,
+                  iconSize: 18,
+                ),
               ),
             ),
             const SizedBox(width: 10),
@@ -290,32 +270,12 @@ class _SearchResultTile extends StatelessWidget {
               child: SizedBox(
                 width: 50,
                 height: 75,
-                child: item.posterPath != null
-                    ? CachedNetworkImage(
-                        imageUrl: imageUrl,
-                        fit: BoxFit.cover,
-                        placeholder: (_, __) => Container(
-                          color: AppTheme.surfaceVariant,
-                          child: const Center(
-                            child: Icon(Icons.movie_outlined,
-                                color: AppTheme.textSecondary, size: 18),
-                          ),
-                        ),
-                        errorWidget: (_, __, ___) => Container(
-                          color: AppTheme.surfaceVariant,
-                          child: const Center(
-                            child: Icon(Icons.broken_image_outlined,
-                                color: AppTheme.textSecondary, size: 18),
-                          ),
-                        ),
-                      )
-                    : Container(
-                        color: AppTheme.surfaceVariant,
-                        child: const Center(
-                          child: Icon(Icons.movie_outlined,
-                              color: AppTheme.textSecondary, size: 18),
-                        ),
-                      ),
+                child: CachedImage(
+                  url: item.posterPath == null ? null : imageUrl,
+                  fit: BoxFit.cover,
+                  icon: Icons.movie_outlined,
+                  iconSize: 18,
+                ),
               ),
             ),
             const SizedBox(width: 10),

--- a/app/lib/features/person/ui/person_detail_sheet.dart
+++ b/app/lib/features/person/ui/person_detail_sheet.dart
@@ -1,10 +1,10 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shimmer/shimmer.dart';
 import '../../../core/config/app_config.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../../discover/data/discover_api_service.dart';
 import '../../discover/data/tmdb_models.dart';
 import '../logic/person_detail_provider.dart';
@@ -187,32 +187,12 @@ class _PersonDetailSheetState extends ConsumerState<_PersonDetailSheet> {
             child: SizedBox(
               width: 100,
               height: 100,
-              child: imageUrl.isNotEmpty
-                  ? CachedNetworkImage(
-                      imageUrl: imageUrl,
-                      fit: BoxFit.cover,
-                      placeholder: (_, __) => Container(
-                        color: AppTheme.surfaceVariant,
-                        child: const Center(
-                          child: Icon(Icons.person,
-                              color: AppTheme.textSecondary, size: 32),
-                        ),
-                      ),
-                      errorWidget: (_, __, ___) => Container(
-                        color: AppTheme.surfaceVariant,
-                        child: const Center(
-                          child: Icon(Icons.person,
-                              color: AppTheme.textSecondary, size: 32),
-                        ),
-                      ),
-                    )
-                  : Container(
-                      color: AppTheme.surfaceVariant,
-                      child: const Center(
-                        child: Icon(Icons.person,
-                            color: AppTheme.textSecondary, size: 32),
-                      ),
-                    ),
+              child: CachedImage(
+                url: imageUrl.isEmpty ? null : imageUrl,
+                fit: BoxFit.cover,
+                icon: Icons.person,
+                iconSize: 32,
+              ),
             ),
           ),
           const SizedBox(width: 14),
@@ -402,27 +382,12 @@ class _PersonDetailSheetState extends ConsumerState<_PersonDetailSheet> {
               child: SizedBox(
                 width: 60,
                 height: 90,
-                child: credit.posterPath != null
-                    ? CachedNetworkImage(
-                        imageUrl: posterUrl,
-                        fit: BoxFit.cover,
-                        placeholder: (_, __) => Container(
-                            color: AppTheme.surfaceVariant),
-                        errorWidget: (_, __, ___) => Container(
-                          color: AppTheme.surfaceVariant,
-                          child: const Center(
-                            child: Icon(Icons.movie_outlined,
-                                color: AppTheme.textSecondary, size: 18),
-                          ),
-                        ),
-                      )
-                    : Container(
-                        color: AppTheme.surfaceVariant,
-                        child: const Center(
-                          child: Icon(Icons.movie_outlined,
-                              color: AppTheme.textSecondary, size: 18),
-                        ),
-                      ),
+                child: CachedImage(
+                  url: credit.posterPath == null ? null : posterUrl,
+                  fit: BoxFit.cover,
+                  icon: Icons.movie_outlined,
+                  iconSize: 18,
+                ),
               ),
             ),
             const SizedBox(width: 10),

--- a/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
@@ -1,9 +1,9 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../../../core/widgets/status_pill.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -280,16 +280,12 @@ class _Header extends StatelessWidget {
           child: SizedBox(
             width: 100,
             height: 150,
-            child: movie.posterUrl != null
-                ? CachedNetworkImage(
-                    imageUrl: movie.posterUrl!,
-                    fit: BoxFit.cover,
-                  )
-                : Container(
-                    color: AppTheme.surfaceVariant,
-                    child: const Icon(Icons.movie,
-                        color: AppTheme.textSecondary, size: 28),
-                  ),
+            child: CachedImage(
+              url: movie.posterUrl,
+              fit: BoxFit.cover,
+              icon: Icons.movie,
+              iconSize: 28,
+            ),
           ),
         ),
         const SizedBox(width: 14),

--- a/app/lib/features/radarr/ui/radarr_movie_list.dart
+++ b/app/lib/features/radarr/ui/radarr_movie_list.dart
@@ -1,6 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../data/radarr_models.dart';
 
 /// List of Radarr movies with swipe actions.
@@ -108,16 +108,11 @@ class _MovieTile extends StatelessWidget {
         child: SizedBox(
           width: 45,
           height: 67,
-          child: movie.posterUrl != null
-              ? CachedNetworkImage(
-                  imageUrl: movie.posterUrl!,
-                  fit: BoxFit.cover,
-                )
-              : Container(
-                  color: AppTheme.surfaceVariant,
-                  child: const Icon(Icons.movie,
-                      color: AppTheme.textSecondary, size: 20),
-                ),
+          child: CachedImage(
+            url: movie.posterUrl,
+            fit: BoxFit.cover,
+            icon: Icons.movie,
+          ),
         ),
       ),
       title: Text(

--- a/app/lib/features/sonarr/ui/sonarr_series_list.dart
+++ b/app/lib/features/sonarr/ui/sonarr_series_list.dart
@@ -1,6 +1,6 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../data/sonarr_models.dart';
 
 /// List of Sonarr series with swipe-to-delete and progress indicators.
@@ -111,16 +111,11 @@ class _SeriesTile extends StatelessWidget {
         child: SizedBox(
           width: 45,
           height: 67,
-          child: show.posterUrl != null
-              ? CachedNetworkImage(
-                  imageUrl: show.posterUrl!,
-                  fit: BoxFit.cover,
-                )
-              : Container(
-                  color: AppTheme.surfaceVariant,
-                  child: const Icon(Icons.tv,
-                      color: AppTheme.textSecondary, size: 20),
-                ),
+          child: CachedImage(
+            url: show.posterUrl,
+            fit: BoxFit.cover,
+            icon: Icons.tv,
+          ),
         ),
       ),
       title: Text(

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
 
   # Image loading
   cached_network_image: ^3.4.1
+  flutter_cache_manager: ^3.4.1
 
   # Storage
   flutter_secure_storage: ^9.2.3


### PR DESCRIPTION
## Images
Chaptarr cover/author art never rendered because the app read the `remoteUrl` field, but this fork populates **`url`** instead — so `coverUrl` was always null (placeholders everywhere).

- **Author photos** → absolute metadata URLs, load directly.
- **Owned/library book covers** → relative `/MediaCover/...`, which the Chaptarr web layer gates behind a login session. Routed through the backend's instance proxy under the **key-authed** `/api/v1/MediaCover/...` twin with the user's bearer token (curl-verified 200). Wired into the dashboard book tile, author list, and author detail.

> Not-yet-owned **search** covers come back as `/MediaCoverProxy/...`, which has no key-authed route (web-session only). Tracked as a follow-up — pending whether we add a local-addresses toggle or backend login.

## Caching, everywhere
- New shared **`appImageCache`** (1000 objects / 30 days) and a single **`CachedImage`** widget (consistent placeholder/error/fade, optional auth headers).
- Routed **all 14** network-image sites — posters, covers, author/person photos, release art, chat previews — through it (converting to `CachedImage` where a clean drop-in, else adding `cacheManager: appImageCache`). Previously every site used the per-widget default cache (~200 objects); now one shared, bounded cache so a poster fetched on the dashboard is reused on detail screens.

## Verification
`flutter analyze` — no new issues (only the same pre-existing `info` lints). `flutter test` — **165 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)