### PR TITLE
Confirm before reassigning users pinned to a sibling instance

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -90,7 +90,7 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 - **Per-category preferences** -- request decisions, new movies, new episodes, and admin-only categories (new requests, issues, agent fixes), plus a test-push diagnostic.
 
 ### Settings
-- **Instances** (admin) -- add/edit all eight service types; test connections; set the global default (single-default invariant with takeover confirmation) or per-user default pins; assign users to a Chaptarr instance (the Books access grant); copy the per-instance **webhook URL** for Radarr/Sonarr > Connect.
+- **Instances** (admin) -- add/edit all eight service types; test connections; set the global default (single-default invariant with takeover confirmation) or per-user default pins; assign users to a Chaptarr instance (the Books access grant); assigning a user pinned to a sibling instance asks for confirmation before removing them from it; copy the per-instance **webhook URL** for Radarr/Sonarr > Connect.
 - **Users** (admin) -- roles, connect links / re-invites / device links, per-user password & passkey enablement (disabling is a real revoke), per-user request settings (tri-state inherit/on/off + default instances), test push.
 - **Request policy** (admin) -- global require-approval, season choice + default scope, quality choice + default profiles.
 - **Devices** (admin) -- every connected device with hardware model, last-seen, "This device" badge, and revoke.

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -360,6 +360,68 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
     return id;
   }
 
+  /// Selected users who are currently pinned to a sibling instance, grouped
+  /// by that sibling's name. Saving moves them off it — for Chaptarr that
+  /// also moves their Books access.
+  Map<String, List<String>> get _pendingUserMoves {
+    final moves = <String, List<String>>{};
+    for (final user in _users ?? const <UserSummary>[]) {
+      if (!_assignedUserIds.contains(user.id)) continue;
+      final pinnedTo = _pins[user.id];
+      if (pinnedTo == null || pinnedTo == widget.instanceId) continue;
+      moves.putIfAbsent(_instanceName(pinnedTo), () => []).add(user.username);
+    }
+    return moves;
+  }
+
+  static String _joinNames(List<String> names) {
+    if (names.length == 1) return names.first;
+    return '${names.sublist(0, names.length - 1).join(', ')} and ${names.last}';
+  }
+
+  /// Assigning a user who is pinned to a sibling instance removes them there
+  /// — spell out exactly who is removed from which instance, and let the
+  /// admin back out, before anything is saved.
+  Future<bool> _confirmUserMoves() async {
+    final moves = _pendingUserMoves;
+    if (moves.isEmpty) return true;
+    final newName = _nameController.text.trim();
+    final total = moves.values.fold<int>(0, (n, names) => n + names.length);
+    final String description;
+    if (moves.length == 1) {
+      final entry = moves.entries.first;
+      description = 'This removes ${_joinNames(entry.value)} from '
+          '"${entry.key}" and assigns them to "$newName".';
+    } else {
+      final lines = moves.entries
+          .map((e) => '• ${_joinNames(e.value)} — from "${e.key}"')
+          .join('\n');
+      description = 'This removes $total users from their current instances '
+          'and assigns them to "$newName":\n\n$lines';
+    }
+    final note = _isChaptarr
+        ? 'Their Books access will come from "$newName" instead.'
+        : 'Their requests and dashboard statuses will use "$newName" instead.';
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('Reassign $total user${total == 1 ? '' : 's'}?'),
+        content: Text('$description\n\n$note'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Reassign'),
+          ),
+        ],
+      ),
+    );
+    return confirmed == true;
+  }
+
   /// Per-user assignment: for Chaptarr this IS the access model (selected
   /// users get Books through this instance); for Radarr/Sonarr it pins the
   /// selected users to this instance as an override of the global default.
@@ -460,8 +522,6 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
     if (!await _confirmDefaultTakeover()) return;
     if (!mounted) return;
 
-    setState(() => _isSaving = true);
-
     // Chaptarr never carries the global default flag (the server enforces
     // this too); its instances are only assigned per user below.
     final isDefault = !_isChaptarr && _isDefault;
@@ -472,6 +532,12 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
         _users != null &&
         !_sameSelection(_assignedUserIds, _savedAssignedUserIds);
     final assignedIds = _assignedUserIds.toList()..sort();
