### PR TITLE
Instance config: verify Chaptarr web login + explain the dual auth

### DIFF
--- a/app/lib/features/settings/data/instance_api_service.dart
+++ b/app/lib/features/settings/data/instance_api_service.dart
@@ -86,4 +86,31 @@ class InstanceApiService {
       return false;
     }
   }
+
+  /// Verifies a Chaptarr web login through the backend (which performs the same
+  /// forms login it uses to fetch cover art). Pass [instanceId] when editing so
+  /// a blank password falls back to the stored one. Returns success + any error.
+  Future<({bool success, String? error})> testWebLogin({
+    required String url,
+    required String username,
+    required String password,
+    String? instanceId,
+  }) async {
+    try {
+      final resp = await _dio.post('/api/instances/test-web-login', data: {
+        'url': url,
+        'username': username,
+        'password': password,
+        if (instanceId != null) 'instance_id': instanceId,
+      });
+      final data = resp.data as Map<String, dynamic>?;
+      final err = data?['error'] as String?;
+      return (
+        success: data?['success'] == true,
+        error: (err != null && err.isNotEmpty) ? err : null,
+      );
+    } catch (_) {
+      return (success: false, error: 'Could not reach the server');
+    }
+  }
 }

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -44,6 +44,9 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
   bool _isSaving = false;
   bool _isTesting = false;
   String? _testResult;
+  bool _isVerifyingLogin = false;
+  bool _webLoginOk = false;
+  String? _webLoginResult;
 
   static const _serviceTypes = <(String, String)>[
     ('radarr', 'Radarr'),
@@ -143,6 +146,29 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
     setState(() {
       _isTesting = false;
       _testResult = success ? 'Connection successful!' : 'Connection failed';
+    });
+  }
+
+  Future<void> _verifyWebLogin() async {
+    setState(() {
+      _isVerifyingLogin = true;
+      _webLoginResult = null;
+    });
+    final service =
+        InstanceApiService(backendDio: ref.read(backendClientProvider));
+    final result = await service.testWebLogin(
+      url: _urlController.text.trim(),
+      username: _usernameController.text.trim(),
+      password: _passwordController.text,
+      instanceId: widget.isEditing ? widget.instanceId : null,
+    );
+    if (!mounted) return;
+    setState(() {
+      _isVerifyingLogin = false;
+      _webLoginOk = result.success;
+      _webLoginResult = result.success
+          ? 'Web login OK — cover art will load.'
+          : 'Web login failed${result.error != null ? ': ${result.error}' : ''}';
     });
   }
 
@@ -416,6 +442,33 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
           // backend fetch search-result cover art.
           if (_serviceType == 'chaptarr') ...[
             const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: AppTheme.surfaceVariant,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: const Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.info_outline,
+                      size: 16, color: AppTheme.textSecondary),
+                  SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Chaptarr needs both: the API key above (search, requests, '
+                      'and owned-book covers) and an optional web login below. '
+                      'Search-result cover art is served only to a logged-in web '
+                      'session — not the API key — so without the web login those '
+                      'covers stay blank.',
+                      style:
+                          TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
             TextField(
               controller: _usernameController,
               decoration: const InputDecoration(
@@ -435,6 +488,28 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
               ),
               obscureText: true,
             ),
+            const SizedBox(height: 12),
+            OutlinedButton.icon(
+              onPressed: _isVerifyingLogin ? null : _verifyWebLogin,
+              icon: _isVerifyingLogin
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.login),
+              label: const Text('Verify web login'),
+            ),
+            if (_webLoginResult != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                _webLoginResult!,
+                style: TextStyle(
+                  color: _webLoginOk ? AppTheme.available : AppTheme.error,
+                  fontSize: 13,
+                ),
+              ),
+            ],
           ],
           const SizedBox(height: 16),
 

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -281,6 +281,9 @@ func NewRouter(
 				r.Use(auth.RequirePermission(auth.PermissionInstancesManage))
 				r.Get("/instances", instanceHandler.List)
 				r.Post("/instances", instanceHandler.Create)
+				// Verify a Chaptarr web login (for cover fetching). Static path,
+				// so it's matched before /instances/{instanceID}.
+				r.Post("/instances/test-web-login", proxyHandler.TestWebLogin())
 				r.Put("/instances/{instanceID}", instanceHandler.Update)
 				r.Delete("/instances/{instanceID}", instanceHandler.Delete)
 			})

