### PR TITLE
Issues: auto-resolve auto-detected issues when the problem clears

### DIFF
--- a/server/internal/remediation/autodispatch.go
+++ b/server/internal/remediation/autodispatch.go
@@ -63,6 +63,20 @@ func (a *AutoDispatcher) OpenAutoIssue(serviceType, instanceID, downloadID strin
 	a.svc.Enqueue(id)
 }
 
+// CloseAutoIssue resolves the open auto issue for a download the poller no longer
+// flags (it recovered or left the queue). Gated only on the master switch — NOT
+// AutoDispatch — so a recovered issue still auto-closes even after the circuit
+// breaker disarmed dispatch. A no-op when there's no matching open issue.
+func (a *AutoDispatcher) CloseAutoIssue(serviceType, instanceID, downloadID string) {
+	if a == nil || a.svc == nil {
+		return
+	}
+	if !a.svc.Settings().Enabled {
+		return
+	}
+	a.svc.CloseAutoIssueForDownload(instanceID, downloadID)
+}
+
 // --- circuit breaker ---
 //
 // The breaker bounds how many unattended auto-dispatch investigations can fail

--- a/server/internal/remediation/autodispatch_test.go
+++ b/server/internal/remediation/autodispatch_test.go
@@ -88,6 +88,41 @@ func TestAutoDispatcherOpensExactlyOneIssueAcrossPolls(t *testing.T) {
 	}
 }
 
+// TestCloseAutoIssueResolvesRecoveredDownload proves that when the poller stops
+// flagging a download, the matching open auto issue is resolved and closed.
+func TestCloseAutoIssueResolvesRecoveredDownload(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	enableAutoDispatch(t, svc, 5)
+	ad := NewAutoDispatcher(svc)
+
+	d := stalledDiagnosis()
+	ad.OpenAutoIssue("radarr", "inst1", "stuckHash", d)
+	ad.OpenAutoIssue("radarr", "inst1", "stuckHash", d) // dedupe, still one open
+	drainJobs(svc)
+	if got := countOpenAutoIssues(t, svc); got != 1 {
+		t.Fatalf("open auto issues = %d, want 1", got)
+	}
+
+	// The download recovered / left the queue → close.
+	ad.CloseAutoIssue("radarr", "inst1", "stuckHash")
+	if got := countOpenAutoIssues(t, svc); got != 0 {
+		t.Fatalf("open auto issues after recovery = %d, want 0", got)
+	}
+	var n int
+	if err := svc.db.QueryRow(
+		"SELECT COUNT(*) FROM issues WHERE source = ? AND status = ? AND closed_at IS NOT NULL",
+		SourceAuto, IssueResolved,
+	).Scan(&n); err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("resolved+closed auto issues = %d, want 1", n)
+	}
+
+	// A second close for a download with no open issue is a harmless no-op.
+	ad.CloseAutoIssue("radarr", "inst1", "stuckHash")
+}
+
 // TestAutoDispatcherGatedOff proves the opener is a no-op unless BOTH the master
 // switch and the auto-dispatch sub-toggle are on — checked at call time so a live
 // toggle takes effect without a restart.

--- a/server/internal/remediation/service.go
+++ b/server/internal/remediation/service.go
@@ -222,6 +222,27 @@ func (s *Service) OpenAutoIssue(scope, instanceID, downloadID string, d arr.Diag
 	return true, newID
 }
 
+// CloseAutoIssueForDownload resolves the open auto issue for a download whose
+// problem the poller no longer detects (it recovered or left the queue). A
+// no-op when there's no matching open issue. Idempotent via ConcludeIssue's CAS.
+func (s *Service) CloseAutoIssueForDownload(instanceID, downloadID string) {
+	if downloadID == "" {
+		return
+	}
+	var issueID int64
+	err := s.db.QueryRow(
+		`SELECT id FROM issues
+		 WHERE source = ? AND instance_id = ? AND download_id = ? AND closed_at IS NULL
+		 LIMIT 1`,
+		SourceAuto, instanceID, downloadID,
+	).Scan(&issueID)
+	if err != nil {
+		return // sql.ErrNoRows (nothing open) or a read error: nothing to do.
+	}
+	_ = s.ConcludeIssue(context.Background(), issueID, IssueResolved,
+		"Auto-resolved: the download is no longer stuck or blocked — the problem cleared.")
+}
+
 // notifyIssueCreated fires the issue_created admin notification carrying the
 // live open-issue count for badging. The title is passed as a structured field
 // (arr/user-sourced) — the push layer builds the human-readable body from fixed

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -66,6 +66,12 @@ type IssueOpener interface {
 	// stable download-client hash; d is the classifier's verdict. It must not
 	// block the poll goroutine (the Runner is enqueued, never run inline).
 	OpenAutoIssue(serviceType, instanceID, downloadID string, d arr.Diagnosis)
+
+	// CloseAutoIssue is called when a download that WAS a confirmed problem is no
+	// longer detected on a successful poll (it recovered or left the queue). The
+	// implementation resolves the matching open auto-issue; a no-op when there's
+	// none. Must not block the poll goroutine.
+	CloseAutoIssue(serviceType, instanceID, downloadID string)
 }
 
 // queueSignalItem bundles a queue item's stable download-client id with the
@@ -519,12 +525,21 @@ func (h *Hub) dispatchDetailedItems(serviceType, instanceID string, items []queu
 		}
 	}
 	// Replace the remembered problems for THIS instance: drop stale keys (other
