### PR TITLE
Let users request their Plex invite from the guide

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -87,18 +87,18 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 
 ### Notifications (iOS)
 - **Native APNs push** via a `MethodChannel` -- no Firebase. Tokens register with the backend per device; taps deep-link to the right screen (detail page, approvals, issue thread...).
-- **Per-category preferences** -- request decisions, new movies, new episodes, and admin-only categories (new requests, issues, agent fixes), plus a test-push diagnostic.
+- **Per-category preferences** -- request decisions, new movies, new episodes, and admin-only categories (new requests, issues, agent fixes, Plex access requests), plus a test-push diagnostic.
 
 ### Settings
 - **Instances** (admin) -- add/edit all eight service types; test connections; set the global default (single-default invariant with takeover confirmation) or per-user default pins; assign users to a Chaptarr instance (the Books access grant); assigning a user pinned to a sibling instance asks for confirmation before removing them from it; copy the per-instance **webhook URL** for Radarr/Sonarr > Connect.
-- **Users** (admin) -- roles, connect links / re-invites / device links, per-user password & passkey enablement (disabling is a real revoke), per-user request settings (tri-state inherit/on/off + default instances), test push.
+- **Users** (admin) -- roles, connect links / re-invites / device links, per-user password & passkey enablement (disabling is a real revoke), per-user request settings (tri-state inherit/on/off + default instances), test push. Shows each user's shared Plex email with an **Invite in Plex…** action (copies the address, opens Plex's Manage Library Access page).
 - **Request policy** (admin) -- global require-approval, season choice + default scope, quality choice + default profiles.
 - **Devices** (admin) -- every connected device with hardware model, last-seen, "This device" badge, and revoke.
 - **Credentials** (admin, write-only) -- TMDB, Trakt, and AI provider keys + provider/model selection.
 - **AI tools** (admin) -- per-tool toggles for chat + MCP, and a one-hour debug-logging switch.
 - **AI remediation** (admin) -- master switch, auto-dispatch, reporting affordance, autonomy tier, provider/model, and run budgets.
 - **Notifications, Passkeys, Password** -- self-service (passkey/password screens appear when admin-enabled).
-- **Watch on Plex guide** -- requester-focused walkthrough (install the Plex app, sign in, accept the invite, start watching); hideable from the guide itself or via a Settings toggle that also removes it from the menu.
+- **Watch on Plex guide** -- requester-focused walkthrough (install the Plex app, sign in, accept the invite, start watching) with a **Request your invite** step: the user shares their Plex email and admins get a push pointing at the Users screen. Hideable from the guide itself or via a Settings toggle that also removes it from the menu.
 
 ### Auth
 - **Connect links** -- open one and the account connects instantly (`cantinarr://connect` deep links on iOS); passwordless by default with a long-lived, auto-refreshing session.

