### PR TITLE
Instance defaults: single-default invariant, Chaptarr user-assignment, per-user pins in the editor

### DIFF
--- a/app/lib/features/settings/data/instance_api_service.dart
+++ b/app/lib/features/settings/data/instance_api_service.dart
@@ -70,6 +70,27 @@ class InstanceApiService {
     await _dio.delete('/api/instances/$id');
   }
 
+  /// Per-user default pins for this instance's service type, keyed by user id.
+  /// The pinned id may be a sibling instance of the same type, so the edit
+  /// screen can show who is currently assigned where.
+  Future<Map<int, String>> getInstanceUsers(String id) async {
+    final resp = await _dio.get('/api/instances/$id/users');
+    final pins = <int, String>{};
+    for (final row in (resp.data as List<dynamic>? ?? const [])) {
+      final map = row as Map<String, dynamic>;
+      pins[(map['user_id'] as num).toInt()] = map['instance_id'] as String;
+    }
+    return pins;
+  }
+
+  /// Pin this instance as the per-user default for exactly [userIds]: listed
+  /// users are pinned here (moving off a sibling instance if needed); users
+  /// previously pinned here but not listed revert to the global default (for
+  /// Chaptarr, they lose access).
+  Future<void> updateInstanceUsers(String id, List<int> userIds) async {
+    await _dio.put('/api/instances/$id/users', data: {'user_ids': userIds});
+  }
+
   /// Test connection to a service URL.
   Future<bool> testConnection(String url, String apiKey) async {
     try {

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -3,8 +3,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../core/models/backend_connection.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../auth/data/auth_service.dart';
+import '../../auth/logic/auth_provider.dart';
 import '../data/instance_api_service.dart';
 
 /// Form for creating or editing a service instance.
@@ -47,6 +50,21 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
   String? _testResult;
   String? _webhookToken;
 
+  /// Fresh instance list from the server — the login-time copy in the auth
+  /// state can be stale, and both the first-of-type auto-default and the
+  /// default-takeover confirmation depend on what actually exists right now.
+  List<ServiceInstance> _instances = const [];
+  bool _instancesLoaded = false;
+
+  // User-assignment section state: all accounts, their current per-user pin
+  // for this service type (user id → instance id, possibly a sibling
+  // instance), the working selection, and the selection as last saved.
+  List<UserSummary>? _users;
+  Map<int, String> _pins = const {};
+  Set<int> _assignedUserIds = <int>{};
+  Set<int> _savedAssignedUserIds = <int>{};
+  String? _userSelectError;
+
   static const _serviceTypes = <(String, String)>[
     ('radarr', 'Radarr'),
     ('sonarr', 'Sonarr'),
@@ -79,6 +97,27 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
   bool get _supportsDirectTest =>
       _serviceType == 'radarr' || _serviceType == 'sonarr';
 
+  bool get _isChaptarr => _serviceType == 'chaptarr';
+
+  /// Source types feed requests and dashboard statuses, so they support
+  /// per-user assignment; download clients and Tautulli are global-only.
+  bool get _supportsUserAssignment =>
+      _serviceType == 'radarr' || _serviceType == 'sonarr' || _isChaptarr;
+
+  /// Chaptarr has no global default — its instances are only ever assigned
+  /// directly to users — so it always shows the user-select. The other source
+  /// types show it when this instance is NOT the global default, as a
+  /// per-user override of that default.
+  bool get _showUserSelect =>
+      _supportsUserAssignment && (_isChaptarr || !_isDefault);
+
+  String get _serviceLabel {
+    for (final t in _serviceTypes) {
+      if (t.$1 == _serviceType) return t.$2;
+    }
+    return _serviceType;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -91,6 +130,92 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
     _serviceType = widget.initialServiceType ?? 'radarr';
     _isDefault = widget.initialIsDefault;
     if (widget.isEditing) _loadDetails();
+    _loadDirectory();
+  }
+
+  /// Loads the fresh instance list plus the users and their current pins for
+  /// the user-assignment section.
+  Future<void> _loadDirectory() async {
+    try {
+      final service =
+          InstanceApiService(backendDio: ref.read(backendClientProvider));
+      final instancesFuture = service.listInstances();
+      final usersFuture = ref.read(authProvider.notifier).listUsers();
+      final instances = await instancesFuture;
+      final users = await usersFuture;
+      users.sort((a, b) =>
+          a.username.toLowerCase().compareTo(b.username.toLowerCase()));
+      if (!mounted) return;
+      setState(() {
+        _instances = instances;
+        _instancesLoaded = true;
+        _users = users;
+        _applyAutoDefault();
+      });
+      await _loadPins();
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _userSelectError = 'Could not load users');
+    }
+  }
+
+  /// The default toggle starts ON when creating the first instance of a type —
+  /// there is nothing else the type could default to — and OFF once siblings
+  /// exist (the admin opts in explicitly, confirming the takeover on save).
+  /// Mutates state; call from within setState.
+  void _applyAutoDefault() {
+    if (widget.isEditing || !_instancesLoaded || _isChaptarr) return;
+    _isDefault = !_instances.any((i) => i.serviceType == _serviceType);
+  }
+
+  /// Fetches the per-user pins for the selected service type. The endpoint is
+  /// instance-scoped but answers for the whole type, so when creating we can
+  /// ask via any existing sibling; a type with no instances can have no pins.
+  Future<void> _loadPins() async {
+    if (!_supportsUserAssignment) return;
+    String? anchorId = widget.instanceId;
+    if (anchorId == null) {
+      for (final i in _instances) {
+        if (i.serviceType == _serviceType) {
+          anchorId = i.id;
+          break;
+        }
+      }
+    }
+    if (anchorId == null) {
+      if (!mounted) return;
+      setState(() {
+        _pins = const {};
+        _assignedUserIds = <int>{};
+        _savedAssignedUserIds = <int>{};
+      });
+      return;
+    }
+    try {
+      final service =
+          InstanceApiService(backendDio: ref.read(backendClientProvider));
+      final pins = await service.getInstanceUsers(anchorId);
+      if (!mounted) return;
+      setState(() {
+        _pins = pins;
+        _assignedUserIds = widget.isEditing
+            ? pins.entries
+                .where((e) => e.value == widget.instanceId)
+                .map((e) => e.key)
+                .toSet()
+            : <int>{};
+        _savedAssignedUserIds = Set.of(_assignedUserIds);
+        _userSelectError = null;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _userSelectError = 'Could not load user assignments');
+    }
+  }
+
+  void _retryDirectory() {
+    setState(() => _userSelectError = null);
+    _loadDirectory();
   }
 
   /// The config payload only carries id/type/name, so fetch the full record
@@ -179,6 +304,151 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
     return e.toString();
   }
 
+  /// The sibling instance currently holding the global default for the
+  /// selected type, if any (excludes the instance being edited).
+  ServiceInstance? get _currentDefaultSibling {
+    for (final i in _instances) {
+      if (i.serviceType == _serviceType &&
+          i.isDefault &&
+          i.id != widget.instanceId) {
+        return i;
+      }
+    }
+    return null;
+  }
+
+  /// Making this instance the default displaces the current one — spell out
+  /// exactly which instance the default moves from and to, and let the admin
+  /// back out, before anything is saved.
+  Future<bool> _confirmDefaultTakeover() async {
+    final sibling = _currentDefaultSibling;
+    if (!_isDefault || _isChaptarr || sibling == null) return true;
+    final label = _serviceLabel;
+    final newName = _nameController.text.trim();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Change default $label instance?'),
+        content: Text(
+          '"${sibling.name}" is currently the default $label instance. '
+          'Saving will move the default from "${sibling.name}" to "$newName": '
+          'requests and dashboard statuses for users without a per-user '
+          'instance will switch to "$newName".',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Make Default'),
+          ),
+        ],
+      ),
+    );
+    return confirmed == true;
+  }
+
+  bool _sameSelection(Set<int> a, Set<int> b) =>
+      a.length == b.length && a.containsAll(b);
+
+  String _instanceName(String id) {
+    for (final i in _instances) {
+      if (i.id == id) return i.name;
+    }
+    return id;
+  }
+
+  /// Per-user assignment: for Chaptarr this IS the access model (selected
+  /// users get Books through this instance); for Radarr/Sonarr it pins the
+  /// selected users to this instance as an override of the global default.
+  List<Widget> _buildUserSelect() {
+    final users = _users;
+    return [
+      const SizedBox(height: 16),
+      Text(
+        _isChaptarr ? 'Assigned Users' : 'Per-User Default',
+        style: const TextStyle(
+            color: AppTheme.textSecondary,
+            fontSize: 13,
+            fontWeight: FontWeight.w600),
+      ),
+      const SizedBox(height: 4),
+      Text(
+        _isChaptarr
+            ? 'Chaptarr instances are assigned per user: selected users get '
+                'Books access through this instance. Unselecting a user '
+                'removes their access.'
+            : 'Selected users use this instance for requests and dashboard '
+                'statuses instead of the default $_serviceLabel instance.',
+        style: const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+      ),
+      const SizedBox(height: 8),
+      if (_userSelectError != null)
+        Row(
+          children: [
+            Expanded(
+              child: Text(_userSelectError!,
+                  style:
+                      const TextStyle(color: AppTheme.error, fontSize: 13)),
+            ),
+            TextButton(
+              onPressed: _retryDirectory,
+              child: const Text('Retry'),
+            ),
+          ],
+        )
+      else if (users == null)
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 12),
+          child: Center(
+            child: SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(
+                  strokeWidth: 2, color: AppTheme.accent),
+            ),
+          ),
+        )
+      else if (users.isEmpty)
+        const Text('No users yet.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13))
+      else
+        ...users.map(_userTile),
+    ];
+  }
+
+  Widget _userTile(UserSummary user) {
+    final pinnedTo = _pins[user.id];
+    // Surface where the user is assigned today, so selecting them here is a
+    // visible move rather than a silent one.
+    final movingFrom = pinnedTo != null && pinnedTo != widget.instanceId
+        ? _instanceName(pinnedTo)
+        : null;
+    return CheckboxListTile(
+      dense: true,
+      contentPadding: EdgeInsets.zero,
+      controlAffinity: ListTileControlAffinity.leading,
+      activeColor: AppTheme.accent,
+      title: Text(user.username,
+          style: const TextStyle(color: AppTheme.textPrimary)),
+      subtitle: movingFrom != null
+          ? Text('Currently assigned to "$movingFrom"',
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 12))
+          : null,
+      value: _assignedUserIds.contains(user.id),
+      onChanged: (checked) => setState(() {
+        if (checked == true) {
+          _assignedUserIds.add(user.id);
+        } else {
+          _assignedUserIds.remove(user.id);
+        }
+      }),
+    );
+  }
+
   Future<void> _save() async {
     final validationError = _validate();
     if (validationError != null) {
@@ -187,8 +457,21 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
       );
       return;
     }
