### PR TITLE
Books search: Request more reflects ownership that loads after the button

### DIFF
--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -396,10 +396,18 @@ class _BookRequestButton extends StatefulWidget {
 }
 
 class _BookRequestButtonState extends State<_BookRequestButton> {
-  BookRequestStatusDetail _detail = const BookRequestStatusDetail();
+  // The async-loaded request state (no ownership). Ownership is layered on in
+  // [_detail] on every read, so the button reflects the owned-books digest even
+  // when it loads AFTER this button was first built (the chip already does) —
+  // otherwise an owned-but-unrequested format reads as "Request", not
+  // "Request more".
+  BookRequestStatusDetail _serverDetail = const BookRequestStatusDetail();
   RequestStatus _status = RequestStatus.unavailable;
   bool _loading = true;
   bool _busy = false;
+
+  BookRequestStatusDetail get _detail =>
+      _serverDetail.withOwnership(widget.ownership);
 
   @override
   void initState() {
@@ -407,13 +415,20 @@ class _BookRequestButtonState extends State<_BookRequestButton> {
     _check();
   }
 
+  @override
+  void didUpdateWidget(covariant _BookRequestButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // If this row got reused for a different book, re-fetch its request state.
+    if (oldWidget.foreignId != widget.foreignId) {
+      _check();
+    }
+  }
+
   Future<void> _check() async {
     final detail = await widget.service.checkBookStatusDetail(widget.foreignId);
     if (!mounted) return;
     setState(() {
-      // Union request state with library ownership so an owned format is also
-      // treated as covered (unrequestable).
-      _detail = detail.withOwnership(widget.ownership);
+      _serverDetail = detail;
       _status = detail.status;
       _loading = false;
     });


### PR DESCRIPTION
**Why one had "Request more" and the other didn't.** Both *Ahsoka* and *Heir to the Empire* are owned (ebook downloaded, audiobook missing) and both show the green **Downloaded** chip — but *Heir* showed **Request** while *Ahsoka* showed **Request more**.

The request button computed its per-format coverage **once** in `initState` (request state unioned with ownership) and cached it. The owned-books digest typically loads *after* the button is first built, and the button never re-applied it — so an owned-but-**unrequested** format kept reading as "Request". *Ahsoka* looked correct only because the user had requested its ebook, so coverage came from the **request_log** (always fetched), independent of the late ownership. The "Downloaded" chip is rebuilt every frame, so it reflected ownership — hence the mismatch.

## Fix
Keep the async request state separate (`_serverDetail`) and layer the **current** ownership on every read via a `_detail` getter, so the button reflects the digest the moment it arrives — same source of truth as the chip. Also re-fetch request state if a row is reused for a different book (`didUpdateWidget`).

Net: every incomplete book shows **Request / Request more**; only a book with both formats as files shows none.

## Verification
Analyze clean; **167 tests pass** (incl. the `isCovered` ownership-union gating tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)