### PR TITLE
Sonarr: episode multi-select with automatic batch search

### DIFF
--- a/app/lib/features/sonarr/logic/episode_selection.dart
+++ b/app/lib/features/sonarr/logic/episode_selection.dart
@@ -1,0 +1,10 @@
+import '../data/sonarr_models.dart';
+
+/// Episode ids the "Undownloaded" quick-select targets: episodes that have
+/// aired but have no file. Unaired and TBA episodes are skipped — searching
+/// for them finds nothing (an early release that did land already has a file
+/// and is excluded as downloaded).
+List<int> undownloadedEpisodeIds(List<SonarrEpisode> episodes) => [
+      for (final e in episodes)
+        if (!e.hasFile && e.hasAired) e.id,
+    ];

--- a/app/lib/features/sonarr/ui/sonarr_season_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_season_screen.dart
@@ -6,6 +6,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
+import '../logic/episode_selection.dart';
 import 'episode_detail_sheet.dart';
 import 'sonarr_releases_screen.dart';
 import 'sonarr_series_detail_screen.dart' show seasonLabel;
@@ -13,7 +14,12 @@ import 'widgets/episode_status.dart';
 
 /// Episode list for one season: number, title, air date and the per-episode
 /// status line (download progress / quality+size / Missing / Unaired). Tapping
-/// an episode opens its detail sheet; the magnifier runs a per-episode search.
+/// an episode opens its detail sheet; the magnifier runs an automatic
+/// per-episode search. The Automatic button's arrow (or a long-press on an
+/// episode) enters selection mode: pick episodes — All / Undownloaded / None
+/// quick-selects — and search them all automatically in one go. Interactive
+/// search only works on a single episode/season, so it is disabled while
+/// selecting.
 class SonarrSeasonScreen extends ConsumerStatefulWidget {
   final String instanceId;
   final SonarrSeries series;
@@ -37,6 +43,8 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
   Map<int, SonarrQueueItem> _queueByEpisode = {};
   bool _isLoading = true;
   String? _error;
+  bool _selecting = false;
+  final Set<int> _selectedIds = {};
 
   @override
   void initState() {
@@ -69,6 +77,9 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
           for (final q in queue)
             if (q.episodeId != null) q.episodeId!: q,
         };
+        // Drop selected ids that no longer exist after a refresh.
+        final ids = {for (final e in episodes) e.id};
+        _selectedIds.retainAll(ids);
         _isLoading = false;
         _error = null;
       });
@@ -135,6 +146,54 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
     );
   }
 