+    if (!await _confirmDefaultTakeover()) return;
+    if (!mounted) return;
 
     setState(() => _isSaving = true);
+
+    // Chaptarr never carries the global default flag (the server enforces
+    // this too); its instances are only assigned per user below.
+    final isDefault = !_isChaptarr && _isDefault;
+    // Apply assignments only when the section is visible and the selection
+    // actually changed — a hidden section must never silently rewrite pins.
+    final applyAssignments = _showUserSelect &&
+        _userSelectError == null &&
+        _users != null &&
+        !_sameSelection(_assignedUserIds, _savedAssignedUserIds);
+    final assignedIds = _assignedUserIds.toList()..sort();
 
     try {
       final backendDio = ref.read(backendClientProvider);
@@ -202,25 +485,60 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
           apiKey: _apiKeyController.text.trim(),
           username: _usernameController.text.trim(),
           password: _passwordController.text,
-          isDefault: _isDefault,
+          isDefault: isDefault,
         );
-      } else {
-        await service.createInstance(
-          serviceType: _serviceType,
-          name: _nameController.text.trim(),
-          url: _urlController.text.trim(),
-          apiKey: _apiKeyController.text.trim(),
-          username: _usernameController.text.trim(),
-          password: _passwordController.text,
-          isDefault: _isDefault,
-        );
+        if (applyAssignments) {
+          try {
+            await service.updateInstanceUsers(widget.instanceId!, assignedIds);
+          } catch (e) {
+            // The instance itself saved; stay here so Save can retry the
+            // assignments (re-updating the instance is idempotent).
+            setState(() => _isSaving = false);
+            if (mounted) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                    content: Text('Instance saved, but assigning users '
+                        'failed: ${_errorMessage(e)}')),
+              );
+            }
+            return;
+          }
+        }
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Instance updated')),
+          );
+          context.pop(true); // Return true to signal refresh needed
+        }
+        return;
       }
 
