### PR TITLE
Sonarr: episode long-press menu, All Seasons view, delete selected files

### DIFF
--- a/app/lib/features/sonarr/data/sonarr_api_service.dart
+++ b/app/lib/features/sonarr/data/sonarr_api_service.dart
@@ -116,6 +116,26 @@ class SonarrApiService {
     });
   }
 
+  /// Sets the monitored flag on the given episodes.
+  Future<void> setEpisodesMonitored(
+    List<int> episodeIds, {
+    required bool monitored,
+  }) async {
+    if (episodeIds.isEmpty) return;
+    await _dio.put('$_basePath/episode/monitor', data: {
+      'episodeIds': episodeIds,
+      'monitored': monitored,
+    });
+  }
+
+  /// Deletes downloaded episode files from disk (bulk).
+  Future<void> deleteEpisodeFiles(List<int> episodeFileIds) async {
+    if (episodeFileIds.isEmpty) return;
+    await _dio.delete('$_basePath/episodefile/bulk', data: {
+      'episodeFileIds': episodeFileIds,
+    });
+  }
+
   Future<List<Map<String, dynamic>>> getQueue() async {
     final resp = await _dio.get('$_basePath/queue',
         queryParameters: {'includeSeries': true, 'pageSize': 50});

--- a/app/lib/features/sonarr/ui/sonarr_season_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_season_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/action_sheet.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
@@ -12,24 +13,25 @@ import 'sonarr_releases_screen.dart';
 import 'sonarr_series_detail_screen.dart' show seasonLabel;
 import 'widgets/episode_status.dart';
 
-/// Episode list for one season: number, title, air date and the per-episode
-/// status line (download progress / quality+size / Missing / Unaired). Tapping
-/// an episode opens its detail sheet; the magnifier runs an automatic
-/// per-episode search. The Automatic button's arrow (or a long-press on an
-/// episode) enters selection mode: pick episodes — All / Undownloaded / None
-/// quick-selects — and search them all automatically in one go. Interactive
-/// search only works on a single episode/season, so it is disabled while
-/// selecting.
+/// Episode list for one season — or the whole series when [seasonNumber] is
+/// null ("All Seasons", grouped by season headers). Tapping an episode opens
+/// its detail sheet; the magnifier runs an automatic per-episode search;
+/// long-pressing one opens its action menu (searches, select, monitor toggle,
+/// delete file). The Automatic button's arrow enters selection mode — pick
+/// episodes with All / Undownloaded / None quick-selects, then search them all
+/// at once or delete their downloaded files.
 class SonarrSeasonScreen extends ConsumerStatefulWidget {
   final String instanceId;
   final SonarrSeries series;
-  final int seasonNumber;
+
+  /// The season to show, or null for every season in the series.
+  final int? seasonNumber;
 
   const SonarrSeasonScreen({
     super.key,
     required this.instanceId,
     required this.series,
-    required this.seasonNumber,
+    this.seasonNumber,
   });
 
   @override
@@ -45,6 +47,11 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
   String? _error;
   bool _selecting = false;
   final Set<int> _selectedIds = {};
+
+  bool get _allSeasons => widget.seasonNumber == null;
+
+  String get _title =>
+      _allSeasons ? 'All Seasons' : seasonLabel(widget.seasonNumber!);
 
   @override
   void initState() {
@@ -70,7 +77,9 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
       final episodes = await episodesFuture;
       final queue = await queueFuture;
       if (!mounted) return;
-      episodes.sort((a, b) => b.episodeNumber.compareTo(a.episodeNumber));
+      episodes.sort((a, b) => b.seasonNumber != a.seasonNumber
+          ? b.seasonNumber.compareTo(a.seasonNumber)
+          : b.episodeNumber.compareTo(a.episodeNumber));
       setState(() {
         _episodes = episodes;
         _queueByEpisode = {
@@ -92,26 +101,68 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
     }
   }
 
-  Future<void> _automaticSeasonSearch() async {
+  void _toast(String message) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
+  }
+
+  /// Season scope: SeasonSearch for one season, SeriesSearch (monitored
+  /// episodes) for All Seasons.
+  Future<void> _automaticSearch() async {
     try {
-      await _service.searchSeason(widget.series.id, widget.seasonNumber);
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text('Searching for ${seasonLabel(widget.seasonNumber)}…')));
+      if (_allSeasons) {
+        await _service.searchSeries(widget.series.id);
+        _toast('Searching for monitored episodes of ${widget.series.title}…');
+      } else {
+        await _service.searchSeason(widget.series.id, widget.seasonNumber!);
+        _toast('Searching for ${seasonLabel(widget.seasonNumber!)}…');
+      }
     } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Search failed: $e')));
+      _toast('Search failed: $e');
     }
   }
 
-  void _interactiveSeasonSearch() {
+  /// Interactive search is season-scoped; in All Seasons mode pick the season
+  /// first.
+  Future<void> _interactiveSearch() async {
+    var seasonNumber = widget.seasonNumber;
+    if (seasonNumber == null) {
+      final seasons = [...widget.series.seasons]
+        ..sort((a, b) => a.seasonNumber.compareTo(b.seasonNumber));
+      if (seasons.isEmpty) {
+        _toast('No seasons available');
+        return;
+      }
+      seasonNumber = await showDialog<int>(
+        context: context,
+        builder: (ctx) => SimpleDialog(
+          backgroundColor: AppTheme.surface,
+          title: const Text('Select Season'),
+          children: seasons
+              .map((s) => SimpleDialogOption(
+                    onPressed: () => Navigator.pop(ctx, s.seasonNumber),
+                    child: Text(
+                      seasonLabel(s.seasonNumber),
+                      style: TextStyle(
+                        color: s.monitored
+                            ? AppTheme.textPrimary
+                            : AppTheme.textSecondary,
+                        fontSize: 15,
+                      ),
+                    ),
+                  ))
+              .toList(),
+        ),
+      );
+      if (seasonNumber == null || !mounted) return;
+    }
     Navigator.of(context, rootNavigator: true).push(
       MaterialPageRoute(
         builder: (_) => SonarrReleasesScreen(
           instanceId: widget.instanceId,
           seriesId: widget.series.id,
-          seasonNumber: widget.seasonNumber,
+          seasonNumber: seasonNumber!,
           seriesTitle: widget.series.title,
         ),
       ),
@@ -121,13 +172,9 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
   Future<void> _automaticEpisodeSearch(SonarrEpisode episode) async {
     try {
       await _service.searchEpisodes([episode.id]);
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text('Searching for ${episode.seasonEpisodeLabel}…')));
+      _toast('Searching for ${episode.seasonEpisodeLabel}…');
     } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Search failed: $e')));
+      _toast('Search failed: $e');
     }
   }
 
@@ -137,13 +184,102 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
         builder: (_) => SonarrReleasesScreen(
           instanceId: widget.instanceId,
           seriesId: widget.series.id,
-          seasonNumber: widget.seasonNumber,
+          seasonNumber: episode.seasonNumber,
           seriesTitle: widget.series.title,
           episodeId: episode.id,
           episodeLabel: episode.seasonEpisodeLabel,
         ),
       ),
     );