+  // --- Episode selection mode ---
+
+  void _startSelecting({Iterable<int> preselect = const []}) {
+    setState(() {
+      _selecting = true;
+      _selectedIds
+        ..clear()
+        ..addAll(preselect);
+    });
+  }
+
+  void _stopSelecting() {
+    setState(() {
+      _selecting = false;
+      _selectedIds.clear();
+    });
+  }
+
+  void _toggleSelected(SonarrEpisode episode) {
+    setState(() {
+      if (!_selectedIds.remove(episode.id)) _selectedIds.add(episode.id);
+    });
+  }
+
+  /// Entry point for the Automatic button's "Individual episodes" option:
+  /// everything aired-but-missing starts selected.
+  void _startIndividualDownloads() {
+    _startSelecting(preselect: undownloadedEpisodeIds(_episodes));
+  }
+
+  Future<void> _searchSelected() async {
+    final ids = _selectedIds.toList()..sort();
+    if (ids.isEmpty) return;
+    try {
+      await _service.searchEpisodes(ids);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text(ids.length == 1
+              ? 'Searching for 1 episode…'
+              : 'Searching for ${ids.length} episodes…')));
+      _stopSelecting();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Search failed: $e')));
+    }
+  }
+
   Future<void> _openEpisode(SonarrEpisode episode) async {
     final changed = await showModalBottomSheet<bool>(
       context: context,
@@ -177,10 +236,30 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
       ),
       body: Column(
         children: [
+          if (_selecting)
+            _SelectionBar(
+              selectedCount: _selectedIds.length,
+              onSelectAll: () => setState(() {
+                _selectedIds
+                  ..clear()
+                  ..addAll(_episodes.map((e) => e.id));
+              }),
+              onSelectUndownloaded: () => setState(() {
+                _selectedIds
+                  ..clear()
+                  ..addAll(undownloadedEpisodeIds(_episodes));
+              }),
+              onSelectNone: () => setState(_selectedIds.clear),
+              onClose: _stopSelecting,
+            ),
           Expanded(child: _buildBody()),
           _ActionBar(
+            selecting: _selecting,
+            selectedCount: _selectedIds.length,
             onAutomatic: _automaticSeasonSearch,
+            onAutomaticEpisodes: _startIndividualDownloads,
             onInteractive: _interactiveSeasonSearch,
+            onSearchSelected: _searchSelected,
           ),
         ],
       ),
@@ -214,8 +293,15 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
           return _EpisodeTile(
             episode: episode,
             queueItem: _queueByEpisode[episode.id],
-            onTap: () => _openEpisode(episode),
-            onSearch: () => _interactiveEpisodeSearch(episode),
+            selecting: _selecting,
+            selected: _selectedIds.contains(episode.id),
+            onTap: _selecting
+                ? () => _toggleSelected(episode)
+                : () => _openEpisode(episode),
+            onLongPress: _selecting
+                ? null
+                : () => _startSelecting(preselect: [episode.id]),
+            onSearch: () => _automaticEpisodeSearch(episode),
           );
         },
       ),
@@ -233,13 +319,19 @@ String formatEpisodeAirDate(SonarrEpisode e) {
 class _EpisodeTile extends StatelessWidget {
   final SonarrEpisode episode;
   final SonarrQueueItem? queueItem;
+  final bool selecting;
+  final bool selected;
   final VoidCallback onTap;
+  final VoidCallback? onLongPress;
   final VoidCallback onSearch;
 
   const _EpisodeTile({
     required this.episode,
     required this.queueItem,
+    required this.selecting,
+    required this.selected,
     required this.onTap,
+    required this.onLongPress,
     required this.onSearch,
   });
 
@@ -248,11 +340,28 @@ class _EpisodeTile extends StatelessWidget {
     final status = episodeStatusLine(episode, queueItem);
     return InkWell(
       onTap: onTap,
+      onLongPress: onLongPress,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            if (selecting) ...[
+              SizedBox(
+                width: 24,
+                height: 24,
+                child: Checkbox(
+                  value: selected,
+                  onChanged: (_) => onTap(),
+                  activeColor: AppTheme.accent,
+                  checkColor: AppTheme.background,
+                  side: const BorderSide(color: AppTheme.textSecondary),
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  visualDensity: VisualDensity.compact,
+                ),
+              ),
+              const SizedBox(width: 10),
+            ],
             SizedBox(
               width: 28,
               child: Text(
@@ -294,11 +403,12 @@ class _EpisodeTile extends StatelessWidget {
                 ],
               ),
             ),
-            IconButton(
-              icon: const Icon(Icons.search, color: AppTheme.textSecondary),
-              tooltip: 'Search releases',
-              onPressed: onSearch,
-            ),
+            if (!selecting)
+              IconButton(
+                icon: const Icon(Icons.search, color: AppTheme.textSecondary),
+                tooltip: 'Automatic search',
+                onPressed: onSearch,
+              ),
           ],
         ),
       ),
@@ -306,11 +416,91 @@ class _EpisodeTile extends StatelessWidget {
   }
 }
 
