### PR TITLE
Sonarr: long-press menus, Edit Series, links + action buttons

### DIFF
--- a/app/lib/core/widgets/action_sheet.dart
+++ b/app/lib/core/widgets/action_sheet.dart
@@ -22,48 +22,51 @@ Future<T?> showActionSheet<T>(
   return showModalBottomSheet<T>(
     context: context,
     backgroundColor: Colors.transparent,
-    builder: (ctx) => Container(
-      decoration: const BoxDecoration(
-        color: AppTheme.surface,
-        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
-      ),
-      padding: EdgeInsets.only(bottom: MediaQuery.of(ctx).padding.bottom + 8),
-      // Scrolls when the actions don't fit the sheet's max height (short or
-      // landscape screens) instead of overflowing.
-      child: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const SizedBox(height: 12),
-            Container(
-              width: 40,
-              height: 4,
-              decoration: BoxDecoration(
-                color: AppTheme.textSecondary,
-                borderRadius: BorderRadius.circular(2),
+    // A Material (not a decorated Container) so the ListTiles' ink splashes
+    // paint on it instead of being hidden behind the background color.
+    builder: (ctx) => Material(
+      color: AppTheme.surface,
+      borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+      clipBehavior: Clip.antiAlias,
+      child: Padding(
+        padding: EdgeInsets.only(bottom: MediaQuery.of(ctx).padding.bottom + 8),
+        // Scrolls when the actions don't fit the sheet's max height (short or
+        // landscape screens) instead of overflowing.
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 12),
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: AppTheme.textSecondary,
+                  borderRadius: BorderRadius.circular(2),
+                ),
               ),
-            ),
-            Padding(
-              padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
-              child: Text(
-                title,
-                style: const TextStyle(
-                    color: AppTheme.textPrimary,
-                    fontSize: 17,
-                    fontWeight: FontWeight.bold),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
+                child: Text(
+                  title,
+                  style: const TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontSize: 17,
+                      fontWeight: FontWeight.bold),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
               ),
-            ),
-            ...actions.map((a) => ListTile(
-                  leading: Icon(a.icon, color: a.color ?? AppTheme.accent),
-                  title: Text(a.label,
-                      style: TextStyle(
-                          color: a.color ?? AppTheme.textPrimary,
-                          fontSize: 15)),
-                  onTap: () => Navigator.pop(ctx, a.value),
-                )),
-          ],
+              ...actions.map((a) => ListTile(
+                    leading: Icon(a.icon, color: a.color ?? AppTheme.accent),
+                    title: Text(a.label,
+                        style: TextStyle(
+                            color: a.color ?? AppTheme.textPrimary,
+                            fontSize: 15)),
+                    onTap: () => Navigator.pop(ctx, a.value),
+                  )),
+            ],
+          ),
         ),
       ),
     ),

--- a/app/lib/core/widgets/action_sheet.dart
+++ b/app/lib/core/widgets/action_sheet.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import '../theme/app_theme.dart';
+
+/// One row in an [showActionSheet] menu.
+class SheetAction<T> {
+  final T value;
+  final IconData icon;
+  final String label;
+  final Color? color;
+
+  const SheetAction(this.value, this.icon, this.label, {this.color});
+}
+
+/// Bottom sheet of actions for one item (a series, a season, …): drag handle,
+/// item title, then a tappable row per action. Resolves to the chosen action's
+/// value, or null when dismissed.
+Future<T?> showActionSheet<T>(
+  BuildContext context, {
+  required String title,
+  required List<SheetAction<T>> actions,
+}) {
+  return showModalBottomSheet<T>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    builder: (ctx) => Container(
+      decoration: const BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      padding: EdgeInsets.only(bottom: MediaQuery.of(ctx).padding.bottom + 8),
+      // Scrolls when the actions don't fit the sheet's max height (short or
+      // landscape screens) instead of overflowing.
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 12),
+            Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: AppTheme.textSecondary,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 16, 20, 4),
+              child: Text(
+                title,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontSize: 17,
+                    fontWeight: FontWeight.bold),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            ...actions.map((a) => ListTile(
+                  leading: Icon(a.icon, color: a.color ?? AppTheme.accent),
+                  title: Text(a.label,
+                      style: TextStyle(
+                          color: a.color ?? AppTheme.textPrimary,
+                          fontSize: 15)),
+                  onTap: () => Navigator.pop(ctx, a.value),
+                )),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/app/lib/features/sonarr/data/sonarr_api_service.dart
+++ b/app/lib/features/sonarr/data/sonarr_api_service.dart
@@ -92,6 +92,14 @@ class SonarrApiService {
     });
   }
 
