### PR TITLE
Auto issues: store the movie/tv media_type, not the arr service type

### DIFF
--- a/app/lib/features/issues/data/issue_models.dart
+++ b/app/lib/features/issues/data/issue_models.dart
@@ -109,10 +109,17 @@ class Issue {
   /// A short scope label for list/thread subtitles:
   /// "S2·E4" / "Season 2" / "Movie".
   String get scopeLabel {
-    if (!isTv) return 'Movie';
-    if (seasonNumber <= 0) return 'Series';
-    if (episodeNumber <= 0) return 'Season $seasonNumber';
-    return 'S$seasonNumber·E$episodeNumber';
+    if (isTv) {
+      if (seasonNumber <= 0) return 'Series';
+      if (episodeNumber <= 0) return 'Season $seasonNumber';
+      return 'S$seasonNumber·E$episodeNumber';
+    }
+    if (mediaType.isNotEmpty && mediaType != 'movie') {
+      // 'book', or an off-contract value from an older server (auto issues
+      // once stored the *arr service type here) — never claim "Movie".
+      return '${mediaType[0].toUpperCase()}${mediaType.substring(1)}';
+    }
+    return 'Movie';
   }
 
   factory Issue.fromJson(Map<String, dynamic> json) => Issue(

--- a/app/test/issues/issue_models_test.dart
+++ b/app/test/issues/issue_models_test.dart
@@ -60,6 +60,25 @@ void main() {
       expect(movie.scopeLabel, 'Movie');
       expect(movie.status, IssueStatus.resolved);
     });
+
+    test('never claims "Movie" for a non-movie media_type', () {
+      // An older server's auto issues stored the *arr service type here.
+      final offContract = Issue.fromJson({
+        'id': 9,
+        'media_type': 'sonarr',
+        'status': 'open',
+        'tmdb_id': 0,
+      });
+      expect(offContract.scopeLabel, 'Sonarr');
+
+      final book = Issue.fromJson({
+        'id': 10,
+        'media_type': 'book',
+        'status': 'open',
+        'tmdb_id': 0,
+      });
+      expect(book.scopeLabel, 'Book');
+    });
   });
 
   group('RemediationSettings', () {

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -207,7 +207,7 @@ CREATE TABLE IF NOT EXISTS issues (
     reporter_id INTEGER REFERENCES users(id),  -- NULL for auto-detected
     tmdb_id INTEGER NOT NULL,
     tvdb_id INTEGER,
-    media_type TEXT NOT NULL,                   -- 'movie' | 'tv'
+    media_type TEXT NOT NULL,                   -- 'movie' | 'tv' | 'book'
     title TEXT NOT NULL DEFAULT '',
     season_number INTEGER NOT NULL DEFAULT 0,   -- TV scope (0 = whole series / movie)
     episode_number INTEGER NOT NULL DEFAULT 0,  -- TV scope (0 = whole season / movie)
@@ -409,6 +409,22 @@ func Open(dbPath string) (*sql.DB, error) {
 	); err != nil {
 		db.Close()
 		return nil, fmt.Errorf("clear chaptarr default flags: %w", err)
+	}
+
+	// Auto-detected issues used to store the *arr service type in media_type
+	// (e.g. 'sonarr'), which clients rendered under the fallback "Movie" label.
+	// Normalize legacy rows to the 'movie'|'tv'|'book' contract. Runs every
+	// boot; idempotent and the table is tiny.
+	if _, err := db.Exec(
+		`UPDATE issues SET media_type = CASE media_type
+			WHEN 'sonarr' THEN 'tv'
+			WHEN 'radarr' THEN 'movie'
+			WHEN 'chaptarr' THEN 'book'
+		 END
+		 WHERE media_type IN ('sonarr', 'radarr', 'chaptarr')`,
+	); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("normalize issue media types: %w", err)
 	}
 
 	return db, nil

--- a/server/internal/remediation/autodispatch_test.go
+++ b/server/internal/remediation/autodispatch_test.go
@@ -88,6 +88,34 @@ func TestAutoDispatcherOpensExactlyOneIssueAcrossPolls(t *testing.T) {
 	}
 }
 
+// TestOpenAutoIssueStoresMediaTypeNotServiceType pins the wire contract: the
+// poller reports the *service* type, but the stored media_type must be the
+// client-facing 'movie'|'tv' value (a raw "sonarr" made clients render the
+// fallback "Movie" label on TV issues).
+func TestOpenAutoIssueStoresMediaTypeNotServiceType(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	enableAutoDispatch(t, svc, 5)
+	ad := NewAutoDispatcher(svc)
+
+	d := stalledDiagnosis()
+	ad.OpenAutoIssue("sonarr", "inst1", "tvHash", d)
+	ad.OpenAutoIssue("radarr", "inst1", "movieHash", d)
+	drainJobs(svc)
+
+	for downloadID, want := range map[string]string{"tvHash": "tv", "movieHash": "movie"} {
+		var got string
+		if err := svc.db.QueryRow(
+			"SELECT media_type FROM issues WHERE source = ? AND download_id = ?",
+			SourceAuto, downloadID,
+		).Scan(&got); err != nil {
+			t.Fatalf("read media_type for %s: %v", downloadID, err)
+		}
+		if got != want {
+			t.Fatalf("media_type for %s = %q, want %q", downloadID, got, want)
+		}
+	}
+}
+
 // TestCloseAutoIssueResolvesRecoveredDownload proves that when the poller stops
 // flagging a download, the matching open auto issue is resolved and closed.
 func TestCloseAutoIssueResolvesRecoveredDownload(t *testing.T) {

--- a/server/internal/remediation/service.go
+++ b/server/internal/remediation/service.go
@@ -186,9 +186,22 @@ func (s *Service) bumpDuplicateUserIssue(reporterID int64, req *CreateIssueReque
 // returns created=false. A terminal (closed) issue does not block a genuinely
 // new recurrence: once closed_at is set the partial unique index no longer
 // guards that key, so the same download re-failing later opens a fresh issue.
-func (s *Service) OpenAutoIssue(scope, instanceID, downloadID string, d arr.Diagnosis) (created bool, id int64) {
+func (s *Service) OpenAutoIssue(serviceType, instanceID, downloadID string, d arr.Diagnosis) (created bool, id int64) {
 	sum := sha256.Sum256([]byte(instanceID + "|" + downloadID + "|" + d.Problem))
 	dedupeKey := hex.EncodeToString(sum[:])
+
+	// The poller hands us the *service* type, but media_type on an issues row is
+	// the client-facing 'movie'|'tv' contract — storing it raw made clients fall
+	// back to a "Movie" label on Sonarr issues.
+	mediaType := serviceType
+	switch serviceType {
+	case "radarr":
+		mediaType = "movie"
+	case "sonarr":
+		mediaType = "tv"
+	case "chaptarr":
+		mediaType = "book"
+	}
 
 	res, err := s.db.Exec(
 		`INSERT INTO issues
@@ -197,7 +210,7 @@ func (s *Service) OpenAutoIssue(scope, instanceID, downloadID string, d arr.Diag
 		 WHERE NOT EXISTS (
 			SELECT 1 FROM issues WHERE dedupe_key = ? AND closed_at IS NULL
 		 )`,
-		SourceAuto, IssueOpen, scope, 0, d.Problem, sqlNullStr(instanceID), sqlNullStr(downloadID), d.Transparency, dedupeKey,
+		SourceAuto, IssueOpen, mediaType, 0, d.Problem, sqlNullStr(instanceID), sqlNullStr(downloadID), d.Transparency, dedupeKey,
 		dedupeKey,
 	)
 	if err != nil {


### PR DESCRIPTION
## Problem

Auto-detected issues (Import Doctor / queue poller) showed the scope label **"Movie"** on the issues page even for Sonarr/TV problems — e.g. the "Release contents don't match" issue for *Avatar: The Last Airbender* episodes.

## Root cause

The websocket hub's `IssueOpener` passes the **service type** (`"sonarr"`/`"radarr"`), and `Service.OpenAutoIssue` wrote it straight into `issues.media_type` — a column whose contract is `'movie' | 'tv'`. The app's `Issue.scopeLabel` treats anything that isn't `'tv'` as a movie, so every Sonarr auto issue rendered as "Movie".

## Fix

- **Server** (`remediation/service.go`): translate the service type to the media-type contract at insert (`sonarr`→`tv`, `radarr`→`movie`, `chaptarr`→`book` for when book auto-issues exist). Param renamed `scope`→`serviceType` to match the hub interface it implements.
- **Backfill** (`db/db.go`): idempotent boot-time UPDATE normalizes existing rows that stored the raw service type, so already-filed issues (like the one in the report) display correctly after deploy.
- **App** (`issue_models.dart`): `scopeLabel` no longer claims "Movie" for a non-movie `media_type` — off-contract values (older server) and `'book'` render capitalized verbatim.

## Testing

- New `TestOpenAutoIssueStoresMediaTypeNotServiceType` pins sonarr→tv / radarr→movie on the insert path.
- New Dart test pins that `scopeLabel` never renders "Movie" for `sonarr`/`book` values.
- `go test ./...` (server) passes; `flutter analyze` + `flutter test test/issues/issue_models_test.dart` pass (remaining analyzer infos are pre-existing, unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)