### PR TITLE
Verify web login: actually test cover fetching, not just login

### DIFF
--- a/app/lib/features/settings/data/instance_api_service.dart
+++ b/app/lib/features/settings/data/instance_api_service.dart
@@ -87,13 +87,17 @@ class InstanceApiService {
     }
   }
 
-  /// Verifies a Chaptarr web login through the backend (which performs the same
-  /// forms login it uses to fetch cover art). Pass [instanceId] when editing so
-  /// a blank password falls back to the stored one. Returns success + any error.
-  Future<({bool success, String? error})> testWebLogin({
+  /// Verifies Chaptarr cover fetching through the backend: it performs the same
+  /// forms login it uses for covers AND samples a real cover, so [coverOk]
+  /// reflects whether covers actually load (Chaptarr's cover proxy can fail even
+  /// when login works). Pass [instanceId] when editing so blank secrets fall
+  /// back to the stored ones.
+  Future<({bool success, String? error, bool coverOk, String? coverDetail})>
+      testWebLogin({
     required String url,
     required String username,
     required String password,
+    String apiKey = '',
     String? instanceId,
   }) async {
     try {
@@ -101,16 +105,25 @@ class InstanceApiService {
         'url': url,
         'username': username,
         'password': password,
+        'api_key': apiKey,
         if (instanceId != null) 'instance_id': instanceId,
       });
       final data = resp.data as Map<String, dynamic>?;
       final err = data?['error'] as String?;
+      final detail = data?['cover_detail'] as String?;
       return (
         success: data?['success'] == true,
         error: (err != null && err.isNotEmpty) ? err : null,
+        coverOk: data?['cover_ok'] != false, // true unless explicitly false
+        coverDetail: (detail != null && detail.isNotEmpty) ? detail : null,
       );
     } catch (_) {
-      return (success: false, error: 'Could not reach the server');
+      return (
+        success: false,
+        error: 'Could not reach the server',
+        coverOk: false,
+        coverDetail: null,
+      );
     }
   }
 }

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -45,7 +45,7 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
   bool _isTesting = false;
   String? _testResult;
   bool _isVerifyingLogin = false;
-  bool _webLoginOk = false;
+  Color _webLoginColor = AppTheme.error;
   String? _webLoginResult;
 
   static const _serviceTypes = <(String, String)>[
@@ -160,15 +160,27 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
       url: _urlController.text.trim(),
       username: _usernameController.text.trim(),
       password: _passwordController.text,
+      apiKey: _apiKeyController.text.trim(),
       instanceId: widget.isEditing ? widget.instanceId : null,
     );
     if (!mounted) return;
     setState(() {
       _isVerifyingLogin = false;
-      _webLoginOk = result.success;
-      _webLoginResult = result.success
-          ? 'Web login OK — cover art will load.'
-          : 'Web login failed${result.error != null ? ': ${result.error}' : ''}';
+      if (!result.success) {
+        _webLoginColor = AppTheme.error;
+        _webLoginResult =
+            'Web login failed${result.error != null ? ': ${result.error}' : ''}';
+      } else if (result.coverOk) {
+        _webLoginColor = AppTheme.available;
+        _webLoginResult = 'Web login OK — cover art loads.';
+      } else {
+        // Login works but Chaptarr's cover proxy failed (a Chaptarr-side issue).
+        _webLoginColor = AppTheme.downloading;
+        _webLoginResult =
+            'Login OK, but ${result.coverDetail ?? 'covers failed to load'}. '
+            "New-book covers won't show (a Chaptarr-side issue); owned-book "
+            'covers still do.';
+      }
     });
   }
 
@@ -504,10 +516,7 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
               const SizedBox(height: 8),
               Text(
                 _webLoginResult!,
-                style: TextStyle(
-                  color: _webLoginOk ? AppTheme.available : AppTheme.error,
-                  fontSize: 13,
-                ),
+                style: TextStyle(color: _webLoginColor, fontSize: 13),
               ),
             ],
           ],