--- a/app/lib/core/models/user_profile.dart
+++ b/app/lib/core/models/user_profile.dart
@@ -14,6 +14,10 @@ class UserProfile {
   final bool passwordEnabled;
   final bool passkeyEnabled;
 
+  /// The email this user shared for their Plex server invite. Empty until
+  /// they submit one (from the Watch on Plex guide).
+  final String plexEmail;
+
   const UserProfile({
     required this.id,
     required this.username,
@@ -22,6 +26,7 @@ class UserProfile {
     this.hasPassword,
     this.passwordEnabled = false,
     this.passkeyEnabled = false,
+    this.plexEmail = '',
   });
 
   bool get isAdmin => role == 'admin';
@@ -44,9 +49,10 @@ class UserProfile {
         hasPassword: json['has_password'] as bool?,
         passwordEnabled: json['password_enabled'] as bool? ?? false,
         passkeyEnabled: json['passkey_enabled'] as bool? ?? false,
+        plexEmail: json['plex_email'] as String? ?? '',
       );
 
-  UserProfile copyWith({bool? hasPassword}) => UserProfile(
+  UserProfile copyWith({bool? hasPassword, String? plexEmail}) => UserProfile(
         id: id,
         username: username,
         role: role,
@@ -54,6 +60,7 @@ class UserProfile {
         hasPassword: hasPassword ?? this.hasPassword,
         passwordEnabled: passwordEnabled,
         passkeyEnabled: passkeyEnabled,
+        plexEmail: plexEmail ?? this.plexEmail,
       );
 
   Map<String, dynamic> toJson() => {
@@ -64,5 +71,6 @@ class UserProfile {
         if (hasPassword != null) 'has_password': hasPassword,
         'password_enabled': passwordEnabled,
         'passkey_enabled': passkeyEnabled,
+        'plex_email': plexEmail,
       };
 }

--- a/app/lib/features/auth/data/auth_service.dart
+++ b/app/lib/features/auth/data/auth_service.dart
@@ -115,6 +115,21 @@ class AuthService {
     );
   }
 
+  /// Share or update the email the user wants their Plex invite sent to.
+  /// The server notifies admins when the address is new or changed.
+  Future<void> setPlexEmail(
+    String serverUrl,
+    String accessToken,
+    String email,
+  ) async {
+    final dio = _createDio(serverUrl);
+    await dio.post(
+      '/api/auth/plex-email',
+      data: {'email': email},
+      options: Options(headers: {'Authorization': 'Bearer $accessToken'}),
+    );
+  }
+
   /// Fetch server configuration (TMDB key, available services, etc.).
   Future<ServerConfig> fetchConfig(
     String serverUrl,
@@ -421,6 +436,9 @@ class UserSummary {
   final bool passkeyEnabled;
   final bool hasPendingInvite;
 
+  /// The email this user shared for their Plex server invite ('' = none yet).
+  final String plexEmail;
+
   const UserSummary({
     required this.id,
     required this.username,
@@ -432,6 +450,7 @@ class UserSummary {
     required this.passwordEnabled,
     required this.passkeyEnabled,
     required this.hasPendingInvite,
+    this.plexEmail = '',
   });
 
   bool get isAdmin => role == 'admin';
@@ -450,6 +469,7 @@ class UserSummary {
         passwordEnabled: json['password_enabled'] as bool? ?? false,
         passkeyEnabled: json['passkey_enabled'] as bool? ?? false,
         hasPendingInvite: json['has_pending_invite'] as bool? ?? false,
+        plexEmail: json['plex_email'] as String? ?? '',
       );
 }
 

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -625,6 +625,22 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     }
   }
 
+  /// Share or update the email this user wants their Plex invite sent to.
+  /// The server notifies admins when the address is new or changed.
+  Future<void> setPlexEmail(String email) async {
+    final current = state.valueOrNull;
+    final conn = current?.connection;
+    if (current == null || conn == null) throw Exception('Not authenticated');
+    final trimmed = email.trim();
+    await _authService.setPlexEmail(conn.serverUrl, conn.accessToken, trimmed);
+    final user = current.user;
+    if (user != null) {
+      state = AsyncData(
+        current.copyWith(user: user.copyWith(plexEmail: trimmed)),
+      );
+    }
+  }
+
   /// Generate a connect link for a new user (admin only).
   Future<ConnectTokenResponse> generateConnectToken(String name) async {
     final conn = state.valueOrNull?.connection;

--- a/app/lib/features/notifications/notification_prefs.dart
+++ b/app/lib/features/notifications/notification_prefs.dart
@@ -1,16 +1,27 @@
 /// A user's push-notification preferences. Each flag toggles one category of
 /// push notification the server may send to this user's devices.
+///
+/// IMPORTANT: the server's PUT replaces the full preference row, treating
+/// missing keys as false — so this model must carry EVERY category the server
+/// knows (including admin-only ones), or saving any toggle silently disables
+/// the omitted categories.
 class NotificationPrefs {
   final bool requestDecision;
   final bool requestPending;
   final bool newMovie;
   final bool newEpisode;
+  final bool issueCreated;
+  final bool agentActionPending;
+  final bool plexAccessRequest;
 
   const NotificationPrefs({
     required this.requestDecision,
     required this.requestPending,
     required this.newMovie,
     required this.newEpisode,
+    this.issueCreated = true,
+    this.agentActionPending = true,
+    this.plexAccessRequest = true,
   });
 
   factory NotificationPrefs.fromJson(Map<String, dynamic> json) =>
@@ -19,6 +30,11 @@ class NotificationPrefs {
         requestPending: json['request_pending'] as bool? ?? false,
         newMovie: json['new_movie'] as bool? ?? false,
         newEpisode: json['new_episode'] as bool? ?? false,
+        // Admin categories default on server-side; mirror that when a key is
+        // absent (e.g. an older server).
+        issueCreated: json['issue_created'] as bool? ?? true,
+        agentActionPending: json['agent_action_pending'] as bool? ?? true,
+        plexAccessRequest: json['plex_access_request'] as bool? ?? true,
       );
 
   Map<String, dynamic> toJson() => {
@@ -26,6 +42,9 @@ class NotificationPrefs {
         'request_pending': requestPending,
         'new_movie': newMovie,
         'new_episode': newEpisode,
+        'issue_created': issueCreated,
+        'agent_action_pending': agentActionPending,
+        'plex_access_request': plexAccessRequest,
       };
 
   NotificationPrefs copyWith({
@@ -33,11 +52,17 @@ class NotificationPrefs {
     bool? requestPending,
     bool? newMovie,
     bool? newEpisode,
+    bool? issueCreated,
+    bool? agentActionPending,
+    bool? plexAccessRequest,
   }) =>
       NotificationPrefs(
         requestDecision: requestDecision ?? this.requestDecision,
         requestPending: requestPending ?? this.requestPending,
         newMovie: newMovie ?? this.newMovie,
         newEpisode: newEpisode ?? this.newEpisode,
+        issueCreated: issueCreated ?? this.issueCreated,
+        agentActionPending: agentActionPending ?? this.agentActionPending,
+        plexAccessRequest: plexAccessRequest ?? this.plexAccessRequest,
       );
 }

--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -136,6 +136,10 @@ class PushService {
       case 'agent_action_pending':
         // A fix needs approval — go straight to the agent approval queue.
         router.push('/agent-actions');
+      case 'plex_access_request':
+        // A user shared their Plex email — the Users screen shows it with the
+        // "Invite in Plex" action.
+        router.push('/settings/users');
       case 'remediation_autodispatch_disabled':
         // The circuit breaker turned auto-dispatch off — open the settings the
         // admin uses to re-enable it.

--- a/app/lib/features/notifications/ui/notification_preferences_screen.dart
+++ b/app/lib/features/notifications/ui/notification_preferences_screen.dart
@@ -187,13 +187,34 @@ class _NotificationPreferencesScreenState
           value: prefs.requestDecision,
           onChanged: (v) => _save(prefs.copyWith(requestDecision: v), prefs),
         ),
-        if (isAdmin)
+        if (isAdmin) ...[
           _toggle(
             title: 'New requests to review',
             subtitle: 'When someone submits a request needing approval',
             value: prefs.requestPending,
             onChanged: (v) => _save(prefs.copyWith(requestPending: v), prefs),
           ),
+          _toggle(
+            title: 'Problem reports',
+            subtitle: 'When someone reports a problem with their media',
+            value: prefs.issueCreated,
+            onChanged: (v) => _save(prefs.copyWith(issueCreated: v), prefs),
+          ),
+          _toggle(
+            title: 'Fixes awaiting approval',
+            subtitle: 'When the assistant proposes a fix that needs approval',
+            value: prefs.agentActionPending,
+            onChanged: (v) =>
+                _save(prefs.copyWith(agentActionPending: v), prefs),
+          ),
+          _toggle(
+            title: 'Plex access requests',
+            subtitle: 'When someone shares their Plex email for an invite',
+            value: prefs.plexAccessRequest,
+            onChanged: (v) =>
+                _save(prefs.copyWith(plexAccessRequest: v), prefs),
+          ),
+        ],
         _toggle(
           title: 'New movie available',
           subtitle: 'When a movie finishes downloading',

--- a/app/lib/features/settings/ui/users_screen.dart
+++ b/app/lib/features/settings/ui/users_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/data/auth_service.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -44,6 +45,27 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
         _isLoading = false;
       });
     }
+  }
+
+  /// Copies the user's Plex email and opens Plex's Manage Library Access page,
+  /// where the admin pastes it into Grant Library Access. Plex offers no way
+  /// to prefill the invite, so copy-then-paste is the fastest honest flow.
+  Future<void> _inviteInPlex(UserSummary user) async {
+    await Clipboard.setData(ClipboardData(text: user.plexEmail));
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Copied ${user.plexEmail} — paste it into Grant Library Access',
+          ),
+        ),
+      );
+    }
+    await launchUrl(
+      Uri.parse(
+          'https://app.plex.tv/desktop/#!/settings/manage-library-access'),
+      mode: LaunchMode.externalApplication,
+    );
   }
 
   Future<void> _changeRole(UserSummary user, String newRole) async {
@@ -328,6 +350,7 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
             onDelete: () => _deleteUser(user),
             onResendInvite: () => _resendInvite(user),
             onSendTestPush: () => _sendTestPush(user),
+            onInviteInPlex: () => _inviteInPlex(user),
             onRequestSettings: () => context.push(
               '/settings/users/${user.id}/request-settings',
               extra: user.username,
@@ -353,6 +376,7 @@ class _UserTile extends StatelessWidget {
     required this.onDelete,
     required this.onResendInvite,
     required this.onSendTestPush,
+    required this.onInviteInPlex,
     required this.onSetAuthMethods,
     required this.onRequestSettings,
   });
@@ -363,6 +387,7 @@ class _UserTile extends StatelessWidget {
   final VoidCallback onDelete;
   final VoidCallback onResendInvite;
   final VoidCallback onSendTestPush;
+  final VoidCallback onInviteInPlex;
   final void Function({bool? passwordEnabled, bool? passkeyEnabled})
       onSetAuthMethods;
   final VoidCallback onRequestSettings;
@@ -428,6 +453,8 @@ class _UserTile extends StatelessWidget {
               const _Tag(label: 'Password', color: AppTheme.textSecondary),
             if (user.passkeyEnabled)
               const _Tag(label: 'Passkey', color: AppTheme.textSecondary),
+            if (user.plexEmail.isNotEmpty)
+              _Tag(label: user.plexEmail, color: AppTheme.textSecondary),
           ],
         ),
       ),
