### PR TITLE
Sessions never die: opaque immortal refresh tokens + client restore resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Optional server env vars for deployment tuning:
 |---|---|---|
 | `CANTINARR_PORT` | `8585` | HTTP listen port |
 | `CANTINARR_SERVER_NAME` | `Cantinarr` | Display name shown in clients |
-| `CANTINARR_JWT_SECRET` | auto-generated | HMAC secret for JWT signing |
+| `CANTINARR_JWT_SECRET` | auto-generated | HMAC secret for signing short-lived access tokens. Device sessions do not depend on it: changing it never signs anyone out |
 | `CANTINARR_ENCRYPTION_KEY` | auto-generated key file | Base64 32-byte key for secrets-at-rest (default: `/config/encryption.key`) |
 | `CANTINARR_AI_PROVIDER` | `anthropic` | Fallback AI provider when none is saved in the admin UI |
 | `CANTINARR_AI_MODEL` | provider default | Fallback model when none is saved in the admin UI |
@@ -145,7 +145,7 @@ Optional server env vars for deployment tuning:
 
 Native app passkeys require a public HTTPS server domain associated with the app (AASA for Apple, Digital Asset Links for Android). Browser passkey setup remains available when native association isn't possible. See [`server/README.md`](server/README.md#configuration) for details.
 
-By default, users are passwordless and passkeyless: a connect link starts a long-lived session that refreshes automatically (an idle session lasts a year and every use extends it), so household members never deal with credentials. Admins grant a password and/or passkey per user from **Settings > Users** when a user needs one. A password is what authorizes MCP clients on deployments served over plain HTTP, where passkeys are unavailable (WebAuthn requires a secure context). Disabling a method is a real revoke -- it clears the stored password or deletes the user's passkeys. To recover access, an admin issues a fresh connect link.
+By default, users are passwordless and passkeyless: a connect link starts a permanent device session, so household members never deal with credentials. A session never expires -- not from idle time, server restarts, upgrades, or secret rotation -- and ends only when an admin revokes the device (**Settings > Devices**) or deletes the user. Admins grant a password and/or passkey per user from **Settings > Users** when a user needs one. A password is what authorizes MCP clients on deployments served over plain HTTP, where passkeys are unavailable (WebAuthn requires a secure context). Disabling a method is a real revoke -- it clears the stored password or deletes the user's passkeys. To recover access, an admin issues a fresh connect link.
 
 ## How It Works
 

--- a/app/lib/core/network/backend_auth_interceptor.dart
+++ b/app/lib/core/network/backend_auth_interceptor.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import '../config/app_config.dart';
 
 /// Dio interceptor that handles JWT authentication and automatic token refresh.
 ///
