### PR TITLE
Chaptarr search covers: fetch via a backend login session

### DIFF
--- a/app/lib/features/chaptarr/data/chaptarr_image.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_image.dart
@@ -8,10 +8,11 @@ typedef ChaptarrImageSource = ({String url, Map<String, String>? headers});
 /// Resolves a Chaptarr image `url` field into something loadable.
 ///
 /// Author art comes back as an absolute metadata-provider URL (hardcover, etc.)
-/// and loads directly. Book covers come back relative (`/MediaCover/...`), which
-/// the Chaptarr web layer gates behind a login session — but prefixing the path
-/// with `/api/v1` makes it API-key authed, so we route it through the backend's
-/// authenticated instance proxy and attach the user's bearer token.
+/// and loads directly. Book covers come back relative (`/MediaCover/...` or
+/// `/MediaCoverProxy/...`), which the Chaptarr web layer gates behind a login
+/// session — so we route them through the backend's cover endpoint, which logs
+/// in with the instance's web credentials and streams the image. The user's
+/// bearer token authorizes the backend call.
 ///
 /// Returns null when there's no usable url or the connection isn't ready.
 ChaptarrImageSource? chaptarrImageSource(
@@ -26,10 +27,12 @@ ChaptarrImageSource? chaptarrImageSource(
   final serverUrl = conn?.serverUrl;
   if (serverUrl == null || serverUrl.isEmpty) return null;
 
-  final base =
-      serverUrl.endsWith('/') ? serverUrl.substring(0, serverUrl.length - 1) : serverUrl;
+  final base = serverUrl.endsWith('/')
+      ? serverUrl.substring(0, serverUrl.length - 1)
+      : serverUrl;
   final path = rawUrl.startsWith('/') ? rawUrl : '/$rawUrl';
-  final url = '$base/api/instances/$instanceId/api/v1$path';
+  final url = '$base/api/instances/$instanceId/cover'
+      '?path=${Uri.encodeQueryComponent(path)}';
 
   final token = conn?.accessToken ?? '';
   final headers = token.isEmpty ? null : {'Authorization': 'Bearer $token'};

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -411,6 +411,31 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
               ),
               obscureText: true,
             ),
+          // Chaptarr also takes an optional web login: its cover images are
+          // served behind the web session (not the API key), so these let the
+          // backend fetch search-result cover art.
+          if (_serviceType == 'chaptarr') ...[
+            const SizedBox(height: 16),
+            TextField(
+              controller: _usernameController,
+              decoration: const InputDecoration(
+                labelText: 'Web username (optional)',
+                hintText: 'Chaptarr web login — shows cover art in search',
+              ),
+              autocorrect: false,
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _passwordController,
+              decoration: InputDecoration(
+                labelText: 'Web password (optional)',
+                hintText: widget.isEditing
+                    ? 'Leave blank to keep existing'
+                    : 'Chaptarr web login password',
+              ),
+              obscureText: true,
+            ),
+          ],
           const SizedBox(height: 16),
 
           SwitchListTile(

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -285,6 +285,12 @@ func NewRouter(
 				r.Delete("/instances/{instanceID}", instanceHandler.Delete)
 			})
 
+			// Cover-image fetch — Chaptarr's /MediaCover(Proxy) is gated behind a
+			// login session, not the API key, so this logs in with the instance's
+			// web credentials and streams the image. Registered before the
+			// catch-all so chi matches the static `cover` segment first.
+			r.With(auth.RequireArrProxyAccess(instanceStore)).Get("/instances/{instanceID}/cover", proxyHandler.CoverProxy())
+
 			// Instance proxy — forward to specific instance. Read-only
 			// Radarr/Sonarr browsing is allowed for non-admins (arr:browse);
 			// every other request (writes, commands, interactive search, config,

--- a/server/internal/proxy/handler.go
+++ b/server/internal/proxy/handler.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -11,11 +12,12 @@ import (
 )
 
 type Handler struct {
-	store *instance.Store
+	store    *instance.Store
+	sessions *sessionCache
 }
 
 func NewHandler(store *instance.Store) *Handler {
-	return &Handler{store: store}
+	return &Handler{store: store, sessions: newSessionCache()}
 }
 
 // InstanceProxy proxies requests to a specific service instance by ID.
@@ -59,4 +61,54 @@ func (h *Handler) proxyRequest(w http.ResponseWriter, r *http.Request, target *u
 		},
 	}
 	proxy.ServeHTTP(w, r)