+  }
+
+  /// Long-press menu for one episode.
+  Future<void> _showEpisodeMenu(SonarrEpisode episode) async {
+    final title = episode.title != null && episode.title!.isNotEmpty
+        ? '${episode.seasonEpisodeLabel} • ${episode.title}'
+        : episode.seasonEpisodeLabel;
+    final action = await showActionSheet<String>(
+      context,
+      title: title,
+      actions: [
+        const SheetAction('automatic', Icons.search, 'Automatic Search'),
+        const SheetAction(
+            'interactive', Icons.manage_search, 'Interactive Search'),
+        const SheetAction('select', Icons.checklist, 'Select Episodes'),
+        SheetAction(
+            'monitor',
+            episode.monitored ? Icons.bookmark_border : Icons.bookmark,
+            episode.monitored ? 'Unmonitor Episode' : 'Monitor Episode'),
+        if (episode.hasFile)
+          const SheetAction('delete', Icons.delete_outline, 'Delete File',
+              color: AppTheme.error),
+      ],
+    );
+    if (action == null || !mounted) return;
+    switch (action) {
+      case 'automatic':
+        _automaticEpisodeSearch(episode);
+      case 'interactive':
+        _interactiveEpisodeSearch(episode);
+      case 'select':
+        _startSelecting(preselect: [episode.id]);
+      case 'monitor':
+        try {
+          await _service.setEpisodesMonitored([episode.id],
+              monitored: !episode.monitored);
+          _toast(episode.monitored
+              ? 'Unmonitored ${episode.seasonEpisodeLabel}'
+              : 'Monitoring ${episode.seasonEpisodeLabel}');
+          _load();
+        } catch (e) {
+          _toast('Could not change monitoring: $e');
+        }
+      case 'delete':
+        _confirmDeleteFiles([episode]);
+    }
+  }
+
+  /// Confirms then deletes the downloaded files of [episodes] (those that
+  /// have one). Used by the episode menu and the selection-mode Delete button.
+  Future<void> _confirmDeleteFiles(List<SonarrEpisode> episodes) async {
+    final withFiles = [
+      for (final e in episodes)
+        if (e.hasFile && e.episodeFileId > 0) e,
+    ];
+    if (withFiles.isEmpty) return;
+    final what = withFiles.length == 1
+        ? 'the downloaded file for ${withFiles.single.seasonEpisodeLabel}'
+        : '${withFiles.length} downloaded files';
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppTheme.surface,
+        title: const Text('Delete Files'),
+        content: Text('Delete $what from disk?'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    try {
+      await _service
+          .deleteEpisodeFiles([for (final e in withFiles) e.episodeFileId]);
+      _toast(withFiles.length == 1
+          ? 'Deleted 1 file'
+          : 'Deleted ${withFiles.length} files');
+      if (_selecting) _stopSelecting();
+      _load();
+    } catch (e) {
+      _toast('Delete failed: $e');
+    }
   }
 
   // --- Episode selection mode ---
@@ -176,21 +312,24 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
     _startSelecting(preselect: undownloadedEpisodeIds(_episodes));
   }
 