+  /// Asks Sonarr to refresh a series' metadata and rescan its files.
+  Future<void> refreshSeries(int seriesId) async {
+    await _dio.post('$_basePath/command', data: {
+      'name': 'RefreshSeries',
+      'seriesId': seriesId,
+    });
+  }
+
   Future<void> searchSeason(int seriesId, int seasonNumber) async {
     await _dio.post('$_basePath/command', data: {
       'name': 'SeasonSearch',
@@ -286,6 +294,30 @@ class SonarrApiService {
       }
     }
     await _dio.put('$_basePath/series/$seriesId', data: series);
+  }
+
+  /// Updates a handful of series fields. Sonarr's series PUT expects the whole
+  /// resource, so the current series JSON is fetched raw, the given fields are
+  /// merged in, and everything else is sent back unchanged. Admin only (proxy
+  /// requires instances:manage).
+  Future<void> updateSeriesFields(
+      int seriesId, Map<String, dynamic> fields) async {
+    final resp = await _dio.get('$_basePath/series/$seriesId');
+    final series = Map<String, dynamic>.from(resp.data as Map);
+    series.addAll(fields);
+    await _dio.put('$_basePath/series/$seriesId', data: series);
+  }
+
+  /// Toggles monitoring for a whole series (seasons/episodes untouched).
+  Future<void> setSeriesMonitored(int seriesId, {required bool monitored}) =>
+      updateSeriesFields(seriesId, {'monitored': monitored});
+
+  /// Lists the instance's tags (id + label).
+  Future<List<SonarrTag>> getTags() async {
+    final resp = await _dio.get('$_basePath/tag');
+    return (resp.data as List<dynamic>)
+        .map((t) => SonarrTag.fromJson(t as Map<String, dynamic>))
+        .toList();
   }
 
   // --- Import Doctor (admin; proxy requires instances:manage) ---

--- a/app/lib/features/sonarr/data/sonarr_models.dart
+++ b/app/lib/features/sonarr/data/sonarr_models.dart
@@ -4,16 +4,19 @@ class SonarrSeries {
   final String title;
   final int? tvdbId;
   final int? tmdbId;
+  final String? imdbId;
   final int? year;
   final String? overview;
   final String? titleSlug;
   final bool monitored;
+  final bool seasonFolder;
   final String? path;
   final String seriesType;
   final List<SonarrImage> images;
   final SonarrStatistics? statistics;
   final String? status;
   final int qualityProfileId;
+  final List<int> tags;
   final List<SonarrSeason> seasons;
 
   const SonarrSeries({
@@ -21,16 +24,19 @@ class SonarrSeries {
     required this.title,
     this.tvdbId,
     this.tmdbId,
+    this.imdbId,
     this.year,
     this.overview,
     this.titleSlug,
     this.monitored = true,
+    this.seasonFolder = true,
     this.path,
     this.seriesType = 'standard',
     this.images = const [],
     this.statistics,
     this.status,
     this.qualityProfileId = 0,
+    this.tags = const [],
     this.seasons = const [],
   });
 
@@ -39,10 +45,12 @@ class SonarrSeries {
         title: json['title'] as String? ?? 'Untitled',
         tvdbId: json['tvdbId'] as int?,
         tmdbId: json['tmdbId'] as int?,
+        imdbId: json['imdbId'] as String?,
         year: json['year'] as int?,
         overview: json['overview'] as String?,
         titleSlug: json['titleSlug'] as String?,
         monitored: json['monitored'] as bool? ?? true,
+        seasonFolder: json['seasonFolder'] as bool? ?? true,
         path: json['path'] as String?,
         seriesType: json['seriesType'] as String? ?? 'standard',
         images: (json['images'] as List<dynamic>?)
@@ -55,6 +63,7 @@ class SonarrSeries {
             : null,
         status: json['status'] as String?,
         qualityProfileId: json['qualityProfileId'] as int? ?? 0,
+        tags: (json['tags'] as List<dynamic>?)?.cast<int>() ?? const [],
         seasons: (json['seasons'] as List<dynamic>?)
                 ?.map((s) => SonarrSeason.fromJson(s as Map<String, dynamic>))
                 .toList() ??
@@ -66,14 +75,17 @@ class SonarrSeries {
         'title': title,
         'tvdbId': tvdbId,
         'tmdbId': tmdbId,
+        'imdbId': imdbId,
         'year': year,
         'overview': overview,
         'titleSlug': titleSlug,
         'monitored': monitored,
+        'seasonFolder': seasonFolder,
         'path': path,
         'seriesType': seriesType,
         'images': images.map((i) => i.toJson()).toList(),
         'qualityProfileId': qualityProfileId,
+        'tags': tags,
         'seasons': seasons.map((s) => s.toJson()).toList(),
       };
 
@@ -91,6 +103,19 @@ class SonarrSeries {
     if (statistics == null || statistics!.episodeCount == 0) return 0;
     return statistics!.episodeFileCount / statistics!.episodeCount;
   }
+}
+
+/// A Sonarr tag (id + label), used by the Edit Series tag picker.
+class SonarrTag {
+  final int id;
+  final String label;
+
+  const SonarrTag({required this.id, required this.label});
+
+  factory SonarrTag.fromJson(Map<String, dynamic> json) => SonarrTag(
+        id: json['id'] as int? ?? 0,
+        label: json['label'] as String? ?? '',
+      );
 }
 
 class SonarrImage {

--- a/app/lib/features/sonarr/ui/edit_series_screen.dart
+++ b/app/lib/features/sonarr/ui/edit_series_screen.dart
@@ -1,0 +1,420 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../data/sonarr_api_service.dart';
+import '../data/sonarr_models.dart';
+
+/// Edit a series' Sonarr settings: monitored, season folders, quality profile,
+/// series type, path and tags. Saving PUTs the whole series resource back with
+/// only these fields changed. Pops `true` after a successful update so callers
+/// can reload. Admin only (the proxy requires instances:manage for the PUT).
+class EditSeriesScreen extends ConsumerStatefulWidget {
+  final String instanceId;
+  final SonarrSeries series;
+
+  const EditSeriesScreen({
+    super.key,
+    required this.instanceId,
+    required this.series,
+  });
+
+  @override
+  ConsumerState<EditSeriesScreen> createState() => _EditSeriesScreenState();
+}
+
+class _EditSeriesScreenState extends ConsumerState<EditSeriesScreen> {
+  static const _seriesTypes = ['standard', 'daily', 'anime'];
+
+  late final SonarrApiService _service;
+  bool _isLoading = true;
+  bool _isSaving = false;
+  String? _error;
+
+  List<SonarrQualityProfile> _profiles = [];
+  // Null when the tag list couldn't be loaded — the Tags row is hidden then.
+  List<SonarrTag>? _allTags;
+
+  late bool _monitored;
+  late bool _seasonFolder;
+  late int _qualityProfileId;
+  late String _seriesType;
+  late String _path;
+  late Set<int> _tagIds;
+
+  @override
+  void initState() {
+    super.initState();
+    _service = SonarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: widget.instanceId,
+    );
+    _seedFrom(widget.series);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  void _seedFrom(SonarrSeries s) {
+    _monitored = s.monitored;
+    _seasonFolder = s.seasonFolder;
+    _qualityProfileId = s.qualityProfileId;
+    _seriesType = s.seriesType;
+    _path = s.path ?? '';
+    _tagIds = {...s.tags};
+  }
+
+  Future<void> _load() async {
+    setState(() => _isLoading = true);
+    try {
+      // Profiles and the fresh series are required; tags are optional.
+      final profilesFuture = _service.getQualityProfiles();
+      final seriesFuture = _service.getSeriesById(widget.series.id);
+      final profiles = await profilesFuture;
+      final series = await seriesFuture;
+      List<SonarrTag>? tags;
+      try {
+        tags = await _service.getTags();
+      } catch (_) {
+        tags = null;
+      }
+      if (!mounted) return;
+      setState(() {
+        _profiles = profiles;
+        _allTags = tags;
+        _seedFrom(series);
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load series settings: $e';
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    setState(() => _isSaving = true);
+    try {
+      await _service.updateSeriesFields(widget.series.id, {
+        'monitored': _monitored,
+        'seasonFolder': _seasonFolder,
+        'qualityProfileId': _qualityProfileId,
+        'seriesType': _seriesType,
+        'path': _path,
+        'tags': _tagIds.toList()..sort(),
+      });
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Series updated')));
+      Navigator.of(context).pop(true);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isSaving = false);
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Update failed: $e')));
+    }
+  }
+
+  String get _profileName {
+    for (final p in _profiles) {
+      if (p.id == _qualityProfileId) return p.name;
+    }
+    return 'Profile $_qualityProfileId';
+  }
+
+  String get _tagsSummary {
+    final tags = _allTags;
+    if (tags == null || _tagIds.isEmpty) return 'Not Set';
+    final labels = [
+      for (final t in tags)
+        if (_tagIds.contains(t.id)) t.label,
+    ];
+    return labels.isEmpty ? 'Not Set' : labels.join(', ');
+  }
+
+  Future<void> _pickQualityProfile() async {
+    final picked = await showDialog<int>(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        backgroundColor: AppTheme.surface,
+        title: const Text('Quality Profile'),
+        children: _profiles
+            .map((p) => SimpleDialogOption(
+                  onPressed: () => Navigator.pop(ctx, p.id),
+                  child: Text(p.name,
+                      style: TextStyle(
+                        color: p.id == _qualityProfileId
+                            ? AppTheme.accent
+                            : AppTheme.textPrimary,
+                        fontSize: 15,
+                      )),
+                ))
+            .toList(),
+      ),
+    );
+    if (picked != null) setState(() => _qualityProfileId = picked);
+  }
+
+  Future<void> _pickSeriesType() async {
+    final picked = await showDialog<String>(
+      context: context,
+      builder: (ctx) => SimpleDialog(
+        backgroundColor: AppTheme.surface,
+        title: const Text('Series Type'),
+        children: _seriesTypes
+            .map((t) => SimpleDialogOption(
+                  onPressed: () => Navigator.pop(ctx, t),
+                  child: Text(
+                    t[0].toUpperCase() + t.substring(1),
+                    style: TextStyle(
+                      color: t == _seriesType
+                          ? AppTheme.accent
+                          : AppTheme.textPrimary,
+                      fontSize: 15,
+                    ),
+                  ),
+                ))
+            .toList(),
+      ),
+    );
+    if (picked != null) setState(() => _seriesType = picked);
+  }
+
+  Future<void> _editPath() async {
+    final controller = TextEditingController(text: _path);
+    final picked = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppTheme.surface,
+        title: const Text('Series Path'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          style: const TextStyle(color: AppTheme.textPrimary, fontSize: 14),
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, controller.text.trim()),
+            child: const Text('Set'),
+          ),
+        ],
+      ),
+    );
+    controller.dispose();
+    if (picked != null && picked.isNotEmpty) setState(() => _path = picked);
+  }
+
+  Future<void> _pickTags() async {
+    final tags = _allTags;
+    if (tags == null) return;
+    final selection = {..._tagIds};
+    final picked = await showDialog<Set<int>>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          backgroundColor: AppTheme.surface,
+          title: const Text('Tags'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: tags.isEmpty
+                ? const Text('No tags defined in Sonarr.',
+                    style:
+                        TextStyle(color: AppTheme.textSecondary, fontSize: 14))
+                : ListView(
+                    shrinkWrap: true,
+                    children: tags
+                        .map((t) => CheckboxListTile(
+                              value: selection.contains(t.id),
+                              onChanged: (v) => setDialogState(() =>
+                                  v == true
+                                      ? selection.add(t.id)
+                                      : selection.remove(t.id)),
+                              title: Text(t.label,
+                                  style: const TextStyle(fontSize: 14)),
+                              contentPadding: EdgeInsets.zero,
+                              controlAffinity:
+                                  ListTileControlAffinity.leading,
+                              activeColor: AppTheme.accent,
+                            ))
+                        .toList(),
+                  ),
+          ),
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('Cancel')),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, selection),
+              child: const Text('Done'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (picked != null) setState(() => _tagIds = picked);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppTheme.background,
+      appBar: AppBar(
+        backgroundColor: AppTheme.background,
+        title: const Text('Edit Series'),
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null) {
+      return FullScreenError(message: _error!, onRetry: _load);
+    }
+    return Column(
+      children: [
+        Expanded(
+          child: ListView(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            children: [
+              _SettingCard(
+                child: SwitchListTile(
+                  value: _monitored,
+                  onChanged: (v) => setState(() => _monitored = v),
+                  title: const Text('Monitored',
+                      style: TextStyle(
+                          color: AppTheme.textPrimary, fontSize: 15)),
+                  activeTrackColor: AppTheme.accent,
+                ),
+              ),
+              _SettingCard(
+                child: SwitchListTile(
+                  value: _seasonFolder,
+                  onChanged: (v) => setState(() => _seasonFolder = v),
+                  title: const Text('Use Season Folders',
+                      style: TextStyle(
+                          color: AppTheme.textPrimary, fontSize: 15)),
+                  activeTrackColor: AppTheme.accent,
+                ),
+              ),
+              _SettingCard(
+                child: _PickerTile(
+                  title: 'Quality Profile',
+                  value: _profileName,
+                  onTap: _pickQualityProfile,
+                ),
+              ),
+              _SettingCard(
+                child: _PickerTile(
+                  title: 'Series Type',
+                  value: _seriesType[0].toUpperCase() + _seriesType.substring(1),
+                  onTap: _pickSeriesType,
+                ),
+              ),
+              _SettingCard(
+                child: _PickerTile(
+                  title: 'Series Path',
+                  value: _path.isEmpty ? 'Not Set' : _path,
+                  onTap: _editPath,
+                ),
+              ),
+              if (_allTags != null)
+                _SettingCard(
+                  child: _PickerTile(
+                    title: 'Tags',
+                    value: _tagsSummary,
+                    onTap: _pickTags,
+                  ),
+                ),
+            ],
+          ),
+        ),
+        Container(
+          padding: EdgeInsets.fromLTRB(
+              12, 10, 12, 10 + MediaQuery.of(context).padding.bottom),
+          decoration: const BoxDecoration(
+            color: AppTheme.surface,
+            border:
+                Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
+          ),
+          child: SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              onPressed: _isSaving ? null : _save,
+              icon: _isSaving
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                          strokeWidth: 2, color: AppTheme.accent))
+                  : const Icon(Icons.edit_outlined,
+                      size: 18, color: AppTheme.accent),
+              label: const Text('Update',
+                  style: TextStyle(color: AppTheme.textPrimary)),
+              style: OutlinedButton.styleFrom(
+                side: const BorderSide(color: AppTheme.border),
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10)),
+                padding: const EdgeInsets.symmetric(vertical: 12),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SettingCard extends StatelessWidget {
+  final Widget child;
+  const _SettingCard({required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppTheme.border, width: 0.5),
+      ),
+      child: child,
+    );
+  }
+}
+
+class _PickerTile extends StatelessWidget {
+  final String title;
+  final String value;
+  final VoidCallback onTap;
+
+  const _PickerTile({
+    required this.title,
+    required this.value,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      onTap: onTap,
+      title: Text(title,
+          style: const TextStyle(color: AppTheme.textPrimary, fontSize: 15)),
+      subtitle: Text(
+        value,
+        style: const TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: const Icon(Icons.chevron_right, color: AppTheme.textSecondary),
+    );
+  }
+}

--- a/app/lib/features/sonarr/ui/edit_series_screen.dart
+++ b/app/lib/features/sonarr/ui/edit_series_screen.dart
@@ -196,8 +196,7 @@ class _EditSeriesScreenState extends ConsumerState<EditSeriesScreen> {
         ),
         actions: [
           TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('Cancel')),
+              onPressed: () => Navigator.pop(ctx), child: const Text('Cancel')),
           TextButton(
             onPressed: () => Navigator.pop(ctx, controller.text.trim()),
             child: const Text('Set'),
@@ -230,15 +229,13 @@ class _EditSeriesScreenState extends ConsumerState<EditSeriesScreen> {
                     children: tags
                         .map((t) => CheckboxListTile(
                               value: selection.contains(t.id),
-                              onChanged: (v) => setDialogState(() =>
-                                  v == true
-                                      ? selection.add(t.id)
-                                      : selection.remove(t.id)),
+                              onChanged: (v) => setDialogState(() => v == true
+                                  ? selection.add(t.id)
+                                  : selection.remove(t.id)),
                               title: Text(t.label,
                                   style: const TextStyle(fontSize: 14)),
                               contentPadding: EdgeInsets.zero,
-                              controlAffinity:
-                                  ListTileControlAffinity.leading,
+                              controlAffinity: ListTileControlAffinity.leading,
                               activeColor: AppTheme.accent,
                             ))
                         .toList(),
@@ -290,8 +287,8 @@ class _EditSeriesScreenState extends ConsumerState<EditSeriesScreen> {
                   value: _monitored,
                   onChanged: (v) => setState(() => _monitored = v),
                   title: const Text('Monitored',
-                      style: TextStyle(
-                          color: AppTheme.textPrimary, fontSize: 15)),
+                      style:
+                          TextStyle(color: AppTheme.textPrimary, fontSize: 15)),
                   activeTrackColor: AppTheme.accent,
                 ),
               ),
@@ -300,8 +297,8 @@ class _EditSeriesScreenState extends ConsumerState<EditSeriesScreen> {
                   value: _seasonFolder,
                   onChanged: (v) => setState(() => _seasonFolder = v),
                   title: const Text('Use Season Folders',
-                      style: TextStyle(
-                          color: AppTheme.textPrimary, fontSize: 15)),
+                      style:
+                          TextStyle(color: AppTheme.textPrimary, fontSize: 15)),
                   activeTrackColor: AppTheme.accent,
                 ),
               ),