@@ -81,7 +82,12 @@ class BackendAuthInterceptor extends Interceptor {
     final completer = _refreshCompleter = Completer<bool>();
 
     try {
-      final dio = Dio();
+      // A dedicated client with explicit timeouts: a hung refresh would
+      // otherwise block every queued 401 retry behind the shared completer.
+      final dio = Dio(BaseOptions(
+        connectTimeout: AppConfig.requestTimeout,
+        receiveTimeout: AppConfig.requestTimeout,
+      ));
       final serverUrl = getServerUrl();
       final refreshToken = getRefreshToken();
 

--- a/app/lib/core/storage/secure_storage.dart
+++ b/app/lib/core/storage/secure_storage.dart
@@ -12,12 +12,30 @@ abstract class StorageService {
   Future<String?> read({required String key});
   Future<void> write({required String key, required String? value});
   Future<void> delete({required String key});
+
+  /// Best-effort, one-time upgrade of already-stored auth items to the
+  /// current protection class. Call only after a successful [read] of the
+  /// auth keys (i.e. when the store is known to be readable).
+  Future<void> hardenAuthKeys();
 }
 
 class _NativeStorageService implements StorageService {
+  /// `first_unlock` instead of the plugin default (`unlocked`): iOS prewarms
+  /// and background-launches the app while the device is locked, where
+  /// `unlocked`-class keychain items are unreadable — which used to surface
+  /// as users being "logged out" at launch with their tokens still present.
+  /// `first_unlock` items are readable any time after the first unlock since
+  /// boot, and are included in encrypted backups so a session survives
+  /// migration to a new phone.
   final _storage = const FlutterSecureStorage(
     aOptions: AndroidOptions(encryptedSharedPreferences: true),
+    iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+    mOptions: MacOsOptions(accessibility: KeychainAccessibility.first_unlock),
   );
+
+  /// Non-secure marker (readable even while the keychain is locked) recording
+  /// that existing items were rewritten under the current protection class.
+  static const _hardenedMarker = 'cantinarr_secure_storage_first_unlock';
 
   @override
   Future<String?> read({required String key}) => _storage.read(key: key);
@@ -28,6 +46,44 @@ class _NativeStorageService implements StorageService {
 
   @override
   Future<void> delete({required String key}) => _storage.delete(key: key);
+
+  @override
+  Future<void> hardenAuthKeys() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      if (prefs.getBool(_hardenedMarker) == true) return;
+
+      // The plugin migrates an existing item's protection class by deleting
+      // and re-adding it, so copy the refresh token to its backup key FIRST:
+      // a brand-new item is a single add (no delete window), guaranteeing the
+      // one value that cannot be re-minted client-side survives a crash at
+      // any point during the rewrite below.
+      final refreshToken = await read(key: StorageKeys.refreshToken);
+      if (refreshToken != null) {
+        await write(key: StorageKeys.refreshTokenBackup, value: refreshToken);
+      }
+
+      for (final key in [
+        StorageKeys.serverUrl,
+        StorageKeys.jwt,
+        StorageKeys.refreshToken,
+        StorageKeys.deviceId,
+        StorageKeys.hardwareId,
+        StorageKeys.sessionUser,
+        StorageKeys.sessionConnection,
+      ]) {
+        final value = await read(key: key);
+        if (value != null) {
+          await write(key: key, value: value);
+        }
+      }
+
+      await prefs.setBool(_hardenedMarker, true);
+    } catch (e) {
+      // Never let hardening interfere with the session; retry next launch.
+      debugPrint('Secure storage hardening deferred: $e');
+    }
+  }
 }
 
 class _WebStorageService implements StorageService {
@@ -54,6 +110,11 @@ class _WebStorageService implements StorageService {
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove('$_prefix$key');
   }
+
+  @override
+  Future<void> hardenAuthKeys() async {
+    // localStorage has no protection classes.
+  }
 }
 
 /// Provides access to token/credential storage.
@@ -70,6 +131,12 @@ class StorageKeys {
   static const String refreshToken = 'jwt_refresh_token';
   static const String serverUrl = 'server_url';
   static const String deviceId = 'device_id';
+
+  // Redundant copy of the refresh token — the single value whose loss ends a
+  // passwordless session. Written alongside every refresh-token write and
+  // consulted when the primary key comes back empty, so one corrupted or
+  // dropped keychain item can never log a user out.
+  static const String refreshTokenBackup = 'jwt_refresh_token_backup';
 
   // Stable per-device id (persisted; deliberately NOT cleared on logout) used
   // to dedupe reconnects of the same physical device when the platform exposes

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -69,6 +69,13 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   /// Guards against overlapping background validations.
   bool _validating = false;
 
+  /// True when secure storage itself could not be read during restore (locked
+  /// keychain in a prewarmed/background launch, keystore not ready yet). The
+  /// session almost certainly still exists — it must never be treated as
+  /// logged out; restore is retried on resume and on a short timer.
+  bool _restoreBlocked = false;
+  Timer? _restoreRetryTimer;
+
   @override
   Future<AuthState> build() async {
     _authService = ref.read(authServiceProvider);
@@ -77,6 +84,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     ref.onDispose(() {
       _reconnectTimer?.cancel();
       _reconnectTimer = null;
+      _restoreRetryTimer?.cancel();
+      _restoreRetryTimer = null;
     });
 
     // Try to restore session from secure storage
@@ -84,12 +93,39 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   }
 
   Future<AuthState> _tryRestoreSession() async {
-    final serverUrl = await _storage.read(key: StorageKeys.serverUrl);
-    final accessToken = await _storage.read(key: StorageKeys.jwt);
-    final refreshToken = await _storage.read(key: StorageKeys.refreshToken);
+    final String? serverUrl;
+    final String? accessToken;
+    String? refreshToken;
+    var usedBackupToken = false;
+    try {
+      serverUrl = await _storage.read(key: StorageKeys.serverUrl);
+      accessToken = await _storage.read(key: StorageKeys.jwt);
+      refreshToken = await _storage.read(key: StorageKeys.refreshToken);
+      if (refreshToken == null) {
+        refreshToken = await _storage.read(key: StorageKeys.refreshTokenBackup);
+        usedBackupToken = refreshToken != null;
+      }
+    } catch (e) {
+      // Storage is unreadable right now — NOT absent. Showing login here
+      // would present a signed-out app to a user whose tokens are intact.
+      debugPrint('Secure storage unavailable during restore (will retry): $e');
+      _restoreBlocked = true;
+      _scheduleRestoreRetry();
+      return const AuthState();
+    }
+    _restoreBlocked = false;
+    _stopRestoreRetry();
 
     if (serverUrl == null || accessToken == null || refreshToken == null) {
       return const AuthState();
+    }
+
+    // Storage is readable: opportunistically upgrade item protection classes
+    // (one-time, marker-guarded) and heal the primary token from its backup.
+    unawaited(_storage.hardenAuthKeys());
+    if (usedBackupToken) {
+      unawaited(
+          _storage.write(key: StorageKeys.refreshToken, value: refreshToken));
     }
 
     // If a session snapshot is cached, open straight into an optimistic,
@@ -106,6 +142,31 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     return _restoreInline(serverUrl, accessToken, refreshToken);
   }
 
+  /// Re-runs session restore after storage was unreadable (e.g. the device
+  /// has been unlocked since a prewarmed launch). Only replaces state while
+  /// it is still unauthenticated so it can never clobber a live session.
+  Future<void> _retryRestore() async {
+    if (!_restoreBlocked) return;
+    _restoreBlocked = false;
+    final restored = await _tryRestoreSession();
+    final current = state.valueOrNull;
+    if (current == null || !current.isAuthenticated) {
+      state = AsyncData(restored);
+    }
+  }
+
+  void _scheduleRestoreRetry() {
+    if (_restoreRetryTimer != null) return;
+    _restoreRetryTimer = Timer.periodic(const Duration(seconds: 5), (_) {
+      unawaited(_retryRestore());
+    });
+  }
+
+  void _stopRestoreRetry() {
+    _restoreRetryTimer?.cancel();
+    _restoreRetryTimer = null;
+  }
+
   /// Builds an optimistic [AuthState] from the cached session snapshot plus the
   /// stored tokens, or null when no snapshot is cached. The access token may be
   /// stale; [_validateSession] refreshes it. Marked reconnecting until then.
@@ -114,8 +175,15 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     String accessToken,
     String refreshToken,
   ) async {
-    final userJson = await _storage.read(key: StorageKeys.sessionUser);
-    final connJson = await _storage.read(key: StorageKeys.sessionConnection);
+    final String? userJson;
+    final String? connJson;
+    try {
+      userJson = await _storage.read(key: StorageKeys.sessionUser);
+      connJson = await _storage.read(key: StorageKeys.sessionConnection);
+    } catch (e) {
+      debugPrint('Cached session unreadable (falling back to inline): $e');
+      return null;
+    }
     if (userJson == null || connJson == null) return null;
     try {
       final user =
@@ -149,47 +217,87 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   /// Validates the restored session against the server and reconciles state:
   /// fresh data on success, login on a genuine 401, or a "reconnecting" hold
   /// (with a retry scheduled) on a transport failure. Safe to call repeatedly.
+  ///
+  /// Only the refresh call itself can end the session, and only with a 401 —
+  /// the server's explicit "this token is revoked". Storage hiccups, transport
+  /// failures, 5xx answers, and config-fetch failures of any kind all keep the
+  /// session and retry.
   Future<void> _validateSession() async {
     if (_validating) return;
     _validating = true;
     try {
-      final serverUrl = await _storage.read(key: StorageKeys.serverUrl);
-      final refreshToken = await _storage.read(key: StorageKeys.refreshToken);
-      final deviceId = await _storage.read(key: StorageKeys.deviceId);
+      final String? serverUrl;
+      String? refreshToken;
+      final String? deviceId;
+      try {
+        serverUrl = await _storage.read(key: StorageKeys.serverUrl);
+        refreshToken = await _storage.read(key: StorageKeys.refreshToken);
+        refreshToken ??=
+            await _storage.read(key: StorageKeys.refreshTokenBackup);
+        deviceId = await _storage.read(key: StorageKeys.deviceId);
+      } catch (e) {
+        debugPrint('Session validation deferred (storage unavailable): $e');
+        _markReconnecting();
+        return;
+      }
       if (serverUrl == null || refreshToken == null) return;
 
-      // Refresh first, persist immediately (the refresh token is single-use),
-      // then fetch config.
-      final authResp = await _authService.refreshToken(serverUrl, refreshToken);
+      final AuthResponse authResp;
+      try {
+        authResp = await _authService.refreshToken(serverUrl, refreshToken);
+      } on DioException catch (e) {
+        if (e.response?.statusCode == 401) {
+          // The server rejected the refresh token: the session is truly dead.
+          _stopReconnect();
+          await _clearStorage();
+          state = const AsyncData(AuthState());
+        } else {
+          // Server unreachable or faulting: keep the user in and keep trying.
+          debugPrint('Session validation deferred (server unreachable): $e');
+          _markReconnecting();
+        }
+        return;
+      }
       await _saveTokens(serverUrl, authResp.accessToken, authResp.refreshToken,
           authResp.deviceId ?? deviceId);
-      final config =
-          await _authService.fetchConfig(serverUrl, authResp.accessToken);
-      final connection = BackendConnection(
-        serverUrl: serverUrl,
-        accessToken: authResp.accessToken,
-        refreshToken: authResp.refreshToken,
-        serverName: config.serverName,
-        services: config.services,
-        instances: config.instances,
-        issuesEnabled: config.issuesEnabled,
-        allowReporting: config.allowReporting,
-      );
-      await _persistSession(connection, authResp.user);
+
+      // The session is confirmed alive; config is enrichment. On any config
+      // failure fall back to the snapshot the optimistic session was built
+      // from rather than touching the session.
+      BackendConnection? connection;
+      try {
+        final config =
+            await _authService.fetchConfig(serverUrl, authResp.accessToken);
+        connection = BackendConnection(
+          serverUrl: serverUrl,
+          accessToken: authResp.accessToken,
+          refreshToken: authResp.refreshToken,
+          serverName: config.serverName,
+          services: config.services,
+          instances: config.instances,
+          issuesEnabled: config.issuesEnabled,
+          allowReporting: config.allowReporting,
+        );
+        await _persistSession(connection, authResp.user);
+      } catch (e) {
+        debugPrint('Config fetch failed (session kept, using cached): $e');
+        final cached = state.valueOrNull?.connection;
+        if (cached != null && cached.serverUrl == serverUrl) {
+          connection = cached.copyWith(
+            accessToken: authResp.accessToken,
+            refreshToken: authResp.refreshToken,
+          );
+        }
+      }
+      if (connection == null) {
+        // Refreshed fine but no config to render with (no snapshot either):
+        // hold the optimistic state and let the retry loop finish the job.
+        _markReconnecting();
+        return;
+      }
       _stopReconnect();
       state = AsyncData(AuthState(connection: connection, user: authResp.user));
       _registerForPush();
-    } on DioException catch (e) {
-      if (e.response?.statusCode == 401) {
-        // The server rejected the refresh token: the session is truly dead.
-        _stopReconnect();
-        await _clearStorage();
-        state = const AsyncData(AuthState());
-      } else {
-        // Server unreachable: keep the user in the app and keep retrying.
-        debugPrint('Session validation deferred (server unreachable): $e');
-        _markReconnecting();
-      }
     } catch (e) {
       debugPrint('Session validation error (staying optimistic): $e');
       _markReconnecting();
@@ -199,16 +307,41 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   }
 
   /// No-snapshot fallback: validate the stored tokens inline and return the
-  /// resulting state. Keeps tokens on a transport failure (only a real 401
-  /// clears them) and writes a session snapshot on success.
+  /// resulting state. Keeps tokens on a transport failure (only a 401 from the
+  /// refresh call itself clears them) and writes a session snapshot on success.
   Future<AuthState> _restoreInline(
     String serverUrl,
     String accessToken,
     String refreshToken,
   ) async {
-    final deviceId = await _storage.read(key: StorageKeys.deviceId);
+    String? deviceId;
     try {
-      final authResp = await _authService.refreshToken(serverUrl, refreshToken);
+      deviceId = await _storage.read(key: StorageKeys.deviceId);
+    } catch (_) {
+      // Tokens were readable moments ago; treat the device id as optional.
+    }
+
+    final AuthResponse authResp;
+    try {
+      authResp = await _authService.refreshToken(serverUrl, refreshToken);
+    } on DioException catch (e) {
+      // Only a genuine 401 clears the session; a transport failure keeps the
+      // tokens so the next launch can restore. (Without a snapshot we can't show
+      // an optimistic session yet, so this lands on login until connectivity
+      // returns — the snapshot written on the first success fixes that.)
+      if (e.response?.statusCode == 401) {
+        debugPrint('Session restore rejected by server (401); clearing.');
+        await _clearStorage();
+      } else {
+        debugPrint('Session restore deferred (server unreachable): $e');
+      }
+      return const AuthState();
+    } catch (e) {
+      debugPrint('Session restore error (tokens kept): $e');
+      return const AuthState();
+    }
+
+    try {
       await _saveTokens(serverUrl, authResp.accessToken, authResp.refreshToken,
           authResp.deviceId ?? deviceId);
       final config =
@@ -226,21 +359,22 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
       await _persistSession(connection, authResp.user);
       _registerForPush();
       return AuthState(connection: connection, user: authResp.user);
-    } on DioException catch (e) {
-      // Only a genuine 401 clears the session; a transport failure keeps the
-      // tokens so the next launch can restore. (Without a snapshot we can't show
-      // an optimistic session yet, so this lands on login until connectivity
-      // returns — the snapshot written on the first success fixes that.)
-      if (e.response?.statusCode == 401) {
-        debugPrint('Session restore rejected by server (401); clearing.');
-        await _clearStorage();
-      } else {
-        debugPrint('Session restore deferred (server unreachable): $e');
-      }
-      return const AuthState();
     } catch (e) {
-      debugPrint('Session restore error (tokens kept): $e');
-      return const AuthState();
+      // The session is confirmed alive (the refresh succeeded) — a failure
+      // from here on must not land on login. Enter the app with a minimal
+      // connection; the reconnect loop fetches the full config shortly.
+      debugPrint('Config fetch failed after restore (entering degraded): $e');
+      final connection = BackendConnection(
+        serverUrl: serverUrl,
+        accessToken: authResp.accessToken,
+        refreshToken: authResp.refreshToken,
+      );
+      _scheduleReconnect();
+      return AuthState(
+        connection: connection,
+        user: authResp.user,
+        isReconnecting: true,
+      );
     }
   }
 
@@ -267,10 +401,15 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     _reconnectTimer = null;
   }
 
-  /// Retry validation now (e.g. when the app returns to the foreground) instead
-  /// of waiting for the periodic timer. No-op unless we're holding a
-  /// reconnecting session.
+  /// Retry validation now (e.g. when the app returns to the foreground)
+  /// instead of waiting for the periodic timers. Also retries a restore that
+  /// was blocked on unreadable secure storage (locked keychain at launch) —
+  /// by the time the user foregrounds the app the device is unlocked.
   void reconnectNow() {
+    if (_restoreBlocked) {
+      unawaited(_retryRestore());
+      return;
+    }
     final current = state.valueOrNull;
     if (current != null && current.isAuthenticated && current.isReconnecting) {
       unawaited(_validateSession());
@@ -663,7 +802,13 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     );
 
     await _storage.write(key: StorageKeys.jwt, value: accessToken);
-    await _storage.write(key: StorageKeys.refreshToken, value: refreshToken);
+    // The refresh token is stable under the current server scheme; only touch
+    // its (redundant) storage when it actually changes.
+    if (refreshToken != current.connection!.refreshToken) {
+      await _storage.write(
+          key: StorageKeys.refreshTokenBackup, value: refreshToken);
+      await _storage.write(key: StorageKeys.refreshToken, value: refreshToken);
+    }
 
     // A successful refresh means we reached the server — clear any reconnecting
     // hold and stop the retry loop.
@@ -716,6 +861,10 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   ) async {
     await _storage.write(key: StorageKeys.serverUrl, value: serverUrl);
     await _storage.write(key: StorageKeys.jwt, value: accessToken);
+    // Backup copy first: if anything interrupts between the two writes, at
+    // least one intact copy of the refresh token survives.
+    await _storage.write(
+        key: StorageKeys.refreshTokenBackup, value: refreshToken);
     await _storage.write(key: StorageKeys.refreshToken, value: refreshToken);
     if (deviceId != null) {
       await _storage.write(key: StorageKeys.deviceId, value: deviceId);
@@ -724,9 +873,12 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
 
   Future<void> _clearStorage() async {
     _stopReconnect();
+    _stopRestoreRetry();
+    _restoreBlocked = false;
     await _storage.delete(key: StorageKeys.serverUrl);
     await _storage.delete(key: StorageKeys.jwt);
     await _storage.delete(key: StorageKeys.refreshToken);
+    await _storage.delete(key: StorageKeys.refreshTokenBackup);
     await _storage.delete(key: StorageKeys.deviceId);
     await _storage.delete(key: StorageKeys.sessionUser);
     await _storage.delete(key: StorageKeys.sessionConnection);

--- a/app/test/auth/auth_restore_test.dart
+++ b/app/test/auth/auth_restore_test.dart
@@ -175,6 +175,111 @@ void main() {
       expect(state.isAuthenticated, isFalse);
       expect(storage[StorageKeys.refreshToken], isNull);
     });
+
+    test('enters the app degraded (not login) when config fails after a '
+        'successful refresh', () async {
+      final storage = tokensOnlyStorage();
+      final container = makeContainer(
+        storage,
+        _FakeAuthService(
+          refreshResult: freshResp,
+          configError: DioException(
+            requestOptions: RequestOptions(path: '/api/config'),
+            type: DioExceptionType.badResponse,
+            response: Response(
+              requestOptions: RequestOptions(path: '/api/config'),
+              statusCode: 401,
+            ),
+          ),
+        ),
+      );
+
+      final state = await container.read(authProvider.future);
+      expect(state.isAuthenticated, isTrue,
+          reason: 'the server just accepted the refresh token — a config '
+              'failure (even a 401) must never end the session');
+      expect(state.isReconnecting, isTrue);
+      expect(storage[StorageKeys.refreshToken], 'new-refresh');
+    });
+  });
+
+  group('config failures with a cached snapshot', () {
+    test('keeps the session on cached config when the config fetch fails',
+        () async {
+      final storage = snapshotStorage();
+      final container = makeContainer(
+        storage,
+        _FakeAuthService(
+          refreshResult: freshResp,
+          configError: DioException(
+            requestOptions: RequestOptions(path: '/api/config'),
+            type: DioExceptionType.connectionError,
+          ),
+        ),
+      );
+
+      await container.read(authProvider.future);
+      await _pumpUntil(() =>
+          storage[StorageKeys.jwt] == 'new-access'); // refresh persisted
+      await Future<void>.delayed(const Duration(milliseconds: 30));
+
+      final s = container.read(authProvider).valueOrNull!;
+      expect(s.isAuthenticated, isTrue);
+      expect(s.connection?.services.radarr, isTrue,
+          reason: 'falls back to the snapshot config');
+      expect(s.connection?.accessToken, 'new-access',
+          reason: 'fresh tokens ride on the cached config');
+      expect(storage[StorageKeys.sessionUser], isNotNull);
+    });
+  });
+
+  group('unreadable secure storage (locked keychain at launch)', () {
+    test('never treats a blocked read as logged out, and restores once '
+        'storage is readable again', () async {
+      final storage = snapshotStorage();
+      // First read throws (prewarmed launch while locked); later reads work.
+      final blocked = _BlockedStorage(storage, failingReads: 1);
+      final container = ProviderContainer(overrides: [
+        storageServiceProvider.overrideWithValue(blocked),
+        authServiceProvider.overrideWithValue(
+            _FakeAuthService(refreshResult: freshResp, config: config)),
+      ]);
+      addTearDown(container.dispose);
+
+      final initial = await container.read(authProvider.future);
+      expect(initial.isAuthenticated, isFalse,
+          reason: 'no session can be shown yet — storage is unreadable');
+      expect(storage[StorageKeys.refreshToken], 'old-refresh',
+          reason: 'blocked storage must never be cleared');
+
+      // The user foregrounds the app (device now unlocked).
+      container.read(authProvider.notifier).reconnectNow();
+      await _pumpUntil(() =>
+          container.read(authProvider).valueOrNull?.isAuthenticated == true);
+
+      final restored = container.read(authProvider).valueOrNull!;
+      expect(restored.user?.username, 'tester');
+    });
+
+    test('falls back to the backup refresh token when the primary is missing',
+        () async {
+      final storage = snapshotStorage();
+      storage.remove(StorageKeys.refreshToken);
+      storage[StorageKeys.refreshTokenBackup] = 'old-refresh';
+      final container = makeContainer(
+        storage,
+        _FakeAuthService(refreshResult: freshResp, config: config),
+      );
+
+      final optimistic = await container.read(authProvider.future);
+      expect(optimistic.isAuthenticated, isTrue);
+      await _pumpUntil(() {
+        final s = container.read(authProvider).valueOrNull;
+        return s != null && !s.isReconnecting;
+      });
+      expect(storage[StorageKeys.refreshToken], isNotNull,
+          reason: 'the primary key is healed from the backup');
+    });
   });
 }
 
@@ -211,16 +316,43 @@ class _FakeStorage implements StorageService {
 
   @override
   Future<void> delete({required String key}) async => _data.remove(key);
+
+  @override
+  Future<void> hardenAuthKeys() async {}
+}
+
+/// Storage whose reads throw for a while before working — models a locked
+/// keychain during an iOS prewarmed/background launch that becomes readable
+/// once the device is unlocked.
+class _BlockedStorage extends _FakeStorage {
+  _BlockedStorage(super.data, {required this.failingReads});
+
+  int failingReads;
+
+  @override
+  Future<String?> read({required String key}) async {
+    if (failingReads > 0) {
+      failingReads--;
+      throw Exception('keychain unavailable (locked)');
+    }
+    return super.read(key: key);
+  }
 }
 
 /// Fake [AuthService] that returns a canned refresh result or throws a chosen
 /// error, so restore can be driven through every branch without the network.
 class _FakeAuthService extends AuthService {
-  _FakeAuthService({this.refreshResult, this.refreshError, this.config});
+  _FakeAuthService({
+    this.refreshResult,
+    this.refreshError,
+    this.config,
+    this.configError,
+  });
 
   final AuthResponse? refreshResult;
   final Object? refreshError;
   final ServerConfig? config;
+  final Object? configError;
   int refreshCalls = 0;
 
   @override
@@ -233,6 +365,8 @@ class _FakeAuthService extends AuthService {
 
   @override
   Future<ServerConfig> fetchConfig(String serverUrl, String accessToken) async {
+    final error = configError;
+    if (error != null) throw error;
     return config ??
         const ServerConfig(serverName: 'Home', services: AvailableServices());
   }

--- a/server/README.md
+++ b/server/README.md
@@ -29,7 +29,7 @@ A single Go binary that bridges your arr stack, serves the web UI, and keeps API
 - **Books via Chaptarr** -- A Readarr-API (v1) books module with per-format (ebook/audiobook) monitoring, requesting, and library awareness. Chaptarr access is granted per user by an admin.
 - **Automatic ID bridging** -- Transparently translates TMDB IDs to TVDB IDs for Sonarr. Falls back to Trakt cross-references, then title+year search. Results cached in SQLite for 30 days.
 - **Availability computed live** -- Request status is derived from the arrs' real episode/file state (never from a stale snapshot or monitored-only stats), refreshed by queue polling and instant arr webhooks.
-- **Connect link auth, passwordless by default** -- Admins generate connect links; sessions are long-lived JWTs that refresh on use. Passwords and passkeys (WebAuthn, incl. native iOS/Android/Windows) are admin-gated per user.
+- **Connect link auth, passwordless by default** -- Admins generate connect links; redeeming one starts a permanent device session (an opaque refresh token validated against the DB -- never expires, never rotates, independent of the JWT secret) that mints 15-minute access JWTs. Sessions end only by device revocation or user deletion. Passwords and passkeys (WebAuthn, incl. native iOS/Android/Windows) are admin-gated per user.
 - **AI assistant + remediation agent** -- Anthropic, OpenAI, or Gemini-powered chat with server-side tool execution, plus an autonomous investigation agent that diagnoses reported/detected media problems and proposes fixes an admin approves.
 - **MCP server** -- The same 26 tools exposed at `/mcp` (Streamable HTTP) with full OAuth: discovery metadata, dynamic client registration, PKCE, browser/passkey login, rotating refresh tokens.
 - **Import Doctor** -- Plain-English diagnosis of stuck downloads with one-click fixes (manual/force import, remove+blocklist+re-search, category hand-off, rescan), shared by the app, the AI assistant, and MCP.
@@ -83,7 +83,7 @@ Optional env vars for deployment tuning (a `.env` file next to the binary is aut
 |---|---|---|
 | `CANTINARR_PORT` | `8585` | HTTP listen port |
 | `CANTINARR_SERVER_NAME` | `Cantinarr` | Display name shown in clients |
-| `CANTINARR_JWT_SECRET` | auto-generated | HMAC secret for JWT signing (persisted encrypted when auto-generated) |
+| `CANTINARR_JWT_SECRET` | auto-generated | HMAC secret for signing short-lived access tokens (persisted encrypted when auto-generated). Opaque device-session refresh tokens do not depend on it, so changing it never signs devices out |
 | `CANTINARR_ENCRYPTION_KEY` | auto-generated key file | Base64 32-byte key for secrets-at-rest (default: `/config/encryption.key`) |
 | `CANTINARR_AI_PROVIDER` | `anthropic` | Fallback AI provider when none is saved in the admin UI (`anthropic`, `openai`, `gemini`) |
 | `CANTINARR_AI_MODEL` | provider default | Fallback model when none is saved in the admin UI |
@@ -108,7 +108,7 @@ Auth levels: **public**, **user** (any signed-in account), **admin**. Public aut
 GET    /api/auth/status                    # public: is setup complete, login methods
 POST   /api/auth/setup                     # public: first-run admin account creation
 POST   /api/auth/login                     # public: { username, password } -> tokens
-POST   /api/auth/refresh                   # public: rotate refresh token
+POST   /api/auth/refresh                   # public: mint access token (refresh token is stable; legacy JWT refresh tokens migrate to the opaque scheme; 401 only on genuine revocation, 503 on transient faults)
 POST   /api/auth/connect                   # public: redeem a connect-link token -> session
 POST   /api/auth/passkey/login/begin|finish   # public: WebAuthn login
 POST   /api/auth/passkey/setup/begin|finish   # public: passkey setup via short-lived link

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
@@ -242,11 +243,17 @@ func newProcToken() string {
 
 // ensureJWTSecret loads the JWT secret from the settings table, or generates
 // and persists a new one. This ensures tokens survive server restarts.
+// Only a definitively-missing row may trigger generation: minting a fresh
+// secret on a transient read fault would invalidate every outstanding access
+// token, so any other error refuses to boot instead.
 func ensureJWTSecret(database *sql.DB, cipher *secrets.Cipher) (string, error) {
 	var stored string
 	err := database.QueryRow("SELECT value FROM settings WHERE key = 'jwt_secret'").Scan(&stored)
 	if err == nil {
 		return cipher.Decrypt(stored)
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return "", fmt.Errorf("read persisted secret: %w", err)
 	}
 
 	// Generate a new secret

--- a/server/internal/auth/handler.go
+++ b/server/internal/auth/handler.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -56,11 +57,18 @@ func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.service.Refresh(req.RefreshToken)
 	if err != nil {
-		if errors.Is(err, ErrDeviceRevoked) {
+		// 401 is reserved for a genuine rejection: clients erase their stored
+		// session on it. Every other failure (DB hiccup, signing fault) is a
+		// 503 so the client keeps the token and retries later.
+		switch {
+		case errors.Is(err, ErrDeviceRevoked):
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "device has been revoked"})
-			return
+		case errors.Is(err, ErrInvalidCredentials):
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid refresh token"})
+		default:
+			log.Printf("auth: refresh answered 503 (client will retry, session kept): %v", err)
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "temporarily unavailable, retry shortly"})
 		}
-		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid refresh token"})
 		return
 	}
 

--- a/server/internal/auth/middleware.go
+++ b/server/internal/auth/middleware.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 )
@@ -39,6 +40,13 @@ func (s *Service) AuthMiddleware(next http.Handler) http.Handler {
 
 		claims, user, err := s.AuthenticateToken(token)
 		if err != nil {
+			// A fault while evaluating the token (DB error) must not read as a
+			// rejection: clients treat 401 as "session dead". Answer 503 so
+			// they retry with the same credentials.
+			if errors.Is(err, ErrAuthUnavailable) {
+				http.Error(w, `{"error":"temporarily unavailable, retry shortly"}`, http.StatusServiceUnavailable)
+				return
+			}
 			http.Error(w, `{"error":"invalid or expired token"}`, http.StatusUnauthorized)
 			return
 		}

--- a/server/internal/auth/oauth.go
+++ b/server/internal/auth/oauth.go
@@ -250,7 +250,7 @@ func (s *Service) RefreshOAuthToken(clientID, refreshToken, resource string) (*O
 	if err != nil {
 		return nil, ErrInvalidCredentials
 	}
-	if err := s.validateActiveDevice(&Claims{UserID: stored.UserID, DeviceID: stored.DeviceID}); err != nil {
+	if err := s.requireActiveDevice(stored.DeviceID, stored.UserID); err != nil {
 		return nil, err
 	}
 

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -38,6 +39,12 @@ var (
 	ErrPasswordNotAllowed   = errors.New("password sign-in is not enabled for this account")
 	ErrPasskeyNotAllowed    = errors.New("passkeys are not enabled for this account")
 	ErrCannotModifyAdmin    = errors.New("cannot change sign-in methods for an admin")
+	// ErrAuthUnavailable marks a failure to *evaluate* credentials (DB error,
+	// signing error) as opposed to a rejection of them. Handlers must map it to
+	// a 5xx, never a 401: clients treat a 401 as "this session is dead" and
+	// erase their stored tokens, so answering a transient fault with 401 logs
+	// the user out permanently.
+	ErrAuthUnavailable = errors.New("authentication temporarily unavailable")
 )
 
 // minPasswordLength is the minimum length for an account password. It matches
@@ -45,16 +52,28 @@ var (
 const minPasswordLength = 8
 
 const (
-	// refreshTokenTTL is how long an idle session survives before it must be
-	// re-established with a fresh connect link. Each refresh issues a new token
-	// with a fresh TTL, so an actively used session effectively never expires.
-	refreshTokenTTL = 365 * 24 * time.Hour
-	// refreshRotationGrace is a short window after a refresh token is rotated
-	// during which the just-superseded token is still accepted. It prevents a
-	// client that fails to persist the rotated token (crash, dropped response)
-	// from being logged out, without leaving tokens replayable indefinitely.
-	refreshRotationGrace = 60 * time.Second
+	// opaqueRefreshPrefix marks the current refresh-token scheme: an opaque
+	// random secret validated purely against the refresh_tokens table. Device
+	// sessions built on it never expire, never rotate, and do not depend on
+	// the JWT secret — a session survives server restarts, upgrades, JWT
+	// secret changes, and any amount of idle time. The ONLY ways to end one
+	// are explicit: revoke the device or delete the user. That is the product
+	// contract for passwordless household accounts (a connect link is
+	// redeemed once; the resulting session must never silently die).
+	opaqueRefreshPrefix = "cnr1."
+
+	// legacyRefreshMinLifetime separates legacy JWT *refresh* tokens (issued
+	// with 30- or 365-day expiries by older versions) from access tokens
+	// (always 15 minutes). Only tokens minted with a lifetime above this bar
+	// are accepted on the refresh amnesty path, so a leaked short-lived
+	// access token can never be laundered into a permanent session.
+	legacyRefreshMinLifetime = 24 * time.Hour
 )
+
+// refreshNeverExpires is the expires_at sentinel stored for opaque refresh
+// tokens. The column is NOT NULL in existing databases, so "no expiry" is a
+// date the periodic cleanup can never reach.
+var refreshNeverExpires = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // passwordAllowed reports whether the account may use password sign-in. Admins
 // are always allowed so an install can never be locked out of its own server.
@@ -298,74 +317,156 @@ func (s *Service) SetPassword(userID int64, newPassword string) error {
 	return nil
 }
 
+// Refresh exchanges a refresh token for a fresh access token. This is the one
+// call that keeps a passwordless session alive, so its failure contract is
+// strict: it returns ErrInvalidCredentials / ErrDeviceRevoked ONLY when the
+// session is genuinely dead (token forged or revoked, device revoked, user
+// deleted). Every fault in *evaluating* the token wraps ErrAuthUnavailable so
+// the handler answers 503 and the client retries instead of logging out.
 func (s *Service) Refresh(refreshToken string) (*TokenResponse, error) {
-	claims, err := s.ValidateToken(refreshToken)
-	if err != nil {
-		return nil, ErrInvalidCredentials
+	if strings.HasPrefix(refreshToken, opaqueRefreshPrefix) {
+		return s.refreshOpaque(refreshToken)
 	}
+	return s.refreshLegacyJWT(refreshToken)
+}
 
-	// Verify the refresh token exists in our store (rotation check).
-	oldHash := hashToken(refreshToken)
+// refreshOpaque validates a current-scheme refresh token against the store and
+// issues a new access token. The refresh token itself is returned unchanged:
+// no rotation means there is no rotated value the client can fail to persist,
+// so a crash, a lost response, or server downtime mid-refresh can never strand
+// a device. Replay containment comes from device revocation, not rotation.
+func (s *Service) refreshOpaque(refreshToken string) (*TokenResponse, error) {
 	var (
-		storedDeviceID string
-		supersededAt   sql.NullTime
+		deviceID string
+		userID   int64
 	)
-	err = s.db.QueryRow(
-		"SELECT device_id, superseded_at FROM refresh_tokens WHERE token_hash = ?", oldHash,
-	).Scan(&storedDeviceID, &supersededAt)
-	if err != nil {
-		// Token not in store — never issued, expired and cleaned up, or replayed.
+	err := s.db.QueryRow(
+		"SELECT device_id, user_id FROM refresh_tokens WHERE token_hash = ?",
+		hashToken(refreshToken),
+	).Scan(&deviceID, &userID)
+	if errors.Is(err, sql.ErrNoRows) {
+		// Never issued, or deleted by device revocation / user deletion.
 		return nil, ErrInvalidCredentials
 	}
-	if supersededAt.Valid {
-		// Already rotated. Accept it only within the grace window so a client
-		// that failed to persist the rotated token isn't logged out; beyond the
-		// window treat it as a replay.
-		if time.Since(supersededAt.Time) > refreshRotationGrace {
-			return nil, ErrInvalidCredentials
-		}
-	} else {
-		// First use: mark the token superseded (one-time use) but keep the row
-		// so a retry within the grace window still succeeds. Cleanup in
-		// generateTokens removes it once the grace window has passed.
-		_, _ = s.db.Exec(
-			"UPDATE refresh_tokens SET superseded_at = ? WHERE token_hash = ?",
-			time.Now(), oldHash,
-		)
-	}
-
-	// Check device revocation if the token has a device ID
-	if claims.DeviceID != "" {
-		var revokedAt *time.Time
-		err := s.db.QueryRow(
-			"SELECT revoked_at FROM devices WHERE id = ?", claims.DeviceID,
-		).Scan(&revokedAt)
-		if err != nil {
-			return nil, ErrInvalidCredentials
-		}
-		if revokedAt != nil {
-			return nil, ErrDeviceRevoked
-		}
-		// Update last_seen_at
-		_, _ = s.db.Exec(
-			"UPDATE devices SET last_seen_at = ? WHERE id = ?",
-			time.Now(), claims.DeviceID,
-		)
-	}
-
-	user, err := s.getUserByID(claims.UserID)
 	if err != nil {
-		return nil, ErrInvalidCredentials
+		return nil, fmt.Errorf("%w: look up refresh token: %v", ErrAuthUnavailable, err)
 	}
 
-	resp, err := s.generateTokens(user, claims.DeviceID)
+	if err := s.requireActiveDevice(deviceID, userID); err != nil {
+		return nil, err
+	}
+	user, err := s.getUserForAuth(userID)
 	if err != nil {
 		return nil, err
 	}
-	if claims.DeviceID != "" {
-		resp.DeviceID = claims.DeviceID
+
+	accessToken, err := s.signAccessToken(user, deviceID)
+	if err != nil {
+		return nil, err
 	}
+	return &TokenResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		User:         userWithPermissions(user),
+		DeviceID:     deviceID,
+	}, nil
+}
+
+// refreshLegacyJWT is the amnesty path for refresh tokens issued before the
+// opaque scheme: JWTs whose 30/365-day expiry, single-use rotation, and store
+// row made sessions die from idle time, crash-vs-rotation races, restores, or
+// restarts. A legacy token is accepted when its signature verifies and its
+// device is still authorized — deliberately ignoring its baked-in expiry and
+// whether its store row was rotated or lost, because the device row is the
+// real authority and admins revoke devices, not tokens. On success the client
+// is migrated to an opaque token and never touches this path again.
+//
+// The gate is strict about what counts as a refresh token: audience-free,
+// device-bound, and minted with a multi-day lifetime. Access tokens (15 min)
+// and OAuth tokens (audience-bound) can never pass, and forgeries still fail
+// the signature check.
+func (s *Service) refreshLegacyJWT(tokenStr string) (*TokenResponse, error) {
+	parser := jwt.NewParser(
+		jwt.WithValidMethods([]string{"HS256"}),
+		jwt.WithoutClaimsValidation(),
+	)
+	token, err := parser.ParseWithClaims(tokenStr, &Claims{}, func(t *jwt.Token) (interface{}, error) {
+		return s.jwtSecret, nil
+	})
+	if err != nil || !token.Valid {
+		return nil, ErrInvalidCredentials
+	}
+	claims, ok := token.Claims.(*Claims)
+	if !ok {
+		return nil, ErrInvalidCredentials
+	}
+	if len(claims.Audience) > 0 || claims.Scope != "" || claims.DeviceID == "" {
+		return nil, ErrInvalidCredentials
+	}
+	if claims.ExpiresAt == nil || claims.IssuedAt == nil ||
+		claims.ExpiresAt.Sub(claims.IssuedAt.Time) < legacyRefreshMinLifetime {
+		return nil, ErrInvalidCredentials
+	}
+
+	if err := s.requireActiveDevice(claims.DeviceID, claims.UserID); err != nil {
+		return nil, err
+	}
+	user, err := s.getUserForAuth(claims.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Migrate: issue the opaque pair. The legacy row (if any) is left to age
+	// out via the expires_at cleanup; nothing consults it anymore.
+	resp, err := s.generateTokens(user, claims.DeviceID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrAuthUnavailable, err)
+	}
+	resp.DeviceID = claims.DeviceID
 	return resp, nil
+}
+
+// requireActiveDevice confirms the device row exists, belongs to userID, and
+// is not revoked, then bumps last_seen_at. Missing/mismatched rows are a
+// genuine rejection; query faults are ErrAuthUnavailable.
+func (s *Service) requireActiveDevice(deviceID string, userID int64) error {
+	var (
+		ownerID   int64
+		revokedAt sql.NullTime
+	)
+	err := s.db.QueryRow(
+		"SELECT user_id, revoked_at FROM devices WHERE id = ?", deviceID,
+	).Scan(&ownerID, &revokedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrInvalidCredentials
+	}
+	if err != nil {
+		return fmt.Errorf("%w: look up device: %v", ErrAuthUnavailable, err)
+	}
+	if ownerID != userID {
+		return ErrInvalidCredentials
+	}
+	if revokedAt.Valid {
+		return ErrDeviceRevoked
+	}
+	_, _ = s.db.Exec(
+		"UPDATE devices SET last_seen_at = ? WHERE id = ?",
+		time.Now(), deviceID,
+	)
+	return nil
+}
+
+// getUserForAuth loads a user for a credential check: a missing row is a
+// rejection (account deleted), any other failure is ErrAuthUnavailable.
+func (s *Service) getUserForAuth(userID int64) (*User, error) {
+	user, err := s.getUserByID(userID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrInvalidCredentials
+	}
+	if err != nil {
+		return nil, fmt.Errorf("%w: load user: %v", ErrAuthUnavailable, err)
+	}
+	return user, nil
 }
 
 func (s *Service) GetUser(userID int64) (*User, error) {
@@ -810,13 +911,13 @@ func (s *Service) AuthenticateTokenForAudience(tokenStr, audience string) (*Clai
 }
 
 func (s *Service) authenticateClaims(claims *Claims) (*Claims, *User, error) {
-	user, err := s.getUserByID(claims.UserID)
+	user, err := s.getUserForAuth(claims.UserID)
 	if err != nil {
-		return nil, nil, ErrInvalidCredentials
+		return nil, nil, err
 	}
 
 	if claims.DeviceID != "" {
-		if err := s.validateActiveDevice(claims); err != nil {
+		if err := s.requireActiveDevice(claims.DeviceID, claims.UserID); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -836,34 +937,11 @@ func hasAudience(claims *Claims, audience string) bool {
 	return false
 }
 
-func (s *Service) validateActiveDevice(claims *Claims) error {
-	var (
-		userID    int64
-		revokedAt sql.NullTime
-	)
-	err := s.db.QueryRow(
-		"SELECT user_id, revoked_at FROM devices WHERE id = ?",
-		claims.DeviceID,
-	).Scan(&userID, &revokedAt)
-	if err != nil {
-		return ErrInvalidCredentials
-	}
-	if userID != claims.UserID {
-		return ErrInvalidCredentials
-	}
-	if revokedAt.Valid {
-		return ErrDeviceRevoked
-	}
-	_, _ = s.db.Exec(
-		"UPDATE devices SET last_seen_at = ? WHERE id = ?",
-		time.Now(), claims.DeviceID,
-	)
-	return nil
-}
-
-func (s *Service) generateTokens(user *User, deviceID string) (*TokenResponse, error) {
+// signAccessToken mints the short-lived bearer JWT. Signing failures are
+// ErrAuthUnavailable: the credential was already accepted, so failing to mint
+// its successor is a server fault, never a rejection.
+func (s *Service) signAccessToken(user *User, deviceID string) (string, error) {
 	now := time.Now()
-
 	accessClaims := &Claims{
 		UserID:   user.ID,
 		Username: user.Username,
@@ -876,39 +954,47 @@ func (s *Service) generateTokens(user *User, deviceID string) (*TokenResponse, e
 	}
 	accessToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, accessClaims).SignedString(s.jwtSecret)
 	if err != nil {
-		return nil, fmt.Errorf("sign access token: %w", err)
+		return "", fmt.Errorf("%w: sign access token: %v", ErrAuthUnavailable, err)
 	}
+	return accessToken, nil
+}
 
-	refreshExpiry := refreshTokenTTL
-	refreshClaims := &Claims{
-		UserID:   user.ID,
-		Username: user.Username,
-		Role:     user.Role,
-		DeviceID: deviceID,
-		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: jwt.NewNumericDate(now.Add(refreshExpiry)),
-			IssuedAt:  jwt.NewNumericDate(now),
-		},
+// newOpaqueRefreshToken mints a current-scheme refresh token: 32 random bytes
+// behind a versioned prefix. The value is a pure bearer secret — nothing about
+// the session is derivable from it, and only its SHA-256 hash is stored.
+func newOpaqueRefreshToken() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("generate refresh token: %w", err)
 	}
-	refreshToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, refreshClaims).SignedString(s.jwtSecret)
+	return opaqueRefreshPrefix + hex.EncodeToString(b), nil
+}
+
+func (s *Service) generateTokens(user *User, deviceID string) (*TokenResponse, error) {
+	accessToken, err := s.signAccessToken(user, deviceID)
 	if err != nil {
-		return nil, fmt.Errorf("sign refresh token: %w", err)
+		return nil, err
 	}
 
-	// Store refresh token hash for rotation tracking
-	tokenHash := hashToken(refreshToken)
-	_, _ = s.db.Exec(
-		"INSERT INTO refresh_tokens (token_hash, device_id, user_id, expires_at) VALUES (?, ?, ?, ?)",
-		tokenHash, deviceID, user.ID, now.Add(refreshExpiry),
-	)
+	refreshToken, err := newOpaqueRefreshToken()
+	if err != nil {
+		return nil, err
+	}
 
-	// Clean up expired refresh tokens, and ones left over past the rotation
-	// grace window, periodically (best-effort).
+	// The INSERT must succeed before the token is handed out: an unstored
+	// refresh token is a session that dies on its first refresh, silently.
+	if _, err := s.db.Exec(
+		"INSERT INTO refresh_tokens (token_hash, device_id, user_id, expires_at) VALUES (?, ?, ?, ?)",
+		hashToken(refreshToken), deviceID, user.ID, refreshNeverExpires,
+	); err != nil {
+		return nil, fmt.Errorf("store refresh token: %w", err)
+	}
+
+	// Best-effort sweep of legacy rows: expired JWT-era tokens and rotation
+	// bookkeeping. Opaque rows carry the far-future sentinel and never match.
+	now := time.Now()
 	_, _ = s.db.Exec("DELETE FROM refresh_tokens WHERE expires_at < ?", now)
-	_, _ = s.db.Exec(
-		"DELETE FROM refresh_tokens WHERE superseded_at IS NOT NULL AND superseded_at < ?",
-		now.Add(-refreshRotationGrace),
-	)
+	_, _ = s.db.Exec("DELETE FROM refresh_tokens WHERE superseded_at IS NOT NULL")
 
 	return &TokenResponse{
 		AccessToken:  accessToken,

--- a/server/internal/auth/service_test.go
+++ b/server/internal/auth/service_test.go
@@ -1,11 +1,14 @@
 package auth
 
 import (
+	"errors"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/windoze95/cantinarr-server/internal/db"
 )
 
@@ -566,77 +569,206 @@ func TestHashToken_Deterministic(t *testing.T) {
 	}
 }
 
-func TestRefreshRotation_FirstUseSucceeds(t *testing.T) {
+// mintLegacyRefreshJWT reproduces a refresh token exactly as pre-opaque
+// versions issued them: an HS256 JWT with a long lifetime, bound to a device.
+func mintLegacyRefreshJWT(t *testing.T, svc *Service, user *User, deviceID string, issuedAt time.Time, lifetime time.Duration) string {
+	t.Helper()
+	claims := &Claims{
+		UserID:   user.ID,
+		Username: user.Username,
+		Role:     user.Role,
+		DeviceID: deviceID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(issuedAt.Add(lifetime)),
+			IssuedAt:  jwt.NewNumericDate(issuedAt),
+		},
+	}
+	token, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString(svc.jwtSecret)
+	if err != nil {
+		t.Fatalf("sign legacy refresh token: %v", err)
+	}
+	return token
+}
+
+func TestRefresh_OpaqueTokenIsStableAndReusable(t *testing.T) {
 	svc := setupTestService(t)
 
 	loginResp, err := svc.Login("admin", "testpass123", "", "")
 	if err != nil {
 		t.Fatalf("login: %v", err)
 	}
-
-	refreshResp, err := svc.Refresh(loginResp.RefreshToken)
-	if err != nil {
-		t.Fatalf("refresh: %v", err)
+	if !strings.HasPrefix(loginResp.RefreshToken, opaqueRefreshPrefix) {
+		t.Fatalf("login should issue an opaque refresh token, got %q", loginResp.RefreshToken[:10])
 	}
-	if refreshResp.AccessToken == "" || refreshResp.RefreshToken == "" {
-		t.Fatal("refresh response missing tokens")
+
+	// Refresh repeatedly with the same token: no rotation means every retry,
+	// replayed request, or parallel refresh succeeds and the token is stable.
+	for i := 0; i < 3; i++ {
+		resp, err := svc.Refresh(loginResp.RefreshToken)
+		if err != nil {
+			t.Fatalf("refresh #%d: %v", i+1, err)
+		}
+		if resp.AccessToken == "" {
+			t.Fatalf("refresh #%d: missing access token", i+1)
+		}
+		if resp.RefreshToken != loginResp.RefreshToken {
+			t.Fatalf("refresh #%d rotated the token; opaque tokens must be stable", i+1)
+		}
+		if resp.DeviceID != loginResp.DeviceID {
+			t.Fatalf("refresh #%d device = %q, want %q", i+1, resp.DeviceID, loginResp.DeviceID)
+		}
+		if _, _, err := svc.AuthenticateToken(resp.AccessToken); err != nil {
+			t.Fatalf("refresh #%d access token rejected: %v", i+1, err)
+		}
 	}
 }
 
-func TestRefreshRotation_ReplayFails(t *testing.T) {
+// TestRefresh_LegacyJWTAmnesty covers the migration contract: any legacy JWT
+// refresh token whose device is still authorized is accepted — even when its
+// baked-in expiry passed (device idle for months/years) or its store row was
+// rotated away or lost (crash before persisting, restore from backup) — and
+// the session is upgraded to a never-expiring opaque token.
+func TestRefresh_LegacyJWTAmnesty(t *testing.T) {
 	svc := setupTestService(t)
 
 	loginResp, err := svc.Login("admin", "testpass123", "", "")
 	if err != nil {
 		t.Fatalf("login: %v", err)
 	}
-
-	oldRefreshToken := loginResp.RefreshToken
-
-	// JWT NumericDate has second precision; ensure the rotated token gets a
-	// different IssuedAt so it produces a distinct hash from the original.
-	time.Sleep(time.Second)
-
-	// First refresh succeeds and rotates the token
-	_, err = svc.Refresh(oldRefreshToken)
+	user, err := svc.getUserByUsername("admin")
 	if err != nil {
-		t.Fatalf("first refresh: %v", err)
+		t.Fatalf("load user: %v", err)
 	}
 
-	// Age the just-superseded token past the rotation grace window so a replay
-	// is treated as a replay rather than a benign retry.
-	if _, err := svc.db.Exec(
-		"UPDATE refresh_tokens SET superseded_at = ? WHERE token_hash = ?",
-		time.Now().Add(-2*refreshRotationGrace), hashToken(oldRefreshToken),
-	); err != nil {
-		t.Fatalf("age token: %v", err)
+	cases := []struct {
+		name     string
+		issuedAt time.Time
+		lifetime time.Duration
+	}{
+		{"active 365-day token with no store row", time.Now().Add(-time.Hour), 365 * 24 * time.Hour},
+		{"expired 30-day token idle for two years", time.Now().Add(-2 * 365 * 24 * time.Hour), 30 * 24 * time.Hour},
 	}
-
-	// Replaying the old token beyond the grace window should fail
-	if _, err := svc.Refresh(oldRefreshToken); err == nil {
-		t.Fatal("replay of rotated refresh token beyond grace should fail")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			legacy := mintLegacyRefreshJWT(t, svc, user, loginResp.DeviceID, tc.issuedAt, tc.lifetime)
+			// No refresh_tokens row exists for this token (simulates rotation
+			// races, cleanup, and backup restores); amnesty must not care.
+			resp, err := svc.Refresh(legacy)
+			if err != nil {
+				t.Fatalf("legacy refresh: %v", err)
+			}
+			if !strings.HasPrefix(resp.RefreshToken, opaqueRefreshPrefix) {
+				t.Fatal("legacy refresh should migrate to an opaque token")
+			}
+			if _, err := svc.Refresh(resp.RefreshToken); err != nil {
+				t.Fatalf("migrated opaque token rejected: %v", err)
+			}
+		})
 	}
 }
 
-// TestRefreshRotation_GraceAllowsRetry verifies that a client which fails to
-// persist the rotated token can retry with the original within the grace window
-// and stay signed in.
-func TestRefreshRotation_GraceAllowsRetry(t *testing.T) {
+// TestRefresh_RejectsNonRefreshTokens locks the amnesty gate: short-lived
+// access tokens, audience-bound (OAuth/setup) tokens, device-less tokens, and
+// forgeries must never mint a session.
+func TestRefresh_RejectsNonRefreshTokens(t *testing.T) {
 	svc := setupTestService(t)
 
 	loginResp, err := svc.Login("admin", "testpass123", "", "")
 	if err != nil {
 		t.Fatalf("login: %v", err)
 	}
-	old := loginResp.RefreshToken
-	time.Sleep(time.Second)
-
-	if _, err := svc.Refresh(old); err != nil {
-		t.Fatalf("first refresh: %v", err)
+	user, err := svc.getUserByUsername("admin")
+	if err != nil {
+		t.Fatalf("load user: %v", err)
 	}
-	// Immediate retry with the same token is within grace, so it still works.
-	if _, err := svc.Refresh(old); err != nil {
-		t.Fatalf("in-grace retry should succeed: %v", err)
+
+	// A real access token (15-minute lifetime) fails the lifetime bar.
+	if _, err := svc.Refresh(loginResp.AccessToken); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("access token as refresh: err = %v, want ErrInvalidCredentials", err)
+	}
+
+	// Device-less long-lived JWT.
+	deviceless := mintLegacyRefreshJWT(t, svc, user, "", time.Now(), 365*24*time.Hour)
+	if _, err := svc.Refresh(deviceless); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("device-less token: err = %v, want ErrInvalidCredentials", err)
+	}
+
+	// Audience-bound token (OAuth-style), long-lived and device-bound.
+	audClaims := &Claims{
+		UserID:   user.ID,
+		DeviceID: loginResp.DeviceID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Audience:  jwt.ClaimStrings{"https://example.com/mcp"},
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(365 * 24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+	audToken, err := jwt.NewWithClaims(jwt.SigningMethodHS256, audClaims).SignedString(svc.jwtSecret)
+	if err != nil {
+		t.Fatalf("sign audience token: %v", err)
+	}
+	if _, err := svc.Refresh(audToken); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("audience-bound token: err = %v, want ErrInvalidCredentials", err)
+	}
+
+	// Wrong signature.
+	forged, err := jwt.NewWithClaims(jwt.SigningMethodHS256, &Claims{
+		UserID:   user.ID,
+		DeviceID: loginResp.DeviceID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(365 * 24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}).SignedString([]byte("wrong-secret"))
+	if err != nil {
+		t.Fatalf("sign forged token: %v", err)
+	}
+	if _, err := svc.Refresh(forged); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("forged token: err = %v, want ErrInvalidCredentials", err)
+	}
+
+	// Unknown opaque token.
+	if _, err := svc.Refresh(opaqueRefreshPrefix + strings.Repeat("ab", 32)); !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("unknown opaque token: err = %v, want ErrInvalidCredentials", err)
+	}
+}
+
+// TestRefresh_TransientFaultIsUnavailableNotRejection pins the 401/503 split:
+// when the store cannot be consulted at all, the error must be
+// ErrAuthUnavailable (handler → 503, client keeps its session), never a
+// rejection that would erase the client's tokens.
+func TestRefresh_TransientFaultIsUnavailableNotRejection(t *testing.T) {
+	svc := setupTestService(t)
+
+	loginResp, err := svc.Login("admin", "testpass123", "", "")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+
+	svc.db.Close()
+
+	_, err = svc.Refresh(loginResp.RefreshToken)
+	if !errors.Is(err, ErrAuthUnavailable) {
+		t.Fatalf("refresh on closed DB: err = %v, want ErrAuthUnavailable", err)
+	}
+	if errors.Is(err, ErrInvalidCredentials) || errors.Is(err, ErrDeviceRevoked) {
+		t.Fatalf("transient fault must not read as a rejection: %v", err)
+	}
+}
+
+func TestGenerateTokens_FailsWhenStoreWriteFails(t *testing.T) {
+	svc := setupTestService(t)
+	user, err := svc.getUserByUsername("admin")
+	if err != nil {
+		t.Fatalf("load user: %v", err)
+	}
+
+	svc.db.Close()
+
+	// A refresh token that was never stored would strand the device on its
+	// first refresh, so issuance must fail loudly instead.
+	if _, err := svc.generateTokens(user, "some-device"); err == nil {
+		t.Fatal("generateTokens must fail when the refresh token cannot be stored")
 	}
 }
 
@@ -652,9 +784,46 @@ func TestDeviceRevocation_InvalidatesRefreshTokens(t *testing.T) {
 		t.Fatalf("revoke device: %v", err)
 	}
 
-	// Refresh should fail after device revocation
+	// The opaque token dies with its deleted store row.
 	_, err = svc.Refresh(loginResp.RefreshToken)
-	if err == nil {
-		t.Fatal("refresh after device revocation should fail")
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Fatalf("refresh after revocation: err = %v, want ErrInvalidCredentials", err)
+	}
+
+	// The legacy amnesty path must not resurrect a revoked device either.
+	user, err := svc.getUserByUsername("admin")
+	if err != nil {
+		t.Fatalf("load user: %v", err)
+	}
+	legacy := mintLegacyRefreshJWT(t, svc, user, loginResp.DeviceID, time.Now(), 365*24*time.Hour)
+	if _, err := svc.Refresh(legacy); !errors.Is(err, ErrDeviceRevoked) {
+		t.Fatalf("legacy refresh after revocation: err = %v, want ErrDeviceRevoked", err)
+	}
+}
+
+// TestAuthMiddleware_TransientFaultIs503 pins the middleware side of the
+// split: a valid access token evaluated against a broken store must yield
+// 503 (retry), not 401 (client wipes its session).
+func TestAuthMiddleware_TransientFaultIs503(t *testing.T) {
+	svc := setupTestService(t)
+
+	loginResp, err := svc.Login("admin", "testpass123", "", "")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+
+	handler := svc.AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	svc.db.Close()
+
+	req := httptest.NewRequest("GET", "/api/config", nil)
+	req.Header.Set("Authorization", "Bearer "+loginResp.AccessToken)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != 503 {
+		t.Fatalf("status = %d, want 503", rec.Code)
 	}
 }

--- a/server/internal/auth/webauthn.go
+++ b/server/internal/auth/webauthn.go
@@ -402,7 +402,7 @@ func (s *Service) CreatePasskeySetupToken(userID int64, deviceID string) (string
 	if deviceID == "" {
 		return "", time.Time{}, ErrInvalidCredentials
 	}
-	if err := s.validateActiveDevice(&Claims{UserID: user.ID, DeviceID: deviceID}); err != nil {
+	if err := s.requireActiveDevice(deviceID, user.ID); err != nil {
 		return "", time.Time{}, err
 	}
 	now := time.Now()
@@ -437,7 +437,7 @@ func (s *Service) BeginPasskeySetup(token string, r *http.Request) (interface{},
 	if claims.DeviceID == "" {
 		return nil, "", ErrInvalidCredentials
 	}
-	if err := s.validateActiveDevice(claims); err != nil {
+	if err := s.requireActiveDevice(claims.DeviceID, claims.UserID); err != nil {
 		return nil, "", err
 	}
 	return s.BeginPasskeyRegistration(claims.UserID, r)
@@ -454,7 +454,7 @@ func (s *Service) FinishPasskeySetup(token, sessionID, credentialName string, r 
 	if claims.DeviceID == "" {
 		return ErrInvalidCredentials
 	}
-	if err := s.validateActiveDevice(claims); err != nil {
+	if err := s.requireActiveDevice(claims.DeviceID, claims.UserID); err != nil {
 		return err
 	}
 	return s.FinishPasskeyRegistration(claims.UserID, sessionID, credentialName, r)


### PR DESCRIPTION
## Why

Passwordless users kept getting deauthenticated — after container restarts/upgrades, after time away, and seemingly at random. The product contract is the opposite: a connect link is redeemed once and that device stays signed in until an admin revokes it. This PR eliminates every deauthentication path found in an end-to-end audit of both sides.

## Root causes found

**Server**
1. **Refresh rotation + 60s grace**: refresh tokens were single-use; if the rotated token's response was lost (upgrade downtime, flaky VPN, iOS suspending the app between server commit and client persist), the client was left holding a superseded token → 401 → wiped session. Upgrade downtime alone routinely exceeds the grace.
2. **Idle TTL**: tokens issued before June 20 died after 30 days idle; since then, 365 days. Either way, "away for months" could kill a session.
3. **Transient faults answered 401**: the refresh handler mapped *every* error to 401, and the middleware mapped DB errors to 401 — the client (correctly) treats 401 as "session dead" and erases tokens. A disk hiccup could log a user out.
4. **Phantom tokens**: `generateTokens` ignored the refresh-row INSERT error, so a client could receive a token the server never stored — dead on first refresh.
5. **JWT-secret coupling**: refresh validity depended on the JWT signature; env/DB secret flips or restores invalidated every session. `ensureJWTSecret` could also mint a new secret on a transient read error.

**App**
6. **iOS keychain accessibility**: tokens were stored with the default `whenUnlocked` class. iOS 15+ prewarming launches the app while locked → reads fail → user lands on the login screen with valid tokens in the keychain, no retry on unlock.
7. **Config-fetch coupling**: a 401 from `/api/config` during launch validation cleared storage even when the refresh itself had succeeded.

## The fix

**Server — session model**
- Refresh tokens are now **opaque random secrets** (`cnr1.` + 64 hex, SHA-256-hashed in `refresh_tokens`): **no expiry, no rotation, no JWT-secret dependency**. Restarts, upgrades, secret rotation, backup restores, and idle years are all non-events. Kill switches remain exactly: revoke device, delete user.
- **Legacy JWT amnesty**: signature-valid, device-bound, long-lived JWTs are accepted even if expired / rotated / missing their store row, then migrated to the opaque scheme — every session bricked by causes 1–2 recovers on its next refresh, fleet-wide, with no user action. The gate rejects access tokens (15-min lifetime < 24h bar), audience/scope-bound tokens, and forgeries.
- **401 means revoked, period.** Transient faults wrap `ErrAuthUnavailable` → 503 from both the refresh endpoint and the auth middleware (with a server log line). The refresh handler's *default* is now 503, so an unknown bug can never masquerade as a revocation.
- Refresh-row INSERT failures abort token issuance; `ensureJWTSecret` only generates on `sql.ErrNoRows`.

**App — restore resilience**
- Keychain items move to `first_unlock` (readable in background/prewarmed launches after first unlock since boot; included in encrypted backups so sessions survive phone migration). Existing items are rewritten once, marker-guarded, **backup copy first** so no crash window can lose the token.
- Unreadable storage = "blocked, retry on foreground + timer", never "logged out".
- Only a 401 from the refresh call itself ends the session; config failures fall back to the cached snapshot or a degraded reconnecting session.
- Redundant `jwt_refresh_token_backup` copy consulted when the primary read is empty; interceptor refresh client gets explicit timeouts.

## Security posture

Replay containment moves from rotation to device revocation — the admin Devices screen is the kill switch, matching how Plex/Jellyfin treat device tokens and this product's threat model (tokens live in Keychain/EncryptedSharedPreferences and transit only on refresh). Access tokens remain strict 15-minute JWTs; the MCP OAuth flow keeps its spec-compliant rotation untouched. Web (localStorage) remains inherently evictable by the browser — native apps are the never-login surface.

## Verification

- `go vet ./...`, `go test ./...`, `CGO_ENABLED=0 go build ./...` — pass
- `flutter analyze --no-fatal-infos` (0 errors/warnings), `flutter test` (199/199) — pass
- New tests pin: stable/reusable opaque refresh; amnesty for expired + row-less legacy tokens; rejection of access/audience/deviceless/forged tokens; revoked-device 401s on both schemes; ErrAuthUnavailable on DB faults (service + middleware 503); insert-failure abort; locked-keychain restore recovery; backup-token healing; config-401 survival on both restore paths.

## Docs

READMEs updated in this PR: product auth blurb, `/api/auth/refresh` route note, `CANTINARR_JWT_SECRET` env-var rows (now access-tokens-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)