### PR TITLE
Requests: stop 'request more' from unmonitoring the whole series

### DIFF
--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -43,6 +43,13 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
   /// per-season picker.
   final GlobalKey _seasonsKey = GlobalKey();
 
+  /// The request option set the server allows this user (season/quality
+  /// choice). Loaded once for TV so the season picker can hide its request
+  /// affordances when the user may not choose seasons — the server ignores an
+  /// explicit season list from such users, so offering the picker would be a
+  /// silent no-op.
+  RequestOptions? _requestOptions;
+
   @override
   void initState() {
     super.initState();
@@ -61,7 +68,16 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
 
     _detailNotifier.load();
     _requestNotifier.checkStatus();
+    if (widget.mediaType == MediaType.tv) {
+      _requestNotifier.fetchOptions().then((opts) {
+        if (mounted && opts != null) setState(() => _requestOptions = opts);
+      });
+    }
   }
+
+  /// Whether the user may pick specific seasons. Defaults to true (the
+  /// server's out-of-the-box global setting) until the options load.
+  bool get _canChooseSeasons => _requestOptions?.canChooseSeason ?? true;
 
   @override
   Widget build(BuildContext context) {
@@ -304,6 +320,7 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                         notifier: _requestNotifier,
                         title: state.title,
                         tvdbId: state.tvDetail?.externalIds?.tvdbId,
+                        canRequest: _canChooseSeasons,
                       ),
                     ],
 