+      final created = await service.createInstance(
+        serviceType: _serviceType,
+        name: _nameController.text.trim(),
+        url: _urlController.text.trim(),
+        apiKey: _apiKeyController.text.trim(),
+        username: _usernameController.text.trim(),
+        password: _passwordController.text,
+        isDefault: isDefault,
+      );
+      // The instance exists now, so a failed assignment must not re-run
+      // create: surface it and let the admin retry from the edit screen.
+      String? assignmentError;
+      if (applyAssignments) {
+        try {
+          await service.updateInstanceUsers(created.id, assignedIds);
+        } catch (e) {
+          assignmentError = _errorMessage(e);
+        }
+      }
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
-              content: Text(
-                  widget.isEditing ? 'Instance updated' : 'Instance created')),
+              content: Text(assignmentError == null
+                  ? 'Instance created'
+                  : 'Instance created, but assigning users failed: '
+                      '$assignmentError — edit the instance to retry')),
         );
         context.pop(true); // Return true to signal refresh needed
       }
@@ -362,7 +680,13 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
                 setState(() {
                   _serviceType = value;
                   _testResult = null;
+                  // The selection and pins belong to the previous type.
+                  _pins = const {};
+                  _assignedUserIds = <int>{};
+                  _savedAssignedUserIds = <int>{};
+                  _applyAutoDefault();
                 });
+                _loadPins();
               },
             ),
             const SizedBox(height: 24),
@@ -442,21 +766,26 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
           // backend fetch search-result cover art.
           const SizedBox(height: 16),
 
-          SwitchListTile(
-            title: const Text('Default Instance',
-                style: TextStyle(color: AppTheme.textPrimary)),
-            subtitle: Text(
-                _isDownloadClient
-                    ? 'Use this as the default download client'
-                    : (_serviceType == 'tautulli'
-                        ? 'Use this as the default Tautulli instance'
-                        : 'Use this as the default for media requests'),
-                style: const TextStyle(
-                    color: AppTheme.textSecondary, fontSize: 13)),
-            value: _isDefault,
-            onChanged: (value) => setState(() => _isDefault = value),
-            activeTrackColor: AppTheme.accent,
-          ),
+          // Chaptarr has no global default: its instances are assigned
+          // directly to users below instead.
+          if (!_isChaptarr)
+            SwitchListTile(
+              title: const Text('Default Instance',
+                  style: TextStyle(color: AppTheme.textPrimary)),
+              subtitle: Text(
+                  _isDownloadClient
+                      ? 'Use this as the default download client'
+                      : (_serviceType == 'tautulli'
+                          ? 'Use this as the default Tautulli instance'
+                          : 'Use this as the default for media requests'),
+                  style: const TextStyle(
+                      color: AppTheme.textSecondary, fontSize: 13)),
+              value: _isDefault,
+              onChanged: (value) => setState(() => _isDefault = value),
+              activeTrackColor: AppTheme.accent,
+            ),
+
+          if (_showUserSelect) ..._buildUserSelect(),
 
           const SizedBox(height: 24),
 