+  List<SonarrEpisode> get _selectedEpisodes =>
+      [for (final e in _episodes) if (_selectedIds.contains(e.id)) e];
+
+  /// Selected episodes that actually have a file on disk (deletable).
+  int get _selectedFileCount =>
+      _selectedEpisodes.where((e) => e.hasFile && e.episodeFileId > 0).length;
+
   Future<void> _searchSelected() async {
     final ids = _selectedIds.toList()..sort();
     if (ids.isEmpty) return;
     try {
       await _service.searchEpisodes(ids);
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-          content: Text(ids.length == 1
-              ? 'Searching for 1 episode…'
-              : 'Searching for ${ids.length} episodes…')));
+      _toast(ids.length == 1
+          ? 'Searching for 1 episode…'
+          : 'Searching for ${ids.length} episodes…');
       _stopSelecting();
     } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context)
-          .showSnackBar(SnackBar(content: Text('Search failed: $e')));
+      _toast('Search failed: $e');
     }
   }
 
@@ -221,7 +360,7 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
         title: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(seasonLabel(widget.seasonNumber)),
+            Text(_title),
             Text(
               widget.series.title,
               style: const TextStyle(
@@ -256,10 +395,12 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
           _ActionBar(
             selecting: _selecting,
             selectedCount: _selectedIds.length,
-            onAutomatic: _automaticSeasonSearch,
+            selectedFileCount: _selectedFileCount,
+            onAutomatic: _automaticSearch,
             onAutomaticEpisodes: _startIndividualDownloads,
-            onInteractive: _interactiveSeasonSearch,
+            onInteractive: _interactiveSearch,
             onSearchSelected: _searchSelected,
+            onDeleteSelected: () => _confirmDeleteFiles(_selectedEpisodes),
           ),
         ],
       ),
@@ -280,16 +421,32 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
             style: TextStyle(color: AppTheme.textSecondary, fontSize: 16)),
       );
     }