+    // Pulling users off a sibling instance needs the same explicit sign-off
+    // as a default takeover.
+    if (applyAssignments && !await _confirmUserMoves()) return;
+    if (!mounted) return;
+
+    setState(() => _isSaving = true);
 
     try {
       final backendDio = ref.read(backendClientProvider);

--- a/app/test/settings/instance_edit_screen_test.dart
+++ b/app/test/settings/instance_edit_screen_test.dart
@@ -281,7 +281,27 @@ void main() {
 
     await tester.tap(find.widgetWithText(CheckboxListTile, 'bob'));
     await tester.pumpAndSettle();
+
+    // Moving bob off the sibling asks for confirmation naming who moves from
+    // where; cancelling aborts the save entirely.
     await tester.tap(find.widgetWithText(ElevatedButton, 'Save Changes'));
+    await tester.pumpAndSettle();
+    expect(find.text('Reassign 1 user?'), findsOneWidget);
+    expect(
+      find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.textContaining(
+              'removes bob from "Main Radarr" and assigns them to "Radarr B"')),
+      findsOneWidget,
+    );
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(adapter.requests.where((r) => r.method == 'PUT'), isEmpty);
+
+    // Confirming applies both the instance update and the reassignment.
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Save Changes'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reassign'));
     await tester.pumpAndSettle();
 
     expect(
@@ -293,6 +313,73 @@ void main() {
         (r) => r.method == 'PUT' && r.path == '/api/instances/radarr-b/users');
     expect(putUsers.body, {
       'user_ids': [2]
+    });
+  });
+
+  testWidgets('assigning a user pinned to a sibling Chaptarr instance confirms the move',
+      (tester) async {
+    final adapter = _FakeAdapter(
+      instances: [
+        {
+          'id': 'chaptarr-a',
+          'service_type': 'chaptarr',
+          'name': 'Books A',
+          'url': 'http://books-a',
+          'is_default': false,
+          'sort_order': 0,
+        },
+      ],
+      pins: [
+        {'user_id': 1, 'instance_id': 'chaptarr-a'},
+      ],
+    );
+    await _pumpEdit(tester,
+        adapter: adapter, users: [_user(1, 'alice'), _user(2, 'bob')]);
+
+    // Switch the service type to Chaptarr.
+    await tester.tap(find.text('Radarr'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Chaptarr').last);
+    await tester.pumpAndSettle();
+
+    await _fillForm(tester, 'Books B');
+    await tester.tap(find.widgetWithText(CheckboxListTile, 'alice'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Add Instance'));
+    await tester.pumpAndSettle();
+
+    // Alice is pinned to Books A, so creating must confirm the removal and
+    // spell out where her Books access lands; cancelling creates nothing.
+    expect(find.text('Reassign 1 user?'), findsOneWidget);
+    expect(
+      find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.textContaining(
+              'removes alice from "Books A" and assigns them to "Books B"')),
+      findsOneWidget,
+    );
+    expect(
+      find.descendant(
+          of: find.byType(AlertDialog),
+          matching: find.textContaining(
+              'Books access will come from "Books B" instead')),
+      findsOneWidget,
+    );
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+    expect(adapter.requests.where((r) => r.method == 'POST'), isEmpty);
+
+    // Confirming creates the instance and moves alice to it.
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Add Instance'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Reassign'));
+    await tester.pumpAndSettle();
+    final post = adapter.requests.singleWhere((r) => r.method == 'POST');
+    expect(post.body['service_type'], 'chaptarr');
+    final putUsers = adapter.requests.singleWhere((r) =>
+        r.method == 'PUT' && r.path == '/api/instances/chaptarr-new/users');
+    expect(putUsers.body, {
+      'user_ids': [1]
     });
   });
 }


### PR DESCRIPTION
## Summary

Assigning a user to an instance when they're already pinned to a **sibling instance** of the same service type used to move them silently — the server deletes their old pin as a side effect of the upsert, and for Chaptarr that pin *is* the Books access grant, so their access through the old instance vanished without warning.

The move itself is still the right behavior; what was missing was informed consent. Saving the instance editor now shows a confirmation dialog **before anything is written** when the new selection would pull users off a sibling instance:

- Names exactly who is removed from which instance and where they're being assigned (grouped by source instance when there's more than one).
- Adds a consequence line per service type: for Chaptarr, "Their Books access will come from X instead"; for Radarr/Sonarr, requests/dashboard statuses move.
- Cancel aborts the entire save (create or edit) — nothing is created, updated, or reassigned.

This mirrors the existing default-takeover confirmation on the same screen, and complements the per-tile "Currently assigned to …" hint that already existed.

## Changes

- `app/lib/features/settings/ui/instance_edit_screen.dart` — new `_pendingUserMoves` / `_confirmUserMoves()`; `_save()` computes the assignment delta before entering the saving state so the dialog can gate both the create and edit paths.
- `app/test/settings/instance_edit_screen_test.dart` — the existing radarr pin-move test now exercises the dialog (cancel aborts with zero PUTs; confirm applies), plus a new Chaptarr create-flow test asserting the dialog text and that cancel issues no POST.
- `app/README.md` — Instances settings bullet mentions the reassignment confirmation.

No server changes — the move semantics on the server are unchanged.

## Verification

- `flutter analyze --no-fatal-infos` — 16 pre-existing infos, identical count on the base branch; nothing new.
- `flutter test` — all 200 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)