--- a/server/internal/proxy/handler.go
+++ b/server/internal/proxy/handler.go
@@ -64,20 +64,23 @@ func (h *Handler) proxyRequest(w http.ResponseWriter, r *http.Request, target *u
 	proxy.ServeHTTP(w, r)
 }
 
-// TestWebLogin attempts a Chaptarr forms login with the given (or, for an
-// existing instance with a blank password, the stored) web credentials and
-// reports whether it succeeded — so an admin can confirm cover fetching will
-// work. Always 200; the JSON body carries success + any error message.
+// TestWebLogin verifies cover fetching end-to-end with the given (or, for an
+// existing instance with blank fields, the stored) credentials: it performs the
+// forms login AND samples an actual /MediaCoverProxy cover, so the admin learns
+// not just that login works but whether covers really load (Chaptarr's cover
+// proxy can 500 server-side even with a valid session). Always 200; the JSON
+// body carries success/error plus cover_ok/cover_detail.
 func (h *Handler) TestWebLogin() http.HandlerFunc {
 	type request struct {
 		URL        string `json:"url"`
 		Username   string `json:"username"`
 		Password   string `json:"password"`
+		APIKey     string `json:"api_key"`
 		InstanceID string `json:"instance_id"`
 	}
-	write := func(w http.ResponseWriter, success bool, msg string) {
+	write := func(w http.ResponseWriter, body map[string]any) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"success": success, "error": msg})
+		_ = json.NewEncoder(w).Encode(body)
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		var req request
@@ -85,9 +88,9 @@ func (h *Handler) TestWebLogin() http.HandlerFunc {
 			http.Error(w, `{"error":"invalid body"}`, http.StatusBadRequest)
 			return
 		}
