### PR TITLE
Issues: drop the ×N occurrence counter (it was a per-poll re-detection count)

### DIFF
--- a/app/lib/features/issues/ui/issues_list_screen.dart
+++ b/app/lib/features/issues/ui/issues_list_screen.dart
@@ -165,7 +165,6 @@ class _IssueTile extends StatelessWidget {
             children: [
               if (category != null) _chip(category.label),
               _statusChip(issue.status),
-              if (issue.occurrences > 1) _chip('×${issue.occurrences}'),
             ],
           ),
         ],

--- a/server/internal/remediation/autodispatch_test.go
+++ b/server/internal/remediation/autodispatch_test.go
@@ -72,14 +72,15 @@ func TestAutoDispatcherOpensExactlyOneIssueAcrossPolls(t *testing.T) {
 	if got := countOpenAutoIssues(t, svc); got != 1 {
 		t.Fatalf("open auto issues after repeated polls = %d, want exactly 1", got)
 	}
-	// The occurrences counter on the single issue reflects the repeats (1 insert +
-	// 5 duplicate bumps).
+	// Re-detecting the same ongoing problem each poll is not a new occurrence, so
+	// the counter stays at 1 (it used to climb per poll, which was just a confusing
+	// time-open counter).
 	var occ int
 	if err := svc.db.QueryRow("SELECT occurrences FROM issues WHERE source = ? AND closed_at IS NULL", SourceAuto).Scan(&occ); err != nil {
 		t.Fatalf("read occurrences: %v", err)
 	}
-	if occ != 6 {
-		t.Fatalf("occurrences = %d, want 6 (1 create + 5 dedupe bumps)", occ)
+	if occ != 1 {
+		t.Fatalf("occurrences = %d, want 1 (re-polls don't bump)", occ)
 	}
 	// The Runner was enqueued exactly once (only the create path enqueues).
 	if jobs := drainJobs(svc); jobs != 1 {

--- a/server/internal/remediation/service.go
+++ b/server/internal/remediation/service.go
@@ -204,9 +204,12 @@ func (s *Service) OpenAutoIssue(scope, instanceID, downloadID string, d arr.Diag
 		return false, 0
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
-		// Existing open issue for this key: bump occurrences, no new issue.
+		// Existing open issue for this key: just refresh last-seen, no new issue.
+		// Re-detecting the same ongoing problem on every 30s poll is NOT a new
+		// occurrence, so we don't bump occurrences (it only inflated a confusing
+		// per-poll counter that climbed with time-open, not severity).
 		s.db.Exec(
-			"UPDATE issues SET occurrences = occurrences + 1, updated_at = CURRENT_TIMESTAMP WHERE dedupe_key = ? AND closed_at IS NULL",
+			"UPDATE issues SET updated_at = CURRENT_TIMESTAMP WHERE dedupe_key = ? AND closed_at IS NULL",
 			dedupeKey,
 		)
 		return false, 0


### PR DESCRIPTION
**You were right — it was useless and confusing.** The `×N` badge was `issue.occurrences`, and the auto-detector bumped it on **every 30-second poll** that re-saw the *same* ongoing stuck/blocked download. So `×27` meant "the poller re-confirmed this same problem 27 times," i.e. it climbed with **time-open**, not severity or distinct events — and it kept ticking on "Awaiting approval" cards (which read as solved but aren't).

## Change
- Remove the `×N` chip from the issues list.
- Stop bumping `occurrences` when the poller re-detects an already-open auto issue — re-seeing an ongoing problem isn't a new occurrence. Still refreshes last-seen (`updated_at`) and still keeps exactly **one issue per stuck download** via the `dedupe_key`.

The genuine user-report dedupe path is untouched (a user re-reporting the same thing still counts). Test updated: repeated polls of one stuck download now keep `occurrences` at 1.

**Go (all packages) + 167 Flutter tests pass.**

> If you'd ever want a *meaningful* recurrence signal instead, the better one is time-based — e.g. "last active 2 min ago" from `updated_at` — happy to add that; this just removes the misleading counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)