### PR TITLE
Books search: only surface owned/monitored books, not empty shells

### DIFF
--- a/app/lib/features/dashboard/logic/book_ownership_matcher.dart
+++ b/app/lib/features/dashboard/logic/book_ownership_matcher.dart
@@ -166,10 +166,12 @@ BookOwnership? ownershipFor(ChaptarrBook result, List<OwnedTitle> digest) =>
 
 /// Owned digest titles matching the search [query] (every query token appears in
 /// the title), each kept as its own entry so the user sees and picks among their
-/// distinct records — nothing is merged. Skips only a record a lookup result
-/// already lists under the exact same title (that row already carries the chip),
-/// and collapses only literally-identical titles. Injected at the top so a book
-/// the user owns/monitors surfaces even when Chaptarr's search doesn't rank it.
+/// distinct records — nothing is merged. Only titles the user actually has or is
+/// monitoring qualify, so empty library shells (all-missing, unmonitored
+/// duplicate records) don't appear. Skips a record a lookup result already lists
+/// under the exact same title (that row already carries the chip), and collapses
+/// only literally-identical titles. Injected at the top so a book the user
+/// owns/monitors surfaces even when Chaptarr's search doesn't rank it.
 List<OwnedTitle> ownedTitlesForQuery(
   String query,
   List<OwnedTitle> digest,
@@ -182,6 +184,9 @@ List<OwnedTitle> ownedTitlesForQuery(
   final seen = <String>{};
   final out = <OwnedTitle>[];
   for (final owned in digest) {
+    // Only surface books the user actually has or is monitoring — not empty
+    // library shells (all-missing, unmonitored duplicate records).
+    if (!owned.ownership.anyOwned) continue;
     final titleTokens = normalizeTitleTokens(owned.title).toSet();
     if (titleTokens.isEmpty) continue;
     // The query must be contained in the title (a partial-name match).

--- a/app/test/dashboard/book_ownership_matcher_test.dart
+++ b/app/test/dashboard/book_ownership_matcher_test.dart
@@ -205,6 +205,15 @@ void main() {
       expect(injected.single.ownership.ebook.downloaded, isTrue);
     });
 
+    test('skips an empty (all-missing, unmonitored) library shell', () {
+      final two = [
+        _owned('Heir to the Empire', 'Timothy Zahn', ebookDownloaded: true),
+        _owned('Star Wars: Heir to the Empire', 'Timothy Zahn'), // all missing
+      ];
+      final injected = ownedTitlesForQuery('heir', two, const []);
+      expect(injected.map((t) => t.title), ['Heir to the Empire']);
+    });
+
     test('skips a record a lookup result lists under the exact same title', () {
       final lookup = [_result('Heir to the Empire', author: 'Timothy Zahn')];
       expect(ownedTitlesForQuery('heir', digest, lookup), isEmpty);


### PR DESCRIPTION
**Why two "Heir to the Empire" showed in search while Chaptarr seems to have one:** the library actually has two records — the real `fbid 340125` "Heir to the Empire" (with the downloaded ebook) and an empty duplicate `fbid 1288214` "Star Wars: Heir to the Empire" (all 4 files missing, nothing monitored). The search was injecting *every* library title matching the query, including that empty shell, so one owned book looked like two.

## Fix
`ownedTitlesForQuery` now injects a title only when the user actually **has or is monitoring** a format of it (`ownership.anyOwned`). Monitored-but-not-yet-downloaded ("wanted") books still surface; dead all-missing/unmonitored shells don't.

## Verification
New test: an all-missing, unmonitored record matching the query is skipped while the owned one is injected. **167 Flutter tests pass**, analyze clean.

> The empty `Star Wars: Heir to the Empire` records still exist in Chaptarr (junk from an earlier add) — deleting them there is optional cleanup; they just no longer clutter search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)