### PR TITLE
Search chips: requester vocabulary, count unmonitored episodes

### DIFF
--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -225,29 +225,37 @@ class _AppShellState extends ConsumerState<AppShell>
     _dismissKeyboard();
   }
 
+  /// Availability chips for search results, in the requester's vocabulary
+  /// (Available / Partially Available / Requested) so they agree with what the
+  /// detail page will say — never library-manager jargon (Complete / Missing /
+  /// Unmonitored). A title that's in the library but has nothing on disk and
+  /// isn't being fetched gets no chip: to a requester it's simply not
+  /// available yet, same as a title that isn't in the library at all.
   Map<int, LibraryStatus> _buildLibraryStatus(List<MediaItem> searchResults) {
     final map = <int, LibraryStatus>{};
+
+    const available = LibraryStatus(
+      label: 'Available',
+      color: AppTheme.available,
+    );
+    const partial = LibraryStatus(
+      label: 'Partially Available',
+      color: AppTheme.requested,
+    );
+    const requested = LibraryStatus(
+      label: 'Requested',
+      color: AppTheme.requested,
+    );
 
     // Radarr: match by TMDB ID
     final movies = _radarrNotifier?.state.movies ?? [];
     for (final movie in movies) {
-      if (movie.tmdbId != null) {
-        if (movie.hasFile) {
-          map[movie.tmdbId!] = const LibraryStatus(
-            label: 'Downloaded',
-            color: AppTheme.available,
-          );
-        } else if (movie.monitored) {
-          map[movie.tmdbId!] = const LibraryStatus(
-            label: 'Missing',
-            color: AppTheme.requested,
-          );
-        } else {
-          map[movie.tmdbId!] = const LibraryStatus(
-            label: 'Unmonitored',
-            color: AppTheme.unavailable,
-          );
-        }
+      final tmdbId = movie.tmdbId;
+      if (tmdbId == null) continue;
+      if (movie.hasFile) {
+        map[tmdbId] = available;
+      } else if (movie.monitored) {
+        map[tmdbId] = requested;
       }
     }
 
@@ -260,23 +268,18 @@ class _AppShellState extends ConsumerState<AppShell>
       for (final item in searchResults) {
         if (item.mediaType == MediaType.tv && !map.containsKey(item.id)) {
           final match = titleMap[item.title.toLowerCase()];
-          if (match != null) {
-            if (match.percentComplete >= 1.0) {
-              map[item.id] = const LibraryStatus(
-                label: 'Complete',
-                color: AppTheme.available,
-              );
-            } else if (match.status == 'continuing') {
-              map[item.id] = const LibraryStatus(
-                label: 'Continuing',
-                color: AppTheme.downloading,
-              );
-            } else {
-              map[item.id] = const LibraryStatus(
-                label: 'Ended',
-                color: AppTheme.unavailable,
-              );
-            }
+          if (match == null) continue;
+          // episodeTotals, not percentComplete: percentComplete only counts
+          // monitored episodes, so a series with one downloaded season and
+          // the rest unmonitored would read "Available" while most of it is
+          // missing.
+          final (:files, :total) = match.episodeTotals;
+          if (total > 0 && files >= total) {
+            map[item.id] = available;
+          } else if (files > 0) {
+            map[item.id] = partial;
+          } else if (match.monitored) {
+            map[item.id] = requested;
           }
         }
       }

--- a/app/lib/features/sonarr/data/sonarr_models.dart
+++ b/app/lib/features/sonarr/data/sonarr_models.dart
@@ -103,6 +103,33 @@ class SonarrSeries {
     if (statistics == null || statistics!.episodeCount == 0) return 0;
     return statistics!.episodeFileCount / statistics!.episodeCount;
   }
+
+  /// Episode files on disk versus every episode Sonarr knows about, across the
+  /// real (non-Specials) seasons — mirrors the server's Series.EpisodeTotals.
+  /// Use this instead of [percentComplete] for availability decisions:
+  /// percentComplete only counts monitored episodes, so a series with one
+  /// downloaded season and the rest unmonitored reads 100%. Totals include
+  /// unaired episodes, so an airing series under-reports rather than
+  /// over-reports. Falls back to the series-level statistics when Sonarr sent
+  /// no per-season breakdown.
+  ({int files, int total}) get episodeTotals {
+    var files = 0, total = 0;
+    for (final season in seasons) {
+      final stats = season.statistics;
+      if (season.seasonNumber <= 0 || stats == null) continue;
+      files += stats.episodeFileCount;
+      total += stats.totalEpisodeCount != 0
+          ? stats.totalEpisodeCount
+          : stats.episodeCount;
+    }
+    if (files == 0 && total == 0 && statistics != null) {
+      files = statistics!.episodeFileCount;
+      total = statistics!.totalEpisodeCount != 0
+          ? statistics!.totalEpisodeCount
+          : statistics!.episodeCount;
+    }
+    return (files: files, total: total);
+  }
 }
 
 /// A Sonarr tag (id + label), used by the Edit Series tag picker.

--- a/app/test/sonarr/episode_totals_test.dart
+++ b/app/test/sonarr/episode_totals_test.dart
@@ -1,0 +1,81 @@
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+SonarrSeason _season(int number,
+        {bool monitored = true, int files = 0, int episodes = 0, int total = 0}) =>
+    SonarrSeason(
+      seasonNumber: number,
+      monitored: monitored,
+      statistics: SonarrStatistics(
+        episodeFileCount: files,
+        episodeCount: episodes,
+        totalEpisodeCount: total,
+      ),
+    );
+
+void main() {
+  group('SonarrSeries.episodeTotals', () {
+    test('counts unmonitored seasons that percentComplete ignores', () {
+      // One monitored, fully downloaded season; three unmonitored empty ones.
+      // Sonarr's monitored-only statistics call this series 100% complete.
+      final series = SonarrSeries(
+        id: 1,
+        title: 'Stranger Things',
+        statistics: const SonarrStatistics(
+          episodeFileCount: 9,
+          episodeCount: 9,
+          totalEpisodeCount: 34,
+        ),
+        seasons: [
+          _season(1, monitored: false, episodes: 0, total: 8),
+          _season(2, monitored: false, episodes: 0, total: 9),
+          _season(3, monitored: false, episodes: 0, total: 8),
+          _season(4, files: 9, episodes: 9, total: 9),
+        ],
+      );
+
+      expect(series.percentComplete, 1.0);
+      final (:files, :total) = series.episodeTotals;
+      expect(files, 9);
+      expect(total, 34);
+    });
+
+    test('excludes Specials and reads complete when all seasons have files',
+        () {
+      final series = SonarrSeries(
+        id: 2,
+        title: 'Done',
+        seasons: [
+          _season(0, files: 1, episodes: 2, total: 2),
+          _season(1, files: 8, episodes: 8, total: 8),
+        ],
+      );
+
+      final (:files, :total) = series.episodeTotals;
+      expect(files, 8);
+      expect(total, 8);
+    });
+
+    test('falls back to episodeCount, then series statistics', () {
+      // Older payloads may omit totalEpisodeCount (0) or the whole seasons
+      // statistics; the getter falls back rather than reporting 0/0.
+      final perSeason = SonarrSeries(
+        id: 3,
+        title: 'No totals',
+        seasons: [_season(1, files: 3, episodes: 6, total: 0)],
+      );
+      expect(perSeason.episodeTotals, (files: 3, total: 6));
+
+      const seriesOnly = SonarrSeries(
+        id: 4,
+        title: 'No seasons',
+        statistics: SonarrStatistics(
+          episodeFileCount: 5,
+          episodeCount: 10,
+          totalEpisodeCount: 12,
+        ),
+      );
+      expect(seriesOnly.episodeTotals, (files: 5, total: 12));
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Searching for a series whose only monitored season is downloaded showed a green **Complete** chip, while the detail page correctly said **Partially Available** (screenshot: Stranger Things with just S4 on disk). The chip was derived from `percentComplete`, which uses Sonarr's monitored-only statistics — and the rest of the chip set leaked library-manager jargon (**Missing**, **Unmonitored**, **Continuing**, **Ended**) into the request side, where users are deliberately abstracted from *arr concepts.

## Change

- Search chips now use the same requester vocabulary and colors as the detail page: **Available** (green), **Partially Available** (amber), **Requested** (amber).
- TV availability comes from a new `SonarrSeries.episodeTotals` getter that mirrors the server's `Series.EpisodeTotals`: files on disk vs **all** episodes across real (non-Specials) seasons, monitored or not, with a fallback to series-level statistics. Totals include unaired episodes, so an airing series under-reports (shows Partially Available) rather than over-reports — same conservative skew as the server's documented fallback path.
- Movies map the same way the server's status endpoint does: file on disk → Available, monitored without a file → Requested.
- In-library titles with nothing on disk and nothing being fetched get **no chip** — to a requester that's the same as not in the library at all (the detail page will offer Request). The Sonarr/Radarr module screens keep their management-side labels; this only changes the shared search surface.

## Verification

- `flutter analyze` — no issues in changed files (20 pre-existing info lints elsewhere, untouched)
- `flutter test` — all 186 existing tests pass, plus new `episode_totals_test.dart` covering the monitored-only skew (the Stranger Things case), Specials exclusion, and statistics fallbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnaqMdC9sBhWYEWg1euEqA