### PR TITLE
Books search: reuse owned cover art (no login needed for owned results)

### DIFF
--- a/app/lib/features/dashboard/logic/book_ownership_matcher.dart
+++ b/app/lib/features/dashboard/logic/book_ownership_matcher.dart
@@ -145,20 +145,24 @@ List<OwnedTitle> _matchingTitles(ChaptarrBook result, List<OwnedTitle> digest) {
   return out;
 }
 
-/// Decides whether the user already owns [result], by matching it against the
-/// ownership [digest]. Returns a SINGLE matching record's ownership — preferring
-/// the one whose title exactly equals the result's, else the first match — so a
-/// result's chip/gating reflects one real record rather than a blend of several
-/// (the user's separate records are surfaced as their own rows, not merged).
-/// Null when no row qualifies.
-BookOwnership? ownershipFor(ChaptarrBook result, List<OwnedTitle> digest) {
+/// The single digest row [result] matches — preferring the one whose title
+/// exactly equals the result's, else the first match (the user's separate
+/// records are surfaced as their own rows, not merged). Null when none qualify.
+/// Exposes the matched [OwnedTitle] so callers can reuse its cached cover.
+OwnedTitle? ownedMatchFor(ChaptarrBook result, List<OwnedTitle> digest) {
   final matches = _matchingTitles(result, digest);
   if (matches.isEmpty) return null;
   for (final m in matches) {
-    if (m.title == result.title) return m.ownership;
+    if (m.title == result.title) return m;
   }
-  return matches.first.ownership;
+  return matches.first;
 }
+
+/// Decides whether the user already owns [result], by matching it against the
+/// ownership [digest] — a single real record's ownership (see [ownedMatchFor]),
+/// not a blend. Null when no row qualifies.
+BookOwnership? ownershipFor(ChaptarrBook result, List<OwnedTitle> digest) =>
+    ownedMatchFor(result, digest)?.ownership;
 
 /// Owned digest titles matching the search [query] (every query token appears in
 /// the title), each kept as its own entry so the user sees and picks among their

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -183,15 +183,22 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
         : ownedTitlesForQuery(_searchedTerm, digest, _results);
     // Mark each lookup result with its ownership and float owned titles to the
     // top, preserving Chaptarr's relevance order within each bucket (don't
-    // collapse versions — the user wants to see ones they don't own).
-    final owned = <(ChaptarrBook, BookOwnership?)>[];
-    final rest = <(ChaptarrBook, BookOwnership?)>[];
+    // collapse versions — the user wants to see ones they don't own). Each row
+    // carries the cover to show: prefer the owned record's cached cover (loads
+    // with the API key) over the lookup's login-gated /MediaCoverProxy cover.
+    final owned = <(ChaptarrBook, BookOwnership?, String?)>[];
+    final rest = <(ChaptarrBook, BookOwnership?, String?)>[];
     for (final book in _results) {
-      final o = digest.isEmpty ? null : ownershipFor(book, digest);
-      ((o?.anyOwned ?? false) ? owned : rest).add((book, o));
+      final match = digest.isEmpty ? null : ownedMatchFor(book, digest);
+      final cover = (match != null && match.cover.isNotEmpty)
+          ? match.cover
+          : book.coverUrl;
+      ((match?.ownership.anyOwned ?? false) ? owned : rest)
+          .add((book, match?.ownership, cover));
     }
-    final ordered = <(ChaptarrBook, BookOwnership?)>[
-      for (final t in injected) (_ownedTitleAsBook(t), t.ownership),
+    final ordered = <(ChaptarrBook, BookOwnership?, String?)>[
+      for (final t in injected)
+        (_ownedTitleAsBook(t), t.ownership, t.cover.isNotEmpty ? t.cover : null),
       ...owned,
       ...rest,
     ];
@@ -233,7 +240,7 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
         ownership: ordered[i].$2,
         cover: instanceId == null
             ? null
-            : chaptarrImageSource(ref, ordered[i].$1.coverUrl, instanceId),
+            : chaptarrImageSource(ref, ordered[i].$3, instanceId),
         requestService: requestService,
       ),
     );