--- a/server/internal/proxy/handler.go
+++ b/server/internal/proxy/handler.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -61,6 +62,52 @@ func (h *Handler) proxyRequest(w http.ResponseWriter, r *http.Request, target *u
 		},
 	}
 	proxy.ServeHTTP(w, r)
+}
+
+// TestWebLogin attempts a Chaptarr forms login with the given (or, for an
+// existing instance with a blank password, the stored) web credentials and
+// reports whether it succeeded — so an admin can confirm cover fetching will
+// work. Always 200; the JSON body carries success + any error message.
+func (h *Handler) TestWebLogin() http.HandlerFunc {
+	type request struct {
+		URL        string `json:"url"`
+		Username   string `json:"username"`
+		Password   string `json:"password"`
+		InstanceID string `json:"instance_id"`
+	}
+	write := func(w http.ResponseWriter, success bool, msg string) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"success": success, "error": msg})
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req request
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, `{"error":"invalid body"}`, http.StatusBadRequest)
+			return
+		}
+		url, username, password := req.URL, req.Username, req.Password
+		// Editing with a blank password: fall back to the stored credentials.
+		if password == "" && req.InstanceID != "" {
+			if inst, _ := h.store.Get(req.InstanceID); inst != nil {
+				if url == "" {
+					url = inst.URL
+				}
+				if username == "" {
+					username = inst.Username
+				}
+				password = inst.Password
+			}
+		}
+		if url == "" || username == "" || password == "" {
+			write(w, false, "URL, username, and password are required")
+			return
+		}
+		if _, err := h.sessions.login(url, username, password); err != nil {
+			write(w, false, err.Error())
+			return
+		}
+		write(w, true, "")
+	}
 }
 
 // CoverProxy streams a Chaptarr cover image. Chaptarr serves /MediaCover and

--- a/server/internal/proxy/session_test.go
+++ b/server/internal/proxy/session_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -84,6 +85,43 @@ func TestSessionLogin(t *testing.T) {
 	}
 	if _, err := sc.login(srv.URL, "admin", "wrong"); err == nil {
 		t.Error("expected error on bad credentials (loginFailed)")
+	}
+}
+
+func TestWebLoginHandler(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		if r.URL.Path == "/login" && r.FormValue("password") == "secret" {
+			http.SetCookie(w, &http.Cookie{Name: "auth", Value: "t"})
+			w.Header().Set("Location", "/")
+			w.WriteHeader(http.StatusFound)
+			return
+		}
+		w.Header().Set("Location", "/login?loginFailed=true")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+	h := NewHandler(nil)
+
+	call := func(body string) (int, bool) {
+		req := httptest.NewRequest(http.MethodPost, "/instances/test-web-login", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		h.TestWebLogin()(rec, req)
+		var resp struct {
+			Success bool `json:"success"`
+		}
+		_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+		return rec.Code, resp.Success
+	}
+
+	if code, ok := call(`{"url":"` + srv.URL + `","username":"admin","password":"secret"}`); code != http.StatusOK || !ok {
+		t.Errorf("valid creds: code=%d success=%v, want 200/true", code, ok)
+	}
+	if _, ok := call(`{"url":"` + srv.URL + `","username":"admin","password":"wrong"}`); ok {
+		t.Error("bad creds: want success=false")
+	}
+	if _, ok := call(`{"url":"` + srv.URL + `","username":"admin","password":""}`); ok {
+		t.Error("missing password: want success=false")
 	}
 }
 


### PR DESCRIPTION
Admins had no way to confirm the Chaptarr web login worked (it's only exercised lazily when fetching covers), and nothing explained *why* an instance needs **both** an API key and a web login.

## Verify web login
- **Backend**: `POST /api/instances/test-web-login` (admin-only) attempts the forms login with the supplied creds — or, when editing with a blank password, the stored ones — and returns `{success, error}`. Reuses the same `session.login()` the cover proxy uses, so a pass means covers will fetch.
- **App**: a **"Verify web login"** button on the Chaptarr instance form reports pass/fail inline (green "Web login OK — cover art will load." or the failure reason).

## The note
The Chaptarr form now shows an info box explaining the split:
> Chaptarr needs both: the API key above (search, requests, and owned-book covers) and an optional web login below. Search-result cover art is served only to a logged-in web session — not the API key — so without the web login those covers stay blank.

## Verification
Go handler test covers valid / invalid / missing creds. **Go + 166 Flutter tests pass**, analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)