--- a/app/test/settings/instance_edit_screen_test.dart
+++ b/app/test/settings/instance_edit_screen_test.dart
@@ -1,0 +1,298 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/features/auth/data/auth_service.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/settings/ui/instance_edit_screen.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+/// Fake Dio adapter: serves the instance list and per-type user pins, and
+/// records every request (method, path, decoded body) for assertions.
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter({this.instances = const [], this.pins = const []});
+
+  final List<Map<String, dynamic>> instances;
+  final List<Map<String, dynamic>> pins;
+  final List<({String method, String path, dynamic body})> requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    dynamic body;
+    if (requestStream != null) {
+      final bytes = await requestStream.expand((c) => c).toList();
+      if (bytes.isNotEmpty) body = jsonDecode(utf8.decode(bytes));
+    }
+    final path = options.uri.path;
+    requests.add((method: options.method, path: path, body: body));
+
+    dynamic response = <String, dynamic>{};
+    if (options.method == 'GET' && path == '/api/instances') {
+      response = instances;
+    } else if (options.method == 'GET' && path.endsWith('/users')) {
+      response = pins;
+    } else if (options.method == 'POST' && path == '/api/instances') {
+      final map = body as Map<String, dynamic>;
+      response = {...map, 'id': '${map['service_type']}-new'};
+    } else if (options.method == 'PUT' && path.endsWith('/users')) {
+      response = pins;
+    } else if (options.method == 'PUT') {
+      // Instance update echo; the id encodes the service type (radarr-b).
+      final id = path.split('/').last;
+      response = {
+        ...body as Map<String, dynamic>,
+        'id': id,
+        'service_type': id.split('-').first,
+      };
+    }
+    return ResponseBody.fromString(
+      jsonEncode(response),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _FakeAuthNotifier extends AuthNotifier {
+  _FakeAuthNotifier(this.users);
+
+  final List<UserSummary> users;
+
+  @override
+  Future<AuthState> build() async => const AuthState(
+        connection: BackendConnection(
+          serverUrl: 'http://localhost',
+          accessToken: 'access',
+          refreshToken: 'refresh',
+        ),
+        user: UserProfile(id: 1, username: 'admin', role: 'admin'),
+      );
+
+  @override
+  Future<List<UserSummary>> listUsers() async => users;
+}
+
+UserSummary _user(int id, String username) => UserSummary(
+      id: id,
+      username: username,
+      role: 'user',
+      permissions: const [],
+      createdAt: '',
+      deviceCount: 0,
+      hasPassword: false,
+      passwordEnabled: false,
+      passkeyEnabled: false,
+      hasPendingInvite: false,
+    );
+
+const _mainRadarr = {
+  'id': 'radarr-main',
+  'service_type': 'radarr',
+  'name': 'Main Radarr',
+  'url': 'http://radarr-main',
+  'is_default': true,
+  'sort_order': 0,
+};
+
+const _radarrB = {
+  'id': 'radarr-b',
+  'service_type': 'radarr',
+  'name': 'Radarr B',
+  'url': 'http://radarr-b',
+  'is_default': false,
+  'sort_order': 1,
+};
+
+Future<void> _pumpEdit(
+  WidgetTester tester, {
+  required _FakeAdapter adapter,
+  required List<UserSummary> users,
+  InstanceEditScreen screen = const InstanceEditScreen(),
+}) async {
+  // Tall viewport so the whole (lazily built) form list is materialized.
+  tester.view.physicalSize = const Size(800, 1800);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+    ..httpClientAdapter = adapter;
+  // A dummy root route so the screen's context.pop(true) has somewhere to go.
+  final router = GoRouter(
+    initialLocation: '/',
+    routes: [
+      GoRoute(path: '/', builder: (_, __) => const Scaffold(body: SizedBox())),
+      GoRoute(path: '/edit', builder: (_, __) => screen),
+    ],
+  );
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authProvider.overrideWith(() => _FakeAuthNotifier(users)),
+        backendClientProvider.overrideWithValue(dio),
+      ],
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+  await tester.pumpAndSettle();
+  router.push('/edit');
+  await tester.pumpAndSettle();
+}
+
+Future<void> _fillForm(WidgetTester tester, String name) async {
+  await tester.enterText(find.widgetWithText(TextField, 'Name'), name);
+  await tester.enterText(
+      find.widgetWithText(TextField, 'URL'), 'http://localhost:9999');
+  await tester.enterText(find.widgetWithText(TextField, 'API Key'), 'key');
+}
+
+void main() {
+  testWidgets('first instance of a type starts as the default', (tester) async {
+    final adapter = _FakeAdapter();
+    await _pumpEdit(tester, adapter: adapter, users: [_user(1, 'alice')]);
+
+    final toggle = tester.widget<SwitchListTile>(
+        find.widgetWithText(SwitchListTile, 'Default Instance'));
+    expect(toggle.value, isTrue);
+  });
+
+  testWidgets('creating a sibling starts non-default and shows the user-select',
+      (tester) async {
+    final adapter = _FakeAdapter(instances: [Map.of(_mainRadarr)]);
+    await _pumpEdit(tester, adapter: adapter, users: [_user(1, 'alice')]);
+
+    final toggle = tester.widget<SwitchListTile>(
+        find.widgetWithText(SwitchListTile, 'Default Instance'));
+    expect(toggle.value, isFalse);
+    expect(find.text('Per-User Default'), findsOneWidget);
+    expect(find.widgetWithText(CheckboxListTile, 'alice'), findsOneWidget);
+  });
+
+  testWidgets('taking over the default asks for confirmation naming both instances',
+      (tester) async {
+    final adapter = _FakeAdapter(instances: [Map.of(_mainRadarr)]);
+    await _pumpEdit(tester, adapter: adapter, users: [_user(1, 'alice')]);
+
+    await _fillForm(tester, 'Radarr B');
+    await tester.tap(find.widgetWithText(SwitchListTile, 'Default Instance'));
+    await tester.pumpAndSettle();
+
+    // Cancelling the takeover aborts the save entirely.
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Add Instance'));
+    await tester.pumpAndSettle();
+    expect(find.text('Change default Radarr instance?'), findsOneWidget);
+    expect(
+      find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.textContaining('Main Radarr')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.textContaining('Radarr B')),
+      findsOneWidget,
+    );
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(adapter.requests.where((r) => r.method == 'POST'), isEmpty);
+
+    // Confirming saves the instance as the new default.
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Add Instance'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Make Default'));
+    await tester.pumpAndSettle();
+    final post = adapter.requests.singleWhere((r) => r.method == 'POST');
+    expect(post.body['is_default'], isTrue);
+  });
+
+  testWidgets('Chaptarr hides the default toggle and assigns selected users',
+      (tester) async {
+    final adapter = _FakeAdapter();
+    await _pumpEdit(tester,
+        adapter: adapter, users: [_user(1, 'alice'), _user(2, 'bob')]);
+
+    // Switch the service type to Chaptarr.
+    await tester.tap(find.text('Radarr'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Chaptarr').last);
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(SwitchListTile, 'Default Instance'),
+        findsNothing);
+    expect(find.text('Assigned Users'), findsOneWidget);
+
+    await _fillForm(tester, 'Books');
+    await tester.tap(find.widgetWithText(CheckboxListTile, 'alice'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Add Instance'));
+    await tester.pumpAndSettle();
+
+    // No confirmation dialog for chaptarr, the flag is forced off, and the
+    // selected users are assigned to the new instance.
+    final post = adapter.requests.singleWhere((r) => r.method == 'POST');
+    expect(post.body['service_type'], 'chaptarr');
+    expect(post.body['is_default'], isFalse);
+    final putUsers = adapter.requests.singleWhere(
+        (r) => r.method == 'PUT' && r.path == '/api/instances/chaptarr-new/users');
+    expect(putUsers.body, {
+      'user_ids': [1]
+    });
+  });
+
+  testWidgets('editing a non-default instance pins users and shows current pins',
+      (tester) async {
+    final adapter = _FakeAdapter(
+      instances: [Map.of(_mainRadarr), Map.of(_radarrB)],
+      pins: [
+        {'user_id': 2, 'instance_id': 'radarr-main'},
+      ],
+    );
+    await _pumpEdit(
+      tester,
+      adapter: adapter,
+      users: [_user(1, 'alice'), _user(2, 'bob')],
+      screen: const InstanceEditScreen(
+        instanceId: 'radarr-b',
+        initialServiceType: 'radarr',
+        initialName: 'Radarr B',
+        initialUrl: 'http://radarr-b',
+        initialIsDefault: false,
+      ),
+    );
+
+    // Bob is pinned to the sibling instance; selecting him here is a move.
+    expect(find.text('Per-User Default'), findsOneWidget);
+    expect(find.text('Currently assigned to "Main Radarr"'), findsOneWidget);
+
+    await tester.tap(find.widgetWithText(CheckboxListTile, 'bob'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Save Changes'));
+    await tester.pumpAndSettle();
+
+    expect(
+      adapter.requests.any(
+          (r) => r.method == 'PUT' && r.path == '/api/instances/radarr-b'),
+      isTrue,
+    );
+    final putUsers = adapter.requests.singleWhere(
+        (r) => r.method == 'PUT' && r.path == '/api/instances/radarr-b/users');
+    expect(putUsers.body, {
+      'user_ids': [2]
+    });
+  });
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -290,6 +290,12 @@ func NewRouter(
 				r.Post("/instances", instanceHandler.Create)
 				r.Put("/instances/{instanceID}", instanceHandler.Update)
 				r.Delete("/instances/{instanceID}", instanceHandler.Delete)
+				// Instance-centric view of user_default_instances (the static
+				// "users" segment wins over the proxy wildcard below): which
+				// users are pinned to which instance of this instance's service
+				// type, and (PUT) assign this instance to an exact set of users.
+				r.Get("/instances/{instanceID}/users", instanceHandler.GetInstanceUsers)
+				r.Put("/instances/{instanceID}/users", instanceHandler.UpdateInstanceUsers)
 			})
 
 			// Instance proxy — forward to specific instance. Read-only

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -400,5 +400,16 @@ func Open(dbPath string) (*sql.DB, error) {
 		}
 	}
 
+	// Chaptarr has no global default — instances are granted per user — but
+	// older versions let the flag be set. Zero any legacy rows so the
+	// admin/AI fallback (GetDefault) resolves purely by sort order. Runs every
+	// boot; idempotent and the table is tiny.
+	if _, err := db.Exec(
+		"UPDATE service_instances SET is_default = 0 WHERE service_type = 'chaptarr' AND is_default = 1",
+	); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("clear chaptarr default flags: %w", err)
+	}
+
 	return db, nil
 }

--- a/server/internal/instance/handler.go
+++ b/server/internal/instance/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -266,6 +267,77 @@ func (h *Handler) UpdateUserDefaultInstances(w http.ResponseWriter, r *http.Requ
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(defaults)
+}
+
+// instanceUserPin is one user's per-user default row within a service type,
+// as served by the instance-centric assignment endpoints.
+type instanceUserPin struct {
+	UserID     int64  `json:"user_id"`
+	InstanceID string `json:"instance_id"`
+}
+
+// writeInstanceUsers responds with every per-user default pin for the service
+// type — not just the addressed instance — so the admin UI can also show which
+// users are currently pinned to a sibling instance.
+func (h *Handler) writeInstanceUsers(w http.ResponseWriter, serviceType string) {
+	pins, err := h.store.ListTypeUserDefaults(serviceType)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+		return
+	}
+	resp := make([]instanceUserPin, 0, len(pins))
+	for userID, instanceID := range pins {
+		resp = append(resp, instanceUserPin{UserID: userID, InstanceID: instanceID})
+	}
+	sort.Slice(resp, func(i, j int) bool { return resp[i].UserID < resp[j].UserID })
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+// GetInstanceUsers returns the per-user default pins for the addressed
+// instance's service type (admin-only).
+func (h *Handler) GetInstanceUsers(w http.ResponseWriter, r *http.Request) {
+	instanceID := chi.URLParam(r, "instanceID")
+	serviceType, err := h.store.ServiceTypeOf(instanceID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+		return
+	}
+	if serviceType == "" {
+		http.Error(w, `{"error":"instance not found"}`, http.StatusNotFound)
+		return
+	}
+	h.writeInstanceUsers(w, serviceType)
+}
+
+// UpdateInstanceUsers pins the addressed instance as the per-user default for
+// exactly the posted user ids (admin-only). Users previously pinned to this
+// instance but absent from the list revert to the global default (for
+// chaptarr: access revoked). Returns the updated pins for the service type.
+func (h *Handler) UpdateInstanceUsers(w http.ResponseWriter, r *http.Request) {
+	instanceID := chi.URLParam(r, "instanceID")
+	serviceType, err := h.store.ServiceTypeOf(instanceID)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+		return
+	}
+	if serviceType == "" {
+		http.Error(w, `{"error":"instance not found"}`, http.StatusNotFound)
+		return
+	}
+	var body struct {
+		UserIDs []int64 `json:"user_ids"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+	if err := h.store.SetInstanceUsers(instanceID, body.UserIDs); err != nil {
+		// Covers unknown user ids too (the user_id foreign key rejects them).
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusBadRequest)
+		return
+	}
+	h.writeInstanceUsers(w, serviceType)
 }
 
 // validateRequiredFields enforces per-service-type required fields.

--- a/server/internal/instance/handler_test.go
+++ b/server/internal/instance/handler_test.go
@@ -1,0 +1,95 @@
+package instance
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// newUsersRouter mounts the instance-users endpoints the way router.go does,
+// so the tests exercise the real URL params and JSON shapes the app relies on.
+func newUsersRouter(h *Handler) http.Handler {
+	r := chi.NewRouter()
+	r.Get("/instances/{instanceID}/users", h.GetInstanceUsers)
+	r.Put("/instances/{instanceID}/users", h.UpdateInstanceUsers)
+	return r
+}
+
+func TestInstanceUsersEndpoints(t *testing.T) {
+	s := newTestStore(t)
+	h := NewHandler(s, nil)
+	router := newUsersRouter(h)
+	alice := createUser(t, s, "alice")
+	bob := createUser(t, s, "bob")
+	r1 := mkInstance(t, s, "radarr", "R1")
+	r2 := mkInstance(t, s, "radarr", "R2")
+
+	do := func(method, path, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest(method, path, strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec
+	}
+	decodePins := func(rec *httptest.ResponseRecorder) map[int64]string {
+		t.Helper()
+		var rows []struct {
+			UserID     int64  `json:"user_id"`
+			InstanceID string `json:"instance_id"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &rows); err != nil {
+			t.Fatalf("decode %q: %v", rec.Body.String(), err)
+		}
+		pins := make(map[int64]string, len(rows))
+		for _, row := range rows {
+			pins[row.UserID] = row.InstanceID
+		}
+		return pins
+	}
+
+	// No pins yet: an empty JSON array, not null.
+	rec := do("GET", "/instances/"+r1+"/users", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET = %d %s", rec.Code, rec.Body.String())
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != "[]" {
+		t.Fatalf("empty pins body = %q, want []", got)
+	}
+
+	// Assign alice; the response reports the whole service type, so bob's
+	// separate pin to a sibling instance shows up too.
+	if err := s.SetUserDefault(bob, "radarr", r2); err != nil {
+		t.Fatalf("SetUserDefault: %v", err)
+	}
+	rec = do("PUT", "/instances/"+r1+"/users", `{"user_ids":[`+jsonInt(alice)+`]}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT = %d %s", rec.Code, rec.Body.String())
+	}
+	pins := decodePins(rec)
+	if pins[alice] != r1 || pins[bob] != r2 {
+		t.Fatalf("pins = %v, want alice=%s bob=%s", pins, r1, r2)
+	}
+
+	// Unknown instance → 404; unknown user → 400 (FK).
+	if rec := do("GET", "/instances/radarr-missing/users", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("GET unknown instance = %d, want 404", rec.Code)
+	}
+	if rec := do("PUT", "/instances/radarr-missing/users", `{"user_ids":[]}`); rec.Code != http.StatusNotFound {
+		t.Fatalf("PUT unknown instance = %d, want 404", rec.Code)
+	}
+	if rec := do("PUT", "/instances/"+r1+"/users", `{"user_ids":[999999]}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("PUT unknown user = %d, want 400", rec.Code)
+	}
+	if rec := do("PUT", "/instances/"+r1+"/users", `not json`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("PUT invalid body = %d, want 400", rec.Code)
+	}
+}
+
+func jsonInt(v int64) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/server/internal/instance/store.go
+++ b/server/internal/instance/store.go
@@ -112,22 +112,58 @@ func (s *Store) Get(id string) (*Instance, error) {
 	return &inst, nil
 }
 