--- a/app/lib/features/request/data/book_ownership.dart
+++ b/app/lib/features/request/data/book_ownership.dart
@@ -57,21 +57,28 @@ class OwnedTitle {
   final String title;
   final String author;
   final int year;
+
+  /// The owned record's cover path (e.g. `/MediaCover/...`), if any. Loads with
+  /// the API key, so it shows real art for an owned result without the
+  /// login-gated lookup cover. Empty when the record has no cached cover.
+  final String cover;
   final BookOwnership ownership;
 
   const OwnedTitle({
     required this.title,
     required this.author,
     this.year = 0,
+    this.cover = '',
     required this.ownership,
   });
 
-  /// Parses one digest entry: `title`/`author`/`year` plus the `ebook` and
-  /// `audiobook` format objects.
+  /// Parses one digest entry: `title`/`author`/`year`/`cover` plus the `ebook`
+  /// and `audiobook` format objects.
   factory OwnedTitle.fromJson(Map<String, dynamic> json) => OwnedTitle(
         title: json['title'] as String? ?? '',
         author: json['author'] as String? ?? '',
         year: json['year'] as int? ?? 0,
+        cover: json['cover'] as String? ?? '',
         ownership: BookOwnership(
           ebook: FormatOwnership.fromJson(
               json['ebook'] as Map<String, dynamic>?),

--- a/app/test/dashboard/book_ownership_matcher_test.dart
+++ b/app/test/dashboard/book_ownership_matcher_test.dart
@@ -171,6 +171,22 @@ void main() {
       expect(o!.ebook.downloaded, isFalse);
       expect(o.ebook.monitored, isTrue);
     });
+
+    test('ownedMatchFor exposes the matched record cover', () {
+      final digest = [
+        OwnedTitle.fromJson({
+          'title': 'Ahsoka',
+          'author': 'E.K. Johnston',
+          'cover': '/MediaCover/Books/9/cover.jpg',
+          'ebook': {'downloaded': true},
+        }),
+      ];
+      final match =
+          ownedMatchFor(_result('Ahsoka', author: 'E.K. Johnston'), digest);
+      expect(match, isNotNull);
+      expect(match!.cover, '/MediaCover/Books/9/cover.jpg');
+      expect(match.ownership.ebook.downloaded, isTrue);
+    });
   });
 
   group('ownedTitlesForQuery surfaces owned books lookup missed', () {

--- a/server/internal/request/library.go
+++ b/server/internal/request/library.go
@@ -26,9 +26,13 @@ type FormatOwnership struct {
 // two) Chaptarr records that share a foreignBookId. Both Ebook and Audiobook are
 // always present; a format with no record is the zero {false,false}.
 type LibraryTitle struct {
-	Title     string          `json:"title"`
-	Author    string          `json:"author"`
-	Year      int             `json:"year"`
+	Title  string `json:"title"`
+	Author string `json:"author"`
+	Year   int    `json:"year"`
+	// Cover is the owned record's relative cover path (e.g. /MediaCover/...),
+	// which loads with the API key — so an owned search result can show real art
+	// without the login-session-gated /MediaCoverProxy lookup cover.
+	Cover     string          `json:"cover"`
 	Ebook     FormatOwnership `json:"ebook"`
 	Audiobook FormatOwnership `json:"audiobook"`
 }
@@ -81,6 +85,10 @@ func reduceLibrary(books []chaptarr.Book) BookLibraryDigest {
 		if g.title.Title == "" {
 			g.title.Title = book.Title
 		}
+		// Take the cover from the first record in the group that has one.
+		if g.title.Cover == "" {
+			g.title.Cover = coverOf(book)
+		}
 
 		own := FormatOwnership{
 			Monitored:  book.Monitored,
@@ -109,6 +117,22 @@ func groupKey(book chaptarr.Book) string {
 		return book.ForeignBookID
 	}
 	return fmt.Sprintf("id:%d", book.ID)
+}
+
+// coverOf returns a book's cover image path, preferring the "cover" type, else
+// the first image with a URL.
+func coverOf(book chaptarr.Book) string {
+	for _, img := range book.Images {
+		if img.URL != "" && img.CoverType == "cover" {
+			return img.URL
+		}
+	}
+	for _, img := range book.Images {
+		if img.URL != "" {
+			return img.URL
+		}
+	}
+	return ""
 }
 
 // recordFormat resolves the single format a Chaptarr book record represents: its

--- a/server/internal/request/library_test.go
+++ b/server/internal/request/library_test.go
@@ -35,6 +35,9 @@ func TestReduceLibraryMergesFormatsByForeignBookID(t *testing.T) {
 			ReleaseDate:   &rel,
 			Author:        &chaptarr.AuthorContext{AuthorName: "Timothy Zahn"},
 			Statistics:    chaptarr.BookStatistics{BookFileCount: 1},
+			Images: []chaptarr.Image{
+				{CoverType: "cover", URL: "/MediaCover/Books/1/cover.jpg"},
+			},
 		},
 		{
 			ID:            2,
@@ -60,6 +63,9 @@ func TestReduceLibraryMergesFormatsByForeignBookID(t *testing.T) {
 	}
 	if !lt.Audiobook.Monitored || lt.Audiobook.Downloaded {
 		t.Errorf("audiobook = %+v, want monitored && !downloaded", lt.Audiobook)
+	}
+	if lt.Cover != "/MediaCover/Books/1/cover.jpg" {
+		t.Errorf("cover = %q, want /MediaCover/Books/1/cover.jpg", lt.Cover)
 	}
 }
 


### PR DESCRIPTION
Your idea — for a search result we own (the ones floated to the top), we already have its cover at **`/MediaCover`**, which loads with the API key, so there's no reason to use the login-gated `/MediaCoverProxy` lookup cover. This surfaces real art for **owned + injected** results **without needing the web-login session at all**.

## Changes
- **Digest** carries the owned record's cover path: `LibraryTitle.Cover`, set from the group's first image via `coverOf()` (verified live: **990/1027** titles have one). `OwnedTitle` parses `cover`.
- **Matcher** exposes the matched record via `ownedMatchFor()`; `ownershipFor()` now delegates to it.
- **Dashboard** prefers the matched owned cover over the lookup cover for owned results, and injected "you own this" rows now show their cover too. Only genuinely-not-owned results fall back to `/MediaCoverProxy` (the creds path from #122).

## Net effect
Owned books in search — the relevant ones at the top — show real cover art with just the API key, regardless of whether the web-login creds are set or working. The creds/session path now only matters for covers of books you *don't* own.

## Verification
Go: reducer emits the cover (`/MediaCover/Books/1/cover.jpg`). Dart: `ownedMatchFor` exposes it. **Go + 166 Flutter tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)