-class _ActionBar extends StatelessWidget {
-  final VoidCallback onAutomatic;
-  final VoidCallback onInteractive;
+/// Selection-mode header: quick-selects (All / Undownloaded / None) and the
+/// close (cancel) affordance. The selected count lives in the action bar's
+/// "Search N episodes" button.
+class _SelectionBar extends StatelessWidget {
+  final int selectedCount;
+  final VoidCallback onSelectAll;
+  final VoidCallback onSelectUndownloaded;
+  final VoidCallback onSelectNone;
+  final VoidCallback onClose;
 
-  const _ActionBar({required this.onAutomatic, required this.onInteractive});
+  const _SelectionBar({
+    required this.selectedCount,
+    required this.onSelectAll,
+    required this.onSelectUndownloaded,
+    required this.onSelectNone,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final buttonStyle = TextButton.styleFrom(
+      foregroundColor: AppTheme.accent,
+      visualDensity: VisualDensity.compact,
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      textStyle: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+    );
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      decoration: const BoxDecoration(
+        color: AppTheme.surface,
+        border: Border(bottom: BorderSide(color: AppTheme.border, width: 0.5)),
+      ),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.close, color: AppTheme.textSecondary),
+            tooltip: 'Cancel selection',
+            onPressed: onClose,
+          ),
+          Expanded(
+            child: Text(
+              '$selectedCount selected',
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          TextButton(
+              onPressed: onSelectAll, style: buttonStyle,
+              child: const Text('All')),
+          TextButton(
+              onPressed: onSelectUndownloaded, style: buttonStyle,
+              child: const Text('Undownloaded')),
+          TextButton(
+              onPressed: onSelectNone, style: buttonStyle,
+              child: const Text('None')),
+        ],
+      ),
+    );
+  }
+}
+
+class _ActionBar extends StatelessWidget {
+  final bool selecting;
+  final int selectedCount;
+  final VoidCallback onAutomatic;
+  final VoidCallback onAutomaticEpisodes;
+  final VoidCallback onInteractive;
+  final VoidCallback onSearchSelected;
+
+  const _ActionBar({
+    required this.selecting,
+    required this.selectedCount,
+    required this.onAutomatic,
+    required this.onAutomaticEpisodes,
+    required this.onInteractive,
+    required this.onSearchSelected,
+  });
+
+  ButtonStyle _buttonStyle({BorderRadius? radius}) => OutlinedButton.styleFrom(
+        side: const BorderSide(color: AppTheme.border),
+        shape: RoundedRectangleBorder(
+            borderRadius: radius ?? BorderRadius.circular(10)),
+        padding: const EdgeInsets.symmetric(vertical: 12),
+      );
 
   @override
   Widget build(BuildContext context) {
@@ -324,32 +514,99 @@ class _ActionBar extends StatelessWidget {
       child: Row(
         children: [
           Expanded(
-            child: OutlinedButton.icon(
-              onPressed: onAutomatic,
-              icon: const Icon(Icons.search, size: 18, color: AppTheme.available),
-              label: const Text('Automatic',
-                  style: TextStyle(color: AppTheme.textPrimary)),
-              style: OutlinedButton.styleFrom(
-                side: const BorderSide(color: AppTheme.border),
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10)),
-                padding: const EdgeInsets.symmetric(vertical: 12),
-              ),
-            ),
+            child: selecting ? _buildSearchSelected() : _buildSplitAutomatic(),
           ),
           const SizedBox(width: 10),
           Expanded(
             child: OutlinedButton.icon(
-              onPressed: onInteractive,
-              icon: const Icon(Icons.person_outline,
-                  size: 18, color: AppTheme.available),
-              label: const Text('Interactive',
+              // Interactive search targets one episode or season at a time —
+              // it can't act on a multi-selection, so disable it while
+              // selecting.
+              onPressed: selecting ? null : onInteractive,
+              icon: Icon(Icons.person_outline,
+                  size: 18,
+                  color: selecting
+                      ? AppTheme.textSecondary
+                      : AppTheme.available),
+              label: Text('Interactive',
+                  style: TextStyle(
+                      color: selecting
+                          ? AppTheme.textSecondary
+                          : AppTheme.textPrimary)),
+              style: _buttonStyle(),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchSelected() {
+    final enabled = selectedCount > 0;
+    return OutlinedButton.icon(
+      onPressed: enabled ? onSearchSelected : null,
+      icon: Icon(Icons.search,
+          size: 18,
+          color: enabled ? AppTheme.available : AppTheme.textSecondary),
+      label: Text(
+        selectedCount == 1 ? 'Search 1 episode' : 'Search $selectedCount episodes',
+        style: TextStyle(
+            color: enabled ? AppTheme.textPrimary : AppTheme.textSecondary),
+      ),
+      style: _buttonStyle(),
+    );
+  }
+
+  /// Split button: the main segment runs the season-wide automatic search, the
+  /// arrow reveals "Individual episodes" (selection mode, undownloaded
+  /// preselected).
+  Widget _buildSplitAutomatic() {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Expanded(
+            child: OutlinedButton.icon(
+              onPressed: onAutomatic,
+              icon:
+                  const Icon(Icons.search, size: 18, color: AppTheme.available),
+              label: const Text('Automatic',
                   style: TextStyle(color: AppTheme.textPrimary)),
-              style: OutlinedButton.styleFrom(
-                side: const BorderSide(color: AppTheme.border),
-                shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(10)),
-                padding: const EdgeInsets.symmetric(vertical: 12),
+              style: _buttonStyle(
+                  radius: const BorderRadius.horizontal(
+                      left: Radius.circular(10))),
+            ),
+          ),
+          SizedBox(
+            width: 34,
+            child: MenuAnchor(
+              style: const MenuStyle(
+                backgroundColor:
+                    WidgetStatePropertyAll(AppTheme.surfaceVariant),
+              ),
+              menuChildren: [
+                MenuItemButton(
+                  leadingIcon: const Icon(Icons.checklist,
+                      size: 18, color: AppTheme.textSecondary),
+                  onPressed: onAutomaticEpisodes,
+                  child: const Text('Individual episodes',
+                      style: TextStyle(
+                          color: AppTheme.textPrimary, fontSize: 14)),
+                ),
+              ],
+              builder: (context, controller, _) => OutlinedButton(
+                onPressed: () =>
+                    controller.isOpen ? controller.close() : controller.open(),
+                style: OutlinedButton.styleFrom(
+                  side: const BorderSide(color: AppTheme.border),
+                  shape: const RoundedRectangleBorder(
+                      borderRadius:
+                          BorderRadius.horizontal(right: Radius.circular(10))),
+                  padding: EdgeInsets.zero,
+                  minimumSize: Size.zero,
+                ),
+                child: const Icon(Icons.arrow_drop_up,
+                    size: 20, color: AppTheme.textSecondary),
               ),
             ),
           ),

--- a/app/test/sonarr/season_selection_test.dart
+++ b/app/test/sonarr/season_selection_test.dart
@@ -1,0 +1,219 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:cantinarr/features/sonarr/logic/episode_selection.dart';
+import 'package:cantinarr/features/sonarr/ui/sonarr_season_screen.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fake Dio adapter routing by path: /episode and /queue get canned bodies,
+/// every request (notably POST /command) is recorded for assertions.
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter({required this.episodes});
+
+  final List<Map<String, dynamic>> episodes;
+  final List<({String method, String path, dynamic body})> requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    dynamic body;
+    if (requestStream != null) {
+      final bytes = await requestStream.expand((c) => c).toList();
+      if (bytes.isNotEmpty) body = jsonDecode(utf8.decode(bytes));
+    }
+    requests.add(
+        (method: options.method, path: options.uri.path, body: body));
+
+    final path = options.uri.path;
+    dynamic response = <String, dynamic>{};
+    if (path.endsWith('/episode')) response = episodes;
+    if (path.endsWith('/queue')) response = {'records': <dynamic>[]};
+    return ResponseBody.fromString(
+      jsonEncode(response),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Map<String, dynamic> _episodeJson({
+  required int id,
+  required int episodeNumber,
+  required bool hasFile,
+  required bool aired,
+}) =>
+    {
+      'id': id,
+      'seriesId': 7,
+      'seasonNumber': 1,
+      'episodeNumber': episodeNumber,
+      'title': 'Episode $episodeNumber',
+      'hasFile': hasFile,
+      'monitored': false,
+      'airDateUtc': DateTime.now()
+          .toUtc()
+          .add(Duration(days: aired ? -30 : 30))
+          .toIso8601String(),
+    };
+
+SonarrEpisode _episode({
+  required int id,
+  bool hasFile = false,
+  bool aired = true,
+  bool tba = false,
+}) =>
+    SonarrEpisode.fromJson(_episodeJson(
+        id: id, episodeNumber: id, hasFile: hasFile, aired: aired)
+      ..remove(tba ? 'airDateUtc' : ''));
+
+Future<_FakeAdapter> _pumpSeasonScreen(WidgetTester tester,
+    {required List<Map<String, dynamic>> episodes}) async {
+  final adapter = _FakeAdapter(episodes: episodes);
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+    ..httpClientAdapter = adapter;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [backendClientProvider.overrideWithValue(dio)],
+      child: const MaterialApp(
+        home: SonarrSeasonScreen(
+          instanceId: 'inst1',
+          series: SonarrSeries(id: 7, title: 'Example'),
+          seasonNumber: 1,
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return adapter;
+}
+
+/// OutlinedButton.icon returns a private OutlinedButton subclass on some
+/// Flutter versions, so match by subtype rather than exact runtime type.
+Finder _button(String label) => find.ancestor(
+    of: find.text(label), matching: find.bySubtype<OutlinedButton>());
+
+void main() {
+  group('undownloadedEpisodeIds', () {
+    test('picks aired episodes without a file; skips unaired, TBA and '
+        'downloaded', () {
+      final episodes = [
+        _episode(id: 1, hasFile: true), // downloaded
+        _episode(id: 2), // aired + missing -> wanted
+        _episode(id: 3, aired: false), // unaired
+        _episode(id: 4, tba: true), // no air date at all
+        _episode(id: 5), // aired + missing -> wanted
+      ];
+      expect(undownloadedEpisodeIds(episodes), [2, 5]);
+    });
+  });
+
+  group('SonarrSeasonScreen', () {
+    // Episode 101 downloaded, 102 aired+missing, 103 unaired.
+    final episodes = [
+      _episodeJson(id: 101, episodeNumber: 1, hasFile: true, aired: true),
+      _episodeJson(id: 102, episodeNumber: 2, hasFile: false, aired: true),
+      _episodeJson(id: 103, episodeNumber: 3, hasFile: false, aired: false),
+    ];
+
+    List<({String method, String path, dynamic body})> commands(
+            _FakeAdapter adapter) =>
+        adapter.requests.where((r) => r.path.endsWith('/command')).toList();
+
+    testWidgets('episode magnifier runs an automatic EpisodeSearch',
+        (tester) async {
+      final adapter = await _pumpSeasonScreen(tester, episodes: episodes);
+
+      // Tiles are sorted newest first: episode 3, 2, 1.
+      await tester.tap(find.byTooltip('Automatic search').last);
+      await tester.pumpAndSettle();
+
+      final sent = commands(adapter);
+      expect(sent, hasLength(1));
+      expect(sent.single.body,
+          {'name': 'EpisodeSearch', 'episodeIds': [101]});
+      // No interactive releases screen was pushed.
+      expect(find.text('Automatic'), findsOneWidget);
+    });
+
+    testWidgets(
+        'arrow menu enters selection mode with undownloaded preselected '
+        'and searches the selection', (tester) async {
+      final adapter = await _pumpSeasonScreen(tester, episodes: episodes);
+
+      await tester.tap(find.byIcon(Icons.arrow_drop_up));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Individual episodes'));
+      await tester.pumpAndSettle();
+
+      // Only the aired-but-missing episode (102) starts selected.
+      expect(find.text('1 selected'), findsOneWidget);
+      expect(find.byType(Checkbox), findsNWidgets(3));
+      expect(_button('Search 1 episode'), findsOneWidget);
+
+      // Interactive can't run on a multi-selection: disabled.
+      final interactive =
+          tester.widget<OutlinedButton>(_button('Interactive'));
+      expect(interactive.onPressed, isNull);
+
+      // Quick-selects.
+      await tester.tap(find.text('All'));
+      await tester.pump();
+      expect(find.text('3 selected'), findsOneWidget);
+      await tester.tap(find.text('None'));
+      await tester.pump();
+      expect(find.text('0 selected'), findsOneWidget);
+      final searchNone =
+          tester.widget<OutlinedButton>(_button('Search 0 episodes'));
+      expect(searchNone.onPressed, isNull);
+      await tester.tap(find.text('Undownloaded'));
+      await tester.pump();
+      expect(find.text('1 selected'), findsOneWidget);
+
+      // Tapping a tile toggles it: add the unaired episode 3 (first tile).
+      await tester.tap(find.text('Episode 3'));
+      await tester.pump();
+      expect(find.text('2 selected'), findsOneWidget);
+
+      await tester.tap(_button('Search 2 episodes'));
+      await tester.pumpAndSettle();
+
+      final sent = commands(adapter);
+      expect(sent, hasLength(1));
+      expect(sent.single.body,
+          {'name': 'EpisodeSearch', 'episodeIds': [102, 103]});
+      // Selection mode exits after the search is sent.
+      expect(find.byType(Checkbox), findsNothing);
+      expect(find.text('Automatic'), findsOneWidget);
+    });
+
+    testWidgets('long-press enters selection mode with that episode selected',
+        (tester) async {
+      await _pumpSeasonScreen(tester, episodes: episodes);
+
+      await tester.longPress(find.text('Episode 2'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('1 selected'), findsOneWidget);
+      expect(_button('Search 1 episode'), findsOneWidget);
+
+      // Close returns to the normal action bar.
+      await tester.tap(find.byTooltip('Cancel selection'));
+      await tester.pump();
+      expect(find.byType(Checkbox), findsNothing);
+      expect(find.text('Automatic'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## What

1. **Episode selection mode** in the Sonarr season screen: episodes get checkboxes, with **All / Undownloaded / None** quick-selects in a header bar ("Undownloaded" = aired episodes without a file — unaired/TBA are skipped since searching them finds nothing). Long-pressing an episode also enters selection mode with that episode selected.
2. **Split Automatic button**: the season Automatic button gains a small arrow revealing **Individual episodes** — choosing it enters selection mode with every undownloaded episode preselected. The action bar then switches to **Search N episodes**, which fires a single `EpisodeSearch` command for the whole selection. Interactive search can't act on a multi-selection, so its button is disabled while selecting.
3. **Per-episode magnifier → automatic search**: the episode tile's magnifying glass now triggers an automatic `EpisodeSearch` instead of opening the interactive releases screen. This matches the wanted screens and the Radarr module, whose magnifiers already ran automatic search (verified — no Radarr changes needed). Interactive search per episode remains available in the episode detail sheet.

## Notes

- No server changes: the existing verbatim proxy + Sonarr's `EpisodeSearch` command (which accepts an `episodeIds` list and bypasses monitored checks for user-invoked searches) cover the batch path.
- Tests: pure-logic coverage for the undownloaded selector, plus widget tests driving the real screen through a fake Dio adapter — magnifier sends a single-id `EpisodeSearch`, arrow menu → preselection → quick-selects → batch `EpisodeSearch` payload, long-press entry, disabled Interactive/zero-selection states, and selection-mode exit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191Ybc6vnNGtEve37m7Zt2v