+}
+
+// CoverProxy streams a Chaptarr cover image. Chaptarr serves /MediaCover and
+// /MediaCoverProxy from its web layer (login-session gated), not the API key, so
+// when the instance has web credentials we fetch with a logged-in session
+// cookie; otherwise we fall back to the API-key route (/api/v1/MediaCover, which
+// only covers owned books). The image path is taken from a ?path= query param so
+// it can carry its own query string (e.g. ?lastWrite=...).
+func (h *Handler) CoverProxy() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		instanceID := chi.URLParam(r, "instanceID")
+		inst, err := h.store.Get(instanceID)
+		if err != nil {
+			http.Error(w, `{"error":"failed to get instance"}`, http.StatusInternalServerError)
+			return
+		}
+		if inst == nil {
+			http.Error(w, `{"error":"instance not found"}`, http.StatusNotFound)
+			return
+		}
+
+		coverPath, ok := sanitizeCoverPath(r.URL.Query().Get("path"))
+		if !ok {
+			http.Error(w, `{"error":"invalid cover path"}`, http.StatusBadRequest)
+			return
+		}
+		base := strings.TrimRight(inst.URL, "/")
+
+		var resp *http.Response
+		if inst.Username != "" && inst.Password != "" {
+			resp, err = h.sessions.fetchCover(inst, base+coverPath)
+		} else {
+			resp, err = h.sessions.fetchWithKey(base+"/api/v1"+coverPath, inst.APIKey)
+		}
+		if err != nil {
+			http.Error(w, `{"error":"cover unavailable"}`, http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		if ct := resp.Header.Get("Content-Type"); ct != "" {
+			w.Header().Set("Content-Type", ct)
+		}
+		if cl := resp.Header.Get("Content-Length"); cl != "" {
+			w.Header().Set("Content-Length", cl)
+		}
+		w.Header().Set("Cache-Control", "public, max-age=86400")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.Copy(w, resp.Body)
+	}
 }

