### PR TITLE
Books search: Request more works on owned books missing a format

### DIFF
--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -342,12 +342,14 @@ Widget? _ownershipChip(BookOwnership? o) {
   );
 }
 
-/// A synthetic, non-requestable result for an owned library title the metadata
-/// search didn't return. The digest carries no foreignBookId, so the tile shows
-/// the ownership chip with no Request button.
+/// A synthetic result for an owned library title the metadata search didn't
+/// return. It carries the owned record's foreignBookId, so a partly-owned title
+/// (e.g. ebook present, audiobook missing) still gets a "Request more" button to
+/// complete the missing format.
 ChaptarrBook _ownedTitleAsBook(OwnedTitle t) => ChaptarrBook(
       id: 0,
       title: t.title,
+      foreignBookId: t.foreignBookId.isNotEmpty ? t.foreignBookId : null,
       author: ChaptarrAuthorContext(id: 0, authorName: t.author),
       releaseDate: t.year > 0 ? DateTime(t.year) : null,
     );

--- a/app/lib/features/request/data/book_ownership.dart
+++ b/app/lib/features/request/data/book_ownership.dart
@@ -62,6 +62,11 @@ class OwnedTitle {
   /// the API key, so it shows real art for an owned result without the
   /// login-gated lookup cover. Empty when the record has no cached cover.
   final String cover;
+
+  /// The owned book's foreignBookId, so a surfaced owned result can request its
+  /// missing format (the backend completes the existing record). Empty when the
+  /// record has none.
+  final String foreignBookId;
   final BookOwnership ownership;
 
   const OwnedTitle({
@@ -69,16 +74,18 @@ class OwnedTitle {
     required this.author,
     this.year = 0,
     this.cover = '',
+    this.foreignBookId = '',
     required this.ownership,
   });
 
-  /// Parses one digest entry: `title`/`author`/`year`/`cover` plus the `ebook`
-  /// and `audiobook` format objects.
+  /// Parses one digest entry: `title`/`author`/`year`/`cover`/`foreign_book_id`
+  /// plus the `ebook` and `audiobook` format objects.
   factory OwnedTitle.fromJson(Map<String, dynamic> json) => OwnedTitle(
         title: json['title'] as String? ?? '',
         author: json['author'] as String? ?? '',
         year: json['year'] as int? ?? 0,
         cover: json['cover'] as String? ?? '',
+        foreignBookId: json['foreign_book_id'] as String? ?? '',
         ownership: BookOwnership(
           ebook: FormatOwnership.fromJson(
               json['ebook'] as Map<String, dynamic>?),

--- a/server/internal/request/library.go
+++ b/server/internal/request/library.go
@@ -29,6 +29,9 @@ type LibraryTitle struct {
 	Title  string `json:"title"`
 	Author string `json:"author"`
 	Year   int    `json:"year"`
+	// ForeignBookID lets the app request the missing format of an owned book: the
+	// request carries it back and the backend completes the existing record.
+	ForeignBookID string `json:"foreign_book_id"`
 	// Cover is the owned record's relative cover path (e.g. /MediaCover/...),
 	// which loads with the API key — so an owned search result can show real art
 	// without the login-session-gated /MediaCoverProxy lookup cover.
@@ -88,6 +91,9 @@ func reduceLibrary(books []chaptarr.Book) BookLibraryDigest {
 		// Take the cover from the first record in the group that has one.
 		if g.title.Cover == "" {
 			g.title.Cover = coverOf(book)
+		}
+		if g.title.ForeignBookID == "" {
+			g.title.ForeignBookID = book.ForeignBookID
 		}
 
 		own := FormatOwnership{
@@ -150,6 +156,30 @@ func recordFormat(book chaptarr.Book) string {
 		return chaptarr.FormatOf(book.Editions[0].Format)
 	}
 	return chaptarr.FormatUnknown
+}
+
+// recordsByForeignID indexes a foreignBookId's library records by format
+// ("ebook"/"audiobook") and returns the title. Used to complete the missing
+// format of an owned book — the request carries a library foreignBookId the
+// metadata lookup can't match, so we act on the existing records instead.
+func recordsByForeignID(books []chaptarr.Book, foreignID string) (string, map[string]*chaptarr.Book) {
+	byFormat := make(map[string]*chaptarr.Book)
+	title := ""
+	for i := range books {
+		if books[i].ForeignBookID != foreignID || foreignID == "" {
+			continue
+		}
+		if title == "" {
+			title = books[i].Title
+		}
+		switch recordFormat(books[i]) {
+		case chaptarr.FormatEbook:
+			byFormat[chaptarr.FormatEbook] = &books[i]
+		case chaptarr.FormatAudiobook:
+			byFormat[chaptarr.FormatAudiobook] = &books[i]
+		}
+	}
+	return title, byFormat
 }
 
 // GetBookLibraryDigest returns the requesting user's reduced, cached Chaptarr

--- a/server/internal/request/library_test.go
+++ b/server/internal/request/library_test.go
@@ -67,6 +67,30 @@ func TestReduceLibraryMergesFormatsByForeignBookID(t *testing.T) {
 	if lt.Cover != "/MediaCover/Books/1/cover.jpg" {
 		t.Errorf("cover = %q, want /MediaCover/Books/1/cover.jpg", lt.Cover)
 	}
+	if lt.ForeignBookID != "fb-1" {
+		t.Errorf("foreignBookID = %q, want fb-1", lt.ForeignBookID)
+	}
+}
+
+func TestRecordsByForeignID(t *testing.T) {
+	books := []chaptarr.Book{
+		{ID: 1, Title: "Ahsoka", ForeignBookID: "fb-9", MediaType: "ebook"},
+		{ID: 2, Title: "Ahsoka", ForeignBookID: "fb-9", MediaType: "audiobook"},
+		{ID: 3, Title: "Other", ForeignBookID: "fb-x", MediaType: "ebook"},
+	}
+	title, byFormat := recordsByForeignID(books, "fb-9")
+	if title != "Ahsoka" {
+		t.Fatalf("title = %q, want Ahsoka", title)
+	}
+	if byFormat[chaptarr.FormatEbook] == nil || byFormat[chaptarr.FormatEbook].ID != 1 {
+		t.Errorf("ebook = %+v, want id 1", byFormat[chaptarr.FormatEbook])
+	}
+	if byFormat[chaptarr.FormatAudiobook] == nil || byFormat[chaptarr.FormatAudiobook].ID != 2 {
+		t.Errorf("audiobook = %+v, want id 2", byFormat[chaptarr.FormatAudiobook])
+	}
+	if title, _ := recordsByForeignID(books, ""); title != "" {
+		t.Errorf("empty foreignID matched %q, want nothing", title)
+	}
 }
 
 // TestReduceLibraryRoutesByLoneEditionFormat asserts a record with no mediaType

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -601,7 +601,10 @@ func (s *Service) addToChaptarr(r *resolvedRequest) (string, string, error) {
 		}
 	}
 	if match == nil {
-		return "", "", fmt.Errorf("book not found for foreign id %s", r.foreignID)
+		// The foreignBookId belongs to a book already in the library (owned
+		// records carry a library foreignBookId the metadata lookup can't match);
+		// complete the missing format from the existing records instead of adding.
+		return s.completeOwnedBook(client, r)
 	}
 
 	qps, err := client.GetQualityProfiles()
@@ -642,6 +645,41 @@ func (s *Service) addToChaptarr(r *resolvedRequest) (string, string, error) {
 	}
 	if added == 0 {
 		return "", "", fmt.Errorf("add book failed: %w", lastErr)
+	}
+	return StatusRequested, title, nil
+}
+
+// completeOwnedBook fulfils a request whose foreignBookId is an owned library
+// record (not a current metadata id, so the lookup above couldn't match it): it
+// monitors and searches the existing record(s) for the requested format(s) to
+// fetch the missing file, rather than adding a fresh book.
+func (s *Service) completeOwnedBook(client *chaptarr.Client, r *resolvedRequest) (string, string, error) {
+	books, err := client.GetAllBooks()
+	if err != nil {
+		return "", "", fmt.Errorf("book not found for foreign id %s", r.foreignID)
+	}
+	title, byFormat := recordsByForeignID(books, r.foreignID)
+	if title == "" {
+		return "", "", fmt.Errorf("book not found for foreign id %s", r.foreignID)
+	}
+
+	var lastErr error
+	done := 0
+	for _, mediaType := range chaptarrRequestFormats(r.bookFormat) {
+		rec := byFormat[mediaType]
+		if rec == nil {
+			lastErr = fmt.Errorf("no %s edition of %q exists to complete", mediaType, title)
+			continue
+		}
+		if err := client.SetBookMonitored([]int{rec.ID}, true); err != nil {
+			lastErr = fmt.Errorf("monitor %s: %w", mediaType, err)
+			continue
+		}
+		_ = client.TriggerBookSearch([]int{rec.ID})
+		done++
+	}
+	if done == 0 {
+		return "", "", fmt.Errorf("could not complete %q: %w", title, lastErr)
 	}
 	return StatusRequested, title, nil
 }


### PR DESCRIPTION
The rule: a book shows **Request / Request more** unless it has **both** formats as files. An owned book surfaced in search — e.g. **Ahsoka** (ebook downloaded, audiobook missing) — showed **no button**, because the injected row had no `foreignBookId` and the request flow could only add via a metadata-lookup match that an owned record's id can't satisfy.

## Fix
- **Digest** carries the owned record's `foreignBookId` (`LibraryTitle.ForeignBookID`); the injected synthetic row uses it, so a partly-owned title renders its **Request more** button again.
- **`addToChaptarr`**: when the metadata lookup can't match the `foreignBookId` (i.e. it's an owned book), fall back to **`completeOwnedBook`** — find the existing format record(s) by `foreignBookId` (`recordsByForeignID`) and **monitor + search** the requested one to fetch the missing file, instead of failing ("book not found") or adding a duplicate.

So *Ahsoka → Request more → Audiobook* monitors+searches the existing audiobook record (no metadata add, no duplicate).

## Verification
Live (read-only): Ahsoka's audiobook record (id 7567, fbid 445725) is found by `foreignBookId`, so the request will act on it. Unit tests: digest `foreignBookId`, `recordsByForeignID` (finds ebook+audiobook, empty id matches nothing). **Go + 167 Flutter tests pass**, analyze clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)