-	// downloads/instances are untouched), record the current ones.
+	// downloads/instances are untouched), record the current ones. A key that
+	// drops out — was a problem last poll, absent on this (successful) poll —
+	// means the download recovered or left the queue, so its issue can close.
+	// This only runs after a successful queue fetch (the caller returns on
+	// error), so a failed poll can never mass-close an instance's issues.
 	prefix := serviceType + ":" + instanceID + ":"
+	var toClose []string
 	for k := range h.prevArrProblems {
-		if strings.HasPrefix(k, prefix) {
-			delete(h.prevArrProblems, k)
+		if !strings.HasPrefix(k, prefix) {
+			continue
 		}
+		if _, stillAProblem := current[k]; !stillAProblem {
+			toClose = append(toClose, strings.TrimPrefix(k, prefix))
+		}
+		delete(h.prevArrProblems, k)
 	}
 	for k, v := range current {
 		h.prevArrProblems[k] = v
@@ -533,6 +548,9 @@ func (h *Hub) dispatchDetailedItems(serviceType, instanceID string, items []queu
 
 	for _, d := range toOpen {
 		h.opener.OpenAutoIssue(serviceType, instanceID, d.downloadID, d.diagnosis)
+	}
+	for _, downloadID := range toClose {
+		h.opener.CloseAutoIssue(serviceType, instanceID, downloadID)
 	}
 }
 

--- a/server/internal/websocket/hub_test.go
+++ b/server/internal/websocket/hub_test.go
@@ -14,8 +14,9 @@ import (
 // reaches the opener, and the opener is then called once per confirming poll
 // (the real DB dedupe — exercised separately — collapses those into one issue).
 type fakeOpener struct {
-	mu    sync.Mutex
-	calls []openCall
+	mu     sync.Mutex
+	calls  []openCall
+	closes []openCall
 }
 
 type openCall struct {
@@ -31,10 +32,52 @@ func (f *fakeOpener) OpenAutoIssue(serviceType, instanceID, downloadID string, d
 	f.calls = append(f.calls, openCall{serviceType, instanceID, downloadID, d.Problem})
 }
 
+func (f *fakeOpener) CloseAutoIssue(serviceType, instanceID, downloadID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closes = append(f.closes, openCall{serviceType, instanceID, downloadID, ""})
+}
+
 func (f *fakeOpener) count() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.calls)
+}
+
+func (f *fakeOpener) closeCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.closes)
+}
+
+// TestDispatchClosesWhenProblemClears asserts a confirmed problem that later
+// drops out of a successful poll triggers exactly one CloseAutoIssue, and that a
+// further absent poll doesn't re-close (the key already dropped from the map).
+func TestDispatchClosesWhenProblemClears(t *testing.T) {
+	f := &fakeOpener{}
+	h := newTestHub(f)
+
+	// Two confirming polls open the issue.
+	h.dispatchDetailedItems("radarr", "inst1", []queueSignalItem{stuckItem("dl1")})
+	h.dispatchDetailedItems("radarr", "inst1", []queueSignalItem{stuckItem("dl1")})
+	if f.count() == 0 {
+		t.Fatal("expected the stuck download to open after two polls")
+	}
+
+	// The download is gone on a successful poll → recovered → close once.
+	h.dispatchDetailedItems("radarr", "inst1", nil)
+	if f.closeCount() != 1 {
+		t.Fatalf("close calls = %d, want 1 after the problem cleared", f.closeCount())
+	}
+	if c := f.closes[0]; c.downloadID != "dl1" || c.instanceID != "inst1" {
+		t.Fatalf("close call = %+v, want dl1/inst1", c)
+	}
+
+	// Still gone next poll → no duplicate close (key already dropped out).
+	h.dispatchDetailedItems("radarr", "inst1", nil)
+	if f.closeCount() != 1 {
+		t.Fatalf("close calls = %d, want still 1 (no re-close)", f.closeCount())
+	}
 }
 
 // newTestHub builds a hub wired with only the given opener. The other


### PR DESCRIPTION
You're right — "if it's no longer an issue, it shouldn't still be an open ticket." Auto-opened issues (stuck/blocked downloads) had **no way to close themselves**: once a download recovered, completed, or you fixed it in Radarr directly, the ticket lingered "open" forever until an agent or admin acted.

## How
The 30s poller already tracks the live per-download problem set and rebuilds it each successful poll — so a download that **drops out** is exactly the "recovered" signal.

- **hub**: when a previously-confirmed problem download is absent from a *successful* poll, call the new `IssueOpener.CloseAutoIssue`. Drop detection is **prefix-scoped per instance**, and the poller `return`s on a queue-fetch error before this runs — so a failed poll can **never** mass-close an instance's issues (an empty queue only closes things when the fetch genuinely succeeded).
- **`AutoDispatcher.CloseAutoIssue` → `Service.CloseAutoIssueForDownload`** finds the open auto issue by `instance_id` + `download_id` and `ConcludeIssue(resolved)`. CAS on `closed_at`, so it's idempotent and a no-op when nothing's open. Gated on the **master switch only** (not AutoDispatch), so recovery still closes issues even after the circuit breaker disarms dispatch.

Net: a stuck download that unsticks (or that you fix yourself) now auto-resolves its ticket within a poll, instead of sitting open. The opening debounce stays 2 polls (conservative); closing is 1 poll (responsive).

## Verification
Tests: a cleared problem closes exactly once with no re-close on later empty polls; the service resolves+closes the matching open issue and no-ops when there's nothing open. **Go (all packages) pass.**

> Auto-resolve currently fires the normal "issue resolved" notification (same as an agent resolving one). If that's noisy when several clear at once, I can make auto-recovery a quiet close — say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)