+
+    // In All Seasons mode a header row precedes each season's episodes.
+    final rows = <Object>[];
+    int? lastSeason;
+    for (final e in _episodes) {
+      if (_allSeasons && e.seasonNumber != lastSeason) {
+        rows.add(e.seasonNumber);
+        lastSeason = e.seasonNumber;
+      }
+      rows.add(e);
+    }
+
     return RefreshIndicator(
       onRefresh: _load,
       color: AppTheme.accent,
       child: ListView.separated(
         padding: const EdgeInsets.symmetric(vertical: 8),
-        itemCount: _episodes.length,
-        separatorBuilder: (_, __) =>
-            const Divider(color: AppTheme.border, height: 1),
+        itemCount: rows.length,
+        separatorBuilder: (_, index) =>
+            rows[index] is int || rows[index + 1] is int
+                ? const SizedBox.shrink()
+                : const Divider(color: AppTheme.border, height: 1),
         itemBuilder: (context, index) {
-          final episode = _episodes[index];
+          final row = rows[index];
+          if (row is int) return _SeasonHeader(seasonNumber: row);
+          final episode = row as SonarrEpisode;
           return _EpisodeTile(
             episode: episode,
             queueItem: _queueByEpisode[episode.id],
@@ -298,9 +455,7 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
             onTap: _selecting
                 ? () => _toggleSelected(episode)
                 : () => _openEpisode(episode),
-            onLongPress: _selecting
-                ? null
-                : () => _startSelecting(preselect: [episode.id]),
+            onLongPress: _selecting ? null : () => _showEpisodeMenu(episode),
             onSearch: () => _automaticEpisodeSearch(episode),
           );
         },
@@ -314,6 +469,31 @@ String formatEpisodeAirDate(SonarrEpisode e) {
       (e.airDate != null ? DateTime.tryParse(e.airDate!) : null);
   if (dt == null) return 'TBA';
   return DateFormat('MMMM d, yyyy').format(dt);
+}
+
+/// "Season N" divider used in All Seasons mode.
+class _SeasonHeader extends StatelessWidget {
+  final int seasonNumber;
+  const _SeasonHeader({required this.seasonNumber});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 18, 16, 6),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(seasonLabel(seasonNumber),
+              style: const TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold)),
+          const SizedBox(height: 4),
+          Container(width: 44, height: 2, color: AppTheme.accent),
+        ],
+      ),
+    );
+  }
 }
 
 class _EpisodeTile extends StatelessWidget {
@@ -464,13 +644,16 @@ class _SelectionBar extends StatelessWidget {
             ),
           ),
           TextButton(
-              onPressed: onSelectAll, style: buttonStyle,
+              onPressed: onSelectAll,
+              style: buttonStyle,
               child: const Text('All')),
           TextButton(
-              onPressed: onSelectUndownloaded, style: buttonStyle,
+              onPressed: onSelectUndownloaded,
+              style: buttonStyle,
               child: const Text('Undownloaded')),
           TextButton(
-              onPressed: onSelectNone, style: buttonStyle,
+              onPressed: onSelectNone,
+              style: buttonStyle,
               child: const Text('None')),
         ],
       ),
@@ -481,18 +664,22 @@ class _SelectionBar extends StatelessWidget {
 class _ActionBar extends StatelessWidget {
   final bool selecting;
   final int selectedCount;
+  final int selectedFileCount;
   final VoidCallback onAutomatic;
   final VoidCallback onAutomaticEpisodes;
   final VoidCallback onInteractive;
   final VoidCallback onSearchSelected;
+  final VoidCallback onDeleteSelected;
 
   const _ActionBar({
     required this.selecting,
     required this.selectedCount,
+    required this.selectedFileCount,
     required this.onAutomatic,
     required this.onAutomaticEpisodes,
     required this.onInteractive,
     required this.onSearchSelected,
+    required this.onDeleteSelected,
   });
 
   ButtonStyle _buttonStyle({BorderRadius? radius}) => OutlinedButton.styleFrom(
@@ -518,26 +705,21 @@ class _ActionBar extends StatelessWidget {
           ),
           const SizedBox(width: 10),
           Expanded(
-            child: OutlinedButton.icon(
-              // Interactive search targets one episode or season at a time —
-              // it can't act on a multi-selection, so disable it while
-              // selecting.
-              onPressed: selecting ? null : onInteractive,
-              icon: Icon(Icons.person_outline,
-                  size: 18,
-                  color: selecting
-                      ? AppTheme.textSecondary
-                      : AppTheme.available),
-              label: Text('Interactive',
-                  style: TextStyle(
-                      color: selecting
-                          ? AppTheme.textSecondary
-                          : AppTheme.textPrimary)),
-              style: _buttonStyle(),
-            ),
+            child: selecting ? _buildDeleteSelected() : _buildInteractive(),
           ),
         ],
       ),
+    );
+  }
+
+  Widget _buildInteractive() {
+    return OutlinedButton.icon(
+      onPressed: onInteractive,
+      icon: const Icon(Icons.person_outline,
+          size: 18, color: AppTheme.available),
+      label: const Text('Interactive',
+          style: TextStyle(color: AppTheme.textPrimary)),
+      style: _buttonStyle(),
     );
   }
 