@@ -451,6 +478,9 @@ class _UserTile extends StatelessWidget {
             break;
           case 'test_push':
             onSendTestPush();
+            break;
+          case 'invite_in_plex':
+            onInviteInPlex();
             break;
           case 'request_settings':
             onRequestSettings();
@@ -494,6 +524,17 @@ class _UserTile extends StatelessWidget {
                     ? 'New invite link'
                     : (_needsInvite ? 'Re-invite' : 'Issue device link'),
               ),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+        // The user shared their Plex email: copy it and jump to Plex's
+        // sharing settings to send the actual invite.
+        if (user.plexEmail.isNotEmpty)
+          const PopupMenuItem(
+            value: 'invite_in_plex',
+            child: ListTile(
+              leading: Icon(Icons.play_circle_outline),
+              title: Text('Invite in Plex…'),
               contentPadding: EdgeInsets.zero,
             ),
           ),

--- a/app/lib/features/setup_wizard/ui/plex_watch_guide.dart
+++ b/app/lib/features/setup_wizard/ui/plex_watch_guide.dart
@@ -3,14 +3,33 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/storage/preferences.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../auth/logic/auth_provider.dart';
 
-/// Requester-focused guide: install Plex, connect to the shared server,
-/// and start watching. Hideable via [plexGuideEnabledProvider].
-class PlexWatchGuide extends ConsumerWidget {
+/// Requester-focused guide: install Plex, request a server invite with your
+/// Plex email, and start watching. Hideable via [plexGuideEnabledProvider].
+class PlexWatchGuide extends ConsumerStatefulWidget {
   const PlexWatchGuide({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<PlexWatchGuide> createState() => _PlexWatchGuideState();
+}
+
+class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
+  @override
+  void initState() {
+    super.initState();
+    // The Plex email may have been shared from another device; re-fetch so the
+    // invite section reflects it.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(authProvider.notifier).refreshUser();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final plexEmail =
+        ref.watch(authProvider).valueOrNull?.user?.plexEmail ?? '';
+
     return Scaffold(
       appBar: AppBar(title: const Text('Watch on Plex')),
       body: ListView(
@@ -43,22 +62,23 @@ class PlexWatchGuide extends ConsumerWidget {
             steps: [
               'Open the app and create a free Plex account, or sign in if you already have one',
               'The free account is all you need — no Plex Pass subscription required',
-              'Make sure your server admin knows the email you signed up with, so they can share the library with you',
             ],
           ),
           const SizedBox(height: 24),
+          _buildInviteSection(plexEmail),
+          const SizedBox(height: 24),
           const _GuideSection(
-            number: 3,
+            number: 4,
             title: 'Accept your invite',
             steps: [
-              'Your server admin will send an invite to your email — open it and tap Accept',
+              'Your server admin sends the invite to that email — open it and tap Accept',
               'You can also find pending invites under the bell icon at app.plex.tv',
               'This is a one-time step: the shared libraries stay linked to your account',
             ],
           ),
           const SizedBox(height: 24),
           const _GuideSection(
-            number: 4,
+            number: 5,
             title: 'Start watching',
             steps: [
               'Open Plex on any device you\'re signed in to — the shared movie and TV libraries appear automatically',
@@ -94,6 +114,234 @@ class PlexWatchGuide extends ConsumerWidget {
       ),
     );
   }
+
+  /// Step 3: the interactive part. Shares the user's Plex email with the
+  /// server so admins get notified and can send the invite from Plex.
+  Widget _buildInviteSection(String plexEmail) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const _SectionHeader(number: 3, title: 'Request your invite'),
+        const SizedBox(height: 12),
+        Padding(
+          padding: const EdgeInsets.only(left: 44),
+          child: Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: AppTheme.accent.withValues(alpha: 0.08),
+              borderRadius: BorderRadius.circular(12),
+              border:
+                  Border.all(color: AppTheme.accent.withValues(alpha: 0.2)),
+            ),
+            child: plexEmail.isEmpty
+                ? Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'Tell your server admin where to send your Plex '
+                        'invite. They\'ll get a notification with your email.',
+                        style: TextStyle(
+                          color: AppTheme.textSecondary,
+                          fontSize: 14,
+                          height: 1.4,
+                        ),
+                      ),
+                      const SizedBox(height: 12),
+                      ElevatedButton.icon(
+                        onPressed: () => _showEmailDialog(current: plexEmail),
+                        icon: const Icon(Icons.mail_outline, size: 18),
+                        label: const Text('Share my Plex email'),
+                      ),
+                    ],
+                  )
+                : Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          const Icon(Icons.check_circle,
+                              color: AppTheme.available, size: 18),
+                          const SizedBox(width: 8),
+                          Expanded(
+                            child: Text(
+                              plexEmail,
+                              style: const TextStyle(
+                                color: AppTheme.textPrimary,
+                                fontWeight: FontWeight.w500,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 8),
+                      const Text(
+                        'Your admin has been notified — the invite will '
+                        'arrive at this address.',
+                        style: TextStyle(
+                          color: AppTheme.textSecondary,
+                          fontSize: 13,
+                          height: 1.4,
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: () => _showEmailDialog(current: plexEmail),
+                        style: TextButton.styleFrom(
+                          padding: EdgeInsets.zero,
+                          minimumSize: const Size(0, 32),
+                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        ),
+                        child: const Text('Change email'),
+                      ),
+                    ],
+                  ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _showEmailDialog({required String current}) {
+    final controller = TextEditingController(text: current);
+    String? errorText;
+    bool saving = false;
+
+    // Mirrors the server's shape check: something@something, no whitespace.
+    bool looksLikeEmail(String email) {
+      if (email.isEmpty || email.length > 254 || email.contains(RegExp(r'\s'))) {
+        return false;
+      }
+      final at = email.indexOf('@');
+      return at > 0 && at < email.length - 1;
+    }
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (context, setDialogState) {
+          Future<void> submit() async {
+            final email = controller.text.trim();
+            if (!looksLikeEmail(email)) {
+              setDialogState(() => errorText = 'Enter a valid email address');
+              return;
+            }
+            setDialogState(() {
+              saving = true;
+              errorText = null;
+            });
+            try {
+              await ref.read(authProvider.notifier).setPlexEmail(email);
+              if (dialogContext.mounted) {
+                Navigator.of(dialogContext).pop();
+              }
+              if (mounted) {
+                ScaffoldMessenger.of(this.context).showSnackBar(const SnackBar(
+                  content: Text('Thanks! Your admin has been notified.'),
+                ));
+              }
+            } catch (_) {
+              setDialogState(() {
+                saving = false;
+                errorText = 'Couldn\'t send — check your connection';
+              });
+            }
+          }
+
+          return AlertDialog(
+            title: const Text('Your Plex email'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const Text(
+                  'Enter the email of your Plex account. Your server admin '
+                  'sends the invite there.',
+                  style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+                ),
+                const SizedBox(height: 12),
+                TextField(
+                  controller: controller,
+                  enabled: !saving,
+                  autofocus: true,
+                  keyboardType: TextInputType.emailAddress,
+                  autocorrect: false,
+                  textInputAction: TextInputAction.done,
+                  decoration: InputDecoration(
+                    labelText: 'Email',
+                    hintText: 'you@example.com',
+                    prefixIcon: const Icon(Icons.mail_outline),
+                    errorText: errorText,
+                  ),
+                  onSubmitted: (_) => submit(),
+                ),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: saving
+                    ? null
+                    : () => Navigator.of(dialogContext).pop(),
+                child: const Text('Cancel'),
+              ),
+              ElevatedButton(
+                onPressed: saving ? null : submit,
+                child: saving
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Send'),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+/// Numbered section header: the accent number bubble plus the section title.
+class _SectionHeader extends StatelessWidget {
+  final int number;
+  final String title;
+
+  const _SectionHeader({required this.number, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Container(
+          width: 32,
+          height: 32,
+          decoration: BoxDecoration(
+            color: AppTheme.accent.withValues(alpha: 0.15),
+            shape: BoxShape.circle,
+          ),
+          child: Center(
+            child: Text(
+              '$number',
+              style: const TextStyle(
+                color: AppTheme.accent,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            title,
+            style: const TextStyle(
+              color: AppTheme.textPrimary,
+              fontSize: 18,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
 }
 
 class _GuideSection extends StatelessWidget {
@@ -112,38 +360,7 @@ class _GuideSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          children: [
-            Container(
-              width: 32,
-              height: 32,
-              decoration: BoxDecoration(
-                color: AppTheme.accent.withValues(alpha: 0.15),
-                shape: BoxShape.circle,
-              ),
-              child: Center(
-                child: Text(
-                  '$number',
-                  style: const TextStyle(
-                    color: AppTheme.accent,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text(
-                title,
-                style: const TextStyle(
-                  color: AppTheme.textPrimary,
-                  fontSize: 18,
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ),
-          ],
-        ),
+        _SectionHeader(number: number, title: title),
         const SizedBox(height: 12),
         ...steps.map((step) => Padding(
               padding: const EdgeInsets.only(left: 44, bottom: 8),

--- a/server/README.md
+++ b/server/README.md
@@ -114,6 +114,7 @@ POST   /api/auth/passkey/login/begin|finish   # public: WebAuthn login
 POST   /api/auth/passkey/setup/begin|finish   # public: passkey setup via short-lived link
 GET    /api/auth/me                        # user: profile + permissions
 POST   /api/auth/password                  # user: set password (admin-enabled users only)
+POST   /api/auth/plex-email                # user: share the email for a Plex invite (notifies admins on change)
 POST   /api/auth/passkey/register/begin|finish  # user: add passkey (admin-enabled only)
 POST   /api/auth/passkey/setup-link        # user: mint a browser passkey-setup URL
 GET    /api/auth/passkeys                  # user: list own passkeys
@@ -251,7 +252,7 @@ WebSocket events:
 - `request_status_changed` -- `{ tmdb_id, media_type, status }` (queue polling **and** arr webhooks; status here is `available`, `partially_available`, `requested`, or `unavailable` -- note the longer spelling vs the REST `partial`)
 - `downloads_queue` -- full download-client queue snapshot `{ instance_id, paused, speed_bps, items }`, sent on change
 - `arr_queue_changed` -- `{ instance_id, service_type }` invalidation ping; clients refetch via REST
-- targeted events fanned out per user/admin: `request_pending`, `request_decision`, `issue_created`, `issue_updated`, `agent_action_pending`, `agent_action_decided`, `remediation_autodispatch_disabled`
+- targeted events fanned out per user/admin: `request_pending`, `request_decision`, `issue_created`, `issue_updated`, `agent_action_pending`, `agent_action_decided`, `remediation_autodispatch_disabled`, `plex_access_request`
 
 ## Architecture
 
@@ -323,8 +324,9 @@ Notification categories (per-user preferences; admin-scoped ones are enforced in
 | `new_episode` | on | everyone | new episode(s) import for a series |
 | `issue_created` | on | admins | a problem is reported/detected |
 | `agent_action_pending` | on | admins | the agent proposed a fix needing approval |
+| `plex_access_request` | on | admins | a user shared their Plex email for a server invite (collapse-keyed per user) |
 
-Bodies are server-authored templates (untrusted text never hits the lock screen), sends are fire-and-forget with a 30s timeout, a 10-minute in-process dedupe window absorbs the overlap between queue polling and webhooks, and tokens the gateway reports dead are pruned automatically. Payloads carry deep-link data (`type`, `tmdb_id`/`issue_id`) the app routes on tap.
+Bodies are server-authored templates (untrusted text never hits the lock screen), sends are fire-and-forget with a 30s timeout, a 10-minute in-process dedupe window absorbs the overlap between queue polling and webhooks, and tokens the gateway reports dead are pruned automatically. Payloads carry deep-link data (`type`, `tmdb_id`/`issue_id`/`user_id`) the app routes on tap.
 
 ### MCP server endpoint
 

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -168,6 +168,9 @@ func main() {
 	} else {
 		notifier = push.NewComposite(wsHub)
 	}
+	// The auth handler notifies admins when a user shares their Plex email
+	// (plex_access_request); wired late because the composite needs the hub.
+	authHandler.SetNotifier(notifier)
 	requestService := request.NewService(database, registry, bridge, notifier)
 	requestHandler := request.NewHandler(requestService)
 

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -120,6 +120,7 @@ func NewRouter(
 				r.Use(authService.AuthMiddleware)
 				r.Get("/me", authHandler.Me)
 				r.With(authLimiter.Middleware).Post("/password", authHandler.SetPassword)
+				r.With(authLimiter.Middleware).Post("/plex-email", authHandler.SetPlexEmail)
 
 				// Passkey registration (authenticated)
 				r.Post("/passkey/register/begin", authHandler.BeginPasskeyRegistration)

--- a/server/internal/auth/handler.go
+++ b/server/internal/auth/handler.go
@@ -10,12 +10,27 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// AdminNotifier is the notification fan-out the handler uses for admin-scoped
+// events (currently only "plex_access_request"). Declared here so auth stays
+// free of a push dependency; *push.Composite satisfies it.
+type AdminNotifier interface {
+	NotifyAdmins(eventType string, data map[string]interface{})
+}
+
 type Handler struct {
-	service *Service
+	service  *Service
+	notifier AdminNotifier
 }
 
 func NewHandler(service *Service) *Handler {
 	return &Handler{service: service}
+}
+
+// SetNotifier wires the admin notification fan-out after construction: the
+// composite is built later in startup than the auth handler (it needs the
+// WebSocket hub, which needs this handler's service).
+func (h *Handler) SetNotifier(n AdminNotifier) {
+	h.notifier = n
 }
 
 func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
@@ -331,6 +346,7 @@ func (h *Handler) Me(w http.ResponseWriter, r *http.Request) {
 		"has_password":     user.PasswordHash != "",
 		"password_enabled": user.PasswordEnabled,
 		"passkey_enabled":  user.PasskeyEnabled,
+		"plex_email":       user.PlexEmail,
 	})
 }
 
@@ -363,6 +379,45 @@ func (h *Handler) SetPassword(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		}
 		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// SetPlexEmail stores the email the authenticated user wants their Plex invite
+// sent to, and — when the address is new or changed — notifies admins so they
+// can send the invite from Plex.
+func (h *Handler) SetPlexEmail(w http.ResponseWriter, r *http.Request) {
+	claims := GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+
+	var req SetPlexEmailRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+
+	changed, err := h.service.SetPlexEmail(claims.UserID, req.Email)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrInvalidPlexEmail):
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "enter a valid email address"})
+		case errors.Is(err, ErrUserNotFound):
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "user not found"})
+		default:
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
+		}
+		return
+	}
+
+	if changed && h.notifier != nil {
+		h.notifier.NotifyAdmins("plex_access_request", map[string]interface{}{
+			"user_id":  claims.UserID,
+			"username": claims.Username,
+		})
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})

--- a/server/internal/auth/models.go
+++ b/server/internal/auth/models.go
@@ -11,9 +11,12 @@ type User struct {
 	// PasswordEnabled / PasskeyEnabled are admin-controlled policy: whether the
 	// account may create a password / register a passkey. Both default off for
 	// new users so the default sign-in is a connect link.
-	PasswordEnabled bool      `json:"password_enabled"`
-	PasskeyEnabled  bool      `json:"passkey_enabled"`
-	CreatedAt       time.Time `json:"created_at"`
+	PasswordEnabled bool `json:"password_enabled"`
+	PasskeyEnabled  bool `json:"passkey_enabled"`
+	// PlexEmail is the email the user shared so an admin can invite them to
+	// the Plex server. Empty until the user submits one.
+	PlexEmail string    `json:"plex_email"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // UserSummary is an enriched view of a user for admin user-management screens.
@@ -30,6 +33,7 @@ type UserSummary struct {
 	PasswordEnabled  bool         `json:"password_enabled"`
 	PasskeyEnabled   bool         `json:"passkey_enabled"`
 	HasPendingInvite bool         `json:"has_pending_invite"`
+	PlexEmail        string       `json:"plex_email"`
 }
 
 // UpdateUserRoleRequest changes a user's role.
@@ -117,6 +121,12 @@ type SetupRequest struct {
 // SetPasswordRequest sets or replaces the authenticated user's password.
 type SetPasswordRequest struct {
 	Password string `json:"password"`
+}
+
+// SetPlexEmailRequest sets or replaces the email the authenticated user wants
+// their Plex invite sent to.
+type SetPlexEmailRequest struct {
+	Email string `json:"email"`
 }
 
 type AuthStatusResponse struct {

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -39,6 +39,7 @@ var (
 	ErrPasswordNotAllowed   = errors.New("password sign-in is not enabled for this account")
 	ErrPasskeyNotAllowed    = errors.New("passkeys are not enabled for this account")
 	ErrCannotModifyAdmin    = errors.New("cannot change sign-in methods for an admin")
+	ErrInvalidPlexEmail     = errors.New("invalid email address")
 	// ErrAuthUnavailable marks a failure to *evaluate* credentials (DB error,
 	// signing error) as opposed to a rejection of them. Handlers must map it to
 	// a 5xx, never a 401: clients treat a 401 as "this session is dead" and
@@ -315,6 +316,44 @@ func (s *Service) SetPassword(userID int64, newPassword string) error {
 		return fmt.Errorf("update password: %w", err)
 	}
 	return nil
+}
+
+// SetPlexEmail stores the email the user wants their Plex invite sent to and
+// reports whether it actually changed, so callers can skip re-notifying admins
+// when a user resubmits the same address. Validation is deliberately shallow
+// (shape + length): the address is only ever displayed to an admin who pastes
+// it into Plex, never used for delivery by us.
+func (s *Service) SetPlexEmail(userID int64, email string) (bool, error) {
+	email = strings.TrimSpace(email)
+	if !plexEmailValid(email) {
+		return false, ErrInvalidPlexEmail
+	}
+
+	user, err := s.getUserByID(userID)
+	if err != nil {
+		return false, ErrUserNotFound
+	}
+	if user.PlexEmail == email {
+		return false, nil
+	}
+
+	if _, err := s.db.Exec(
+		"UPDATE users SET plex_email = ? WHERE id = ?",
+		email, userID,
+	); err != nil {
+		return false, fmt.Errorf("update plex email: %w", err)
+	}
+	return true, nil
+}
+
+// plexEmailValid is a shape check, not RFC validation: something@something
+// with no spaces, short enough for a users-table column.
+func plexEmailValid(email string) bool {
+	if email == "" || len(email) > 254 || strings.ContainsAny(email, " \t\n") {
+		return false
+	}
+	at := strings.Index(email, "@")
+	return at > 0 && at < len(email)-1
 }
 
 // Refresh exchanges a refresh token for a fresh access token. This is the one
@@ -655,6 +694,7 @@ func (s *Service) ListUsers() ([]UserSummary, error) {
 			u.password_hash != '' AS has_password,
 			u.password_enabled,
 			u.passkey_enabled,
+			u.plex_email,
 			(SELECT COUNT(*) FROM devices d WHERE d.user_id = u.id AND d.revoked_at IS NULL) AS device_count,
 			EXISTS(
 				SELECT 1 FROM connect_tokens ct
@@ -673,7 +713,7 @@ func (s *Service) ListUsers() ([]UserSummary, error) {
 		var u UserSummary
 		if err := rows.Scan(
 			&u.ID, &u.Username, &u.Role, &u.CreatedAt,
-			&u.HasPassword, &u.PasswordEnabled, &u.PasskeyEnabled,
+			&u.HasPassword, &u.PasswordEnabled, &u.PasskeyEnabled, &u.PlexEmail,
 			&u.DeviceCount, &u.HasPendingInvite,
 		); err != nil {
 			return nil, fmt.Errorf("scan user: %w", err)
@@ -843,6 +883,7 @@ func (s *Service) userSummaryByID(userID int64) (*UserSummary, error) {
 			u.password_hash != '' AS has_password,
 			u.password_enabled,
 			u.passkey_enabled,
+			u.plex_email,
 			(SELECT COUNT(*) FROM devices d WHERE d.user_id = u.id AND d.revoked_at IS NULL) AS device_count,
 			EXISTS(
 				SELECT 1 FROM connect_tokens ct
@@ -852,7 +893,7 @@ func (s *Service) userSummaryByID(userID int64) (*UserSummary, error) {
 		WHERE u.id = ?
 	`, time.Now(), userID).Scan(
 		&u.ID, &u.Username, &u.Role, &u.CreatedAt,
-		&u.HasPassword, &u.PasswordEnabled, &u.PasskeyEnabled,
+		&u.HasPassword, &u.PasswordEnabled, &u.PasskeyEnabled, &u.PlexEmail,
 		&u.DeviceCount, &u.HasPendingInvite,
 	)
 	if err != nil {
@@ -1012,8 +1053,8 @@ func userWithPermissions(user *User) User {
 func (s *Service) getUserByUsername(username string) (*User, error) {
 	var user User
 	err := s.db.QueryRow(
-		"SELECT id, username, password_hash, role, password_enabled, passkey_enabled, created_at FROM users WHERE username = ?", username,
-	).Scan(&user.ID, &user.Username, &user.PasswordHash, &user.Role, &user.PasswordEnabled, &user.PasskeyEnabled, &user.CreatedAt)
+		"SELECT id, username, password_hash, role, password_enabled, passkey_enabled, plex_email, created_at FROM users WHERE username = ?", username,
+	).Scan(&user.ID, &user.Username, &user.PasswordHash, &user.Role, &user.PasswordEnabled, &user.PasskeyEnabled, &user.PlexEmail, &user.CreatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -1023,8 +1064,8 @@ func (s *Service) getUserByUsername(username string) (*User, error) {
 func (s *Service) getUserByID(id int64) (*User, error) {
 	var user User
 	err := s.db.QueryRow(
-		"SELECT id, username, password_hash, role, password_enabled, passkey_enabled, created_at FROM users WHERE id = ?", id,
-	).Scan(&user.ID, &user.Username, &user.PasswordHash, &user.Role, &user.PasswordEnabled, &user.PasskeyEnabled, &user.CreatedAt)
+		"SELECT id, username, password_hash, role, password_enabled, passkey_enabled, plex_email, created_at FROM users WHERE id = ?", id,
+	).Scan(&user.ID, &user.Username, &user.PasswordHash, &user.Role, &user.PasswordEnabled, &user.PasskeyEnabled, &user.PlexEmail, &user.CreatedAt)
 	if err != nil {
 		return nil, err
 	}

--- a/server/internal/auth/service_test.go
+++ b/server/internal/auth/service_test.go
@@ -453,6 +453,89 @@ func TestSetPassword_RequiresEnabled(t *testing.T) {
 	}
 }
 
+func TestSetPlexEmail_StoresTrimsAndReportsChange(t *testing.T) {
+	svc := setupTestService(t)
+	guestID := inviteGuest(t, svc)
+
+	changed, err := svc.SetPlexEmail(guestID, "  pirate@example.com ")
+	if err != nil {
+		t.Fatalf("set plex email: %v", err)
+	}
+	if !changed {
+		t.Fatal("first submission should report changed")
+	}
+
+	user, err := svc.GetUser(guestID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if user.PlexEmail != "pirate@example.com" {
+		t.Fatalf("expected trimmed email, got %q", user.PlexEmail)
+	}
+
+	// Resubmitting the same address is a no-op so admins aren't re-notified.
+	changed, err = svc.SetPlexEmail(guestID, "pirate@example.com")
+	if err != nil {
+		t.Fatalf("resubmit plex email: %v", err)
+	}
+	if changed {
+		t.Fatal("identical resubmission should not report changed")
+	}
+
+	// A different address is a change again, and shows up in ListUsers.
+	changed, err = svc.SetPlexEmail(guestID, "corsair@example.com")
+	if err != nil || !changed {
+		t.Fatalf("expected changed update, got changed=%v err=%v", changed, err)
+	}
+	users, err := svc.ListUsers()
+	if err != nil {
+		t.Fatalf("list users: %v", err)
+	}
+	found := false
+	for _, u := range users {
+		if u.ID == guestID {
+			found = true
+			if u.PlexEmail != "corsair@example.com" {
+				t.Fatalf("ListUsers plex email = %q", u.PlexEmail)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("guest missing from ListUsers")
+	}
+}
+
+func TestSetPlexEmail_RejectsInvalid(t *testing.T) {
+	svc := setupTestService(t)
+	guestID := inviteGuest(t, svc)
+
+	for _, bad := range []string{
+		"",
+		"   ",
+		"no-at-sign",
+		"@nothing-before",
+		"nothing-after@",
+		"has space@example.com",
+		strings.Repeat("a", 250) + "@example.com",
+	} {
+		if _, err := svc.SetPlexEmail(guestID, bad); err != ErrInvalidPlexEmail {
+			t.Fatalf("email %q: expected ErrInvalidPlexEmail, got %v", bad, err)
+		}
+	}
+
+	user, err := svc.GetUser(guestID)
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	if user.PlexEmail != "" {
+		t.Fatalf("rejected emails must not be stored, got %q", user.PlexEmail)
+	}
+
+	if _, err := svc.SetPlexEmail(999999, "ok@example.com"); err != ErrUserNotFound {
+		t.Fatalf("expected ErrUserNotFound, got %v", err)
+	}
+}
+
 func TestSetUserAuthMethods_EnableAndRevokePassword(t *testing.T) {
 	svc := setupTestService(t)
 	guestID := inviteGuest(t, svc)

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS users (
     role TEXT NOT NULL DEFAULT 'user',
     password_enabled BOOLEAN NOT NULL DEFAULT 0,
     passkey_enabled BOOLEAN NOT NULL DEFAULT 0,
+    plex_email TEXT NOT NULL DEFAULT '',
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -118,7 +119,8 @@ CREATE TABLE IF NOT EXISTS notification_prefs (
     new_movie        INTEGER NOT NULL DEFAULT 1,
     new_episode      INTEGER NOT NULL DEFAULT 1,
     issue_created    INTEGER NOT NULL DEFAULT 1,
-    agent_action_pending INTEGER NOT NULL DEFAULT 1
+    agent_action_pending INTEGER NOT NULL DEFAULT 1,
+    plex_access_request INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE TABLE IF NOT EXISTS connect_tokens (
@@ -383,6 +385,12 @@ func Open(dbPath string) (*sql.DB, error) {
 		// Connect→Webhook callbacks. Empty = not yet issued; generated lazily
 		// on first read (instance.Store.WebhookToken) and encrypted at rest.
 		{alter: "ALTER TABLE service_instances ADD COLUMN webhook_token TEXT NOT NULL DEFAULT ''"},
+		// Plex access requests: the email a user shares so an admin can invite
+		// them to the Plex server. Empty = not yet shared.
+		{alter: "ALTER TABLE users ADD COLUMN plex_email TEXT NOT NULL DEFAULT ''"},
+		// Admins are notified when a user shares their Plex email for an
+		// invite, on by default. New on existing databases.
+		{alter: "ALTER TABLE notification_prefs ADD COLUMN plex_access_request INTEGER NOT NULL DEFAULT 1"},
 	}
 	for _, m := range migrations {
 		if _, err := db.Exec(m.alter); err != nil {

--- a/server/internal/push/handler_test.go
+++ b/server/internal/push/handler_test.go
@@ -36,7 +36,7 @@ func TestGetPreferencesDefaults(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true, IssueCreated: true, AgentActionPending: true}
+	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true, IssueCreated: true, AgentActionPending: true, PlexAccessRequest: true}
 	if got != want {
 		t.Errorf("prefs = %+v, want %+v", got, want)
 	}

--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -93,6 +93,8 @@ func (n *Notifier) NotifyAdmins(eventType string, data map[string]interface{}) {
 		n.notifyIssueCreated(client, data)
 	case CategoryAgentActionPending:
 		n.notifyAgentActionPending(client, data)
+	case CategoryPlexAccessRequest:
+		n.notifyPlexAccessRequested(client, data)
 	}
 }
 
@@ -166,6 +168,31 @@ func (n *Notifier) notifyAgentActionPending(client *Client, data map[string]inte
 		opts.Badge = &count
 	}
 	n.sendWithOptions(client, recipients, "A fix needs your approval", "The assistant proposed a fix for a problem and needs you to approve it", out, opts)
+}
+
+// notifyPlexAccessRequested pushes "a user shared their Plex email, invite
+// them" to opted-in admins. The body is a FIXED template — the username and
+// email are user-controlled and never placed on the lock screen; user_id rides
+// along for tap deep-linking to the Users screen. A collapse id per user keeps
+// a user editing their email from stacking alerts.
+func (n *Notifier) notifyPlexAccessRequested(client *Client, data map[string]interface{}) {
+	recipients, err := n.prefs.usersOptedInto(CategoryPlexAccessRequest)
+	if err != nil {
+		n.logger.Error("push: resolve plex_access_request recipients", "err", err)
+		return
+	}
+	if len(recipients) == 0 {
+		return
+	}
+	out := map[string]any{"type": CategoryPlexAccessRequest}
+	if v, ok := data["user_id"]; ok {
+		out["user_id"] = v
+	}
+	var opts SendOptions
+	if id, ok := intval(data["user_id"]); ok {
+		opts.CollapseID = fmt.Sprintf("%s:%d", CategoryPlexAccessRequest, id)
+	}
+	n.sendWithOptions(client, recipients, "Plex access request", "Someone shared their Plex email and is waiting for an invite", out, opts)
 }
 
 // NotifyNewMovie pushes a "movie became available" alert to every user opted

--- a/server/internal/push/prefs.go
+++ b/server/internal/push/prefs.go
@@ -14,6 +14,7 @@ type Prefs struct {
 	NewEpisode         bool `json:"new_episode"`
 	IssueCreated       bool `json:"issue_created"`
 	AgentActionPending bool `json:"agent_action_pending"`
+	PlexAccessRequest  bool `json:"plex_access_request"`
 }
 
 // Notification categories. These are the wire values used by the preferences
@@ -29,6 +30,9 @@ const (
 	// CategoryAgentActionPending notifies admins that the AI agent proposed a fix
 	// awaiting their approval. Admin-scoped, on by default.
 	CategoryAgentActionPending = "agent_action_pending"
+	// CategoryPlexAccessRequest notifies admins that a user shared their Plex
+	// email and is waiting for a server invite. Admin-scoped, on by default.
+	CategoryPlexAccessRequest = "plex_access_request"
 )
 
 // defaultPrefs is the preference set applied when a user has no row. It must
@@ -41,6 +45,7 @@ var defaultPrefs = Prefs{
 	NewEpisode:         true,
 	IssueCreated:       true,
 	AgentActionPending: true,
+	PlexAccessRequest:  true,
 }
 
 // categoryColumn maps a category to its notification_prefs column and the
@@ -56,6 +61,7 @@ var categoryColumn = map[string]struct {
 	CategoryNewEpisode:         {"new_episode", defaultPrefs.NewEpisode},
 	CategoryIssueCreated:       {"issue_created", defaultPrefs.IssueCreated},
 	CategoryAgentActionPending: {"agent_action_pending", defaultPrefs.AgentActionPending},
+	CategoryPlexAccessRequest:  {"plex_access_request", defaultPrefs.PlexAccessRequest},
 }
 
 // PrefsStore reads and writes per-user notification preferences. It is safe to
@@ -74,10 +80,10 @@ func NewPrefsStore(db *sql.DB) *PrefsStore {
 func (s *PrefsStore) Get(userID int64) (Prefs, error) {
 	p := defaultPrefs
 	err := s.db.QueryRow(
-		`SELECT request_decision, request_pending, new_movie, new_episode, issue_created, agent_action_pending
+		`SELECT request_decision, request_pending, new_movie, new_episode, issue_created, agent_action_pending, plex_access_request
 		 FROM notification_prefs WHERE user_id = ?`,
 		userID,
-	).Scan(&p.RequestDecision, &p.RequestPending, &p.NewMovie, &p.NewEpisode, &p.IssueCreated, &p.AgentActionPending)
+	).Scan(&p.RequestDecision, &p.RequestPending, &p.NewMovie, &p.NewEpisode, &p.IssueCreated, &p.AgentActionPending, &p.PlexAccessRequest)
 	if err == sql.ErrNoRows {
 		return defaultPrefs, nil
 	}
@@ -91,16 +97,17 @@ func (s *PrefsStore) Get(userID int64) (Prefs, error) {
 func (s *PrefsStore) Set(userID int64, p Prefs) error {
 	_, err := s.db.Exec(
 		`INSERT INTO notification_prefs
-		   (user_id, request_decision, request_pending, new_movie, new_episode, issue_created, agent_action_pending)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		   (user_id, request_decision, request_pending, new_movie, new_episode, issue_created, agent_action_pending, plex_access_request)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(user_id) DO UPDATE SET
 		   request_decision = excluded.request_decision,
 		   request_pending  = excluded.request_pending,
 		   new_movie        = excluded.new_movie,
 		   new_episode      = excluded.new_episode,
 		   issue_created    = excluded.issue_created,
-		   agent_action_pending = excluded.agent_action_pending`,
-		userID, p.RequestDecision, p.RequestPending, p.NewMovie, p.NewEpisode, p.IssueCreated, p.AgentActionPending,
+		   agent_action_pending = excluded.agent_action_pending,
+		   plex_access_request  = excluded.plex_access_request`,
+		userID, p.RequestDecision, p.RequestPending, p.NewMovie, p.NewEpisode, p.IssueCreated, p.AgentActionPending, p.PlexAccessRequest,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert notification prefs: %w", err)
@@ -128,9 +135,10 @@ func (s *PrefsStore) usersOptedInto(category string) ([]int64, error) {
 		 WHERE COALESCE(p.%s, %d) = 1`,
 		col.column, def,
 	)
-	// Admin-scoped categories: only admins act on pending requests, issues, or
-	// agent-action approvals.
-	if category == CategoryRequestPending || category == CategoryIssueCreated || category == CategoryAgentActionPending {
+	// Admin-scoped categories: only admins act on pending requests, issues,
+	// agent-action approvals, or Plex access requests.
+	if category == CategoryRequestPending || category == CategoryIssueCreated ||
+		category == CategoryAgentActionPending || category == CategoryPlexAccessRequest {
 		query += " AND u.role = 'admin'"
 	}
 

--- a/server/internal/push/prefs_test.go
+++ b/server/internal/push/prefs_test.go
@@ -18,7 +18,7 @@ func TestPrefsGetDefaultsForMissingRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true, IssueCreated: true, AgentActionPending: true}
+	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true, IssueCreated: true, AgentActionPending: true, PlexAccessRequest: true}
 	if got != want {
 		t.Errorf("default prefs = %+v, want %+v", got, want)
 	}
@@ -32,7 +32,7 @@ func TestPrefsSetThenGet(t *testing.T) {
 	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'alice', '', 'user')")
 
 	store := NewPrefsStore(database)
-	want := Prefs{RequestDecision: true, RequestPending: false, NewMovie: false, NewEpisode: true}
+	want := Prefs{RequestDecision: true, RequestPending: false, NewMovie: false, NewEpisode: true, PlexAccessRequest: true}
 	if err := store.Set(1, want); err != nil {
 		t.Fatalf("Set: %v", err)
 	}


### PR DESCRIPTION
## What

The Watch on Plex guide's weakest step was "make sure your admin knows your email." This closes the loop in-app:

**User side** — the guide gains a *Request your invite* step (step 3 of 5): tap **Share my Plex email**, enter the address, done. The email is stored on the account (`users.plex_email`), shown back in the guide with a change affordance, and re-submitting the same address doesn't re-notify anyone.

**Admin side** — a new admin-scoped push category `plex_access_request` (on by default, fixed-template body per the untrusted-text invariant, collapse-keyed per user) fires when an email is added or changed. Tapping it deep-links to Settings → Users, where the shared email now shows as a tag with an **Invite in Plex…** menu action: copies the address to the clipboard and opens Plex's Manage Library Access page. Plex has no documented invite-prefill URL, so copy-then-open is the fastest honest flow (a future upgrade could send the invite via the plex.tv API with an admin Plex token, Wizarr-style).

**Server** — `POST /api/auth/plex-email` (authenticated, rate-limited, shallow shape validation), `plex_email` in `/auth/me` and the admin users list, columns added via the tolerant ALTER list in `db.go`, auth handler takes the notifier composite via `SetNotifier` (wired in `main.go` after the composite exists).

**Bug fix along the way** — the app's `NotificationPrefs` model only carried 4 categories while the server's PUT replaces the full row treating missing keys as false, so **saving any notification toggle silently disabled admins' `issue_created` and `agent_action_pending` pushes**. The model now round-trips every category, and the preferences screen surfaces all admin-only toggles (problem reports, fixes awaiting approval, Plex access requests).

## Verification

- Server: `go vet ./...` clean; `go test ./...` all pass (new tests: `TestSetPlexEmail_StoresTrimsAndReportsChange`, `TestSetPlexEmail_RejectsInvalid`; prefs default/round-trip tests extended for the new category)
- App: `flutter analyze --no-fatal-infos` — no new issues (16 pre-existing infos); `flutter test` — all 200 pass

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [x] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [x] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above

`server/README.md`: new route, `plex_access_request` in the category table + WS event list, `user_id` in deep-link payload data. `app/README.md`: guide bullet (invite-request step), Users bullet (email tag + Invite in Plex), notification categories line. Root `README.md`'s push blurb ("approval/issue alerts for admins, per-user preference toggles") remains accurate at its altitude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)