### PR TITLE
Fix web-only TypeError on arr screens: dedupe proxied Content-Type

### DIFF
--- a/server/internal/proxy/handler.go
+++ b/server/internal/proxy/handler.go
@@ -58,5 +58,11 @@ func (h *Handler) proxyRequest(w http.ResponseWriter, r *http.Request, target *u
 			req.Header.Set("X-Api-Key", apiKey)
 		},
 	}
+	// The /api router pre-sets Content-Type: application/json on every
+	// response, and ReverseProxy appends the upstream's header rather than
+	// replacing it. Browsers merge the duplicates into a value Flutter web
+	// can't parse as JSON, so drop the default and let the upstream header
+	// through verbatim.
+	w.Header().Del("Content-Type")
 	proxy.ServeHTTP(w, r)
 }

--- a/server/internal/proxy/handler_test.go
+++ b/server/internal/proxy/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/windoze95/cantinarr-server/internal/db"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/secrets"
@@ -74,5 +75,60 @@ func TestInstanceProxyForwardsChaptarrLookup(t *testing.T) {
 	}
 	if !bytes.Contains(body, []byte("Dune")) {
 		t.Errorf("response not passed through verbatim: %s", body)
+	}
+}
+
+// TestInstanceProxySingleContentType guards against duplicated Content-Type
+// headers. The /api router pre-sets "application/json" on every response via
+// middleware.SetHeader, and ReverseProxy *appends* the upstream's own header
+// rather than replacing it. Browsers merge duplicates into
+// "application/json, application/json; charset=utf-8", which Dio on Flutter
+// web can't recognize as JSON — every arr screen in the web app then fails
+// with a TypeError while native clients (which pick one value) work fine.
+func TestInstanceProxySingleContentType(t *testing.T) {
+	const upstreamContentType = "application/json; charset=utf-8"
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", upstreamContentType)
+		_, _ = w.Write([]byte(`[{"title":"Attack of the Clones"}]`))
+	}))
+	defer upstream.Close()
+
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer database.Close()
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x42}, 32))
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	store := instance.NewStore(database, cipher)
+	inst := &instance.Instance{
+		ServiceType: "radarr",
+		Name:        "Movies",
+		URL:         upstream.URL,
+		APIKey:      "secret-key",
+	}
+	if err := store.Create(inst); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+
+	r := chi.NewRouter()
+	// Same default the real /api router applies to every response.
+	r.Use(middleware.SetHeader("Content-Type", "application/json"))
+	r.HandleFunc("/api/instances/{instanceID}/*", NewHandler(store).InstanceProxy())
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/instances/" + inst.ID + "/api/v3/movie")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	got := resp.Header.Values("Content-Type")
+	if len(got) != 1 || got[0] != upstreamContentType {
+		t.Errorf("Content-Type = %q, want exactly [%q]", got, upstreamContentType)
 	}
 }


### PR DESCRIPTION
## Problem

On the web app only, every arr screen served through the instance proxy failed with e.g.:

> Failed to load movies: TypeError: "[\n {\n \"title\": \"Star Wars: Episode II - Attack of the Clones\", ...

## Root cause

- The `/api` router pre-sets `Content-Type: application/json` on every response (`middleware.SetHeader`, `router.go`).
- `httputil.ReverseProxy` copies upstream headers with `Header.Add` (append, not replace), so proxied arr responses went out with **two** Content-Type headers: the router default plus the arr's own `application/json; charset=utf-8`.
- Native HTTP stacks (iOS/Android/desktop) surface one value, so Dio parsed JSON fine. Browsers merge duplicate headers into `application/json, application/json; charset=utf-8`, which Dio's mime-type check rejects — the body came back as a raw String and the `as List<dynamic>` cast threw the TypeError.

## Fix

Delete the router's pre-set Content-Type in the proxy handler before serving, so the upstream's header passes through verbatim (matching the proxy's verbatim-read contract).

## Testing

- New regression test `TestInstanceProxySingleContentType` applies the same `SetHeader` middleware as the real router and asserts exactly one Content-Type header — it failed with `["application/json" "application/json; charset=utf-8"]` before the fix, passes after.
- `go vet ./...` and `go test ./...` pass from `server/`.
- No app changes; no documented surface changed, so no doc updates needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)