@@ -549,9 +731,30 @@ class _ActionBar extends StatelessWidget {
           size: 18,
           color: enabled ? AppTheme.available : AppTheme.textSecondary),
       label: Text(
-        selectedCount == 1 ? 'Search 1 episode' : 'Search $selectedCount episodes',
+        selectedCount == 1
+            ? 'Search 1 episode'
+            : 'Search $selectedCount episodes',
         style: TextStyle(
             color: enabled ? AppTheme.textPrimary : AppTheme.textSecondary),
+      ),
+      style: _buttonStyle(),
+    );
+  }
+
+  /// Deletes the downloaded files among the selected episodes; enabled only
+  /// when the selection contains at least one file.
+  Widget _buildDeleteSelected() {
+    final enabled = selectedFileCount > 0;
+    return OutlinedButton.icon(
+      onPressed: enabled ? onDeleteSelected : null,
+      icon: Icon(Icons.delete_outline,
+          size: 18, color: enabled ? AppTheme.error : AppTheme.textSecondary),
+      label: Text(
+        selectedFileCount == 1
+            ? 'Delete 1 file'
+            : 'Delete $selectedFileCount files',
+        style: TextStyle(
+            color: enabled ? AppTheme.error : AppTheme.textSecondary),
       ),
       style: _buttonStyle(),
     );

--- a/app/lib/features/sonarr/ui/sonarr_series_detail_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_series_detail_screen.dart
@@ -130,6 +130,18 @@ class _SonarrSeriesDetailScreenState
     );
   }
 
+  /// Every episode across all seasons, grouped by season headers.
+  void _openAllSeasons() {
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute(
+        builder: (_) => SonarrSeasonScreen(
+          instanceId: widget.instanceId,
+          series: _series,
+        ),
+      ),
+    );
+  }
+
   void _toast(String message) {
     if (!mounted) return;
     ScaffoldMessenger.of(context)
@@ -261,7 +273,7 @@ class _SonarrSeriesDetailScreenState
                 children: [
                   if (_error != null)
                     ErrorBanner(message: _error!, onRetry: _load),
-                  _AllSeasonsCard(series: _series),
+                  _AllSeasonsCard(series: _series, onTap: _openAllSeasons),
                   const SizedBox(height: 4),
                   ...seasons.map((s) => _SeasonCard(
                         season: s,
@@ -315,42 +327,47 @@ class _AvailabilityLine extends StatelessWidget {
 
 class _AllSeasonsCard extends StatelessWidget {
   final SonarrSeries series;
-  const _AllSeasonsCard({required this.series});
+  final VoidCallback onTap;
+  const _AllSeasonsCard({required this.series, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
     final stats = series.statistics;
-    return Container(
-      margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: AppTheme.surface,
-        borderRadius: BorderRadius.circular(10),
-        border: Border.all(color: AppTheme.border, width: 0.5),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                const Text('All Seasons',
-                    style: TextStyle(
-                        color: AppTheme.textPrimary,
-                        fontSize: 17,
-                        fontWeight: FontWeight.bold)),
-                if (stats != null && stats.sizeOnDisk > 0) ...[
-                  const SizedBox(height: 4),
-                  Text(stats.sizeFormatted,
-                      style: const TextStyle(
-                          color: AppTheme.textSecondary, fontSize: 13)),
+    return InkWell(
+      onTap: onTap,
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: AppTheme.surface,
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: AppTheme.border, width: 0.5),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('All Seasons',
+                      style: TextStyle(
+                          color: AppTheme.textPrimary,
+                          fontSize: 17,
+                          fontWeight: FontWeight.bold)),
+                  if (stats != null && stats.sizeOnDisk > 0) ...[
+                    const SizedBox(height: 4),
+                    Text(stats.sizeFormatted,
+                        style: const TextStyle(
+                            color: AppTheme.textSecondary, fontSize: 13)),
+                  ],
+                  const SizedBox(height: 6),
+                  _AvailabilityLine(stats: stats),
                 ],
-                const SizedBox(height: 6),
-                _AvailabilityLine(stats: stats),
-              ],
+              ),
             ),
-          ),
-        ],
+            const Icon(Icons.chevron_right, color: AppTheme.textSecondary),
+          ],
+        ),
       ),
     );
   }