+// normalizeDefault applies the service-type default rules before persisting:
+// Chaptarr has no global default — its instances are granted per user — so the
+// flag is forced off for it.
+func normalizeDefault(inst *Instance) {
+	if inst.ServiceType == "chaptarr" {
+		inst.IsDefault = false
+	}
+}
+
+// clearSiblingDefaults keeps at most one default per service type: saving an
+// instance as default flips the flag off on every other instance of that type,
+// within the caller's transaction.
+func clearSiblingDefaults(tx *sql.Tx, inst *Instance) error {
+	if !inst.IsDefault {
+		return nil
+	}
+	if _, err := tx.Exec(
+		"UPDATE service_instances SET is_default = 0 WHERE service_type = ? AND id <> ?",
+		inst.ServiceType, inst.ID,
+	); err != nil {
+		return fmt.Errorf("clear previous default: %w", err)
+	}
+	return nil
+}
+
 // Create inserts a new instance and returns it with a generated ID.
 func (s *Store) Create(inst *Instance) error {
 	if inst.ID == "" {
 		inst.ID = inst.ServiceType + "-" + uuid.New().String()[:8]
 	}
 	inst.CreatedAt = time.Now()
+	normalizeDefault(inst)
 
 	apiKey, password, err := s.encryptSecrets(inst)
 	if err != nil {
 		return err
 	}
-	_, err = s.db.Exec(
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("create instance: %w", err)
+	}
+	defer tx.Rollback()
+	if err := clearSiblingDefaults(tx, inst); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
 		"INSERT INTO service_instances (id, service_type, name, url, api_key, username, password, is_default, sort_order, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
 		inst.ID, inst.ServiceType, inst.Name, inst.URL, apiKey, inst.Username, password, inst.IsDefault, inst.SortOrder, inst.CreatedAt,
-	)
-	if err != nil {
+	); err != nil {
+		return fmt.Errorf("create instance: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
 		return fmt.Errorf("create instance: %w", err)
 	}
 	return nil
@@ -139,16 +175,34 @@ func (s *Store) Update(inst *Instance) error {
 	if err != nil {
 		return err
 	}
-	result, err := s.db.Exec(
-		"UPDATE service_instances SET name = ?, url = ?, api_key = ?, username = ?, password = ?, is_default = ?, sort_order = ? WHERE id = ?",
-		inst.Name, inst.URL, apiKey, inst.Username, password, inst.IsDefault, inst.SortOrder, inst.ID,
-	)
+	tx, err := s.db.Begin()
 	if err != nil {
 		return fmt.Errorf("update instance: %w", err)
 	}
-	rows, _ := result.RowsAffected()
-	if rows == 0 {
+	defer tx.Rollback()
+	// The stored service type is authoritative (it is immutable and the
+	// caller's copy may be unset); the default rules key off it.
+	err = tx.QueryRow(
+		"SELECT service_type FROM service_instances WHERE id = ?", inst.ID,
+	).Scan(&inst.ServiceType)
+	if err == sql.ErrNoRows {
 		return fmt.Errorf("instance not found: %s", inst.ID)
+	}
+	if err != nil {
+		return fmt.Errorf("update instance: %w", err)
+	}
+	normalizeDefault(inst)
+	if err := clearSiblingDefaults(tx, inst); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(
+		"UPDATE service_instances SET name = ?, url = ?, api_key = ?, username = ?, password = ?, is_default = ?, sort_order = ? WHERE id = ?",
+		inst.Name, inst.URL, apiKey, inst.Username, password, inst.IsDefault, inst.SortOrder, inst.ID,
+	); err != nil {
+		return fmt.Errorf("update instance: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("update instance: %w", err)
 	}
 	return nil
 }
@@ -227,11 +281,13 @@ func (s *Store) Delete(id string) error {
 	return nil
 }
 
-// GetDefault returns the default instance for a service type.
+// GetDefault returns the default instance for a service type. Create/Update
+// keep at most one default per type; the ORDER BY makes the pick deterministic
+// for legacy rows written before that invariant existed.
 func (s *Store) GetDefault(serviceType string) (*Instance, error) {
 	var inst Instance
 	err := s.db.QueryRow(
-		"SELECT "+instanceColumns+" FROM service_instances WHERE service_type = ? AND is_default = 1 LIMIT 1",
+		"SELECT "+instanceColumns+" FROM service_instances WHERE service_type = ? AND is_default = 1 ORDER BY sort_order LIMIT 1",
 		serviceType,
 	).Scan(&inst.ID, &inst.ServiceType, &inst.Name, &inst.URL, &inst.APIKey, &inst.Username, &inst.Password, &inst.IsDefault, &inst.SortOrder, &inst.CreatedAt)
 	if err == sql.ErrNoRows {
@@ -316,6 +372,85 @@ func (s *Store) SetUserDefault(userID int64, serviceType, instanceID string) err
 	)
 	if err != nil {
 		return fmt.Errorf("set user default instance: %w", err)
+	}
+	return nil
+}
+
+// ListTypeUserDefaults returns every per-user default row for a service type
+// as a user id → pinned instance id map, so the instance admin UI can show who
+// is assigned to this instance and who is pinned to a sibling.
+func (s *Store) ListTypeUserDefaults(serviceType string) (map[int64]string, error) {
+	rows, err := s.db.Query(
+		"SELECT user_id, instance_id FROM user_default_instances WHERE service_type = ?",
+		serviceType,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list user defaults for type: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[int64]string)
+	for rows.Next() {
+		var userID int64
+		var instanceID string
+		if err := rows.Scan(&userID, &instanceID); err != nil {
+			return nil, fmt.Errorf("scan user default for type: %w", err)
+		}
+		out[userID] = instanceID
+	}
+	return out, rows.Err()
+}
+
+// ServiceTypeOf returns the stored service type for an instance id, or ""
+// when the instance does not exist. Unlike Get it never touches the encrypted
+// secret columns, so it works even for rows with undecryptable credentials.
+func (s *Store) ServiceTypeOf(instanceID string) (string, error) {
+	var serviceType string
+	err := s.db.QueryRow(
+		"SELECT service_type FROM service_instances WHERE id = ?", instanceID,
+	).Scan(&serviceType)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get instance service type: %w", err)
+	}
+	return serviceType, nil
+}
+
+// SetInstanceUsers pins instanceID as the per-user default for exactly
+// userIDs: listed users are pinned to it (moving off a sibling instance if
+// needed), and users previously pinned to THIS instance but absent from the
+// list revert to the global default (for chaptarr: access revoked). Pins to
+// sibling instances are otherwise untouched.
+func (s *Store) SetInstanceUsers(instanceID string, userIDs []int64) error {
+	serviceType, err := s.ServiceTypeOf(instanceID)
+	if err != nil {
+		return err
+	}
+	if serviceType == "" {
+		return fmt.Errorf("instance not found: %s", instanceID)
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("set instance users: %w", err)
+	}
+	defer tx.Rollback()
+	if _, err := tx.Exec(
+		"DELETE FROM user_default_instances WHERE instance_id = ?", instanceID,
+	); err != nil {
+		return fmt.Errorf("set instance users: %w", err)
+	}
+	for _, userID := range userIDs {
+		if _, err := tx.Exec(
+			"INSERT INTO user_default_instances (user_id, service_type, instance_id) VALUES (?, ?, ?) "+
+				"ON CONFLICT(user_id, service_type) DO UPDATE SET instance_id = excluded.instance_id",
+			userID, serviceType, instanceID,
+		); err != nil {
+			return fmt.Errorf("pin instance for user %d: %w", userID, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("set instance users: %w", err)
 	}
 	return nil
 }

--- a/server/internal/instance/store_test.go
+++ b/server/internal/instance/store_test.go
@@ -121,3 +121,146 @@ func TestUserDefaultInstances(t *testing.T) {
 		t.Fatal("deleting an instance must revoke its per-user grant")
 	}
 }
+
+func mkDefaultInstance(t *testing.T, s *Store, serviceType, name string) string {
+	t.Helper()
+	inst := &Instance{ServiceType: serviceType, Name: name, URL: "http://localhost", APIKey: "key", IsDefault: true}
+	if err := s.Create(inst); err != nil {
+		t.Fatalf("create default %s instance: %v", serviceType, err)
+	}
+	return inst.ID
+}
+
+func isDefault(t *testing.T, s *Store, id string) bool {
+	t.Helper()
+	inst, err := s.Get(id)
+	if err != nil || inst == nil {
+		t.Fatalf("Get %s = %v, %v", id, inst, err)
+	}
+	return inst.IsDefault
+}
+
+func TestSingleDefaultPerServiceType(t *testing.T) {
+	s := newTestStore(t)
+	radarrA := mkDefaultInstance(t, s, "radarr", "Radarr A")
+	sonarr := mkDefaultInstance(t, s, "sonarr", "Sonarr")
+
+	// Creating a second default flips the first one off.
+	radarrB := mkDefaultInstance(t, s, "radarr", "Radarr B")
+	if isDefault(t, s, radarrA) {
+		t.Fatal("creating Radarr B as default must clear Radarr A's flag")
+	}
+	if def, err := s.GetDefault("radarr"); err != nil || def == nil || def.ID != radarrB {
+		t.Fatalf("GetDefault(radarr) = %v, %v, want %s", def, err, radarrB)
+	}
+	// A sibling service type is untouched.
+	if !isDefault(t, s, sonarr) {
+		t.Fatal("radarr default changes must not touch the sonarr default")
+	}
+
+	// Updating an instance to default flips the current default off.
+	instA, err := s.Get(radarrA)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	instA.IsDefault = true
+	// Update resolves the service type from storage, so a stale caller copy
+	// must not defeat the invariant.
+	instA.ServiceType = ""
+	if err := s.Update(instA); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if isDefault(t, s, radarrB) {
+		t.Fatal("updating Radarr A to default must clear Radarr B's flag")
+	}
+	if def, _ := s.GetDefault("radarr"); def == nil || def.ID != radarrA {
+		t.Fatalf("GetDefault(radarr) after update = %v, want %s", def, radarrA)
+	}
+}
+
+func TestChaptarrNeverGlobalDefault(t *testing.T) {
+	s := newTestStore(t)
+	inst := &Instance{ServiceType: "chaptarr", Name: "Books", URL: "http://localhost", APIKey: "key", IsDefault: true}
+	if err := s.Create(inst); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if inst.IsDefault {
+		t.Fatal("Create must normalize chaptarr IsDefault to false on the struct")
+	}
+	if isDefault(t, s, inst.ID) {
+		t.Fatal("chaptarr instance must not be stored as default")
+	}
+
+	got, _ := s.Get(inst.ID)
+	got.IsDefault = true
+	if err := s.Update(got); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if isDefault(t, s, inst.ID) {
+		t.Fatal("Update must not store a chaptarr default flag")
+	}
+
+	// The admin/AI fallback still resolves an instance — by sort order.
+	if def, err := s.GetDefault("chaptarr"); err != nil || def == nil || def.ID != inst.ID {
+		t.Fatalf("GetDefault(chaptarr) = %v, %v, want fallback to %s", def, err, inst.ID)
+	}
+}
+
+func TestSetInstanceUsers(t *testing.T) {
+	s := newTestStore(t)
+	alice := createUser(t, s, "alice")
+	bob := createUser(t, s, "bob")
+	carol := createUser(t, s, "carol")
+	r1 := mkInstance(t, s, "radarr", "R1")
+	r2 := mkInstance(t, s, "radarr", "R2")
+
+	// Alice is pinned to a sibling instance; assigning R1 to others must not
+	// touch her.
+	if err := s.SetUserDefault(alice, "radarr", r2); err != nil {
+		t.Fatalf("SetUserDefault: %v", err)
+	}
+	if err := s.SetInstanceUsers(r1, []int64{bob, carol}); err != nil {
+		t.Fatalf("SetInstanceUsers: %v", err)
+	}
+	pins, err := s.ListTypeUserDefaults("radarr")
+	if err != nil {
+		t.Fatalf("ListTypeUserDefaults: %v", err)
+	}
+	if pins[alice] != r2 || pins[bob] != r1 || pins[carol] != r1 {
+		t.Fatalf("pins = %v, want alice=%s bob=%s carol=%s", pins, r2, r1, r1)
+	}
+
+	// Dropping carol from the list clears her pin; alice still untouched.
+	if err := s.SetInstanceUsers(r1, []int64{bob}); err != nil {
+		t.Fatalf("SetInstanceUsers (shrink): %v", err)
+	}
+	pins, _ = s.ListTypeUserDefaults("radarr")
+	if _, ok := pins[carol]; ok {
+		t.Fatal("carol's pin must be cleared when she is removed from the list")
+	}
+	if pins[alice] != r2 || pins[bob] != r1 {
+		t.Fatalf("pins = %v, want alice=%s bob=%s", pins, r2, r1)
+	}
+
+	// Listing alice moves her off the sibling instance.
+	if err := s.SetInstanceUsers(r1, []int64{alice, bob}); err != nil {
+		t.Fatalf("SetInstanceUsers (move): %v", err)
+	}
+	pins, _ = s.ListTypeUserDefaults("radarr")
+	if pins[alice] != r1 {
+		t.Fatalf("alice pin = %q, want moved to %s", pins[alice], r1)
+	}
+
+	// Unknown instance and unknown user are rejected.
+	if err := s.SetInstanceUsers("radarr-missing", []int64{bob}); err == nil {
+		t.Fatal("SetInstanceUsers with unknown instance should error")
+	}
+	if err := s.SetInstanceUsers(r1, []int64{999999}); err == nil {
+		t.Fatal("SetInstanceUsers with unknown user should error (FK)")
+	}
+	// The failed call must not have wiped the existing assignments.
+	pins, _ = s.ListTypeUserDefaults("radarr")
+	if pins[alice] != r1 || pins[bob] != r1 {
+		t.Fatalf("pins after failed call = %v, want alice/bob still on %s", pins, r1)
+	}
+}


### PR DESCRIPTION
## What

Answers four gaps around instance-module defaults:

**1. Two instances of the same type could both be "default."**
The server never cleared the old flag, and `GetDefault` picked an arbitrary winner (`LIMIT 1`, no ordering). Now `Create`/`Update` clear the sibling flags in the same transaction, and `GetDefault` orders by `sort_order` so legacy multi-default rows resolve deterministically. The editor also asks for confirmation before a takeover, naming both instances: *"Main Radarr" is currently the default… saving will move the default from "Main Radarr" to "Radarr B."*

**2. Default now starts on for the first instance of a type.**
When creating an instance and no other instance of that type exists, the Default toggle is pre-checked; siblings start unchecked (opting in triggers the confirmation above).

**3. Chaptarr can no longer be a global default.**
The flag *was* settable but did almost nothing — user visibility is grant-only; it only tie-broke the admin/AI fallback among multiple Chaptarr instances. The editor now hides the Default toggle for Chaptarr and always shows an **Assigned Users** selector instead (Chaptarr instances are only ever assigned directly to users). Server-side the flag is normalized off on write and legacy rows are zeroed at startup, so `GetDefaultChaptarrClient` resolves purely by sort order, as its doc comment already claimed.

**4. Per-user overrides are now editable from the instance, not just the user.**
Radarr/Sonarr instances that are *not* the default show a **Per-User Default** selector: checked users get this instance as their request/dashboard-status source instead of the global default. Users already pinned to a sibling instance are labeled ("Currently assigned to …") so a move is visible before it happens. This is the instance-centric view of the same `user_default_instances` rows the existing per-user settings screen edits.

## New API

- `GET /api/instances/{id}/users` — every per-user pin for that instance's service type (`[{user_id, instance_id}]`)
- `PUT /api/instances/{id}/users` `{"user_ids":[…]}` — assign the instance to exactly these users; users previously pinned here but absent revert to the global default (for Chaptarr: access revoked). Pins to sibling instances are untouched.

Both live in the `instances:manage` group; the static `users` segment wins over the instance proxy wildcard (verified against chi's routing behavior — deeper paths and other methods still proxy).

## Tests

- Store: single-default invariant (create + update paths), Chaptarr never default, `SetInstanceUsers` move/clear/rollback semantics
- Handler: HTTP shapes and status codes for the new endpoints over real chi URL params
- App: five widget tests driving the real editor against a recorded fake backend — auto-default for first-of-type, sibling starts non-default, takeover confirmation (cancel aborts, confirm saves), Chaptarr toggle hidden + assignment PUT after create, editing pins with "currently assigned" labels

`go vet ./...` + `go test ./...` (server), `flutter analyze` + `flutter test` (194 tests) all pass. Not run: a live full-stack pass (needs Docker + real arr instances).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013meWcryjzZ1trGremeAnAJ