-		url, username, password := req.URL, req.Username, req.Password
-		// Editing with a blank password: fall back to the stored credentials.
-		if password == "" && req.InstanceID != "" {
+		url, username, password, apiKey := req.URL, req.Username, req.Password, req.APIKey
+		// Editing with blank secrets: fall back to the stored credentials.
+		if (password == "" || apiKey == "") && req.InstanceID != "" {
 			if inst, _ := h.store.Get(req.InstanceID); inst != nil {
 				if url == "" {
 					url = inst.URL
@@ -95,18 +98,28 @@ func (h *Handler) TestWebLogin() http.HandlerFunc {
 				if username == "" {
 					username = inst.Username
 				}
-				password = inst.Password
+				if password == "" {
+					password = inst.Password
+				}
+				if apiKey == "" {
+					apiKey = inst.APIKey
+				}
 			}
 		}
 		if url == "" || username == "" || password == "" {
-			write(w, false, "URL, username, and password are required")
+			write(w, map[string]any{"success": false, "error": "URL, username, and password are required"})
 			return
 		}
-		if _, err := h.sessions.login(url, username, password); err != nil {
-			write(w, false, err.Error())
+		cookie, err := h.sessions.login(url, username, password)
+		if err != nil {
+			write(w, map[string]any{"success": false, "error": err.Error()})
 			return
 		}
-		write(w, true, "")
+		coverOK, coverDetail := true, ""
+		if apiKey != "" {
+			coverOK, coverDetail = h.sessions.checkProxyCover(url, apiKey, cookie)
+		}
+		write(w, map[string]any{"success": true, "cover_ok": coverOK, "cover_detail": coverDetail})
 	}
 }
 

--- a/server/internal/proxy/session.go
+++ b/server/internal/proxy/session.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/windoze95/cantinarr-server/internal/chaptarr"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 )
 
@@ -155,6 +156,45 @@ func (sc *sessionCache) fetchWithKey(fullURL, apiKey string) (*http.Response, er
 		return nil, fmt.Errorf("cover upstream returned status %d", resp.StatusCode)
 	}
 	return resp, nil
+}
+
+// checkProxyCover samples a lookup result's /MediaCoverProxy cover and reports
+// whether it actually serves with the session [cookie] — the proxy can fail
+// server-side (e.g. an HTTP 500 when Chaptarr's metadata gives it a bad cover
+// URL) even though login succeeds. Returns ok=true when it can't sample (no
+// lookup results), so a healthy login is never reported as broken.
+func (sc *sessionCache) checkProxyCover(baseURL, apiKey, cookie string) (bool, string) {
+	results, err := chaptarr.NewClient(baseURL, apiKey).LookupBook("the")
+	if err != nil || len(results) == 0 {
+		return true, ""
+	}
+	var coverPath string
+	for _, img := range results[0].Images {
+		if img.URL != "" {
+			coverPath = img.URL
+			break
+		}
+	}
+	if coverPath == "" {
+		return true, ""
+	}
+	req, err := http.NewRequest(http.MethodGet, strings.TrimRight(baseURL, "/")+coverPath, nil)
+	if err != nil {
+		return true, ""
+	}
+	req.Header.Set("Cookie", cookie)
+	resp, err := sc.client.Do(req)
+	if err != nil {
+		return false, "couldn't reach the cover endpoint"
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+	if resp.StatusCode == http.StatusOK {
+		return true, ""
+	}
+	return false, fmt.Sprintf("Chaptarr's cover proxy returned HTTP %d", resp.StatusCode)
 }
 
 // sanitizeCoverPath validates that a requested cover path is a Chaptarr cover

--- a/server/internal/proxy/session_test.go
+++ b/server/internal/proxy/session_test.go
@@ -125,6 +125,32 @@ func TestWebLoginHandler(t *testing.T) {
 	}
 }
 
+func TestCheckProxyCover(t *testing.T) {
+	coverStatus := http.StatusInternalServerError
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/v1/book/lookup"):
+			_, _ = w.Write([]byte(`[{"images":[{"coverType":"cover","url":"/MediaCoverProxy/abc/x.jpg"}]}]`))
+		case strings.HasPrefix(r.URL.Path, "/MediaCoverProxy"):
+			w.WriteHeader(coverStatus)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+	sc := newSessionCache()
+
+	// A 500 from the proxy → not ok, with a detail message.
+	if ok, detail := sc.checkProxyCover(srv.URL, "key", "ChaptarrAuth=x"); ok || detail == "" {
+		t.Errorf("500 cover: ok=%v detail=%q, want ok=false with detail", ok, detail)
+	}
+	// A 200 → ok.
+	coverStatus = http.StatusOK
+	if ok, _ := sc.checkProxyCover(srv.URL, "key", "ChaptarrAuth=x"); !ok {
+		t.Error("200 cover: want ok=true")
+	}
+}
+
 func TestFetchCoverLoginsCachesAndReauths(t *testing.T) {
 	var logins int
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Root cause (confirmed live)
With a valid session cookie, Chaptarr's `/MediaCover/Books/{id}` serves **200**, but **every `/MediaCoverProxy/...` returns HTTP 500**:

> `System.NotSupportedException: The 'file' scheme is not supported.`

So the dashboard search covers fail because **Chaptarr's lookup-cover proxy crashes** trying to fetch its metadata covers from a `file://` URL — a Chaptarr-side bug. Login and the session are fine; the backend asks correctly and gets a 500. Owned-book covers work because they use `/MediaCover`, not the proxy.

## So "Verify web login" was misleading
It only checked login and promised "cover art will load". Now it **tests the real path**: after login it samples an actual `/MediaCoverProxy` cover with the session cookie and reports whether it serves.

- `proxy/session.go` `checkProxyCover()` — looks up a title, fetches its proxy cover with the cookie, returns ok + a detail (`Chaptarr's cover proxy returned HTTP 500`).
- `TestWebLogin` now takes the API key (or the stored one when editing) and returns `cover_ok`/`cover_detail`.
- App shows three honest states: login failed (red), login + covers OK (green), or **login OK but covers failing with the reason** (amber: "New-book covers won't show — a Chaptarr-side issue; owned-book covers still do").

## Verification
`checkProxyCover` unit test (200 vs 500). **Go + 166 Flutter tests pass**, analyze clean.

> The blocker itself is in Chaptarr (bad `file://` cover URLs from its metadata source), not Cantinarr — this just makes the tool tell the truth about it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)