--- a/app/test/sonarr/season_selection_test.dart
+++ b/app/test/sonarr/season_selection_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Fake Dio adapter routing by path: /episode and /queue get canned bodies,
-/// every request (notably POST /command) is recorded for assertions.
+/// every request (command posts, monitor puts, file deletes) is recorded.
 class _FakeAdapter implements HttpClientAdapter {
   _FakeAdapter({required this.episodes});
 
@@ -29,12 +29,13 @@ class _FakeAdapter implements HttpClientAdapter {
       final bytes = await requestStream.expand((c) => c).toList();
       if (bytes.isNotEmpty) body = jsonDecode(utf8.decode(bytes));
     }
-    requests.add(
-        (method: options.method, path: options.uri.path, body: body));
+    requests.add((method: options.method, path: options.uri.path, body: body));
 
     final path = options.uri.path;
     dynamic response = <String, dynamic>{};
-    if (path.endsWith('/episode')) response = episodes;
+    if (options.method == 'GET' && path.endsWith('/episode')) {
+      response = episodes;
+    }
     if (path.endsWith('/queue')) response = {'records': <dynamic>[]};
     return ResponseBody.fromString(
       jsonEncode(response),
@@ -54,14 +55,17 @@ Map<String, dynamic> _episodeJson({
   required int episodeNumber,
   required bool hasFile,
   required bool aired,
+  int seasonNumber = 1,
 }) =>
     {
       'id': id,
       'seriesId': 7,
-      'seasonNumber': 1,
+      'seasonNumber': seasonNumber,
       'episodeNumber': episodeNumber,
       'title': 'Episode $episodeNumber',
       'hasFile': hasFile,
+      // Downloaded episodes carry their file id (used by delete-file flows).
+      'episodeFileId': hasFile ? id * 10 : 0,
       'monitored': false,
       'airDateUtc': DateTime.now()
           .toUtc()
@@ -79,19 +83,22 @@ SonarrEpisode _episode({
         id: id, episodeNumber: id, hasFile: hasFile, aired: aired)
       ..remove(tba ? 'airDateUtc' : ''));
 
-Future<_FakeAdapter> _pumpSeasonScreen(WidgetTester tester,
-    {required List<Map<String, dynamic>> episodes}) async {
+Future<_FakeAdapter> _pumpSeasonScreen(
+  WidgetTester tester, {
+  required List<Map<String, dynamic>> episodes,
+  int? seasonNumber = 1,
+}) async {
   final adapter = _FakeAdapter(episodes: episodes);
   final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
     ..httpClientAdapter = adapter;
   await tester.pumpWidget(
     ProviderScope(
       overrides: [backendClientProvider.overrideWithValue(dio)],
-      child: const MaterialApp(
+      child: MaterialApp(
         home: SonarrSeasonScreen(
           instanceId: 'inst1',
-          series: SonarrSeries(id: 7, title: 'Example'),
-          seasonNumber: 1,
+          series: const SonarrSeries(id: 7, title: 'Example'),
+          seasonNumber: seasonNumber,
         ),
       ),
     ),
@@ -107,7 +114,8 @@ Finder _button(String label) => find.ancestor(
 
 void main() {
   group('undownloadedEpisodeIds', () {
-    test('picks aired episodes without a file; skips unaired, TBA and '
+    test(
+        'picks aired episodes without a file; skips unaired, TBA and '
         'downloaded', () {
       final episodes = [
         _episode(id: 1, hasFile: true), // downloaded
@@ -121,12 +129,16 @@ void main() {
   });
 
   group('SonarrSeasonScreen', () {
-    // Episode 101 downloaded, 102 aired+missing, 103 unaired.
+    // Episode 101 downloaded (file 1010), 102 aired+missing, 103 unaired.
     final episodes = [
       _episodeJson(id: 101, episodeNumber: 1, hasFile: true, aired: true),
       _episodeJson(id: 102, episodeNumber: 2, hasFile: false, aired: true),
       _episodeJson(id: 103, episodeNumber: 3, hasFile: false, aired: false),
     ];
+
+    List<({String method, String path, dynamic body})> ofMethod(
+            _FakeAdapter adapter, String method) =>
+        adapter.requests.where((r) => r.method == method).toList();
 
     List<({String method, String path, dynamic body})> commands(
             _FakeAdapter adapter) =>
@@ -142,8 +154,10 @@ void main() {
 
       final sent = commands(adapter);
       expect(sent, hasLength(1));
-      expect(sent.single.body,
-          {'name': 'EpisodeSearch', 'episodeIds': [101]});
+      expect(sent.single.body, {
+        'name': 'EpisodeSearch',
+        'episodeIds': [101]
+      });
       // No interactive releases screen was pushed.
       expect(find.text('Automatic'), findsOneWidget);
     });
@@ -163,15 +177,17 @@ void main() {
       expect(find.byType(Checkbox), findsNWidgets(3));
       expect(_button('Search 1 episode'), findsOneWidget);
 
-      // Interactive can't run on a multi-selection: disabled.
-      final interactive =
-          tester.widget<OutlinedButton>(_button('Interactive'));
-      expect(interactive.onPressed, isNull);
+      // The selection has no downloaded files, so Delete is disabled.
+      final deleteNone =
+          tester.widget<OutlinedButton>(_button('Delete 0 files'));
+      expect(deleteNone.onPressed, isNull);
 
       // Quick-selects.
       await tester.tap(find.text('All'));
       await tester.pump();
       expect(find.text('3 selected'), findsOneWidget);
+      // Episode 101 has a file now, so Delete becomes available.
+      expect(_button('Delete 1 file'), findsOneWidget);
       await tester.tap(find.text('None'));
       await tester.pump();
       expect(find.text('0 selected'), findsOneWidget);
@@ -192,20 +208,67 @@ void main() {
 
       final sent = commands(adapter);
       expect(sent, hasLength(1));
-      expect(sent.single.body,
-          {'name': 'EpisodeSearch', 'episodeIds': [102, 103]});
+      expect(sent.single.body, {
+        'name': 'EpisodeSearch',
+        'episodeIds': [102, 103]
+      });
       // Selection mode exits after the search is sent.
       expect(find.byType(Checkbox), findsNothing);
       expect(find.text('Automatic'), findsOneWidget);
     });
 
-    testWidgets('long-press enters selection mode with that episode selected',
+    testWidgets('deleting the selection removes its files after confirming',
+        (tester) async {
+      final adapter = await _pumpSeasonScreen(tester, episodes: episodes);
+
+      await tester.tap(find.byIcon(Icons.arrow_drop_up));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Individual episodes'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('All'));
+      await tester.pump();
+
+      await tester.tap(_button('Delete 1 file'));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete Files'), findsOneWidget);
+
+      // Cancel first: nothing deleted, selection stays.
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      expect(ofMethod(adapter, 'DELETE'), isEmpty);
+      expect(find.text('3 selected'), findsOneWidget);
+
+      await tester.tap(_button('Delete 1 file'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      final deletes = ofMethod(adapter, 'DELETE');
+      expect(deletes, hasLength(1));
+      expect(deletes.single.path, endsWith('/episodefile/bulk'));
+      expect(deletes.single.body, {
+        'episodeFileIds': [1010]
+      });
+      // Selection mode exits after the delete.
+      expect(find.byType(Checkbox), findsNothing);
+    });
+
+    testWidgets(
+        'long-press opens the episode menu; Select Episodes enters selection',
         (tester) async {
       await _pumpSeasonScreen(tester, episodes: episodes);
 
       await tester.longPress(find.text('Episode 2'));
       await tester.pumpAndSettle();
 
+      expect(find.text('Automatic Search'), findsOneWidget);
+      expect(find.text('Interactive Search'), findsOneWidget);
+      // Fixtures are unmonitored, and episode 2 has no file to delete.
+      expect(find.text('Monitor Episode'), findsOneWidget);
+      expect(find.text('Delete File'), findsNothing);
+
+      await tester.tap(find.text('Select Episodes'));
+      await tester.pumpAndSettle();
       expect(find.text('1 selected'), findsOneWidget);
       expect(_button('Search 1 episode'), findsOneWidget);
 
@@ -214,6 +277,67 @@ void main() {
       await tester.pump();
       expect(find.byType(Checkbox), findsNothing);
       expect(find.text('Automatic'), findsOneWidget);
+    });
+
+    testWidgets('episode menu toggles monitoring', (tester) async {
+      final adapter = await _pumpSeasonScreen(tester, episodes: episodes);
+
+      await tester.longPress(find.text('Episode 2'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Monitor Episode'));
+      await tester.pumpAndSettle();
+
+      final puts = ofMethod(adapter, 'PUT');
+      expect(puts, hasLength(1));
+      expect(puts.single.path, endsWith('/episode/monitor'));
+      expect(puts.single.body, {
+        'episodeIds': [102],
+        'monitored': true
+      });
+    });
+
+    testWidgets('episode menu deletes a downloaded file after confirming',
+        (tester) async {
+      final adapter = await _pumpSeasonScreen(tester, episodes: episodes);
+
+      await tester.longPress(find.text('Episode 1'));
+      await tester.pumpAndSettle();
+      expect(find.text('Delete File'), findsOneWidget);
+      await tester.tap(find.text('Delete File'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      final deletes = ofMethod(adapter, 'DELETE');
+      expect(deletes, hasLength(1));
+      expect(deletes.single.body, {
+        'episodeFileIds': [1010]
+      });
+    });
+
+    testWidgets(
+        'all-seasons mode groups by season headers and searches the series',
+        (tester) async {
+      final allEpisodes = [
+        _episodeJson(
+            id: 201, episodeNumber: 1, hasFile: true, aired: true,
+            seasonNumber: 2),
+        _episodeJson(
+            id: 101, episodeNumber: 1, hasFile: true, aired: true),
+        _episodeJson(
+            id: 102, episodeNumber: 2, hasFile: false, aired: true),
+      ];
+      final adapter = await _pumpSeasonScreen(tester,
+          episodes: allEpisodes, seasonNumber: null);
+
+      expect(find.text('All Seasons'), findsOneWidget);
+      expect(find.text('Season 2'), findsOneWidget);
+      expect(find.text('Season 1'), findsOneWidget);
+
+      await tester.tap(_button('Automatic'));
+      await tester.pumpAndSettle();
+      final sent = commands(adapter);
+      expect(sent.single.body, {'name': 'SeriesSearch', 'seriesId': 7});
     });
   });
 }

--- a/app/test/sonarr/series_actions_test.dart
+++ b/app/test/sonarr/series_actions_test.dart
@@ -46,6 +46,8 @@ class _FakeAdapter implements HttpClientAdapter {
       if (path.endsWith('/series/7')) response = _rawSeries;
       if (path.endsWith('/qualityprofile')) response = _profiles;
       if (path.endsWith('/tag')) response = _tags;
+      if (path.endsWith('/episode')) response = <dynamic>[];
+      if (path.endsWith('/queue')) response = {'records': <dynamic>[]};
     }
     return ResponseBody.fromString(
       jsonEncode(response),
@@ -295,6 +297,18 @@ void main() {
       await tester.pumpAndSettle();
       return fake.adapter;
     }
+
+    testWidgets('the All Seasons card drills into the all-episodes view',
+        (tester) async {
+      await pumpDetail(tester);
+
+      await tester.tap(find.text('All Seasons'));
+      await tester.pumpAndSettle();
+
+      // The season screen opened in all-seasons mode (empty fixture list).
+      expect(find.text('No episodes'), findsOneWidget);
+      expect(find.text('All Seasons'), findsOneWidget);
+    });
 
     testWidgets('long-pressing a season offers automatic season search',
         (tester) async {


### PR DESCRIPTION
Follow-up to #135, completing the LunaSea-style interaction set.

## What

- **Episode long-press menu**: Automatic Search, Interactive Search, Select Episodes, Monitor/Unmonitor Episode, and Delete File (only when a file exists; confirmed before deleting). Long-press previously entered multi-select directly — that entry point moves into the menu's **Select Episodes** item, alongside the existing Automatic-arrow "Individual episodes" path.
- **All Seasons**: the summary card on the series detail screen is now tappable (chevron added) and opens the episode list in all-seasons mode — every episode grouped under accent-underlined season headers, matching the reference app. In this mode Automatic runs the series-wide monitored search and Interactive asks which season first (interactive search is season-scoped).
- **Selection-mode Delete button**: instead of a disabled Interactive button, selection mode now shows a red **Delete N files** button that bulk-deletes the selected episodes' downloaded files (`DELETE /episodefile/bulk`) after a confirmation dialog. Disabled while the selection contains no files, with a live file count.

## Notes

- Service additions: `setEpisodesMonitored` (PUT `/episode/monitor`) and `deleteEpisodeFiles` (bulk). No server changes — both are admin-gated writes through the existing verbatim proxy.
- Tests assert the wire payloads for the monitor toggle, single and bulk file deletes (including the cancel path), the SeriesSearch command from all-seasons mode, season-header grouping, and the new menu-driven selection entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191Ybc6vnNGtEve37m7Zt2v