### PR TITLE
Requests: derive TV availability from real episodes, not monitored stats

### DIFF
--- a/server/internal/mcp/arr_tools.go
+++ b/server/internal/mcp/arr_tools.go
@@ -820,7 +820,10 @@ func (s *ToolServer) getLibrary(input json.RawMessage) (*ToolResult, error) {
 				if !sr.Monitored {
 					continue
 				}
-				if sr.Statistics != nil && sr.Statistics.PercentOfEpisodes >= 100 {
+				// Skip only truly complete series. percentOfEpisodes would
+				// also skip incomplete series whose few monitored episodes
+				// are all downloaded (it only counts monitored episodes).
+				if files, total := sr.EpisodeTotals(); total > 0 && files >= total {
 					continue
 				}
 			case "unmonitored":
@@ -850,8 +853,8 @@ func (s *ToolServer) getLibrary(input json.RawMessage) (*ToolResult, error) {
 				fmt.Fprintf(&sb, ", TMDB %d", sr.TmdbID)
 			}
 			sb.WriteString("]")
-			if sr.Statistics != nil {
-				fmt.Fprintf(&sb, " — %d/%d episodes", sr.Statistics.EpisodeFileCount, sr.Statistics.EpisodeCount)
+			if files, total := sr.EpisodeTotals(); total > 0 || files > 0 {
+				fmt.Fprintf(&sb, " — %d/%d episodes", files, total)
 			}
 			if !sr.Monitored {
 				sb.WriteString(" — unmonitored")

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -1012,11 +1012,14 @@ func (s *Service) requestExistingSeries(client *sonarr.Client, existing *sonarr.
 			return StatusRequested, existing.Title, nil
 		}
 	}
-	status := StatusRequested
-	if existing.Statistics != nil && existing.Statistics.PercentOfEpisodes >= 100 {
-		status = StatusAvailable
-	} else if existing.Statistics != nil && existing.Statistics.EpisodeFileCount > 0 {
-		status = StatusPartial
+	// Nothing needed to change: report honest completeness (never Sonarr's
+	// monitored-only percentOfEpisodes; see getTVStatus).
+	files, total := existing.EpisodeTotals()
+	status, _ := statusFromCompletion(sonarr.Completion{Files: files, Aired: total}, existing.Monitored)
+	if status == StatusUnavailable {
+		// The series is in Sonarr and this request just (re)confirmed it;
+		// nothing on disk yet still reads as an accepted request.
+		status = StatusRequested
 	}
 	return status, existing.Title, nil
 }
@@ -1298,31 +1301,101 @@ func (s *Service) getTVStatus(userID int64, tmdbID int) (*StatusResponse, error)
 		return &StatusResponse{Status: StatusUnavailable}, nil
 	}
 
+	// Derive availability from the real episode list: "available" strictly
+	// means every aired episode has a file. Sonarr's percentOfEpisodes (and
+	// its season episodeCount) only count monitored episodes, so a series with
+	// two monitored, downloaded episodes and the rest unmonitored would read
+	// 100% / "available" while most of it is missing.
+	if episodes, epErr := sonarrClient.GetAllEpisodes(series.ID); epErr == nil {
+		completion, bySeason := sonarr.SeriesCompletion(episodes, time.Now())
+		status, progress := statusFromCompletion(completion, series.Monitored)
+		return &StatusResponse{
+			Status:   status,
+			Progress: progress,
+			Seasons:  seasonStatusesFromCompletion(series, bySeason),
+		}, nil
+	}
+
+	// Fallback (episode fetch failed): season-statistics totals. Stricter than
+	// the aired-aware path — unaired episodes count as missing — but still
+	// immune to the monitored-episodes-only skew.
 	seasons := seasonStatuses(series)
-
-	if series.Statistics != nil {
-		if series.Statistics.PercentOfEpisodes >= 100 {
-			return &StatusResponse{Status: StatusAvailable, Progress: 1.0, Seasons: seasons}, nil
-		}
-		if series.Statistics.EpisodeFileCount > 0 {
-			progress := series.Statistics.PercentOfEpisodes / 100.0
-			return &StatusResponse{Status: StatusPartial, Progress: progress, Seasons: seasons}, nil
-		}
-	}
-
-	if series.Monitored {
-		return &StatusResponse{Status: StatusRequested, Progress: 0, Seasons: seasons}, nil
-	}
-
-	return &StatusResponse{Status: StatusUnavailable, Seasons: seasons}, nil
+	files, total := series.EpisodeTotals()
+	status, progress := statusFromCompletion(sonarr.Completion{Files: files, Aired: total}, series.Monitored)
+	return &StatusResponse{Status: status, Progress: progress, Seasons: seasons}, nil
 }
 
-// seasonStatuses builds the per-season availability breakdown for a series from
-// its seasons[].statistics. Season 0 / Specials is excluded to match the rest
-// of the app (the TMDB SeasonGrid filters it out too). Each season's status
-// mirrors the title vocabulary, derived from file counts + monitoring (queue
-// isn't consulted here, matching the title-level TV derivation, which keeps
-// status checks to a single Sonarr call).
+// statusFromCompletion maps on-disk completeness (plus the series' monitored
+// flag) onto the request status vocabulary: complete → available, anything on
+// disk → partial (the button offers "Request More"), nothing on disk →
+// requested when monitored, else unavailable.
+func statusFromCompletion(c sonarr.Completion, monitored bool) (string, float64) {
+	switch {
+	case c.Complete():
+		return StatusAvailable, 1.0
+	case c.Files > 0:
+		progress := 0.0
+		if c.Aired > 0 {
+			progress = float64(c.Files) / float64(c.Aired)
+		}
+		return StatusPartial, progress
+	case monitored:
+		return StatusRequested, 0
+	default:
+		return StatusUnavailable, 0
+	}
+}
+
+// seasonStatusesFromCompletion builds the per-season availability breakdown
+// from real episode counts (see SeriesCompletion). EpisodeCount is the aired
+// (obtainable) episode count, so the app's "x/y eps" label reflects true
+// completeness. Season 0 / Specials is excluded to match the rest of the app.
+func seasonStatusesFromCompletion(series *sonarr.Series, bySeason map[int]sonarr.Completion) []SeasonStatus {
+	monitored := make(map[int]bool, len(series.Seasons))
+	numbers := make([]int, 0, len(series.Seasons)+len(bySeason))
+	for _, s := range series.Seasons {
+		monitored[s.SeasonNumber] = s.Monitored
+		numbers = append(numbers, s.SeasonNumber)
+	}
+	// Include seasons that have episodes but are missing from series.Seasons
+	// (defensive; normally the seasons array covers them all).
+	for n := range bySeason {
+		if _, ok := monitored[n]; !ok {
+			numbers = append(numbers, n)
+		}
+	}
+	sort.Ints(numbers)
+
+	out := make([]SeasonStatus, 0, len(numbers))
+	for _, n := range numbers {
+		if n <= 0 {
+			continue // skip Specials
+		}
+		c := bySeason[n]
+		status, progress := statusFromCompletion(c, monitored[n])
+		out = append(out, SeasonStatus{
+			SeasonNumber:     n,
+			EpisodeFileCount: c.Files,
+			EpisodeCount:     c.Aired,
+			Status:           status,
+			Progress:         progress,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// seasonStatuses builds the per-season availability breakdown for a series
+// from its seasons[].statistics — the fallback when the episode list couldn't
+// be fetched (see seasonStatusesFromCompletion for the primary path). Season
+// totals use totalEpisodeCount, NOT episodeCount: Sonarr's episodeCount only
+// counts monitored episodes, which is exactly the skew that made half-empty
+// seasons read "available". totalEpisodeCount includes unaired episodes, so
+// this fallback under-reports availability for airing seasons rather than
+// over-reporting it. Season 0 / Specials is excluded to match the rest of the
+// app (the TMDB SeasonGrid filters it out too).
 func seasonStatuses(series *sonarr.Series) []SeasonStatus {
 	if series == nil || len(series.Seasons) == 0 {
 		return nil
@@ -1334,18 +1407,14 @@ func seasonStatuses(series *sonarr.Series) []SeasonStatus {
 		}
 		ss := SeasonStatus{SeasonNumber: s.SeasonNumber, Status: StatusUnavailable}
 		if s.Statistics != nil {
-			ss.EpisodeFileCount = s.Statistics.EpisodeFileCount
-			ss.EpisodeCount = s.Statistics.EpisodeCount
-			switch {
-			case s.Statistics.EpisodeCount > 0 && s.Statistics.EpisodeFileCount >= s.Statistics.EpisodeCount:
-				ss.Status = StatusAvailable
-				ss.Progress = 1.0
-			case s.Statistics.EpisodeFileCount > 0:
-				ss.Status = StatusPartial
-				ss.Progress = float64(s.Statistics.EpisodeFileCount) / float64(s.Statistics.EpisodeCount)
-			case s.Monitored:
-				ss.Status = StatusRequested
+			total := s.Statistics.TotalEpisodeCount
+			if total == 0 {
+				total = s.Statistics.EpisodeCount
 			}
+			ss.EpisodeFileCount = s.Statistics.EpisodeFileCount
+			ss.EpisodeCount = total
+			ss.Status, ss.Progress = statusFromCompletion(
+				sonarr.Completion{Files: s.Statistics.EpisodeFileCount, Aired: total}, s.Monitored)
 		} else if s.Monitored {
 			ss.Status = StatusRequested
 		}

--- a/server/internal/request/service_test.go
+++ b/server/internal/request/service_test.go
@@ -12,6 +12,71 @@ func seasonStats(fileCount, epCount int) *sonarr.SeasonStatistics {
 	return &sonarr.SeasonStatistics{EpisodeFileCount: fileCount, EpisodeCount: epCount}
 }
 
+// TestStatusFromCompletion maps completeness onto the request status
+// vocabulary, including the reported trap: a series whose few monitored
+// episodes are all downloaded must read partial, not available.
+func TestStatusFromCompletion(t *testing.T) {
+	cases := []struct {
+		name      string
+		c         sonarr.Completion
+		monitored bool
+		want      string
+	}{
+		{"complete", sonarr.Completion{Files: 4, Aired: 4}, true, StatusAvailable},
+		{"trap: files < aired stays partial even when monitored subset is done", sonarr.Completion{Files: 2, Aired: 4}, true, StatusPartial},
+		{"partial while unmonitored (action optional)", sonarr.Completion{Files: 2, Aired: 4}, false, StatusPartial},
+		{"nothing on disk, monitored", sonarr.Completion{Files: 0, Aired: 4}, true, StatusRequested},
+		{"nothing on disk, unmonitored", sonarr.Completion{Files: 0, Aired: 4}, false, StatusUnavailable},
+		{"nothing aired yet, monitored", sonarr.Completion{}, true, StatusRequested},
+	}
+	for _, c := range cases {
+		if got, _ := statusFromCompletion(c.c, c.monitored); got != c.want {
+			t.Errorf("%s: status = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestSeasonStatusesFromCompletion builds season rows from real episode
+// counts: Specials dropped, x/y = files/aired, unknown seasons tolerated.
+func TestSeasonStatusesFromCompletion(t *testing.T) {
+	series := &sonarr.Series{
+		Seasons: []sonarr.SeasonResource{
+			{SeasonNumber: 0, Monitored: true},
+			{SeasonNumber: 1, Monitored: true},
+			{SeasonNumber: 2, Monitored: false},
+		},
+	}
+	bySeason := map[int]sonarr.Completion{
+		0: {Files: 1, Aired: 1},
+		1: {Files: 2, Aired: 4},
+		3: {Files: 5, Aired: 5}, // not in series.Seasons (defensive)
+	}
+	got := seasonStatusesFromCompletion(series, bySeason)
+	want := map[int]struct {
+		status string
+		files  int
+		eps    int
+	}{
+		1: {StatusPartial, 2, 4},
+		2: {StatusUnavailable, 0, 0},
+		3: {StatusAvailable, 5, 5},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d seasons, want %d (Specials excluded): %+v", len(got), len(want), got)
+	}
+	for _, ss := range got {
+		w, ok := want[ss.SeasonNumber]
+		if !ok {
+			t.Errorf("unexpected season %d", ss.SeasonNumber)
+			continue
+		}
+		if ss.Status != w.status || ss.EpisodeFileCount != w.files || ss.EpisodeCount != w.eps {
+			t.Errorf("season %d = %s %d/%d, want %s %d/%d",
+				ss.SeasonNumber, ss.Status, ss.EpisodeFileCount, ss.EpisodeCount, w.status, w.files, w.eps)
+		}
+	}
+}
+
 // TestSeasonStatuses covers the per-season status derivation: Specials are
 // dropped, and each real season's status maps from its file counts + monitoring
 // onto the title status vocabulary.

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -670,6 +670,90 @@ func (c *Client) GetEpisodes(seriesID, seasonNumber int) ([]Episode, error) {
 	return episodes, nil
 }
 
+// GetAllEpisodes lists every episode of a series across all seasons.
+func (c *Client) GetAllEpisodes(seriesID int) ([]Episode, error) {
+	var episodes []Episode
+	path := fmt.Sprintf("/api/v3/episode?seriesId=%d", seriesID)
+	if err := c.do("GET", path, nil, &episodes); err != nil {
+		return nil, fmt.Errorf("sonarr episodes: %w", err)
+	}
+	return episodes, nil
+}
+
+// Completion is an on-disk completeness rollup: how many episodes have files
+// versus how many are actually obtainable right now ("aired": released, or
+// already on disk). Unaired episodes are excluded on purpose — a fully
+// caught-up airing series is complete for availability purposes, while an
+// ended series with gaps is not, regardless of what is monitored.
+type Completion struct {
+	Files int
+	Aired int
+}
+
+// Complete reports whether every obtainable episode has a file.
+func (c Completion) Complete() bool {
+	return c.Aired > 0 && c.Files >= c.Aired
+}
+
+// SeriesCompletion aggregates an episode list into a series-wide completion
+// plus a per-season breakdown. Specials (season 0) are excluded from the
+// series-wide rollup but still reported per-season. Prefer this over
+// Statistics.PercentOfEpisodes for availability decisions: percentOfEpisodes
+// only counts monitored episodes, so a series with two monitored, downloaded
+// episodes and everything else unmonitored reads 100%.
+func SeriesCompletion(episodes []Episode, now time.Time) (series Completion, bySeason map[int]Completion) {
+	bySeason = make(map[int]Completion)
+	for _, e := range episodes {
+		aired := e.HasFile || (e.AirDateUtc != nil && !e.AirDateUtc.After(now))
+		c := bySeason[e.SeasonNumber]
+		if aired {
+			c.Aired++
+		}
+		if e.HasFile {
+			c.Files++
+		}
+		bySeason[e.SeasonNumber] = c
+		if e.SeasonNumber > 0 {
+			if aired {
+				series.Aired++
+			}
+			if e.HasFile {
+				series.Files++
+			}
+		}
+	}
+	return series, bySeason
+}
+
+// EpisodeTotals returns how many episodes are on disk versus every episode
+// Sonarr knows about (aired or not, monitored or not) across the series' real
+// (non-Specials) seasons, from the season statistics already present on the
+// series. Cheaper than SeriesCompletion (no episode fetch) but stricter: a
+// caught-up airing series counts as incomplete because unaired episodes are
+// included. Falls back to the series-level statistics when Sonarr sent no
+// per-season breakdown.
+func (s *Series) EpisodeTotals() (files, total int) {
+	for _, season := range s.Seasons {
+		if season.SeasonNumber <= 0 || season.Statistics == nil {
+			continue
+		}
+		files += season.Statistics.EpisodeFileCount
+		t := season.Statistics.TotalEpisodeCount
+		if t == 0 {
+			t = season.Statistics.EpisodeCount
+		}
+		total += t
+	}
+	if files == 0 && total == 0 && s.Statistics != nil {
+		files = s.Statistics.EpisodeFileCount
+		total = s.Statistics.TotalEpisodeCount
+		if total == 0 {
+			total = s.Statistics.EpisodeCount
+		}
+	}
+	return files, total
+}
+
 // ManualImportRejection is a single reason Sonarr would not auto-import a file,
 // plus whether the rejection is permanent (a force import will likely still
 // fail) or temporary.

--- a/server/internal/sonarr/client_test.go
+++ b/server/internal/sonarr/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 // TestUpdateSeriesMonitoring asserts the series update round-trip: the full
@@ -174,5 +175,83 @@ func TestAddSeriesCarriesSeasons(t *testing.T) {
 	}
 	if _, ok := opts["monitor"]; ok {
 		t.Errorf("addOptions.monitor = %v, want omitted for an explicit-season add", opts["monitor"])
+	}
+}
+
+// TestSeriesCompletion covers the aired-aware completeness rollup: unaired
+// episodes don't count against completeness, Specials are excluded from the
+// series-wide numbers, and monitoring plays no role at all.
+func TestSeriesCompletion(t *testing.T) {
+	now := time.Date(2026, 7, 4, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-24 * time.Hour)
+	future := now.Add(24 * time.Hour)
+	episodes := []Episode{
+		// Specials: on disk, must not count toward the series rollup.
+		{ID: 1, SeasonNumber: 0, HasFile: true, AirDateUtc: &past},
+		// S1: the reported trap — 2 downloaded, 2 aired-but-missing
+		// (unmonitored, irrelevant here), 1 unaired.
+		{ID: 11, SeasonNumber: 1, HasFile: true, AirDateUtc: &past, Monitored: true},
+		{ID: 12, SeasonNumber: 1, HasFile: true, AirDateUtc: &past, Monitored: true},
+		{ID: 13, SeasonNumber: 1, AirDateUtc: &past},
+		{ID: 14, SeasonNumber: 1, AirDateUtc: &past},
+		{ID: 15, SeasonNumber: 1, AirDateUtc: &future},
+		// S2: fully unaired (also one with no air date at all = treated unaired).
+		{ID: 21, SeasonNumber: 2, AirDateUtc: &future},
+		{ID: 22, SeasonNumber: 2},
+		// S3: file present despite a future air date (early release) counts
+		// as obtainable.
+		{ID: 31, SeasonNumber: 3, HasFile: true, AirDateUtc: &future},
+	}
+
+	series, bySeason := SeriesCompletion(episodes, now)
+	if series.Files != 3 || series.Aired != 5 {
+		t.Errorf("series completion = %d/%d, want 3/5", series.Files, series.Aired)
+	}
+	if series.Complete() {
+		t.Error("series with aired episodes missing files must not be complete")
+	}
+	if c := bySeason[1]; c.Files != 2 || c.Aired != 4 || c.Complete() {
+		t.Errorf("season 1 completion = %+v, want 2/4 incomplete", c)
+	}
+	if c := bySeason[2]; c.Files != 0 || c.Aired != 0 || c.Complete() {
+		t.Errorf("season 2 completion = %+v, want 0/0 incomplete", c)
+	}
+	if c := bySeason[3]; !c.Complete() {
+		t.Errorf("season 3 completion = %+v, want complete (early release)", c)
+	}
+	if c := bySeason[0]; c.Files != 1 {
+		t.Errorf("season 0 completion = %+v, want its own per-season entry", c)
+	}
+
+	// A caught-up airing series (all aired downloaded, more announced) IS
+	// complete.
+	caughtUp := []Episode{
+		{ID: 1, SeasonNumber: 1, HasFile: true, AirDateUtc: &past},
+		{ID: 2, SeasonNumber: 1, AirDateUtc: &future},
+	}
+	if c, _ := SeriesCompletion(caughtUp, now); !c.Complete() {
+		t.Errorf("caught-up airing series = %+v, want complete", c)
+	}
+}
+
+// TestEpisodeTotals covers the statistics-based fallback totals: real seasons
+// only, totalEpisodeCount preferred over the monitored-skewed episodeCount,
+// series-level statistics only when no per-season breakdown exists.
+func TestEpisodeTotals(t *testing.T) {
+	s := &Series{
+		Seasons: []SeasonResource{
+			{SeasonNumber: 0, Statistics: &SeasonStatistics{EpisodeFileCount: 9, TotalEpisodeCount: 9}},
+			{SeasonNumber: 1, Statistics: &SeasonStatistics{EpisodeFileCount: 2, EpisodeCount: 2, TotalEpisodeCount: 4}},
+			{SeasonNumber: 2, Statistics: &SeasonStatistics{EpisodeFileCount: 3, EpisodeCount: 3}},
+			{SeasonNumber: 3},
+		},
+	}
+	if files, total := s.EpisodeTotals(); files != 5 || total != 7 {
+		t.Errorf("EpisodeTotals = %d/%d, want 5/7 (specials excluded, total preferred)", files, total)
+	}
+
+	fallback := &Series{Statistics: &SeriesStatistics{EpisodeFileCount: 2, EpisodeCount: 2, TotalEpisodeCount: 12}}
+	if files, total := fallback.EpisodeTotals(); files != 2 || total != 12 {
+		t.Errorf("EpisodeTotals fallback = %d/%d, want 2/12", files, total)
 	}
 }

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -802,9 +802,21 @@ func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
 					log.Printf("websocket: get completed sonarr series %d: %v", seriesID, err)
 					continue
 				}
+				// "available" strictly means every aired episode has a file.
+				// Sonarr's percentOfEpisodes only counts monitored episodes,
+				// so it reads 100 for a series that's mostly unmonitored and
+				// missing — which would flip request buttons green over this
+				// broadcast for incomplete series.
 				status := "available"
-				if series.Statistics != nil && series.Statistics.PercentOfEpisodes < 100 {
-					status = "partially_available"
+				if episodes, err := client.GetAllEpisodes(seriesID); err == nil {
+					if completion, _ := sonarr.SeriesCompletion(episodes, time.Now()); !completion.Complete() {
+						status = "partially_available"
+					}
+				} else {
+					files, total := series.EpisodeTotals()
+					if total == 0 || files < total {
+						status = "partially_available"
+					}
 				}
 				h.Broadcast(Event{
 					Type: "request_status_changed",


### PR DESCRIPTION
## The bug

Follow-up to #132. Sonarr's `percentOfEpisodes` (and its season-level `episodeCount`) only count **monitored** episodes. So a series with two monitored, downloaded episodes and everything else unmonitored read 100% → the request button showed green "Watch Now" for a mostly-missing series, and incomplete series showed as complete.

## The rule now

- **Green / Available** = every **aired** episode has a file — fulfilled, nothing needs action.
- **Gold / Partial ("Request More")** = anything aired is missing from disk, regardless of monitoring — more available, action optional.
- Unaired episodes don't count against completeness: a fully caught-up airing series is green; an ended series with gaps stays gold.

## How

`getTVStatus` now fetches the series' real episode list (one extra Sonarr call per TV status check — status is per-title on demand, not bulk) and derives title + per-season status from actual file/aired counts (`sonarr.SeriesCompletion`). The "x/y eps" labels use the same counts, so the trap series reads **2/4**, not 2/2. A statistics-based fallback (`totalEpisodeCount`, never the skewed `episodeCount`) covers episode-fetch failures.

Same skew fixed where it leaked into other request surfaces:
- **websocket queue-leave broadcast** no longer live-flips request buttons to "available" for incomplete series when a download finishes;
- **MCP TV library "missing" filter** no longer hides incomplete series whose few monitored episodes happen to be downloaded; library listings show true episode totals.

No app changes needed — `partial` already renders the gold "Request More" button; the server just now reports it honestly.

## Verification

Drove the built server end-to-end in Docker against a stateful fake Sonarr (episodes with air dates, stats recomputed Sonarr-style):

- Trap series (2/4 aired downloaded + 1 unaired, monitored subset complete), **no request made** → `partial 0.5`, seasons `[S1 partial 2/4, S2 unavailable 0/0]` (old code: green `available`)
- Simulated the two missing aired episodes downloading → `available 1.0` with the unaired episode still outstanding (caught-up = green)
- Request-more regression on top of the new derivation → episodes monitored (incl. the unaired one, so it grabs on air), one SeasonSearch, status stays `partial 2/4`

`go test ./...` green with new unit coverage for the completion rollup, status mapping, and season rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191Ybc6vnNGtEve37m7Zt2v