@@ -315,7 +312,8 @@ class _EditSeriesScreenState extends ConsumerState<EditSeriesScreen> {
               _SettingCard(
                 child: _PickerTile(
                   title: 'Series Type',
-                  value: _seriesType[0].toUpperCase() + _seriesType.substring(1),
+                  value:
+                      _seriesType[0].toUpperCase() + _seriesType.substring(1),
                   onTap: _pickSeriesType,
                 ),
               ),
@@ -342,8 +340,7 @@ class _EditSeriesScreenState extends ConsumerState<EditSeriesScreen> {
               12, 10, 12, 10 + MediaQuery.of(context).padding.bottom),
           decoration: const BoxDecoration(
             color: AppTheme.surface,
-            border:
-                Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
+            border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
           ),
           child: SizedBox(
             width: double.infinity,
@@ -379,14 +376,19 @@ class _SettingCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // A Material (not a decorated Container) so the tiles' ink splashes paint
+    // on the card instead of being hidden behind the background color.
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      decoration: BoxDecoration(
+      child: Material(
         color: AppTheme.surface,
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: AppTheme.border, width: 0.5),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(10),
+          side: const BorderSide(color: AppTheme.border, width: 0.5),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: child,
       ),
-      child: child,
     );
   }
 }

--- a/app/lib/features/sonarr/ui/series_actions.dart
+++ b/app/lib/features/sonarr/ui/series_actions.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/action_sheet.dart';
+import '../data/sonarr_api_service.dart';
+import '../data/sonarr_models.dart';
+import 'edit_series_screen.dart';
+
+enum SeriesAction { searchMonitored, edit, refresh, remove, toggleMonitor }
+
+/// Long-press / overflow menu for one series: shows the action sheet and runs
+/// the chosen action. [onChanged] fires after anything that alters the series
+/// (edit saved, monitor toggled, refresh triggered); [onRemoved] fires after a
+/// successful remove instead.
+Future<void> showSeriesActions(
+  BuildContext context, {
+  required SonarrApiService service,
+  required String instanceId,
+  required SonarrSeries series,
+  VoidCallback? onChanged,
+  VoidCallback? onRemoved,
+}) async {
+  final action = await showActionSheet<SeriesAction>(
+    context,
+    title: series.title,
+    actions: [
+      const SheetAction(
+          SeriesAction.searchMonitored, Icons.search, 'Search Monitored'),
+      const SheetAction(SeriesAction.edit, Icons.edit_outlined, 'Edit Series'),
+      const SheetAction(SeriesAction.refresh, Icons.refresh, 'Refresh Series'),
+      const SheetAction(SeriesAction.remove, Icons.delete_outline,
+          'Remove Series',
+          color: AppTheme.error),
+      SheetAction(
+          SeriesAction.toggleMonitor,
+          series.monitored ? Icons.bookmark_border : Icons.bookmark,
+          series.monitored ? 'Unmonitor Series' : 'Monitor Series'),
+    ],
+  );
+  if (action == null || !context.mounted) return;
+
+  void toast(String message) {
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  try {
+    switch (action) {
+      case SeriesAction.searchMonitored:
+        await service.searchSeries(series.id);
+        toast('Searching for monitored episodes of ${series.title}…');
+      case SeriesAction.edit:
+        final saved = await Navigator.of(context, rootNavigator: true)
+            .push<bool>(MaterialPageRoute(
+          builder: (_) =>
+              EditSeriesScreen(instanceId: instanceId, series: series),
+        ));
+        if (saved == true) onChanged?.call();
+      case SeriesAction.refresh:
+        await service.refreshSeries(series.id);
+        toast('Refreshing ${series.title}…');
+        onChanged?.call();
+      case SeriesAction.remove:
+        final deleteFiles = await confirmRemoveSeries(context, series.title);
+        if (deleteFiles == null) return;
+        await service.deleteSeries(series.id, deleteFiles: deleteFiles);
+        toast('Removed ${series.title}');
+        onRemoved?.call();
+      case SeriesAction.toggleMonitor:
+        await service.setSeriesMonitored(series.id,
+            monitored: !series.monitored);
+        toast(series.monitored
+            ? 'Stopped monitoring ${series.title}'
+            : 'Monitoring ${series.title}');
+        onChanged?.call();
+    }
+  } catch (e) {
+    toast('Action failed: $e');
+  }
+}
+
+/// Remove confirmation with a "delete files" choice. Resolves to the
+/// delete-files flag, or null when cancelled.
+Future<bool?> confirmRemoveSeries(BuildContext context, String title) {
+  var deleteFiles = false;
+  return showDialog<bool>(
+    context: context,
+    builder: (ctx) => StatefulBuilder(
+      builder: (ctx, setState) => AlertDialog(
+        backgroundColor: AppTheme.surface,
+        title: const Text('Remove Series'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Remove "$title" from Sonarr?'),
+            const SizedBox(height: 8),
+            CheckboxListTile(
+              value: deleteFiles,
+              onChanged: (v) => setState(() => deleteFiles = v ?? false),
+              title: const Text('Delete files from disk',
+                  style: TextStyle(fontSize: 14)),
+              contentPadding: EdgeInsets.zero,
+              controlAffinity: ListTileControlAffinity.leading,
+              activeColor: AppTheme.error,
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, deleteFiles),
+            style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/app/lib/features/sonarr/ui/sonarr_home_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_home_screen.dart
@@ -7,6 +7,7 @@ import '../../../core/widgets/error_banner.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
 import '../logic/sonarr_series_provider.dart';
+import 'series_actions.dart';
 import 'sonarr_releases_screen.dart';
 import 'sonarr_series_detail_screen.dart';
 import 'sonarr_series_list.dart';
@@ -64,16 +65,35 @@ class _SonarrHomeScreenState extends ConsumerState<SonarrHomeScreen> {
     }
   }
 
-  void _openSeries(SonarrSeries show) {
+  Future<void> _openSeries(SonarrSeries show) async {
     final instanceId = ref.read(instanceProvider).activeSonarrInstance?.id;
     if (instanceId == null) return;
-    Navigator.of(context, rootNavigator: true).push(
+    await Navigator.of(context, rootNavigator: true).push(
       MaterialPageRoute(
         builder: (_) => SonarrSeriesDetailScreen(
           instanceId: instanceId,
           series: show,
         ),
       ),
+    );
+    // The detail screen can edit or remove the series; refresh on return.
+    _notifier?.loadSeries();
+  }
+
+  /// Long-press menu: search monitored / edit / refresh / remove / monitor.
+  void _showSeriesActions(SonarrSeries show) {
+    final instanceId = ref.read(instanceProvider).activeSonarrInstance?.id;
+    if (instanceId == null) return;
+    showSeriesActions(
+      context,
+      service: SonarrApiService(
+        backendDio: ref.read(backendClientProvider),
+        instanceId: instanceId,
+      ),
+      instanceId: instanceId,
+      series: show,
+      onChanged: () => _notifier?.loadSeries(),
+      onRemoved: () => _notifier?.loadSeries(),
     );
   }
 
@@ -239,6 +259,7 @@ class _SonarrHomeScreenState extends ConsumerState<SonarrHomeScreen> {
                         onSearch: _triggerAutomaticSearch,
                         onInteractiveSearch: _openInteractiveSearch,
                         onOpen: _openSeries,
+                        onLongPress: _showSeriesActions,
                       ),
                     ),
             ),

--- a/app/lib/features/sonarr/ui/sonarr_series_detail_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_series_detail_screen.dart
@@ -1,15 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/action_sheet.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
+import 'edit_series_screen.dart';
+import 'series_actions.dart';
+import 'sonarr_releases_screen.dart';
 import 'sonarr_season_screen.dart';
 
 /// Series detail: an "All Seasons" summary plus a per-season list with
 /// availability and monitor toggles. Tapping a season drills into its
-/// episodes. Mirrors LunaSea's Series Details > Seasons view.
+/// episodes; long-pressing one offers Automatic/Interactive season search.
+/// The app bar carries external links, Edit Series, and the series action
+/// menu. Mirrors LunaSea's Series Details > Seasons view.
 class SonarrSeriesDetailScreen extends ConsumerStatefulWidget {
   final String instanceId;
   final SonarrSeries series;
@@ -123,6 +130,99 @@ class _SonarrSeriesDetailScreenState
     );
   }
 
+  void _toast(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  /// Long-press menu for a season: automatic or interactive season search.
+  Future<void> _showSeasonActions(SonarrSeason season) async {
+    final action = await showActionSheet<String>(
+      context,
+      title: seasonLabel(season.seasonNumber),
+      actions: const [
+        SheetAction('automatic', Icons.search, 'Automatic Search'),
+        SheetAction('interactive', Icons.manage_search, 'Interactive Search'),
+      ],
+    );
+    if (action == null || !mounted) return;
+    switch (action) {
+      case 'automatic':
+        try {
+          await _service.searchSeason(_series.id, season.seasonNumber);
+          _toast('Searching for ${seasonLabel(season.seasonNumber)}…');
+        } catch (e) {
+          _toast('Search failed: $e');
+        }
+      case 'interactive':
+        Navigator.of(context, rootNavigator: true).push(
+          MaterialPageRoute(
+            builder: (_) => SonarrReleasesScreen(
+              instanceId: widget.instanceId,
+              seriesId: _series.id,
+              seasonNumber: season.seasonNumber,
+              seriesTitle: _series.title,
+            ),
+          ),
+        );
+    }
+  }
+
+  Future<void> _openEdit() async {
+    final saved = await Navigator.of(context, rootNavigator: true).push<bool>(
+      MaterialPageRoute(
+        builder: (_) => EditSeriesScreen(
+          instanceId: widget.instanceId,
+          series: _series,
+        ),
+      ),
+    );
+    if (saved == true && mounted) _load();
+  }
+
+  void _showSeriesMenu() {
+    showSeriesActions(
+      context,
+      service: _service,
+      instanceId: widget.instanceId,
+      series: _series,
+      onChanged: _load,
+      onRemoved: () {
+        if (mounted) Navigator.of(context).pop();
+      },
+    );
+  }
+
+  /// External sites for this series; entries appear only when the matching id
+  /// is known.
+  Future<void> _openLinks() async {
+    final links = <SheetAction<String>>[
+      if ((_series.imdbId ?? '').isNotEmpty)
+        SheetAction('https://www.imdb.com/title/${_series.imdbId}',
+            Icons.movie_outlined, 'IMDb'),
+      if ((_series.tvdbId ?? 0) > 0)
+        SheetAction('https://thetvdb.com/?tab=series&id=${_series.tvdbId}',
+            Icons.live_tv_outlined, 'TheTVDB'),
+      if ((_series.tmdbId ?? 0) > 0)
+        SheetAction('https://www.themoviedb.org/tv/${_series.tmdbId}',
+            Icons.theaters_outlined, 'TMDB'),
+      if ((_series.tvdbId ?? 0) > 0)
+        SheetAction(
+            'https://trakt.tv/search/tvdb/${_series.tvdbId}?id_type=show',
+            Icons.track_changes_outlined,
+            'Trakt'),
+    ];
+    if (links.isEmpty) {
+      _toast('No external links available');
+      return;
+    }
+    final url =
+        await showActionSheet<String>(context, title: _series.title, actions: links);
+    if (url == null) return;
+    launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
+  }
+
   @override
   Widget build(BuildContext context) {
     final seasons = [..._series.seasons]
@@ -135,9 +235,19 @@ class _SonarrSeriesDetailScreenState
         title: Text(_series.title, maxLines: 1, overflow: TextOverflow.ellipsis),
         actions: [
           IconButton(
-            icon: const Icon(Icons.refresh, color: AppTheme.textPrimary),
-            tooltip: 'Refresh',
-            onPressed: _isLoading ? null : _load,
+            icon: const Icon(Icons.link, color: AppTheme.textPrimary),
+            tooltip: 'External links',
+            onPressed: _openLinks,
+          ),
+          IconButton(
+            icon: const Icon(Icons.edit_outlined, color: AppTheme.textPrimary),
+            tooltip: 'Edit series',
+            onPressed: _openEdit,
+          ),
+          IconButton(
+            icon: const Icon(Icons.more_vert, color: AppTheme.textPrimary),
+            tooltip: 'Series actions',
+            onPressed: _showSeriesMenu,
           ),
         ],
       ),
@@ -157,6 +267,7 @@ class _SonarrSeriesDetailScreenState
                         season: s,
                         busy: _togglingSeasons.contains(s.seasonNumber),
                         onTap: () => _openSeason(s),
+                        onLongPress: () => _showSeasonActions(s),
                         onToggleMonitored: () => _toggleSeasonMonitored(s),
                       )),
                   if (seasons.isEmpty && !_isLoading)
@@ -249,12 +360,14 @@ class _SeasonCard extends StatelessWidget {
   final SonarrSeason season;
   final bool busy;
   final VoidCallback onTap;
+  final VoidCallback onLongPress;
   final VoidCallback onToggleMonitored;
 
   const _SeasonCard({
     required this.season,
     required this.busy,
     required this.onTap,
+    required this.onLongPress,
     required this.onToggleMonitored,
   });
 
@@ -263,6 +376,7 @@ class _SeasonCard extends StatelessWidget {
     final stats = season.statistics;
     return InkWell(
       onTap: onTap,
+      onLongPress: onLongPress,
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
         padding: const EdgeInsets.all(14),

--- a/app/lib/features/sonarr/ui/sonarr_series_list.dart
+++ b/app/lib/features/sonarr/ui/sonarr_series_list.dart
@@ -4,12 +4,15 @@ import '../../../core/widgets/cached_image.dart';
 import '../data/sonarr_models.dart';
 
 /// List of Sonarr series with swipe-to-delete and progress indicators.
+/// Long-pressing a tile opens the series action sheet when [onLongPress] is
+/// wired.
 class SonarrSeriesList extends StatelessWidget {
   final List<SonarrSeries> series;
   final void Function(int id) onDelete;
   final void Function(int id) onSearch;
   final void Function(SonarrSeries show)? onInteractiveSearch;
   final void Function(SonarrSeries show)? onOpen;
+  final void Function(SonarrSeries show)? onLongPress;
   final bool embedded;
 
   const SonarrSeriesList({
@@ -19,6 +22,7 @@ class SonarrSeriesList extends StatelessWidget {
     required this.onSearch,
     this.onInteractiveSearch,
     this.onOpen,
+    this.onLongPress,
     this.embedded = false,
   });
 
@@ -57,6 +61,7 @@ class SonarrSeriesList extends StatelessWidget {
                 ? () => onInteractiveSearch!(show)
                 : null,
             onOpen: onOpen != null ? () => onOpen!(show) : null,
+            onLongPress: onLongPress != null ? () => onLongPress!(show) : null,
           ),
         );
       },
@@ -90,12 +95,14 @@ class _SeriesTile extends StatelessWidget {
   final VoidCallback onSearch;
   final VoidCallback? onInteractiveSearch;
   final VoidCallback? onOpen;
+  final VoidCallback? onLongPress;
 
   const _SeriesTile({
     required this.show,
     required this.onSearch,
     this.onInteractiveSearch,
     this.onOpen,
+    this.onLongPress,
   });
 
   @override
@@ -105,6 +112,7 @@ class _SeriesTile extends StatelessWidget {
 
     return ListTile(
       onTap: onOpen,
+      onLongPress: onLongPress,
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       leading: ClipRRect(
         borderRadius: BorderRadius.circular(6),

--- a/app/test/sonarr/series_actions_test.dart
+++ b/app/test/sonarr/series_actions_test.dart
@@ -1,0 +1,345 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_api_service.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:cantinarr/features/sonarr/ui/series_actions.dart';
+import 'package:cantinarr/features/sonarr/ui/sonarr_series_detail_screen.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fake Dio adapter: routes GETs to canned bodies and records every request
+/// (method, path, query, decoded body) for assertions.
+class _FakeAdapter implements HttpClientAdapter {
+  final List<
+      ({
+        String method,
+        String path,
+        Map<String, dynamic> query,
+        dynamic body,
+      })> requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    dynamic body;
+    if (requestStream != null) {
+      final bytes = await requestStream.expand((c) => c).toList();
+      if (bytes.isNotEmpty) body = jsonDecode(utf8.decode(bytes));
+    }
+    final path = options.uri.path;
+    requests.add((
+      method: options.method,
+      path: path,
+      query: options.uri.queryParameters,
+      body: body,
+    ));
+
+    dynamic response = <String, dynamic>{};
+    if (options.method == 'GET') {
+      if (path.endsWith('/series/7')) response = _rawSeries;
+      if (path.endsWith('/qualityprofile')) response = _profiles;
+      if (path.endsWith('/tag')) response = _tags;
+    }
+    return ResponseBody.fromString(
+      jsonEncode(response),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+/// The series as Sonarr returns it, including a field the app doesn't model —
+/// updates must send it back unchanged.
+const _rawSeries = {
+  'id': 7,
+  'title': 'Example',
+  'monitored': true,
+  'seasonFolder': true,
+  'qualityProfileId': 5,
+  'seriesType': 'standard',
+  'path': '/tv/Example',
+  'tvdbId': 999,
+  'tmdbId': 555,
+  'imdbId': 'tt123',
+  'tags': [2],
+  'someUnknownField': {
+    'nested': [1, 2]
+  },
+  'seasons': [
+    {
+      'seasonNumber': 1,
+      'monitored': true,
+      'statistics': {
+        'episodeFileCount': 8,
+        'episodeCount': 8,
+        'totalEpisodeCount': 8,
+        'sizeOnDisk': 1000000000,
+      },
+    },
+    {'seasonNumber': 0, 'monitored': false},
+  ],
+};
+
+const _profiles = [
+  {'id': 5, 'name': 'HD-1080p'},
+  {'id': 9, 'name': 'Best'},
+];
+
+const _tags = [
+  {'id': 2, 'label': 'kids'},
+  {'id': 3, 'label': '4k'},
+];
+
+final _series = SonarrSeries.fromJson(
+    Map<String, dynamic>.from(_rawSeries));
+
+({_FakeAdapter adapter, Dio dio}) _fakeDio() {
+  final adapter = _FakeAdapter();
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+    ..httpClientAdapter = adapter;
+  return (adapter: adapter, dio: dio);
+}
+
+void main() {
+  group('showSeriesActions', () {
+    late _FakeAdapter adapter;
+    var changed = 0;
+    var removed = 0;
+
+    Future<void> pumpHarness(WidgetTester tester) async {
+      final fake = _fakeDio();
+      adapter = fake.adapter;
+      changed = 0;
+      removed = 0;
+      final service =
+          SonarrApiService(backendDio: fake.dio, instanceId: 'inst1');
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [backendClientProvider.overrideWithValue(fake.dio)],
+          child: MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (ctx) => TextButton(
+                  onPressed: () => showSeriesActions(
+                    ctx,
+                    service: service,
+                    instanceId: 'inst1',
+                    series: _series,
+                    onChanged: () => changed++,
+                    onRemoved: () => removed++,
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+    }
+
+    List<({String method, String path, Map<String, dynamic> query, dynamic body})>
+        ofMethod(String method) =>
+            adapter.requests.where((r) => r.method == method).toList();
+
+    testWidgets('shows every action for a monitored series', (tester) async {
+      await pumpHarness(tester);
+      for (final label in [
+        'Search Monitored',
+        'Edit Series',
+        'Refresh Series',
+        'Remove Series',
+        'Unmonitor Series',
+      ]) {
+        expect(find.text(label), findsOneWidget);
+      }
+    });
+
+    testWidgets('Search Monitored posts a SeriesSearch command',
+        (tester) async {
+      await pumpHarness(tester);
+      await tester.tap(find.text('Search Monitored'));
+      await tester.pumpAndSettle();
+
+      final posts = ofMethod('POST');
+      expect(posts, hasLength(1));
+      expect(posts.single.path, endsWith('/command'));
+      expect(posts.single.body, {'name': 'SeriesSearch', 'seriesId': 7});
+    });
+
+    testWidgets('Refresh Series posts RefreshSeries and reloads',
+        (tester) async {
+      await pumpHarness(tester);
+      await tester.tap(find.text('Refresh Series'));
+      await tester.pumpAndSettle();
+
+      final posts = ofMethod('POST');
+      expect(posts.single.body, {'name': 'RefreshSeries', 'seriesId': 7});
+      expect(changed, 1);
+    });
+
+    testWidgets(
+        'Unmonitor round-trips the whole series with only monitored flipped',
+        (tester) async {
+      await pumpHarness(tester);
+      await tester.tap(find.text('Unmonitor Series'));
+      await tester.pumpAndSettle();
+
+      final puts = ofMethod('PUT');
+      expect(puts, hasLength(1));
+      final body = puts.single.body as Map<String, dynamic>;
+      expect(body['monitored'], false);
+      expect(body['someUnknownField'], {'nested': [1, 2]},
+          reason: 'unmodelled fields must survive the round-trip');
+      expect(body['qualityProfileId'], 5);
+      expect(changed, 1);
+    });
+
+    testWidgets('Remove asks for confirmation and honors delete-files',
+        (tester) async {
+      await pumpHarness(tester);
+      await tester.tap(find.text('Remove Series'));
+      await tester.pumpAndSettle();
+
+      // Cancel first: nothing deleted.
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      expect(ofMethod('DELETE'), isEmpty);
+      expect(removed, 0);
+
+      // Again, this time deleting files too.
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Remove Series'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete files from disk'));
+      await tester.pump();
+      await tester.tap(find.text('Remove'));
+      await tester.pumpAndSettle();
+
+      final deletes = ofMethod('DELETE');
+      expect(deletes, hasLength(1));
+      expect(deletes.single.path, endsWith('/series/7'));
+      expect(deletes.single.query['deleteFiles'], 'true');
+      expect(removed, 1);
+    });
+
+    testWidgets(
+        'Edit Series opens the editor; saving PUTs the patch and reloads',
+        (tester) async {
+      await pumpHarness(tester);
+      await tester.tap(find.text('Edit Series'));
+      await tester.pumpAndSettle();
+
+      // The editor loaded the fresh series + profiles + tags.
+      expect(find.text('Edit Series'), findsOneWidget);
+      expect(find.text('HD-1080p'), findsOneWidget);
+      expect(find.text('kids'), findsOneWidget);
+
+      // Flip Monitored off and pick another quality profile.
+      await tester.tap(find.text('Monitored'));
+      await tester.pump();
+      await tester.tap(find.text('Quality Profile'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Best'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Update'));
+      await tester.pumpAndSettle();
+
+      final puts = ofMethod('PUT');
+      expect(puts, hasLength(1));
+      final body = puts.single.body as Map<String, dynamic>;
+      expect(body['monitored'], false);
+      expect(body['qualityProfileId'], 9);
+      expect(body['seasonFolder'], true);
+      expect(body['seriesType'], 'standard');
+      expect(body['path'], '/tv/Example');
+      expect(body['tags'], [2]);
+      expect(body['someUnknownField'], {'nested': [1, 2]},
+          reason: 'unmodelled fields must survive the edit round-trip');
+
+      // The editor popped back to the harness and signalled a change.
+      expect(find.text('open'), findsOneWidget);
+      expect(changed, 1);
+    });
+  });
+
+  group('SonarrSeriesDetailScreen', () {
+    Future<_FakeAdapter> pumpDetail(WidgetTester tester) async {
+      final fake = _fakeDio();
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [backendClientProvider.overrideWithValue(fake.dio)],
+          child: MaterialApp(
+            home: SonarrSeriesDetailScreen(
+              instanceId: 'inst1',
+              series: _series,
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      return fake.adapter;
+    }
+
+    testWidgets('long-pressing a season offers automatic season search',
+        (tester) async {
+      final adapter = await pumpDetail(tester);
+
+      await tester.longPress(find.text('Season 1'));
+      await tester.pumpAndSettle();
+      expect(find.text('Automatic Search'), findsOneWidget);
+      expect(find.text('Interactive Search'), findsOneWidget);
+
+      await tester.tap(find.text('Automatic Search'));
+      await tester.pumpAndSettle();
+
+      final posts =
+          adapter.requests.where((r) => r.method == 'POST').toList();
+      expect(posts, hasLength(1));
+      expect(posts.single.body,
+          {'name': 'SeasonSearch', 'seriesId': 7, 'seasonNumber': 1});
+    });
+
+    testWidgets('app bar carries links, edit and the series action menu',
+        (tester) async {
+      final adapter = await pumpDetail(tester);
+
+      expect(find.byTooltip('External links'), findsOneWidget);
+      expect(find.byTooltip('Edit series'), findsOneWidget);
+
+      // Links sheet lists the sites derivable from the series ids.
+      await tester.tap(find.byTooltip('External links'));
+      await tester.pumpAndSettle();
+      for (final site in ['IMDb', 'TheTVDB', 'TMDB', 'Trakt']) {
+        expect(find.text(site), findsOneWidget);
+      }
+      await tester.tapAt(const Offset(10, 10)); // dismiss without launching
+      await tester.pumpAndSettle();
+
+      // The overflow opens the same series action sheet.
+      await tester.tap(find.byTooltip('Series actions'));
+      await tester.pumpAndSettle();
+      expect(find.text('Search Monitored'), findsOneWidget);
+      await tester.tap(find.text('Search Monitored'));
+      await tester.pumpAndSettle();
+      final posts =
+          adapter.requests.where((r) => r.method == 'POST').toList();
+      expect(posts.single.body, {'name': 'SeriesSearch', 'seriesId': 7});
+    });
+  });
+}


### PR DESCRIPTION
LunaSea-style quick actions for the Sonarr module.

## What

- **Series long-press menu** (library list): Search Monitored, Edit Series, Refresh Series, Remove Series, Monitor/Unmonitor toggle. Remove confirms first, with a "Delete files from disk" checkbox (defaults off). Also reachable from the ⋮ overflow on the series detail screen; removing from there pops back to the list.
- **Season long-press menu** (series detail): Automatic Search / Interactive Search for that season.
- **Series detail app bar**: 🔗 external links sheet (IMDb / TheTVDB / TMDB / Trakt — each shown only when the matching id exists), ✏️ Edit Series, ⋮ series actions. The explicit refresh icon is gone; pull-to-refresh still reloads, and "Refresh Series" in the menu now triggers Sonarr's actual metadata refresh command.
- **Edit Series screen**: Monitored + Use Season Folders toggles, Quality Profile / Series Type / Series Path / Tags editors, Update button. Saves via a raw GET→patch→PUT of the whole series resource so unmodelled fields survive (same round-trip pattern as season monitoring). Tags row hides itself if `/tag` can't be fetched.
- Returning from the series detail screen refreshes the library list so edits/removals show immediately.

## Notes

- All these operations were already admin-gated server-side (`instances:manage` for commands/PUT/DELETE); no server changes.
- Model gains `imdbId`, `seasonFolder`, `tags`; service gains `refreshSeries`, `updateSeriesFields`, `setSeriesMonitored`, `getTags`.
- New shared `showActionSheet` widget; it scrolls when actions exceed the sheet max height (the 600px test viewport caught an 11px overflow — fixed).
- Tests drive the real widgets through a fake Dio adapter and assert the wire payloads: SeriesSearch/RefreshSeries/SeasonSearch command bodies, unmonitor and edit round-trips preserving unknown fields, delete-files query flag, cancel paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191Ybc6vnNGtEve37m7Zt2v