@@ -358,12 +375,20 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
   Future<void> _onRequest() async {
     final s = _detailNotifier.state;
 
+    final options = await _requestNotifier.fetchOptions();
+    if (options != null && mounted) {
+      setState(() => _requestOptions = options);
+    }
+
     // A partially-available show: "Request More" drops the user into the
     // per-season picker below rather than the coarse season-scope sheet, so
-    // they can choose exactly which missing seasons to add.
+    // they can choose exactly which missing seasons to add. Users who may not
+    // choose seasons fall through to the coarse flow instead (the server
+    // applies their default season scope to the missing seasons).
     if (widget.mediaType == MediaType.tv &&
         _requestNotifier.state.status == RequestStatus.partial &&
-        s.seasons.isNotEmpty) {
+        s.seasons.isNotEmpty &&
+        (options?.canChooseSeason ?? true)) {
       _scrollToSeasons();
       return;
     }
@@ -371,7 +396,6 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
     final title = s.title;
     final tvdbId = s.tvDetail?.externalIds?.tvdbId;
 
-    final options = await _requestNotifier.fetchOptions();
     String? seasonScope;
     int? qualityProfileId;
     if (options != null && options.hasChoices) {

--- a/app/lib/features/media_detail/ui/season_table.dart
+++ b/app/lib/features/media_detail/ui/season_table.dart
@@ -8,7 +8,7 @@ import '../../request/logic/request_provider.dart';
 /// with a checkbox, "Season N", an "x/y eps" availability count, and a status
 /// badge. Already-available seasons are shown checked + disabled. Quick
 /// All / First / Latest chips bulk-select. Submitting sends the chosen season
-/// numbers to the request service (the server's seasonpass path).
+/// numbers to the request service.
 ///
 /// The table reads live per-season status from [notifier] and drives its
 /// submit through it, so it stays in sync with the request button above it.
@@ -20,12 +20,20 @@ class SeasonTable extends StatefulWidget {
   final String? title;
   final int? tvdbId;
 
+  /// Whether the current user may pick specific seasons (the server's
+  /// can_choose_season option). When false the table is status-only — no
+  /// checkboxes, chips, or submit button — because the server ignores an
+  /// explicit season list from a user who isn't allowed to choose, which would
+  /// make the picker a silent no-op.
+  final bool canRequest;
+
   const SeasonTable({
     super.key,
     required this.seasons,
     required this.notifier,
     this.title,
     this.tvdbId,
+    this.canRequest = true,
   });
 
   @override
@@ -107,7 +115,8 @@ class _SeasonTableState extends State<SeasonTable> {
       listenable: widget.notifier,
       builder: (context, _) {
         final seasons = _realSeasons;
-        final hasSelectable = _selectableNumbers.isNotEmpty;
+        final hasSelectable =
+            widget.canRequest && _selectableNumbers.isNotEmpty;
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Column(
@@ -140,6 +149,7 @@ class _SeasonTableState extends State<SeasonTable> {
                         status: _statusBySeason[seasons[i].seasonNumber],
                         selected: _selected.contains(seasons[i].seasonNumber),
                         available: _isAvailable(seasons[i].seasonNumber),
+                        selectable: widget.canRequest,
                         onChanged: (v) => _toggle(seasons[i].seasonNumber, v),
                       ),
                     ],
@@ -195,6 +205,7 @@ class _SeasonRow extends StatelessWidget {
   final RequestSeasonStatus? status;
   final bool selected;
   final bool available;
+  final bool selectable;
   final ValueChanged<bool?> onChanged;
 
   const _SeasonRow({
@@ -202,6 +213,7 @@ class _SeasonRow extends StatelessWidget {
     required this.status,
     required this.selected,
     required this.available,
+    required this.selectable,
     required this.onChanged,
   });
 
@@ -211,18 +223,21 @@ class _SeasonRow extends StatelessWidget {
     // user's selection.
     final checked = available || selected;
     return InkWell(
-      onTap: available ? null : () => onChanged(!selected),
+      onTap: (!selectable || available) ? null : () => onChanged(!selected),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
         child: Row(
           children: [
-            Checkbox(
-              value: checked,
-              onChanged: available ? null : onChanged,
-              activeColor: AppTheme.accent,
-              checkColor: Colors.white,
-              side: const BorderSide(color: AppTheme.textSecondary),
-            ),
+            if (selectable)
+              Checkbox(
+                value: checked,
+                onChanged: available ? null : onChanged,
+                activeColor: AppTheme.accent,
+                checkColor: Colors.white,
+                side: const BorderSide(color: AppTheme.textSecondary),
+              )
+            else
+              const SizedBox(width: 12),
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,

--- a/app/lib/features/request/data/request_service.dart
+++ b/app/lib/features/request/data/request_service.dart
@@ -350,9 +350,9 @@ class RequestService {
       };
       if (title != null) body['title'] = title;
       if (tvdbId != null && tvdbId != 0) body['tvdb_id'] = tvdbId;
-      // An explicit season list routes the server to the seasonpass path
-      // (monitor exactly these seasons). It takes precedence over season_scope,
-      // so only send the coarse scope when no explicit list was chosen.
+      // An explicit season list makes the server monitor exactly these
+      // seasons. It takes precedence over season_scope, so only send the
+      // coarse scope when no explicit list was chosen.
       if (seasons != null && seasons.isNotEmpty) {
         body['seasons'] = seasons;
       } else if (seasonScope != null) {

--- a/app/test/request/season_table_gating_test.dart
+++ b/app/test/request/season_table_gating_test.dart
@@ -1,0 +1,58 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cantinarr/features/discover/data/tmdb_models.dart';
+import 'package:cantinarr/features/media_detail/ui/season_table.dart';
+import 'package:cantinarr/features/request/data/request_service.dart';
+import 'package:cantinarr/features/request/logic/request_provider.dart';
+
+/// The season picker must be request-capable only for users the server allows
+/// to choose seasons (can_choose_season). For everyone else the server ignores
+/// an explicit season list, so showing checkboxes and a submit button would be
+/// a silent no-op.
+void main() {
+  const seasons = [
+    Season(id: 1, seasonNumber: 1, name: 'Season 1', episodeCount: 10),
+    Season(id: 2, seasonNumber: 2, name: 'Season 2', episodeCount: 8),
+  ];
+
+  RequestNotifier notifier() => RequestNotifier(
+        service: RequestService(backendDio: Dio()),
+        tmdbId: 123,
+        mediaType: MediaType.tv,
+      );
+
+  Widget host(SeasonTable table) => MaterialApp(
+        home: Scaffold(body: SingleChildScrollView(child: table)),
+      );
+
+  testWidgets('season choice allowed: checkboxes, chips and submit render',
+      (tester) async {
+    await tester.pumpWidget(host(SeasonTable(
+      seasons: seasons,
+      notifier: notifier(),
+    )));
+
+    expect(find.byType(Checkbox), findsNWidgets(2));
+    expect(find.text('All'), findsOneWidget);
+    expect(find.text('Select seasons to request'), findsOneWidget);
+  });
+
+  testWidgets('season choice not allowed: table is status-only',
+      (tester) async {
+    await tester.pumpWidget(host(SeasonTable(
+      seasons: seasons,
+      notifier: notifier(),
+      canRequest: false,
+    )));
+
+    // Season rows still render (status display)...
+    expect(find.text('Season 1'), findsOneWidget);
+    expect(find.text('Season 2'), findsOneWidget);
+    // ...but every request affordance is gone.
+    expect(find.byType(Checkbox), findsNothing);
+    expect(find.text('All'), findsNothing);
+    expect(find.text('Select seasons to request'), findsNothing);
+    expect(find.byType(ElevatedButton), findsNothing);
+  });
+}

--- a/server/internal/radarr/client.go
+++ b/server/internal/radarr/client.go
@@ -413,6 +413,20 @@ func (c *Client) GrabRelease(guid string, indexerID int) error {
 	return nil
 }
 
+// SetMoviesMonitored sets the monitored flag on the given movies via Radarr's
+// bulk movie editor, which applies only the fields present in the payload (no
+// full-object round-trip needed).
+func (c *Client) SetMoviesMonitored(movieIDs []int, monitored bool) error {
+	if len(movieIDs) == 0 {
+		return nil
+	}
+	body := map[string]any{"movieIds": movieIDs, "monitored": monitored}
+	if err := c.do("PUT", "/api/v3/movie/editor", body, nil); err != nil {
+		return fmt.Errorf("radarr set movies monitored: %w", err)
+	}
+	return nil
+}
+
 // triggerCommand posts a command payload to Radarr's command endpoint.
 func (c *Client) triggerCommand(payload map[string]any) error {
 	if err := c.do("POST", "/api/v3/command", payload, nil); err != nil {

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -132,9 +132,9 @@ type CreateRequest struct {
 	SeasonScope      string `json:"season_scope"`
 	QualityProfileID int    `json:"quality_profile_id"`
 	// Seasons is an optional explicit list of season numbers (TV only). When
-	// present & non-empty it takes the seasonpass code path (monitor exactly
-	// these seasons), overriding the coarse SeasonScope. Empty/absent keeps the
-	// existing season_scope behavior.
+	// present & non-empty exactly these seasons are monitored (additively for a
+	// series already in the library), overriding the coarse SeasonScope.
+	// Empty/absent keeps the existing season_scope behavior.
 	Seasons []int `json:"seasons,omitempty"`
 }
 
@@ -274,8 +274,8 @@ type resolvedRequest struct {
 	seasonScope      string
 	qualityProfileID int
 	// seasonNumbers, when non-empty, is an explicit set of seasons to monitor
-	// via the seasonpass path (overrides seasonScope). It round-trips through
-	// the approval flow by being JSON-encoded into the season_scope column.
+	// (overrides seasonScope). It round-trips through the approval flow by
+	// being JSON-encoded into the season_scope column.
 	seasonNumbers []int
 }
 
@@ -463,7 +463,8 @@ func (s *Service) CreateMediaRequest(userID int64, req *CreateRequest) (*CreateR
 	// scope when season choice is allowed: it's normalized, captured on the
 	// resolved request, and JSON-encoded into seasonScope so it persists through
 	// the (pending -> approve) flow in the existing season_scope column. The
-	// addSeries path then routes it to seasonpass instead of addOptions.Monitor.
+	// addSeries path then monitors exactly those seasons instead of using the
+	// coarse addOptions.Monitor enum.
 	if req.MediaType == "tv" {
 		resolved.seasonScope = eff.SeasonScope
 		if req.SeasonScope != "" && eff.AllowSeasonChoice && validSeasonScope(req.SeasonScope) {
@@ -759,11 +760,21 @@ func (s *Service) addMovie(r *resolvedRequest) (string, string, error) {
 
 	existing, err := radarrClient.GetMovieByTMDB(r.tmdbID)
 	if err == nil && existing != nil {
-		status := StatusRequested
 		if existing.HasFile {
-			status = StatusAvailable
+			return StatusAvailable, existing.Title, nil
 		}
-		return status, existing.Title, nil
+		// The movie is in Radarr without a file. If it isn't monitored Radarr
+		// will never grab it, so a fresh request revives it (monitor + search)
+		// instead of reporting "requested" while nothing would ever happen.
+		if !existing.Monitored {
+			if err := radarrClient.SetMoviesMonitored([]int{existing.ID}, true); err != nil {
+				return "", "", fmt.Errorf("monitor movie failed: %w", err)
+			}
+			// Best-effort: with the movie monitored again, RSS will still pick
+			// it up even if this immediate search fails.
+			_ = radarrClient.TriggerMoviesSearch([]int{existing.ID})
+		}
+		return StatusRequested, existing.Title, nil
 	}
 
 	lookup, err := radarrClient.LookupByTMDB(r.tmdbID)
@@ -830,18 +841,12 @@ func (s *Service) addSeries(r *resolvedRequest) (string, string, error) {
 			// existing monitor set (without unmonitoring what's already there) and
 			// kick off a per-season search.
 			if len(r.seasonNumbers) > 0 {
-				if err := s.monitorAndSearchSeasons(sonarrClient, existing, r.seasonNumbers, false); err != nil {
+				if err := s.monitorAndSearchSeasons(sonarrClient, existing, r.seasonNumbers); err != nil {
 					return "", "", err
 				}
 				return StatusRequested, existing.Title, nil
 			}
-			status := StatusRequested
-			if existing.Statistics != nil && existing.Statistics.PercentOfEpisodes >= 100 {
-				status = StatusAvailable
-			} else if existing.Statistics != nil && existing.Statistics.EpisodeFileCount > 0 {
-				status = StatusPartial
-			}
-			return status, existing.Title, nil
+			return s.requestExistingSeries(sonarrClient, existing, r)
 		}
 	}
 
@@ -887,24 +892,19 @@ func (s *Service) addSeries(r *resolvedRequest) (string, string, error) {
 		SeasonFolder:     true,
 	}
 
-	// Explicit season list: Sonarr's add-series API has no field for an
-	// arbitrary set of season numbers (addOptions.Monitor is a single enum), so
-	// a "seasons: [...]" DTO would be silently ignored. Add the series
-	// unmonitored with no search, then drive the exact selection via seasonpass
-	// + a per-season search. The coarse season_scope path below stays the
-	// default for everyone who doesn't pick specific seasons.
+	// Explicit season list: Sonarr's addOptions.monitor enum has no "these
+	// specific seasons" value, but the add payload's seasons[].monitored flags
+	// survive the add and its async metadata refresh, and Sonarr applies
+	// episode monitoring from them (and runs the missing-episode search) once
+	// the refresh completes. Adding unmonitored and fixing monitoring up
+	// afterwards is NOT safe here: the refresh applies addOptions.monitor
+	// asynchronously and would race with — and overwrite — any immediate
+	// follow-up monitoring calls.
 	if len(r.seasonNumbers) > 0 {
-		addReq.AddOptions.SearchForMissingEpisodes = false
-		addReq.AddOptions.Monitor = "none"
+		addReq.Seasons = seasonSelection(lookup.Seasons, r.seasonNumbers)
+		addReq.AddOptions.SearchForMissingEpisodes = true
 		if err := sonarrClient.AddSeries(addReq); err != nil {
 			return "", "", fmt.Errorf("add series failed: %w", err)
-		}
-		added, err := sonarrClient.GetSeriesByTVDB(tvdbID)
-		if err != nil || added == nil {
-			return "", "", fmt.Errorf("add series failed: could not re-read added series for seasonpass: %w", err)
-		}
-		if err := s.monitorAndSearchSeasons(sonarrClient, added, r.seasonNumbers, true); err != nil {
-			return "", "", err
 		}
 		return StatusRequested, lookup.Title, nil
 	}
@@ -918,47 +918,217 @@ func (s *Service) addSeries(r *resolvedRequest) (string, string, error) {
 	return StatusRequested, lookup.Title, nil
 }
 
-// monitorAndSearchSeasons monitors exactly (or, when exclusive is false,
-// additionally) the chosen seasons on an existing Sonarr series via seasonpass,
-// then triggers a SeasonSearch for each chosen season. When exclusive is true
-// the chosen seasons are monitored and every other real season is unmonitored;
-// when false the chosen seasons are added to whatever is already monitored
-// (used for "request more seasons" on a series already in the library). Season
-// 0 / Specials is never touched unless explicitly chosen.
-func (s *Service) monitorAndSearchSeasons(client *sonarr.Client, series *sonarr.Series, seasons []int, exclusive bool) error {
-	chosen := make(map[int]bool, len(seasons))
-	for _, n := range seasons {
-		chosen[n] = true
-	}
-	monitored := make(map[int]bool, len(series.Seasons))
-	for _, s := range series.Seasons {
-		switch {
-		case chosen[s.SeasonNumber]:
-			monitored[s.SeasonNumber] = true
-		case exclusive && s.SeasonNumber > 0:
-			// Exclusive selection: unmonitor other real seasons (leave Specials).
-			monitored[s.SeasonNumber] = false
-		default:
-			// Non-exclusive: preserve the season's current monitored state.
-			monitored[s.SeasonNumber] = s.Monitored
-		}
-	}
-	// Include any chosen season Sonarr didn't list (defensive; normally all
-	// seasons are present once the series is added).
-	for n := range chosen {
-		if _, ok := monitored[n]; !ok {
-			monitored[n] = true
-		}
-	}
-	if err := client.SetSeasonsViaSeasonPass(series.ID, monitored); err != nil {
-		return fmt.Errorf("set seasons failed: %w", err)
+// monitorAndSearchSeasons additively monitors the chosen seasons on an existing
+// Sonarr series ("request more seasons"), then triggers a SeasonSearch for each
+// chosen season. Seasons that aren't chosen keep their current monitored state;
+// a deliberate re-request of the same seasons re-searches them.
+func (s *Service) monitorAndSearchSeasons(client *sonarr.Client, series *sonarr.Series, seasons []int) error {
+	if _, err := s.monitorSeasons(client, series, seasons); err != nil {
+		return err
 	}
 	for _, n := range seasons {
 		// Best-effort: a failed per-season search shouldn't undo the monitor
-		// change. Sonarr will still pick up monitored seasons on its next cycle.
+		// change. Sonarr will still pick up monitored episodes on its next cycle.
 		_ = client.TriggerSeasonSearch(series.ID, n)
 	}
 	return nil
+}
+
+// monitorSeasons makes sure the series itself, the chosen seasons, and the
+// chosen seasons' episodes are all monitored, preserving the monitored state of
+// everything else. It returns the chosen seasons where anything actually had to
+// change, so callers can decide what deserves a fresh search.
+//
+// The per-episode pass matters: Sonarr's series update only syncs episode
+// monitoring for seasons whose flag CHANGES, so a season already flagged
+// monitored can still hold unmonitored episodes that no search would ever grab.
+func (s *Service) monitorSeasons(client *sonarr.Client, series *sonarr.Series, seasons []int) (changed []int, err error) {
+	flags := make(map[int]bool, len(series.Seasons)+len(seasons))
+	for _, ss := range series.Seasons {
+		flags[ss.SeasonNumber] = ss.Monitored
+	}
+	flagChanged := make(map[int]bool, len(seasons))
+	for _, n := range seasons {
+		if !flags[n] {
+			flagChanged[n] = true
+		}
+		flags[n] = true
+	}
+	if err := client.UpdateSeriesMonitoring(series.ID, true, flags); err != nil {
+		return nil, fmt.Errorf("set seasons failed: %w", err)
+	}
+	for _, n := range seasons {
+		episodes, err := client.GetEpisodes(series.ID, n)
+		if err != nil {
+			return nil, fmt.Errorf("load season %d episodes: %w", n, err)
+		}
+		ids := make([]int, 0, len(episodes))
+		for _, e := range episodes {
+			if !e.Monitored {
+				ids = append(ids, e.ID)
+			}
+		}
+		if err := client.SetEpisodesMonitored(ids, true); err != nil {
+			return nil, fmt.Errorf("monitor season %d episodes: %w", n, err)
+		}
+		if len(ids) > 0 || flagChanged[n] || !series.Monitored {
+			changed = append(changed, n)
+		}
+	}
+	return changed, nil
+}
+
+// requestExistingSeries fulfills a coarse-scope request for a series Sonarr
+// already tracks. Returning the current availability without touching Sonarr
+// (the old behavior) made re-requesting a dormant series — unmonitored, or
+// monitored with unmonitored episodes — a silent no-op that could even report
+// "available", since Sonarr's percentOfEpisodes only counts monitored episodes.
+// Instead, apply the scope additively to the seasons that are still missing
+// files, and search only the seasons where something actually changed so
+// repeated requests don't spam the indexers.
+func (s *Service) requestExistingSeries(client *sonarr.Client, existing *sonarr.Series, r *resolvedRequest) (string, string, error) {
+	if r.seasonScope == SeasonScopePilot {
+		if err := s.monitorPilot(client, existing); err != nil {
+			return "", "", err
+		}
+		return StatusRequested, existing.Title, nil
+	}
+	var incomplete []int
+	for _, n := range scopeSeasonNumbers(existing, r.seasonScope) {
+		if !seasonHasAllFiles(existing, n) {
+			incomplete = append(incomplete, n)
+		}
+	}
+	if len(incomplete) > 0 {
+		changed, err := s.monitorSeasons(client, existing, incomplete)
+		if err != nil {
+			return "", "", err
+		}
+		if len(changed) > 0 {
+			for _, n := range changed {
+				// Best-effort, same as monitorAndSearchSeasons.
+				_ = client.TriggerSeasonSearch(existing.ID, n)
+			}
+			return StatusRequested, existing.Title, nil
+		}
+	}
+	status := StatusRequested
+	if existing.Statistics != nil && existing.Statistics.PercentOfEpisodes >= 100 {
+		status = StatusAvailable
+	} else if existing.Statistics != nil && existing.Statistics.EpisodeFileCount > 0 {
+		status = StatusPartial
+	}
+	return status, existing.Title, nil
+}
+
+// monitorPilot makes sure S1E1 of an existing series is monitored and searched.
+// The pilot scope is episode-level, so it can't be expressed as season
+// monitoring; matching Sonarr's own pilot handling, the season flag is left
+// alone (Sonarr deliberately doesn't monitor season 1 for a pilot-only add).
+func (s *Service) monitorPilot(client *sonarr.Client, series *sonarr.Series) error {
+	first := 0
+	for _, ss := range series.Seasons {
+		if ss.SeasonNumber > 0 && (first == 0 || ss.SeasonNumber < first) {
+			first = ss.SeasonNumber
+		}
+	}
+	if first == 0 {
+		return fmt.Errorf("series has no seasons to request")
+	}
+	episodes, err := client.GetEpisodes(series.ID, first)
+	if err != nil {
+		return fmt.Errorf("load season %d episodes: %w", first, err)
+	}
+	for _, e := range episodes {
+		if e.EpisodeNumber != 1 {
+			continue
+		}
+		if e.HasFile {
+			return nil
+		}
+		if !series.Monitored {
+			if err := client.UpdateSeriesMonitoring(series.ID, true, nil); err != nil {
+				return fmt.Errorf("monitor series failed: %w", err)
+			}
+		}
+		if !e.Monitored {
+			if err := client.SetEpisodesMonitored([]int{e.ID}, true); err != nil {
+				return fmt.Errorf("monitor pilot episode: %w", err)
+			}
+		}
+		_ = client.TriggerEpisodeSearch([]int{e.ID})
+		return nil
+	}
+	return fmt.Errorf("pilot episode not found")
+}
+
+// scopeSeasonNumbers expands a coarse season scope to concrete season numbers
+// against the series' real (non-Specials) seasons. The pilot scope is handled
+// separately because it's episode-level.
+func scopeSeasonNumbers(series *sonarr.Series, scope string) []int {
+	real := make([]int, 0, len(series.Seasons))
+	for _, ss := range series.Seasons {
+		if ss.SeasonNumber > 0 {
+			real = append(real, ss.SeasonNumber)
+		}
+	}
+	sort.Ints(real)
+	if len(real) == 0 {
+		return nil
+	}
+	switch scope {
+	case SeasonScopeFirst:
+		return real[:1]
+	case SeasonScopeLatest:
+		return real[len(real)-1:]
+	default: // all
+		return real
+	}
+}
+
+// seasonHasAllFiles reports whether a season already has a file for every
+// episode Sonarr knows about. It prefers totalEpisodeCount (which includes
+// unaired episodes) so an in-progress season still counts as incomplete and a
+// request for it keeps it monitored.
+func seasonHasAllFiles(series *sonarr.Series, seasonNumber int) bool {
+	for _, ss := range series.Seasons {
+		if ss.SeasonNumber != seasonNumber {
+			continue
+		}
+		if ss.Statistics == nil {
+			return false
+		}
+		total := ss.Statistics.TotalEpisodeCount
+		if total == 0 {
+			total = ss.Statistics.EpisodeCount
+		}
+		return total > 0 && ss.Statistics.EpisodeFileCount >= total
+	}
+	return false
+}
+
+// seasonSelection builds the seasons array for an explicit-season add: every
+// season Sonarr's lookup knows about, monitored only when chosen (Specials stay
+// unmonitored unless explicitly chosen). Chosen seasons the lookup doesn't list
+// are included defensively so a stale metadata season list can't silently drop
+// part of the request.
+func seasonSelection(known []sonarr.SeasonResource, chosen []int) []sonarr.SeasonResource {
+	chosenSet := make(map[int]bool, len(chosen))
+	for _, n := range chosen {
+		chosenSet[n] = true
+	}
+	out := make([]sonarr.SeasonResource, 0, len(known)+len(chosen))
+	seen := make(map[int]bool, len(known))
+	for _, ss := range known {
+		seen[ss.SeasonNumber] = true
+		out = append(out, sonarr.SeasonResource{SeasonNumber: ss.SeasonNumber, Monitored: chosenSet[ss.SeasonNumber]})
+	}
+	for _, n := range chosen {
+		if !seen[n] {
+			out = append(out, sonarr.SeasonResource{SeasonNumber: n, Monitored: true})
+		}
+	}
+	return out
 }
 
 // GetStatus reports a title's availability against the GLOBAL default instance
@@ -1113,6 +1283,9 @@ func (s *Service) getTVStatus(userID int64, tmdbID int) (*StatusResponse, error)
 	var tvdbID int
 	err := s.db.QueryRow("SELECT tvdb_id FROM tmdb_tvdb_cache WHERE tmdb_id = ?", tmdbID).Scan(&tvdbID)
 	if err != nil || tvdbID == 0 {
+		if s.bridge == nil {
+			return &StatusResponse{Status: StatusUnavailable}, nil
+		}
 		bridgeResult, err := s.bridge.ResolveTVDBID(tmdbID)
 		if err != nil {
 			return &StatusResponse{Status: StatusUnavailable}, nil
@@ -1254,7 +1427,7 @@ func (s *Service) loadRequest(requestID int64) (*resolvedRequest, string, error)
 	}
 	r.bookFormat = normalizeBookFormat(r.bookFormat)
 	// An explicit season list was stored as JSON in season_scope; decode it so
-	// approval replays the seasonpass path the requester chose.
+	// approval replays the explicit season selection the requester chose.
 	r.seasonNumbers = decodeSeasonNumbers(r.seasonScope)
 	return &r, status, nil
 }

--- a/server/internal/request/service_monitor_test.go
+++ b/server/internal/request/service_monitor_test.go
@@ -1,0 +1,224 @@
+package request
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/sonarr"
+)
+
+// fakeSonarr simulates the Sonarr endpoints the season-monitoring flow touches
+// and records what was written.
+type fakeSonarr struct {
+	seriesJSON string
+
+	seriesPut        map[string]any
+	monitoredIDs     []int
+	monitoredFlag    bool
+	commands         []map[string]any
+	episodesBySeason map[int][]sonarr.Episode
+}
+
+func (f *fakeSonarr) handler(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/series/42":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(f.seriesJSON))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v3/series/42":
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &f.seriesPut)
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/episode":
+			season := 0
+			_, _ = fmt.Sscanf(r.URL.Query().Get("seasonNumber"), "%d", &season)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(f.episodesBySeason[season])
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v3/episode/monitor":
+			var body struct {
+				EpisodeIDs []int `json:"episodeIds"`
+				Monitored  bool  `json:"monitored"`
+			}
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &body)
+			f.monitoredIDs = append(f.monitoredIDs, body.EpisodeIDs...)
+			f.monitoredFlag = body.Monitored
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/command":
+			var cmd map[string]any
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &cmd)
+			f.commands = append(f.commands, cmd)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+func (f *fakeSonarr) commandNames() []string {
+	var names []string
+	for _, c := range f.commands {
+		if n, ok := c["name"].(string); ok {
+			names = append(names, n)
+		}
+	}
+	return names
+}
+
+// TestMonitorAndSearchSeasonsRequestMore reproduces the reported "request more"
+// bug scenario: the season is already flagged monitored and holds two
+// downloaded episodes, but the remaining episodes are unmonitored. The request
+// must explicitly monitor those episodes (Sonarr's series update won't — the
+// season flag doesn't change) and trigger a season search, without ever
+// touching the destructive /seasonpass endpoint.
+func TestMonitorAndSearchSeasonsRequestMore(t *testing.T) {
+	f := &fakeSonarr{
+		seriesJSON: `{"id": 42, "monitored": true, "path": "/tv/x", "qualityProfileId": 3,
+			"seasons": [{"seasonNumber": 1, "monitored": true}, {"seasonNumber": 2, "monitored": false}]}`,
+		episodesBySeason: map[int][]sonarr.Episode{
+			1: {
+				{ID: 101, SeasonNumber: 1, EpisodeNumber: 1, HasFile: true, Monitored: true},
+				{ID: 102, SeasonNumber: 1, EpisodeNumber: 2, HasFile: true, Monitored: true},
+				{ID: 103, SeasonNumber: 1, EpisodeNumber: 3, Monitored: false},
+				{ID: 104, SeasonNumber: 1, EpisodeNumber: 4, Monitored: false},
+			},
+		},
+	}
+	srv := httptest.NewServer(f.handler(t))
+	defer srv.Close()
+
+	client := sonarr.NewClient(srv.URL, "key")
+	series := &sonarr.Series{
+		ID:        42,
+		Monitored: true,
+		Seasons: []sonarr.SeasonResource{
+			{SeasonNumber: 1, Monitored: true},
+			{SeasonNumber: 2, Monitored: false},
+		},
+	}
+
+	svc := &Service{}
+	if err := svc.monitorAndSearchSeasons(client, series, []int{1}); err != nil {
+		t.Fatalf("monitorAndSearchSeasons: %v", err)
+	}
+
+	// The remaining episodes of season 1 must now be monitored.
+	if !f.monitoredFlag || len(f.monitoredIDs) != 2 || f.monitoredIDs[0] != 103 || f.monitoredIDs[1] != 104 {
+		t.Errorf("monitored episodes = %v (flag %v), want [103 104] true", f.monitoredIDs, f.monitoredFlag)
+	}
+
+	// A season search must have been triggered for the chosen season.
+	names := f.commandNames()
+	if len(names) != 1 || names[0] != "SeasonSearch" {
+		t.Errorf("commands = %v, want exactly one SeasonSearch", names)
+	}
+	if got := f.commands[0]["seasonNumber"]; got != float64(1) {
+		t.Errorf("SeasonSearch seasonNumber = %v, want 1", got)
+	}
+
+	// The series update must keep the series monitored, keep season 1
+	// monitored, and leave season 2 alone.
+	if f.seriesPut["monitored"] != true {
+		t.Errorf("series PUT monitored = %v, want true", f.seriesPut["monitored"])
+	}
+	seasons := f.seriesPut["seasons"].([]any)
+	flags := map[int]bool{}
+	for _, s := range seasons {
+		m := s.(map[string]any)
+		flags[int(m["seasonNumber"].(float64))] = m["monitored"].(bool)
+	}
+	if !flags[1] || flags[2] {
+		t.Errorf("series PUT season flags = %v, want season 1 monitored, season 2 not", flags)
+	}
+}
+
+// TestRequestExistingSeriesRevivesDormant covers the coarse-scope path on a
+// series already in Sonarr: previously a silent no-op, a request must revive a
+// dormant (unmonitored) series by monitoring the scope's seasons + episodes and
+// searching, and report "requested".
+func TestRequestExistingSeriesRevivesDormant(t *testing.T) {
+	f := &fakeSonarr{
+		seriesJSON: `{"id": 42, "monitored": false,
+			"seasons": [{"seasonNumber": 1, "monitored": false}]}`,
+		episodesBySeason: map[int][]sonarr.Episode{
+			1: {
+				{ID: 101, SeasonNumber: 1, EpisodeNumber: 1, Monitored: false},
+				{ID: 102, SeasonNumber: 1, EpisodeNumber: 2, Monitored: false},
+			},
+		},
+	}
+	srv := httptest.NewServer(f.handler(t))
+	defer srv.Close()
+
+	client := sonarr.NewClient(srv.URL, "key")
+	series := &sonarr.Series{
+		ID:        42,
+		Title:     "Dormant Show",
+		Monitored: false,
+		Seasons: []sonarr.SeasonResource{
+			{SeasonNumber: 1, Monitored: false, Statistics: &sonarr.SeasonStatistics{TotalEpisodeCount: 2}},
+		},
+	}
+
+	svc := &Service{}
+	status, title, err := svc.requestExistingSeries(client, series, &resolvedRequest{seasonScope: SeasonScopeAll})
+	if err != nil {
+		t.Fatalf("requestExistingSeries: %v", err)
+	}
+	if status != StatusRequested || title != "Dormant Show" {
+		t.Errorf("status/title = %q/%q, want requested/Dormant Show", status, title)
+	}
+	if f.seriesPut["monitored"] != true {
+		t.Errorf("series PUT monitored = %v, want true", f.seriesPut["monitored"])
+	}
+	if len(f.monitoredIDs) != 2 {
+		t.Errorf("monitored episodes = %v, want both episodes", f.monitoredIDs)
+	}
+	if names := f.commandNames(); len(names) != 1 || names[0] != "SeasonSearch" {
+		t.Errorf("commands = %v, want exactly one SeasonSearch", names)
+	}
+}
+
+// TestRequestExistingSeriesFullyAvailableNoOp: when every season already has
+// all its files, a coarse re-request must not fire searches and must report the
+// live availability.
+func TestRequestExistingSeriesFullyAvailableNoOp(t *testing.T) {
+	f := &fakeSonarr{
+		seriesJSON: `{"id": 42, "monitored": true, "seasons": [{"seasonNumber": 1, "monitored": true}]}`,
+	}
+	srv := httptest.NewServer(f.handler(t))
+	defer srv.Close()
+
+	client := sonarr.NewClient(srv.URL, "key")
+	series := &sonarr.Series{
+		ID:         42,
+		Title:      "Complete Show",
+		Monitored:  true,
+		Statistics: &sonarr.SeriesStatistics{EpisodeFileCount: 10, EpisodeCount: 10, TotalEpisodeCount: 10, PercentOfEpisodes: 100},
+		Seasons: []sonarr.SeasonResource{
+			{SeasonNumber: 1, Monitored: true, Statistics: &sonarr.SeasonStatistics{EpisodeFileCount: 10, EpisodeCount: 10, TotalEpisodeCount: 10}},
+		},
+	}
+
+	svc := &Service{}
+	status, _, err := svc.requestExistingSeries(client, series, &resolvedRequest{seasonScope: SeasonScopeAll})
+	if err != nil {
+		t.Fatalf("requestExistingSeries: %v", err)
+	}
+	if status != StatusAvailable {
+		t.Errorf("status = %q, want available", status)
+	}
+	if len(f.commands) != 0 {
+		t.Errorf("commands = %v, want none for a fully available series", f.commands)
+	}
+	if f.seriesPut != nil {
+		t.Errorf("series PUT = %v, want no write for a fully available series", f.seriesPut)
+	}
+}

--- a/server/internal/request/service_test.go
+++ b/server/internal/request/service_test.go
@@ -114,3 +114,90 @@ func TestNormalizeSeasonNumbers(t *testing.T) {
 		t.Errorf("normalizeSeasonNumbers = %v, want %v", got, want)
 	}
 }
+
+// TestScopeSeasonNumbers expands the coarse scopes against a series' real
+// seasons, excluding Specials.
+func TestScopeSeasonNumbers(t *testing.T) {
+	series := &sonarr.Series{
+		Seasons: []sonarr.SeasonResource{
+			{SeasonNumber: 3},
+			{SeasonNumber: 0},
+			{SeasonNumber: 1},
+			{SeasonNumber: 2},
+		},
+	}
+	cases := []struct {
+		scope string
+		want  []int
+	}{
+		{SeasonScopeAll, []int{1, 2, 3}},
+		{SeasonScopeFirst, []int{1}},
+		{SeasonScopeLatest, []int{3}},
+		{"", []int{1, 2, 3}}, // unknown scope behaves like all
+	}
+	for _, c := range cases {
+		if got := scopeSeasonNumbers(series, c.scope); !reflect.DeepEqual(got, c.want) {
+			t.Errorf("scopeSeasonNumbers(%q) = %v, want %v", c.scope, got, c.want)
+		}
+	}
+	if got := scopeSeasonNumbers(&sonarr.Series{}, SeasonScopeAll); got != nil {
+		t.Errorf("scopeSeasonNumbers(no seasons) = %v, want nil", got)
+	}
+}
+
+// TestSeasonHasAllFiles prefers totalEpisodeCount so an in-progress season
+// (aired episodes all downloaded, more announced) still counts as incomplete.
+func TestSeasonHasAllFiles(t *testing.T) {
+	series := &sonarr.Series{
+		Seasons: []sonarr.SeasonResource{
+			{SeasonNumber: 1, Statistics: &sonarr.SeasonStatistics{EpisodeFileCount: 10, EpisodeCount: 10, TotalEpisodeCount: 10}},
+			{SeasonNumber: 2, Statistics: &sonarr.SeasonStatistics{EpisodeFileCount: 2, EpisodeCount: 2, TotalEpisodeCount: 10}},
+			{SeasonNumber: 3, Statistics: &sonarr.SeasonStatistics{EpisodeFileCount: 4, EpisodeCount: 4}},
+			{SeasonNumber: 4},
+		},
+	}
+	cases := []struct {
+		season int
+		want   bool
+	}{
+		{1, true},
+		// The trap season from the reported bug: 2 files, 2 tracked episodes
+		// (percent reads 100) but 10 known episodes -> incomplete.
+		{2, false},
+		{3, true},  // no totalEpisodeCount reported -> fall back to episodeCount
+		{4, false}, // no statistics at all
+		{9, false}, // unknown season
+	}
+	for _, c := range cases {
+		if got := seasonHasAllFiles(series, c.season); got != c.want {
+			t.Errorf("seasonHasAllFiles(season %d) = %v, want %v", c.season, got, c.want)
+		}
+	}
+}
+
+// TestSeasonSelection builds the explicit-season add payload: every known
+// season present with monitored set only for the chosen ones (Specials stay
+// unmonitored unless chosen), plus defensive entries for chosen seasons the
+// lookup didn't list.
+func TestSeasonSelection(t *testing.T) {
+	known := []sonarr.SeasonResource{
+		{SeasonNumber: 0, Monitored: true}, // lookup flags must not leak through
+		{SeasonNumber: 1, Monitored: true},
+		{SeasonNumber: 2},
+	}
+	got := seasonSelection(known, []int{2, 7})
+	want := map[int]bool{0: false, 1: false, 2: true, 7: true}
+	if len(got) != len(want) {
+		t.Fatalf("seasonSelection returned %d seasons, want %d: %+v", len(got), len(want), got)
+	}
+	for _, ss := range got {
+		mon, ok := want[ss.SeasonNumber]
+		if !ok {
+			t.Errorf("unexpected season %d in selection", ss.SeasonNumber)
+			continue
+		}
+		if ss.Monitored != mon {
+			t.Errorf("season %d monitored = %v, want %v", ss.SeasonNumber, ss.Monitored, mon)
+		}
+	}
+}

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -28,23 +28,30 @@ func NewClient(baseURL, apiKey string) *Client {
 }
 
 type Series struct {
-	ID             int    `json:"id"`
-	Title          string `json:"title"`
-	TvdbID         int    `json:"tvdbId"`
-	TmdbID         int    `json:"tmdbId"`
-	Year           int    `json:"year"`
-	Monitored      bool   `json:"monitored"`
-	RootFolderPath string `json:"rootFolderPath,omitempty"`
-	Statistics     *struct {
-		EpisodeFileCount  int     `json:"episodeFileCount"`
-		EpisodeCount      int     `json:"episodeCount"`
-		TotalEpisodeCount int     `json:"totalEpisodeCount"`
-		SizeOnDisk        int64   `json:"sizeOnDisk"`
-		PercentOfEpisodes float64 `json:"percentOfEpisodes"`
-	} `json:"statistics,omitempty"`
+	ID             int               `json:"id"`
+	Title          string            `json:"title"`
+	TvdbID         int               `json:"tvdbId"`
+	TmdbID         int               `json:"tmdbId"`
+	Year           int               `json:"year"`
+	Monitored      bool              `json:"monitored"`
+	RootFolderPath string            `json:"rootFolderPath,omitempty"`
+	Statistics     *SeriesStatistics `json:"statistics,omitempty"`
 	// Seasons carries Sonarr's per-season monitoring + statistics, used to
 	// drive per-season availability in the request UI.
 	Seasons []SeasonResource `json:"seasons,omitempty"`
+}
+
+// SeriesStatistics is the series-wide episode rollup Sonarr returns on a
+// series. Episode counts only cover monitored episodes (plus ones with files),
+// so PercentOfEpisodes reads 100 for a series whose few monitored episodes are
+// all downloaded — availability checks that must not be fooled by partial
+// monitoring should use TotalEpisodeCount.
+type SeriesStatistics struct {
+	EpisodeFileCount  int     `json:"episodeFileCount"`
+	EpisodeCount      int     `json:"episodeCount"`
+	TotalEpisodeCount int     `json:"totalEpisodeCount"`
+	SizeOnDisk        int64   `json:"sizeOnDisk"`
+	PercentOfEpisodes float64 `json:"percentOfEpisodes"`
 }
 
 // SeasonResource is one entry of a series' seasons[] array: its number, whether
@@ -83,6 +90,9 @@ type LookupResult struct {
 		CoverType string `json:"coverType"`
 		RemoteURL string `json:"remoteUrl"`
 	} `json:"images"`
+	// Seasons is the season list Sonarr's metadata knows for the series, used
+	// to seed per-season monitored flags on an explicit-season add.
+	Seasons []SeasonResource `json:"seasons"`
 }
 
 type AddSeriesRequest struct {
@@ -93,11 +103,17 @@ type AddSeriesRequest struct {
 	RootFolderPath   string `json:"rootFolderPath"`
 	Monitored        bool   `json:"monitored"`
 	SeasonFolder     bool   `json:"seasonFolder"`
-	AddOptions       struct {
+	// Seasons carries explicit per-season monitored flags applied at add time.
+	// Sonarr keeps them through its add + metadata refresh, so this is the
+	// reliable way to add a series watching an arbitrary set of seasons; leave
+	// AddOptions.Monitor empty when using it (Sonarr then monitors episodes to
+	// match the season flags).
+	Seasons    []SeasonResource `json:"seasons,omitempty"`
+	AddOptions struct {
 		SearchForMissingEpisodes bool `json:"searchForMissingEpisodes"`
 		// Monitor is Sonarr's monitor scope applied at add time: one of
 		// all/future/missing/existing/firstSeason/lastSeason/pilot/none.
-		// Empty means Sonarr's default (all).
+		// Empty means episode monitoring follows the seasons[].monitored flags.
 		Monitor string `json:"monitor,omitempty"`
 	} `json:"addOptions"`
 }
@@ -279,28 +295,69 @@ func (c *Client) AddSeries(addReq *AddSeriesRequest) error {
 	return nil
 }
 
-// SetSeasonsViaSeasonPass monitors exactly the seasons whose entry in monitored
-// is true and unmonitors the rest, via Sonarr's /seasonpass endpoint. This is
-// the only way to honor an arbitrary set of season numbers: addSeries's
-// AddOptions.Monitor is a single enum (all/firstSeason/...) with no field for an
-// explicit list. monitoringOptions.monitor is "none" so Sonarr applies our
-// per-season flags verbatim instead of overriding them with a scope.
-func (c *Client) SetSeasonsViaSeasonPass(seriesID int, monitored map[int]bool) error {
-	seasons := make([]map[string]any, 0, len(monitored))
-	for seasonNumber, isMonitored := range monitored {
-		seasons = append(seasons, map[string]any{
-			"seasonNumber": seasonNumber,
-			"monitored":    isMonitored,
-		})
+// UpdateSeriesMonitoring sets a series' monitored flag and the monitored flag
+// of each season present in seasonMonitored (seasons absent from the map keep
+// their current flag). It round-trips the full series JSON (GET → patch → PUT)
+// so no fields Sonarr requires are dropped. Sonarr's series update also syncs
+// episode monitoring for any season whose flag CHANGES — but only for those, so
+// callers that need episodes of an already-monitored season watched must set
+// them explicitly via SetEpisodesMonitored.
+//
+// Deliberately NOT implemented with /seasonpass: that endpoint requires a
+// monitoringOptions.monitor scope, and every scope rewrites episode monitoring
+// series-wide ("none" even unmonitors the series and every episode in it).
+func (c *Client) UpdateSeriesMonitoring(seriesID int, seriesMonitored bool, seasonMonitored map[int]bool) error {
+	var raw map[string]json.RawMessage
+	if err := c.do("GET", fmt.Sprintf("/api/v3/series/%d", seriesID), nil, &raw); err != nil {
+		return fmt.Errorf("sonarr get series: %w", err)
 	}
-	payload := map[string]any{
-		"series": []map[string]any{
-			{"id": seriesID, "seasons": seasons},
-		},
-		"monitoringOptions": map[string]any{"monitor": "none"},
+	monitored, err := json.Marshal(seriesMonitored)
+	if err != nil {
+		return fmt.Errorf("encode monitored flag: %w", err)
 	}
-	if err := c.do("POST", "/api/v3/seasonpass", payload, nil); err != nil {
-		return fmt.Errorf("sonarr seasonpass: %w", err)
+	raw["monitored"] = monitored
+	if seasonsRaw, ok := raw["seasons"]; ok {
+		var seasons []map[string]json.RawMessage
+		if err := json.Unmarshal(seasonsRaw, &seasons); err != nil {
+			return fmt.Errorf("decode series seasons: %w", err)
+		}
+		for _, season := range seasons {
+			if season == nil {
+				continue
+			}
+			var num int
+			if err := json.Unmarshal(season["seasonNumber"], &num); err != nil {
+				continue
+			}
+			if want, ok := seasonMonitored[num]; ok {
+				flag, err := json.Marshal(want)
+				if err != nil {
+					return fmt.Errorf("encode season monitored flag: %w", err)
+				}
+				season["monitored"] = flag
+			}
+		}
+		patched, err := json.Marshal(seasons)
+		if err != nil {
+			return fmt.Errorf("encode series seasons: %w", err)
+		}
+		raw["seasons"] = patched
+	}
+	if err := c.do("PUT", fmt.Sprintf("/api/v3/series/%d", seriesID), raw, nil); err != nil {
+		return fmt.Errorf("sonarr update series: %w", err)
+	}
+	return nil
+}
+
+// SetEpisodesMonitored sets the monitored flag on the given episodes. A no-op
+// for an empty id list.
+func (c *Client) SetEpisodesMonitored(episodeIDs []int, monitored bool) error {
+	if len(episodeIDs) == 0 {
+		return nil
+	}
+	body := map[string]any{"episodeIds": episodeIDs, "monitored": monitored}
+	if err := c.do("PUT", "/api/v3/episode/monitor", body, nil); err != nil {
+		return fmt.Errorf("sonarr set episodes monitored: %w", err)
 	}
 	return nil
 }

--- a/server/internal/sonarr/client_test.go
+++ b/server/internal/sonarr/client_test.go
@@ -8,15 +8,96 @@ import (
 	"testing"
 )
 
-// TestSetSeasonsViaSeasonPass asserts the /seasonpass payload Sonarr needs to
-// monitor an arbitrary set of seasons: a single series entry with per-season
-// {seasonNumber, monitored} flags and monitoringOptions.monitor == "none" so
-// Sonarr applies the flags verbatim instead of overriding them with a scope.
-func TestSetSeasonsViaSeasonPass(t *testing.T) {
+// TestUpdateSeriesMonitoring asserts the series update round-trip: the full
+// series JSON Sonarr returned is PUT back with only the monitored flags
+// patched, preserving every other field (Sonarr's series PUT expects the whole
+// resource; dropping fields would corrupt the series). It must NOT use the
+// /seasonpass endpoint: seasonpass forces a monitoringOptions.monitor scope and
+// every scope rewrites episode monitoring series-wide ("none" even unmonitors
+// the series and all of its episodes).
+func TestUpdateSeriesMonitoring(t *testing.T) {
+	seriesJSON := `{
+		"id": 42,
+		"title": "Example",
+		"monitored": false,
+		"qualityProfileId": 7,
+		"path": "/tv/Example",
+		"someUnknownField": {"nested": [1, 2, 3]},
+		"seasons": [
+			{"seasonNumber": 0, "monitored": false, "statistics": {"episodeCount": 1}},
+			{"seasonNumber": 1, "monitored": true},
+			{"seasonNumber": 2, "monitored": false}
+		]
+	}`
+
+	var putBody map[string]any
+	var gotPut bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/series/42":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(seriesJSON))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v3/series/42":
+			gotPut = true
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &putBody)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "key")
+	if err := c.UpdateSeriesMonitoring(42, true, map[int]bool{2: true}); err != nil {
+		t.Fatalf("UpdateSeriesMonitoring: %v", err)
+	}
+	if !gotPut {
+		t.Fatal("expected a PUT /api/v3/series/42")
+	}
+
+	if putBody["monitored"] != true {
+		t.Errorf("monitored = %v, want true", putBody["monitored"])
+	}
+	// Fields not related to monitoring must survive the round-trip verbatim.
+	if putBody["qualityProfileId"] != float64(7) || putBody["path"] != "/tv/Example" {
+		t.Errorf("round-trip dropped fields: qualityProfileId=%v path=%v", putBody["qualityProfileId"], putBody["path"])
+	}
+	if _, ok := putBody["someUnknownField"]; !ok {
+		t.Error("round-trip dropped an unknown field")
+	}
+
+	seasons := putBody["seasons"].([]any)
+	got := map[int]bool{}
+	for _, s := range seasons {
+		m := s.(map[string]any)
+		got[int(m["seasonNumber"].(float64))] = m["monitored"].(bool)
+	}
+	// Season 2 was requested; seasons absent from the map keep their flags.
+	want := map[int]bool{0: false, 1: true, 2: true}
+	for n, mon := range want {
+		if got[n] != mon {
+			t.Errorf("season %d monitored = %v, want %v", n, got[n], mon)
+		}
+	}
+	// Season statistics and other season fields must survive too.
+	s0 := seasons[0].(map[string]any)
+	if _, ok := s0["statistics"]; !ok {
+		t.Error("round-trip dropped season statistics")
+	}
+}
+
+// TestSetEpisodesMonitored asserts the bulk episode monitor payload, and that
+// an empty id list makes no HTTP call at all.
+func TestSetEpisodesMonitored(t *testing.T) {
 	var gotPath, gotMethod string
 	var body map[string]any
+	calls := 0
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
 		gotPath = r.URL.Path
 		gotMethod = r.Method
 		data, _ := io.ReadAll(r.Body)
@@ -26,44 +107,72 @@ func TestSetSeasonsViaSeasonPass(t *testing.T) {
 	defer srv.Close()
 
 	c := NewClient(srv.URL, "key")
-	if err := c.SetSeasonsViaSeasonPass(42, map[int]bool{3: true, 5: true, 1: false}); err != nil {
-		t.Fatalf("SetSeasonsViaSeasonPass: %v", err)
+	if err := c.SetEpisodesMonitored(nil, true); err != nil {
+		t.Fatalf("SetEpisodesMonitored(empty): %v", err)
+	}
+	if calls != 0 {
+		t.Fatalf("empty id list made %d HTTP calls, want 0", calls)
 	}
 
-	if gotMethod != http.MethodPost {
-		t.Errorf("method = %s, want POST", gotMethod)
+	if err := c.SetEpisodesMonitored([]int{11, 12}, true); err != nil {
+		t.Fatalf("SetEpisodesMonitored: %v", err)
 	}
-	if gotPath != "/api/v3/seasonpass" {
-		t.Errorf("path = %s, want /api/v3/seasonpass", gotPath)
+	if gotMethod != http.MethodPut || gotPath != "/api/v3/episode/monitor" {
+		t.Errorf("request = %s %s, want PUT /api/v3/episode/monitor", gotMethod, gotPath)
+	}
+	if body["monitored"] != true {
+		t.Errorf("monitored = %v, want true", body["monitored"])
+	}
+	ids := body["episodeIds"].([]any)
+	if len(ids) != 2 || int(ids[0].(float64)) != 11 || int(ids[1].(float64)) != 12 {
+		t.Errorf("episodeIds = %v, want [11 12]", body["episodeIds"])
+	}
+}
+
+// TestAddSeriesCarriesSeasons asserts an explicit-season add sends per-season
+// monitored flags in the add payload (Sonarr keeps them through the add and its
+// async metadata refresh) and omits addOptions.monitor so episode monitoring
+// follows the season flags.
+func TestAddSeriesCarriesSeasons(t *testing.T) {
+	var body map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(data, &body)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	addReq := &AddSeriesRequest{
+		Title:     "Example",
+		TvdbID:    99,
+		Monitored: true,
+		Seasons: []SeasonResource{
+			{SeasonNumber: 1, Monitored: false},
+			{SeasonNumber: 2, Monitored: true},
+		},
+	}
+	addReq.AddOptions.SearchForMissingEpisodes = true
+
+	c := NewClient(srv.URL, "key")
+	if err := c.AddSeries(addReq); err != nil {
+		t.Fatalf("AddSeries: %v", err)
 	}
 
-	mon, ok := body["monitoringOptions"].(map[string]any)
-	if !ok || mon["monitor"] != "none" {
-		t.Errorf("monitoringOptions.monitor = %v, want \"none\"", body["monitoringOptions"])
-	}
-
-	seriesList, ok := body["series"].([]any)
-	if !ok || len(seriesList) != 1 {
-		t.Fatalf("series = %v, want a single-element array", body["series"])
-	}
-	series0 := seriesList[0].(map[string]any)
-	if int(series0["id"].(float64)) != 42 {
-		t.Errorf("series[0].id = %v, want 42", series0["id"])
-	}
-
-	seasons, ok := series0["seasons"].([]any)
-	if !ok || len(seasons) != 3 {
-		t.Fatalf("seasons = %v, want 3 entries", series0["seasons"])
-	}
+	seasons := body["seasons"].([]any)
 	got := map[int]bool{}
 	for _, s := range seasons {
 		m := s.(map[string]any)
 		got[int(m["seasonNumber"].(float64))] = m["monitored"].(bool)
 	}
-	want := map[int]bool{1: false, 3: true, 5: true}
-	for n, mon := range want {
-		if got[n] != mon {
-			t.Errorf("season %d monitored = %v, want %v", n, got[n], mon)
-		}
+	if !got[2] || got[1] {
+		t.Errorf("seasons monitored = %v, want season 2 only", got)
+	}
+
+	opts := body["addOptions"].(map[string]any)
+	if opts["searchForMissingEpisodes"] != true {
+		t.Errorf("searchForMissingEpisodes = %v, want true", opts["searchForMissingEpisodes"])
+	}
+	if _, ok := opts["monitor"]; ok {
+		t.Errorf("addOptions.monitor = %v, want omitted for an explicit-season add", opts["monitor"])
 	}
 }


### PR DESCRIPTION
## The bug (as reported)

Admin uses **Request more** to grab the rest of a season they had the first two episodes of → the button flips to green "Available", nothing downloads, and no episodes are monitored — the request actually made things *worse*.

## Root cause

Both explicit-season paths drove Sonarr's `POST /api/v3/seasonpass` with `monitoringOptions.monitor: "none"`, believing "none" means "apply my per-season flags verbatim". In Sonarr it means the opposite ([SeasonPassController.cs](https://github.com/Sonarr/Sonarr/blob/develop/src/Sonarr.Api.V3/SeasonPass/SeasonPassController.cs), [EpisodeMonitoredService.cs](https://github.com/Sonarr/Sonarr/blob/develop/src/NzbDrone.Core/Tv/EpisodeMonitoredService.cs)):

1. `series.Monitored = false`
2. every episode in the series unmonitored
3. all season flags recomputed from monitored episodes → all false

So "request more" wiped monitoring series-wide; the follow-up `SeasonSearch` grabbed nothing (automatic searches reject unmonitored series/episodes); and `percentOfEpisodes` — which Sonarr computes **over monitored episodes only** — became 2 files / 2 tracked = 100%, flipping the button to a false green "Available".

## Fixes

**Server**
- **Sonarr client**: `SetSeasonsViaSeasonPass` → `UpdateSeriesMonitoring` (raw `GET → patch monitored/seasons[].monitored → PUT` of the full series JSON, so no fields are dropped) + `SetEpisodesMonitored` (`PUT /episode/monitor`). Sonarr's series PUT only syncs episode monitoring for seasons whose flag *changes*, so request-more also explicitly monitors the chosen seasons' episodes — covering the reported case where the season flag was already true but the remaining episodes weren't monitored.
- **Fresh add with explicit seasons**: season monitored flags now ride in the add payload (Sonarr keeps them through the add and its async metadata refresh) with `searchForMissingEpisodes: true`. The old add-unmonitored-then-seasonpass sequence also **raced** the metadata refresh, which applies `addOptions.monitor` asynchronously and would overwrite immediate follow-up monitoring.
- **Coarse-scope request for a series already in Sonarr** was a silent no-op that could report "available". It now applies the scope additively to seasons still missing files and searches only seasons where something actually changed (so repeat requests don't spam indexers). Pilot scope monitors + searches S1E1.
- **Movies, same bug class**: requesting an existing unmonitored file-less movie returned "requested" while Radarr would never grab it. Now revived via `PUT /movie/editor` + `MoviesSearch`; already-monitored movies aren't re-searched on repeat requests.
- `getTVStatus` no longer dereferences a nil TMDB bridge.

**App**
- The season picker rendered checkboxes + submit even for users with `can_choose_season: false`; the server drops the explicit season list for them, making the picker a silent no-op. It's now status-only for those users, and a partial-status button tap routes them to the coarse request flow instead of the dead picker.

## Verification

Drove the built server end-to-end in Docker against a stateful fake Sonarr/Radarr modeling the exact reported scenario (S1E1-2 downloaded+monitored, E3-4 unmonitored, season flag already true):

- `POST /api/requests {seasons: [1]}` → series PUT round-trips unknown JSON fields intact, episodes 3+4 explicitly monitored, exactly one `SeasonSearch`, **zero** seasonpass calls
- `GET /api/requests/{id}/status` → `partial` 2/4 (previously would read green `available`)
- Repeat request-more → re-search only, no re-mutation; unknown season number → no crash
- Movie request → `movie/editor monitored:true` + `MoviesSearch`; repeat → no new ops

Plus: `go test ./...` green (new httptest coverage for the client round-trip and the request-more/dormant-revive flows), `flutter test` green (167 + new season-table gating widget tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191Ybc6vnNGtEve37m7Zt2v