--- a/server/internal/proxy/session.go
+++ b/server/internal/proxy/session.go
@@ -1,0 +1,182 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/instance"
+)
+
+// sessionCache holds a forms-auth session cookie per instance. Chaptarr's cover
+// images (/MediaCover, /MediaCoverProxy) are served by its web layer, which is
+// gated behind a login session rather than the API key, so to fetch them the
+// backend logs in with the instance's stored web credentials and replays the
+// resulting cookie. The cookie is cached and only re-fetched when it goes stale.
+type sessionCache struct {
+	mu      sync.Mutex
+	cookies map[string]string // instanceID -> Cookie header value
+	client  *http.Client
+}
+
+func newSessionCache() *sessionCache {
+	return &sessionCache{
+		cookies: make(map[string]string),
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+			// Capture the login redirect ourselves instead of following it.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+func (sc *sessionCache) get(instanceID string) string {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	return sc.cookies[instanceID]
+}
+
+func (sc *sessionCache) set(instanceID, cookie string) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sc.cookies[instanceID] = cookie
+}
+
+func (sc *sessionCache) clear(instanceID string) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	delete(sc.cookies, instanceID)
+}
+
+// login performs a forms login and returns the Cookie header value to replay on
+// later requests. A failed login redirects to /login?...loginFailed=true with no
+// auth cookie; a success sets the auth cookie(s) on its redirect response.
+func (sc *sessionCache) login(baseURL, username, password string) (string, error) {
+	form := url.Values{
+		"username":   {username},
+		"password":   {password},
+		"rememberMe": {"true"},
+	}
+	req, err := http.NewRequest(http.MethodPost,
+		strings.TrimRight(baseURL, "/")+"/login", strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := sc.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	if strings.Contains(resp.Header.Get("Location"), "loginFailed") {
+		return "", fmt.Errorf("chaptarr login failed (check the instance's web username/password)")
+	}
+	var parts []string
+	for _, c := range resp.Cookies() {
+		parts = append(parts, c.Name+"="+c.Value)
+	}
+	if len(parts) == 0 {
+		return "", fmt.Errorf("chaptarr login returned no session cookie")
+	}
+	return strings.Join(parts, "; "), nil
+}
+
+// fetchCover GETs a cover URL using the instance's cached session cookie,
+// logging in (or re-logging in) when there's no cookie or the cookie is stale.
+// Returns a 200 response whose body the caller must close, else an error.
+func (sc *sessionCache) fetchCover(inst *instance.Instance, fullURL string) (*http.Response, error) {
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		cookie := sc.get(inst.ID)
+		if cookie == "" {
+			c, err := sc.login(inst.URL, inst.Username, inst.Password)
+			if err != nil {
+				return nil, err
+			}
+			sc.set(inst.ID, c)
+			cookie = c
+		}
+
+		req, err := http.NewRequest(http.MethodGet, fullURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Cookie", cookie)
+		resp, err := sc.client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.StatusCode == http.StatusOK {
+			return resp, nil
+		}
+
+		// Re-login only on an auth bounce (401, or the login redirect); any other
+		// status (e.g. 404 for a cover that doesn't exist) is a real failure.
+		authBounce := resp.StatusCode == http.StatusUnauthorized ||
+			(resp.StatusCode == http.StatusFound &&
+				strings.Contains(resp.Header.Get("Location"), "/login"))
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		if !authBounce {
+			return nil, fmt.Errorf("cover upstream returned status %d", resp.StatusCode)
+		}
+		sc.clear(inst.ID)
+		lastErr = fmt.Errorf("cover unauthorized")
+	}
+	return nil, lastErr
+}
+
+// fetchWithKey GETs a cover via the API-key-authed route (works for /MediaCover
+// only); used when no web credentials are configured.
+func (sc *sessionCache) fetchWithKey(fullURL, apiKey string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodGet, fullURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Api-Key", apiKey)
+	resp, err := sc.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("cover upstream returned status %d", resp.StatusCode)
+	}
+	return resp, nil
+}
+
+// sanitizeCoverPath validates that a requested cover path is a Chaptarr cover
+// path and nothing else, so the cover endpoint can't be turned into an open
+// proxy (with a live session cookie) to arbitrary instance routes.
+func sanitizeCoverPath(p string) (string, bool) {
+	if p == "" {
+		return "", false
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	if strings.Contains(p, "..") {
+		return "", false
+	}
+	u, err := url.Parse(p)
+	if err != nil || u.Scheme != "" || u.Host != "" {
+		return "", false
+	}
+	// Both /MediaCover/... and /MediaCoverProxy/... share this prefix.
+	if !strings.HasPrefix(strings.ToLower(u.Path), "/mediacover") {
+		return "", false
+	}
+	return p, true
+}

--- a/server/internal/proxy/session_test.go
+++ b/server/internal/proxy/session_test.go
@@ -1,0 +1,151 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+)
+
+// Guards the router assumption: the static `cover` route must win over the
+// `/*` proxy wildcard, otherwise cover requests silently fall through to the
+// generic proxy (which can't fetch the login-gated image) and show no art.
+func TestCoverRouteBeatsProxyWildcard(t *testing.T) {
+	r := chi.NewRouter()
+	var hit string
+	r.Get("/instances/{instanceID}/cover", func(http.ResponseWriter, *http.Request) { hit = "cover" })
+	r.HandleFunc("/instances/{instanceID}/*", func(http.ResponseWriter, *http.Request) { hit = "wildcard" })
+
+	r.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/instances/abc/cover", nil))
+	if hit != "cover" {
+		t.Fatalf("/instances/abc/cover hit %q, want cover", hit)
+	}
+	hit = ""
+	r.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/instances/abc/api/v1/book", nil))
+	if hit != "wildcard" {
+		t.Fatalf("/instances/abc/api/v1/book hit %q, want wildcard", hit)
+	}
+}
+
+func TestSanitizeCoverPath(t *testing.T) {
+	cases := []struct {
+		in     string
+		wantOK bool
+		want   string
+	}{
+		{"/MediaCover/Books/541/cover.jpg?lastWrite=1", true, "/MediaCover/Books/541/cover.jpg?lastWrite=1"},
+		{"/MediaCoverProxy/abc/x.jpg", true, "/MediaCoverProxy/abc/x.jpg"},
+		{"MediaCover/Books/1/cover.jpg", true, "/MediaCover/Books/1/cover.jpg"}, // leading slash added
+		{"", false, ""},
+		{"/api/v1/config/host", false, ""},          // not a cover path
+		{"/MediaCover/../api/v1/config", false, ""}, // traversal
+		{"http://evil.example/x.jpg", false, ""},    // absolute url
+		{"//evil.example/x.jpg", false, ""},         // host-relative
+	}
+	for _, c := range cases {
+		got, ok := sanitizeCoverPath(c.in)
+		if ok != c.wantOK || (ok && got != c.want) {
+			t.Errorf("sanitizeCoverPath(%q) = (%q,%v), want (%q,%v)", c.in, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestSessionLogin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/login" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			return
+		}
+		_ = r.ParseForm()
+		if r.FormValue("username") == "admin" && r.FormValue("password") == "secret" {
+			http.SetCookie(w, &http.Cookie{Name: "ReadarrAuth", Value: "tok123"})
+			w.Header().Set("Location", "/")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.Header().Set("Location", "/login?returnUrl=&loginFailed=true")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+
+	sc := newSessionCache()
+	cookie, err := sc.login(srv.URL, "admin", "secret")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if !strings.Contains(cookie, "ReadarrAuth=tok123") {
+		t.Errorf("cookie = %q, want it to contain ReadarrAuth=tok123", cookie)
+	}
+	if _, err := sc.login(srv.URL, "admin", "wrong"); err == nil {
+		t.Error("expected error on bad credentials (loginFailed)")
+	}
+}
+
+func TestFetchCoverLoginsCachesAndReauths(t *testing.T) {
+	var logins int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/login":
+			logins++
+			http.SetCookie(w, &http.Cookie{Name: "auth", Value: "fresh"})
+			w.Header().Set("Location", "/")
+			w.WriteHeader(http.StatusFound)
+		case strings.HasPrefix(r.URL.Path, "/MediaCover"):
+			c := r.Header.Get("Cookie")
+			if c == "" || strings.Contains(c, "stale") {
+				w.Header().Set("Location", "/login")
+				w.WriteHeader(http.StatusFound)
+				return
+			}
+			w.Header().Set("Content-Type", "image/jpeg")
+			_, _ = w.Write([]byte("JPEGDATA"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	inst := &instance.Instance{ID: "i1", URL: srv.URL, Username: "u", Password: "p"}
+	sc := newSessionCache()
+
+	// First fetch logs in once and returns the image.
+	resp, err := sc.fetchCover(inst, srv.URL+"/MediaCover/x.jpg")
+	if err != nil {
+		t.Fatalf("fetchCover: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if string(body) != "JPEGDATA" {
+		t.Errorf("body = %q, want JPEGDATA", body)
+	}
+	if logins != 1 {
+		t.Errorf("logins = %d, want 1", logins)
+	}
+
+	// Second fetch reuses the cached cookie — no new login.
+	resp2, err := sc.fetchCover(inst, srv.URL+"/MediaCover/x.jpg")
+	if err != nil {
+		t.Fatalf("fetchCover 2: %v", err)
+	}
+	resp2.Body.Close()
+	if logins != 1 {
+		t.Errorf("logins after cached fetch = %d, want 1", logins)
+	}
+
+	// A stale cookie triggers exactly one re-login, then succeeds.
+	sc.set("i1", "auth=stale")
+	resp3, err := sc.fetchCover(inst, srv.URL+"/MediaCover/x.jpg")
+	if err != nil {
+		t.Fatalf("fetchCover stale: %v", err)
+	}
+	resp3.Body.Close()
+	if logins != 2 {
+		t.Errorf("logins after stale = %d, want 2", logins)
+	}
+}


### PR DESCRIPTION
Follow-up to #121 (which fixed author + owned-book art). Chaptarr serves cover images (`/MediaCover`, `/MediaCoverProxy`) from its **web layer**, gated behind a login session — not the API key — so search-result covers couldn't be fetched with the key alone (every variant 302s to `/login`). Per your call: the **admin stores the instance's web login, and the backend handles the session** and streams the images.

## Backend
- `proxy/session.go` — per-instance session-cookie cache:
  - `login()` posts the forms login (`username`/`password`/`rememberMe`), captures the auth cookie **name-agnostically**, and detects the `loginFailed` redirect.
  - `fetchCover()` uses the cached cookie and **re-logs-in once** on an auth bounce (401 / login redirect); other statuses are real failures.
  - `fetchWithKey()` — no-creds fallback via the key-authed `/api/v1/MediaCover` (owned books only).
  - `sanitizeCoverPath()` restricts the endpoint to `/MediaCover(Proxy)` paths (no traversal/absolute) so it can't become an open proxy with a live cookie.
- New route **`GET /api/instances/{id}/cover?path=...`**, gated by the same `RequireArrProxyAccess` as the proxy (respects the per-user Chaptarr grant) and registered **before** the `/*` catch-all.
- **No schema change** — reuses the existing encrypted `username`/`password` instance fields.

## App
- `chaptarrImageSource` routes relative cover paths through the cover endpoint (absolute author art still loads directly).
- Instance edit form exposes **optional** "Web username/password" for Chaptarr (the API key stays the only required field).

## Verification
Go tests: login success/failure, cookie caching + single re-auth, path sanitizer, and a guard that the static `cover` route beats the proxy wildcard. **Go + 165 Flutter tests pass.**

> I can't test the live login (I don't have — and don't want — the web password). To enable it: **edit your Chaptarr instance → fill in Web username/password → save**, and search covers should populate. The owned-book/author art from #121 works regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)