### PR TITLE
One-tap and automatic Plex invites via a linked Plex account

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Cantinarr makes it dead simple for your family and friends to discover and reque
 - **Flexible requests** -- request a whole title in one tap, or pick exactly which **seasons** (or book **formats**) you want; partially-available shows surface per-season availability and a one-tap path to request the rest.
 - **Always in sync** -- availability is computed live from the arrs (never from a stale snapshot), and per-instance webhooks (copy one URL into Radarr/Sonarr > Connect) push manual imports, deletes, and adds into the app the moment they happen.
 - **Push notifications** -- APNs via a self-hosted push gateway with zero-config auto-enrollment: new-content alerts for everyone, approval/issue alerts for admins, per-user preference toggles, deep links into the right screen.
+- **Plex onboarding** -- new users request access right from the in-app guide with their Plex email. Link your Plex account once and the server invite is one tap from the Users screen -- or fully automatic, with the user pushed a "check your inbox" the moment it's sent.
 - **Tautulli** -- watch what's playing on Plex right now: active streams with quality/transcode badges, watch history, and top movies/shows/users stats.
 - **Secrets encrypted at rest** -- arr API keys, download-client passwords, webhook tokens, and external credentials are AES-256-GCM encrypted in the database.
 - **Household-friendly** -- Connect links, passwordless by default, role-based access, per-user default instances. Admins manage services; users just browse and request.

--- a/app/README.md
+++ b/app/README.md
@@ -87,18 +87,19 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 
 ### Notifications (iOS)
 - **Native APNs push** via a `MethodChannel` -- no Firebase. Tokens register with the backend per device; taps deep-link to the right screen (detail page, approvals, issue thread...).
-- **Per-category preferences** -- request decisions, new movies, new episodes, and admin-only categories (new requests, issues, agent fixes, Plex access requests), plus a test-push diagnostic.
+- **Per-category preferences** -- request decisions, new movies, new episodes, Plex invite sent, and admin-only categories (new requests, issues, agent fixes, Plex access requests), plus a test-push diagnostic.
 
 ### Settings
 - **Instances** (admin) -- add/edit all eight service types; test connections; set the global default (single-default invariant with takeover confirmation) or per-user default pins; assign users to a Chaptarr instance (the Books access grant); assigning a user pinned to a sibling instance asks for confirmation before removing them from it; copy the per-instance **webhook URL** for Radarr/Sonarr > Connect.
-- **Users** (admin) -- roles, connect links / re-invites / device links, per-user password & passkey enablement (disabling is a real revoke), per-user request settings (tri-state inherit/on/off + default instances), test push. Shows each user's shared Plex email with an **Invite in Plex…** action (copies the address, opens Plex's Manage Library Access page).
+- **Users** (admin) -- roles, connect links / re-invites / device links, per-user password & passkey enablement (disabling is a real revoke), per-user request settings (tri-state inherit/on/off + default instances), test push. Shows each user's shared Plex email and invite state: with a linked Plex account it's a one-tap **Send Plex invite** (resend supported); otherwise **Invite in Plex…** copies the address and opens Plex's Manage Library Access page.
+- **Plex Invites** (admin) -- link a Plex account via the PIN flow, pick the server and libraries invites share, and toggle **auto-invite** (a user sharing their Plex email gets invited with zero admin taps).
 - **Request policy** (admin) -- global require-approval, season choice + default scope, quality choice + default profiles.
 - **Devices** (admin) -- every connected device with hardware model, last-seen, "This device" badge, and revoke.
 - **Credentials** (admin, write-only) -- TMDB, Trakt, and AI provider keys + provider/model selection.
 - **AI tools** (admin) -- per-tool toggles for chat + MCP, and a one-hour debug-logging switch.
 - **AI remediation** (admin) -- master switch, auto-dispatch, reporting affordance, autonomy tier, provider/model, and run budgets.
 - **Notifications, Passkeys, Password** -- self-service (passkey/password screens appear when admin-enabled).
-- **Watch on Plex guide** -- requester-focused walkthrough (install the Plex app, sign in, accept the invite, start watching) with a **Request your invite** step: the user shares their Plex email and admins get a push pointing at the Users screen. Hideable from the guide itself or via a Settings toggle that also removes it from the menu.
+- **Watch on Plex guide** -- requester-focused walkthrough (install the Plex app, sign in, accept the invite, start watching) with a **Request your invite** step: the user shares their Plex email, admins get a push pointing at the Users screen, and once the invite goes out (one-tap or auto) the card flips to "check your inbox" and the user gets a push. Hideable from the guide itself or via a Settings toggle that also removes it from the menu.
 
 ### Auth
 - **Connect links** -- open one and the account connects instantly (`cantinarr://connect` deep links on iOS); passwordless by default with a long-lived, auto-refreshing session.

--- a/app/lib/core/models/user_profile.dart
+++ b/app/lib/core/models/user_profile.dart
@@ -15,8 +15,10 @@ class UserProfile {
   final bool passkeyEnabled;
 
   /// The email this user shared for their Plex server invite. Empty until
-  /// they submit one (from the Watch on Plex guide).
+  /// they submit one (from the Watch on Plex guide). [plexInvitedAt] is set
+  /// once Cantinarr sent their invite (one-tap or auto).
   final String plexEmail;
+  final String? plexInvitedAt;
 
   const UserProfile({
     required this.id,
@@ -27,6 +29,7 @@ class UserProfile {
     this.passwordEnabled = false,
     this.passkeyEnabled = false,
     this.plexEmail = '',
+    this.plexInvitedAt,
   });
 
   bool get isAdmin => role == 'admin';
@@ -50,9 +53,15 @@ class UserProfile {
         passwordEnabled: json['password_enabled'] as bool? ?? false,
         passkeyEnabled: json['passkey_enabled'] as bool? ?? false,
         plexEmail: json['plex_email'] as String? ?? '',
+        plexInvitedAt: json['plex_invited_at'] as String?,
       );
 
-  UserProfile copyWith({bool? hasPassword, String? plexEmail}) => UserProfile(
+  UserProfile copyWith({
+    bool? hasPassword,
+    String? plexEmail,
+    bool clearPlexInvitedAt = false,
+  }) =>
+      UserProfile(
         id: id,
         username: username,
         role: role,
@@ -61,6 +70,7 @@ class UserProfile {
         passwordEnabled: passwordEnabled,
         passkeyEnabled: passkeyEnabled,
         plexEmail: plexEmail ?? this.plexEmail,
+        plexInvitedAt: clearPlexInvitedAt ? null : plexInvitedAt,
       );
 
   Map<String, dynamic> toJson() => {
@@ -72,5 +82,6 @@ class UserProfile {
         'password_enabled': passwordEnabled,
         'passkey_enabled': passkeyEnabled,
         'plex_email': plexEmail,
+        if (plexInvitedAt != null) 'plex_invited_at': plexInvitedAt,
       };
 }

--- a/app/lib/features/auth/data/auth_service.dart
+++ b/app/lib/features/auth/data/auth_service.dart
@@ -436,8 +436,10 @@ class UserSummary {
   final bool passkeyEnabled;
   final bool hasPendingInvite;
 
-  /// The email this user shared for their Plex server invite ('' = none yet).
+  /// The email this user shared for their Plex server invite ('' = none yet),
+  /// and when Cantinarr last sent their invite (null = never).
   final String plexEmail;
+  final String? plexInvitedAt;
 
   const UserSummary({
     required this.id,
@@ -451,6 +453,7 @@ class UserSummary {
     required this.passkeyEnabled,
     required this.hasPendingInvite,
     this.plexEmail = '',
+    this.plexInvitedAt,
   });
 
   bool get isAdmin => role == 'admin';
@@ -470,6 +473,7 @@ class UserSummary {
         passkeyEnabled: json['passkey_enabled'] as bool? ?? false,
         hasPendingInvite: json['has_pending_invite'] as bool? ?? false,
         plexEmail: json['plex_email'] as String? ?? '',
+        plexInvitedAt: json['plex_invited_at'] as String?,
       );
 }
 

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -635,8 +635,12 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     await _authService.setPlexEmail(conn.serverUrl, conn.accessToken, trimmed);
     final user = current.user;
     if (user != null) {
+      // A new address resets the invited stamp locally too — any invite
+      // already sent went to the old email (the server does the same).
       state = AsyncData(
-        current.copyWith(user: user.copyWith(plexEmail: trimmed)),
+        current.copyWith(
+          user: user.copyWith(plexEmail: trimmed, clearPlexInvitedAt: true),
+        ),
       );
     }
   }

--- a/app/lib/features/notifications/notification_prefs.dart
+++ b/app/lib/features/notifications/notification_prefs.dart
@@ -13,6 +13,7 @@ class NotificationPrefs {
   final bool issueCreated;
   final bool agentActionPending;
   final bool plexAccessRequest;
+  final bool plexInviteSent;
 
   const NotificationPrefs({
     required this.requestDecision,
@@ -22,6 +23,7 @@ class NotificationPrefs {
     this.issueCreated = true,
     this.agentActionPending = true,
     this.plexAccessRequest = true,
+    this.plexInviteSent = true,
   });
 
   factory NotificationPrefs.fromJson(Map<String, dynamic> json) =>
@@ -35,6 +37,7 @@ class NotificationPrefs {
         issueCreated: json['issue_created'] as bool? ?? true,
         agentActionPending: json['agent_action_pending'] as bool? ?? true,
         plexAccessRequest: json['plex_access_request'] as bool? ?? true,
+        plexInviteSent: json['plex_invite_sent'] as bool? ?? true,
       );
 
   Map<String, dynamic> toJson() => {
@@ -45,6 +48,7 @@ class NotificationPrefs {
         'issue_created': issueCreated,
         'agent_action_pending': agentActionPending,
         'plex_access_request': plexAccessRequest,
+        'plex_invite_sent': plexInviteSent,
       };
 
   NotificationPrefs copyWith({
@@ -55,6 +59,7 @@ class NotificationPrefs {
     bool? issueCreated,
     bool? agentActionPending,
     bool? plexAccessRequest,
+    bool? plexInviteSent,
   }) =>
       NotificationPrefs(
         requestDecision: requestDecision ?? this.requestDecision,
@@ -64,5 +69,6 @@ class NotificationPrefs {
         issueCreated: issueCreated ?? this.issueCreated,
         agentActionPending: agentActionPending ?? this.agentActionPending,
         plexAccessRequest: plexAccessRequest ?? this.plexAccessRequest,
+        plexInviteSent: plexInviteSent ?? this.plexInviteSent,
       );
 }

--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -138,8 +138,11 @@ class PushService {
         router.push('/agent-actions');
       case 'plex_access_request':
         // A user shared their Plex email — the Users screen shows it with the
-        // "Invite in Plex" action.
+        // invite actions.
         router.push('/settings/users');
+      case 'plex_invite_sent':
+        // The user's invite went out — the guide's step 4 says what to do.
+        router.push('/plex-guide');
       case 'remediation_autodispatch_disabled':
         // The circuit breaker turned auto-dispatch off — open the settings the
         // admin uses to re-enable it.

--- a/app/lib/features/notifications/ui/notification_preferences_screen.dart
+++ b/app/lib/features/notifications/ui/notification_preferences_screen.dart
@@ -227,6 +227,12 @@ class _NotificationPreferencesScreenState
           value: prefs.newEpisode,
           onChanged: (v) => _save(prefs.copyWith(newEpisode: v), prefs),
         ),
+        _toggle(
+          title: 'Plex invite sent',
+          subtitle: 'When your Plex invite email goes out',
+          value: prefs.plexInviteSent,
+          onChanged: (v) => _save(prefs.copyWith(plexInviteSent: v), prefs),
+        ),
         const SizedBox(height: 32),
       ],
     );

--- a/app/lib/features/settings/data/plex_admin_service.dart
+++ b/app/lib/features/settings/data/plex_admin_service.dart
@@ -1,0 +1,166 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+
+/// Admin view of the Plex integration: whether an account is linked and how
+/// invites are configured. The token never leaves the server.
+class PlexStatus {
+  final bool linked;
+  final String account;
+  final String machineIdentifier;
+  final String serverName;
+  final List<int> librarySectionIds;
+  final bool autoInvite;
+  final bool configured;
+
+  const PlexStatus({
+    required this.linked,
+    this.account = '',
+    this.machineIdentifier = '',
+    this.serverName = '',
+    this.librarySectionIds = const [],
+    this.autoInvite = false,
+    this.configured = false,
+  });
+
+  factory PlexStatus.fromJson(Map<String, dynamic> json) => PlexStatus(
+        linked: json['linked'] as bool? ?? false,
+        account: json['account'] as String? ?? '',
+        machineIdentifier: json['machine_identifier'] as String? ?? '',
+        serverName: json['server_name'] as String? ?? '',
+        librarySectionIds: (json['library_section_ids'] as List<dynamic>?)
+                ?.map((e) => (e as num).toInt())
+                .toList() ??
+            const [],
+        autoInvite: json['auto_invite'] as bool? ?? false,
+        configured: json['configured'] as bool? ?? false,
+      );
+}
+
+class PlexServer {
+  final String name;
+  final String machineIdentifier;
+
+  const PlexServer({required this.name, required this.machineIdentifier});
+
+  factory PlexServer.fromJson(Map<String, dynamic> json) => PlexServer(
+        name: json['name'] as String? ?? '',
+        machineIdentifier: json['machine_identifier'] as String? ?? '',
+      );
+}
+
+class PlexLibrary {
+  final int id;
+  final String title;
+  final String type;
+
+  const PlexLibrary({required this.id, required this.title, required this.type});
+
+  factory PlexLibrary.fromJson(Map<String, dynamic> json) => PlexLibrary(
+        id: (json['id'] as num?)?.toInt() ?? 0,
+        title: json['title'] as String? ?? '',
+        type: json['type'] as String? ?? '',
+      );
+}
+
+/// The start of the PIN link flow: open [url] for the admin, then poll
+/// checkLink with [pinId] until they approve.
+class PlexLinkStart {
+  final int pinId;
+  final String code;
+  final String url;
+
+  const PlexLinkStart({required this.pinId, required this.code, required this.url});
+
+  factory PlexLinkStart.fromJson(Map<String, dynamic> json) => PlexLinkStart(
+        pinId: (json['pin_id'] as num?)?.toInt() ?? 0,
+        code: json['code'] as String? ?? '',
+        url: json['url'] as String? ?? '',
+      );
+}
+
+class PlexAdminService {
+  final Dio _dio;
+
+  PlexAdminService({required Dio backendDio}) : _dio = backendDio;
+
+  Future<PlexStatus> status() async {
+    final resp = await _dio.get('/api/admin/plex/status');
+    return PlexStatus.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  Future<PlexLinkStart> beginLink() async {
+    final resp = await _dio.post('/api/admin/plex/link/begin');
+    return PlexLinkStart.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Polls the PIN; linked=false means the admin hasn't approved yet.
+  Future<bool> checkLink(int pinId) async {
+    final resp = await _dio.post(
+      '/api/admin/plex/link/check',
+      data: {'pin_id': pinId},
+    );
+    final data = resp.data as Map<String, dynamic>;
+    return data['linked'] as bool? ?? false;
+  }
+
+  Future<void> unlink() async {
+    await _dio.delete('/api/admin/plex/link');
+  }
+
+  Future<List<PlexServer>> servers() async {
+    final resp = await _dio.get('/api/admin/plex/servers');
+    final list = (resp.data as Map<String, dynamic>)['servers'] as List? ?? [];
+    return list
+        .map((e) => PlexServer.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<List<PlexLibrary>> libraries(String machineIdentifier) async {
+    final resp =
+        await _dio.get('/api/admin/plex/servers/$machineIdentifier/libraries');
+    final list = (resp.data as Map<String, dynamic>)['libraries'] as List? ?? [];
+    return list
+        .map((e) => PlexLibrary.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<PlexStatus> updateSettings({
+    required String machineIdentifier,
+    required String serverName,
+    required List<int> librarySectionIds,
+    required bool autoInvite,
+  }) async {
+    final resp = await _dio.put('/api/admin/plex/settings', data: {
+      'machine_identifier': machineIdentifier,
+      'server_name': serverName,
+      'library_section_ids': librarySectionIds,
+      'auto_invite': autoInvite,
+    });
+    return PlexStatus.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Sends the Plex invite for a user's shared email. Returns the outcome:
+  /// "invited" or "already_shared".
+  Future<String> inviteUser(int userId) async {
+    final resp = await _dio.post('/api/admin/users/$userId/plex-invite');
+    return (resp.data as Map<String, dynamic>)['status'] as String? ?? 'invited';
+  }
+}
+
+final plexAdminServiceProvider = Provider<PlexAdminService>(
+  (ref) => PlexAdminService(backendDio: ref.watch(backendClientProvider)),
+);
+
+/// Whether one-tap invites are available (account linked + server selected).
+/// The Users screen uses this to offer "Send Plex invite" instead of the
+/// copy-email-and-open-Plex fallback. Admin-only endpoint — only watch this
+/// from admin screens. Invalidate after link/unlink/settings changes.
+final plexInviteConfiguredProvider = FutureProvider<bool>((ref) async {
+  try {
+    final status = await ref.watch(plexAdminServiceProvider).status();
+    return status.configured;
+  } catch (_) {
+    return false;
+  }
+});

--- a/app/lib/features/settings/ui/plex_settings_screen.dart
+++ b/app/lib/features/settings/ui/plex_settings_screen.dart
@@ -1,0 +1,477 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../../../core/theme/app_theme.dart';
+import '../data/plex_admin_service.dart';
+
+/// Admin screen for the Plex integration: link a Plex account (PIN flow),
+/// pick the server and libraries invites share, and turn on auto-invite so a
+/// user sharing their Plex email gets invited with zero admin taps.
+class PlexSettingsScreen extends ConsumerStatefulWidget {
+  const PlexSettingsScreen({super.key});
+
+  @override
+  ConsumerState<PlexSettingsScreen> createState() => _PlexSettingsScreenState();
+}
+
+class _PlexSettingsScreenState extends ConsumerState<PlexSettingsScreen> {
+  bool _loading = true;
+  String? _error;
+  PlexStatus? _status;
+
+  // PIN link flow state.
+  bool _linking = false;
+  int? _pinId;
+  String? _linkUrl;
+  Timer? _pollTimer;
+
+  // Invite configuration (edited locally, saved with the Save button).
+  List<PlexServer> _servers = const [];
+  List<PlexLibrary> _libraries = const [];
+  bool _librariesLoading = false;
+  String _machineId = '';
+  String _serverName = '';
+  Set<int> _selectedLibraryIds = {};
+  bool _autoInvite = false;
+  bool _saving = false;
+
+  PlexAdminService get _service => ref.read(plexAdminServiceProvider);
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  @override
+  void dispose() {
+    _pollTimer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final status = await _service.status();
+      if (!mounted) return;
+      setState(() {
+        _status = status;
+        _machineId = status.machineIdentifier;
+        _serverName = status.serverName;
+        _selectedLibraryIds = status.librarySectionIds.toSet();
+        _autoInvite = status.autoInvite;
+        _loading = false;
+      });
+      if (status.linked) {
+        await _loadServers();
+        if (status.machineIdentifier.isNotEmpty) {
+          await _loadLibraries(status.machineIdentifier);
+        }
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _error = 'Failed to load Plex settings';
+        _loading = false;
+      });
+    }
+  }
+
+  Future<void> _loadServers() async {
+    try {
+      final servers = await _service.servers();
+      if (mounted) setState(() => _servers = servers);
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+            content: Text('Could not load your Plex servers — try again')));
+      }
+    }
+  }
+
+  Future<void> _loadLibraries(String machineId) async {
+    setState(() {
+      _librariesLoading = true;
+      _libraries = const [];
+    });
+    try {
+      final libs = await _service.libraries(machineId);
+      if (mounted) setState(() => _libraries = libs);
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+            content: Text('Could not load libraries for that server')));
+      }
+    } finally {
+      if (mounted) setState(() => _librariesLoading = false);
+    }
+  }
+
+  Future<void> _beginLink() async {
+    try {
+      final start = await _service.beginLink();
+      if (!mounted) return;
+      setState(() {
+        _linking = true;
+        _pinId = start.pinId;
+        _linkUrl = start.url;
+      });
+      await launchUrl(Uri.parse(start.url),
+          mode: LaunchMode.externalApplication);
+      // Poll while the admin approves in the browser; the PIN expires
+      // server-side so a forgotten screen just times out quietly.
+      _pollTimer?.cancel();
+      _pollTimer = Timer.periodic(
+        const Duration(seconds: 3),
+        (_) => _checkLink(silent: true),
+      );
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+            content: Text('Could not reach plex.tv — try again')));
+      }
+    }
+  }
+
+  Future<void> _checkLink({bool silent = false}) async {
+    final pinId = _pinId;
+    if (pinId == null) return;
+    try {
+      final linked = await _service.checkLink(pinId);
+      if (!linked || !mounted) return;
+      _pollTimer?.cancel();
+      setState(() {
+        _linking = false;
+        _pinId = null;
+        _linkUrl = null;
+      });
+      ref.invalidate(plexInviteConfiguredProvider);
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Plex account linked!')));
+      await _load();
+    } catch (_) {
+      if (!silent && mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+            content: Text('Not approved yet — finish signing in on plex.tv')));
+      }
+    }
+  }
+
+  void _cancelLink() {
+    _pollTimer?.cancel();
+    setState(() {
+      _linking = false;
+      _pinId = null;
+      _linkUrl = null;
+    });
+  }
+
+  Future<void> _unlink() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: const Text('Unlink Plex account?'),
+        content: const Text(
+            'Cantinarr forgets the Plex token and invite settings. Invites '
+            'already sent are not affected.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Unlink'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    try {
+      await _service.unlink();
+      ref.invalidate(plexInviteConfiguredProvider);
+      await _load();
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Failed to unlink — try again')));
+      }
+    }
+  }
+
+  Future<void> _save() async {
+    if (_machineId.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Pick a server first')));
+      return;
+    }
+    setState(() => _saving = true);
+    try {
+      final status = await _service.updateSettings(
+        machineIdentifier: _machineId,
+        serverName: _serverName,
+        librarySectionIds: _selectedLibraryIds.toList()..sort(),
+        autoInvite: _autoInvite,
+      );
+      ref.invalidate(plexInviteConfiguredProvider);
+      if (!mounted) return;
+      setState(() => _status = status);
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Plex invite settings saved')));
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Failed to save — try again')));
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Plex Invites')),
+      body: _loading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent))
+          : _error != null
+              ? Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(_error!,
+                          style: const TextStyle(color: AppTheme.error)),
+                      const SizedBox(height: 12),
+                      ElevatedButton(
+                          onPressed: _load, child: const Text('Retry')),
+                    ],
+                  ),
+                )
+              : _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    final status = _status!;
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: [
+        const Padding(
+          padding: EdgeInsets.fromLTRB(16, 8, 16, 12),
+          child: Text(
+            'Link your Plex account so Cantinarr can send server invites '
+            'itself: one tap from the Users screen, or automatically the '
+            'moment someone shares their Plex email.',
+            style: TextStyle(
+                color: AppTheme.textSecondary, fontSize: 13, height: 1.4),
+          ),
+        ),
+        if (!status.linked) ..._buildUnlinked() else ..._buildLinked(status),
+        const SizedBox(height: 32),
+      ],
+    );
+  }
+
+  List<Widget> _buildUnlinked() {
+    if (_linking) {
+      return [
+        const ListTile(
+          leading: SizedBox(
+            width: 24,
+            height: 24,
+            child: CircularProgressIndicator(
+                strokeWidth: 2, color: AppTheme.accent),
+          ),
+          title: Text('Waiting for approval…',
+              style: TextStyle(color: AppTheme.textPrimary)),
+          subtitle: Text(
+              'Sign in on the plex.tv page that just opened and approve the link.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Wrap(
+            spacing: 12,
+            runSpacing: 8,
+            children: [
+              OutlinedButton(
+                onPressed: () => _checkLink(),
+                child: const Text("I've approved — check now"),
+              ),
+              if (_linkUrl != null)
+                OutlinedButton(
+                  onPressed: () => launchUrl(Uri.parse(_linkUrl!),
+                      mode: LaunchMode.externalApplication),
+                  child: const Text('Reopen plex.tv'),
+                ),
+              TextButton(
+                onPressed: _cancelLink,
+                child: const Text('Cancel'),
+              ),
+            ],
+          ),
+        ),
+      ];
+    }
+    return [
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: ElevatedButton.icon(
+          onPressed: _beginLink,
+          icon: const Icon(Icons.link, size: 18),
+          label: const Text('Link Plex account'),
+        ),
+      ),
+    ];
+  }
+
+  List<Widget> _buildLinked(PlexStatus status) {
+    return [
+      const _SectionHeader(title: 'Account'),
+      ListTile(
+        leading: const Icon(Icons.check_circle, color: AppTheme.available),
+        title: Text(status.account.isEmpty ? 'Linked' : status.account,
+            style: const TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
+        subtitle: const Text('Plex account linked',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+        trailing: TextButton(
+          onPressed: _unlink,
+          child: const Text('Unlink', style: TextStyle(color: AppTheme.error)),
+        ),
+      ),
+      const SizedBox(height: 8),
+      const _SectionHeader(title: 'Server'),
+      if (_servers.isEmpty)
+        const ListTile(
+          leading: Icon(Icons.dns_outlined, color: AppTheme.textSecondary),
+          title: Text('No owned servers found',
+              style: TextStyle(color: AppTheme.textPrimary)),
+          subtitle: Text(
+              'The linked account must own the Plex Media Server it invites to.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+        )
+      else
+        ..._servers.map((s) {
+          final selected = s.machineIdentifier == _machineId;
+          return ListTile(
+            leading: Icon(
+              selected
+                  ? Icons.radio_button_checked
+                  : Icons.radio_button_unchecked,
+              color: selected ? AppTheme.accent : AppTheme.textSecondary,
+            ),
+            title: Text(s.name,
+                style: const TextStyle(
+                    color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
+            onTap: selected
+                ? null
+                : () {
+                    setState(() {
+                      _machineId = s.machineIdentifier;
+                      _serverName = s.name;
+                      _selectedLibraryIds = {};
+                    });
+                    _loadLibraries(s.machineIdentifier);
+                  },
+          );
+        }),
+      if (_machineId.isNotEmpty) ...[
+        const SizedBox(height: 8),
+        const _SectionHeader(title: 'Libraries'),
+        const Padding(
+          padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
+          child: Text(
+            'Pick the libraries invites share. Leave all unchecked to share '
+            'every library.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+        if (_librariesLoading)
+          const Padding(
+            padding: EdgeInsets.all(16),
+            child: Center(
+              child: SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(
+                    strokeWidth: 2, color: AppTheme.accent),
+              ),
+            ),
+          )
+        else
+          ..._libraries.map((lib) => CheckboxListTile(
+                value: _selectedLibraryIds.contains(lib.id),
+                onChanged: (checked) {
+                  setState(() {
+                    if (checked == true) {
+                      _selectedLibraryIds.add(lib.id);
+                    } else {
+                      _selectedLibraryIds.remove(lib.id);
+                    }
+                  });
+                },
+                activeColor: AppTheme.accent,
+                title: Text(lib.title,
+                    style: const TextStyle(color: AppTheme.textPrimary)),
+                subtitle: Text(lib.type,
+                    style: const TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 13)),
+              )),
+      ],
+      const SizedBox(height: 8),
+      const _SectionHeader(title: 'Invites'),
+      SwitchListTile(
+        value: _autoInvite,
+        onChanged: (v) => setState(() => _autoInvite = v),
+        activeThumbColor: AppTheme.accent,
+        title: const Text('Auto-invite',
+            style: TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
+        subtitle: const Text(
+            'Send the invite automatically when someone shares their Plex email',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+      ),
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: ElevatedButton(
+          onPressed: _saving ? null : _save,
+          child: _saving
+              ? const SizedBox(
+                  width: 18,
+                  height: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Save'),
+        ),
+      ),
+    ];
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  final String title;
+  const _SectionHeader({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Text(
+        title.toUpperCase(),
+        style: const TextStyle(
+          color: AppTheme.accent,
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 1.2,
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -196,6 +196,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               onTap: () => context.push('/settings/users'),
             ),
             _SettingsTile(
+              icon: Icons.play_circle_outline,
+              title: 'Plex Invites',
+              subtitle: 'Link Plex for one-tap and automatic invites',
+              onTap: () => context.push('/settings/plex'),
+            ),
+            _SettingsTile(
               icon: Icons.link,
               title: 'Generate Connect Link',
               subtitle: 'Create a link to invite a new user',

--- a/app/lib/features/settings/ui/users_screen.dart
+++ b/app/lib/features/settings/ui/users_screen.dart
@@ -7,6 +7,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../auth/data/auth_service.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../notifications/push_service.dart';
+import '../data/plex_admin_service.dart';
 
 /// Admin screen for managing user accounts: change roles, remove users, and
 /// see who still has an outstanding connect-link invite.
@@ -47,9 +48,30 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
     }
   }
 
+  /// One-tap invite through the linked Plex account: the server shares the
+  /// configured libraries with the user's email and stamps the invite.
+  Future<void> _sendPlexInvite(UserSummary user) async {
+    try {
+      final status =
+          await ref.read(plexAdminServiceProvider).inviteUser(user.id);
+      await _loadUsers();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(status == 'already_shared'
+            ? '${user.plexEmail} already has access on Plex'
+            : 'Plex invite sent to ${user.plexEmail}'),
+      ));
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content:
+              Text('Plex invite failed — check the Plex Invites settings')));
+    }
+  }
+
   /// Copies the user's Plex email and opens Plex's Manage Library Access page,
-  /// where the admin pastes it into Grant Library Access. Plex offers no way
-  /// to prefill the invite, so copy-then-paste is the fastest honest flow.
+  /// where the admin pastes it into Grant Library Access. The fallback when no
+  /// Plex account is linked (Plex offers no way to prefill the invite).
   Future<void> _inviteInPlex(UserSummary user) async {
     await Clipboard.setData(ClipboardData(text: user.plexEmail));
     if (mounted) {
@@ -333,6 +355,8 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
     }
 
     final currentUserId = ref.read(authProvider).valueOrNull?.user?.id;
+    final plexConfigured =
+        ref.watch(plexInviteConfiguredProvider).valueOrNull ?? false;
 
     return RefreshIndicator(
       onRefresh: _loadUsers,
@@ -346,10 +370,12 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
           return _UserTile(
             user: user,
             isSelf: user.id == currentUserId,
+            plexInviteConfigured: plexConfigured,
             onChangeRole: (role) => _changeRole(user, role),
             onDelete: () => _deleteUser(user),
             onResendInvite: () => _resendInvite(user),
             onSendTestPush: () => _sendTestPush(user),
+            onSendPlexInvite: () => _sendPlexInvite(user),
             onInviteInPlex: () => _inviteInPlex(user),
             onRequestSettings: () => context.push(
               '/settings/users/${user.id}/request-settings',
@@ -372,10 +398,12 @@ class _UserTile extends StatelessWidget {
   const _UserTile({
     required this.user,
     required this.isSelf,
+    required this.plexInviteConfigured,
     required this.onChangeRole,
     required this.onDelete,
     required this.onResendInvite,
     required this.onSendTestPush,
+    required this.onSendPlexInvite,
     required this.onInviteInPlex,
     required this.onSetAuthMethods,
     required this.onRequestSettings,
@@ -383,10 +411,12 @@ class _UserTile extends StatelessWidget {
 
   final UserSummary user;
   final bool isSelf;
+  final bool plexInviteConfigured;
   final ValueChanged<String> onChangeRole;
   final VoidCallback onDelete;
   final VoidCallback onResendInvite;
   final VoidCallback onSendTestPush;
+  final VoidCallback onSendPlexInvite;
   final VoidCallback onInviteInPlex;
   final void Function({bool? passwordEnabled, bool? passkeyEnabled})
       onSetAuthMethods;
@@ -455,6 +485,8 @@ class _UserTile extends StatelessWidget {
               const _Tag(label: 'Passkey', color: AppTheme.textSecondary),
             if (user.plexEmail.isNotEmpty)
               _Tag(label: user.plexEmail, color: AppTheme.textSecondary),
+            if (user.plexInvitedAt != null)
+              const _Tag(label: 'Plex invite sent', color: AppTheme.available),
           ],
         ),
       ),
@@ -478,6 +510,9 @@ class _UserTile extends StatelessWidget {
             break;
           case 'test_push':
             onSendTestPush();
+            break;
+          case 'send_plex_invite':
+            onSendPlexInvite();
             break;
           case 'invite_in_plex':
             onInviteInPlex();
@@ -527,9 +562,20 @@ class _UserTile extends StatelessWidget {
               contentPadding: EdgeInsets.zero,
             ),
           ),
-        // The user shared their Plex email: copy it and jump to Plex's
-        // sharing settings to send the actual invite.
-        if (user.plexEmail.isNotEmpty)
+        // The user shared their Plex email. With a linked Plex account the
+        // invite is one tap; otherwise fall back to copy-email-and-open-Plex.
+        if (user.plexEmail.isNotEmpty && plexInviteConfigured)
+          PopupMenuItem(
+            value: 'send_plex_invite',
+            child: ListTile(
+              leading: const Icon(Icons.send_outlined),
+              title: Text(user.plexInvitedAt != null
+                  ? 'Resend Plex invite'
+                  : 'Send Plex invite'),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
+        if (user.plexEmail.isNotEmpty && !plexInviteConfigured)
           const PopupMenuItem(
             value: 'invite_in_plex',
             child: ListTile(

--- a/app/lib/features/setup_wizard/ui/plex_watch_guide.dart
+++ b/app/lib/features/setup_wizard/ui/plex_watch_guide.dart
@@ -27,8 +27,9 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
 
   @override
   Widget build(BuildContext context) {
-    final plexEmail =
-        ref.watch(authProvider).valueOrNull?.user?.plexEmail ?? '';
+    final user = ref.watch(authProvider).valueOrNull?.user;
+    final plexEmail = user?.plexEmail ?? '';
+    final inviteSent = user?.plexInvitedAt != null;
 
     return Scaffold(
       appBar: AppBar(title: const Text('Watch on Plex')),
@@ -65,7 +66,7 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
             ],
           ),
           const SizedBox(height: 24),
-          _buildInviteSection(plexEmail),
+          _buildInviteSection(plexEmail, inviteSent),
           const SizedBox(height: 24),
           const _GuideSection(
             number: 4,
@@ -116,8 +117,10 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
   }
 
   /// Step 3: the interactive part. Shares the user's Plex email with the
-  /// server so admins get notified and can send the invite from Plex.
-  Widget _buildInviteSection(String plexEmail) {
+  /// server; depending on the server's setup the invite goes out
+  /// automatically or an admin sends it, and the card reflects which state
+  /// this user is in (nothing shared / waiting / invite sent).
+  Widget _buildInviteSection(String plexEmail, bool inviteSent) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -160,8 +163,13 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
                     children: [
                       Row(
                         children: [
-                          const Icon(Icons.check_circle,
-                              color: AppTheme.available, size: 18),
+                          Icon(
+                            inviteSent
+                                ? Icons.mark_email_read_outlined
+                                : Icons.check_circle,
+                            color: AppTheme.available,
+                            size: 18,
+                          ),
                           const SizedBox(width: 8),
                           Expanded(
                             child: Text(
@@ -175,10 +183,14 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
                         ],
                       ),
                       const SizedBox(height: 8),
-                      const Text(
-                        'Your admin has been notified — the invite will '
-                        'arrive at this address.',
-                        style: TextStyle(
+                      Text(
+                        inviteSent
+                            ? 'Your invite has been sent! Check your inbox '
+                                '(and spam) for an email from Plex, then '
+                                'continue with step 4.'
+                            : 'Your admin has been notified — the invite '
+                                'will arrive at this address.',
+                        style: const TextStyle(
                           color: AppTheme.textSecondary,
                           fontSize: 13,
                           height: 1.4,
@@ -238,6 +250,13 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
                 ScaffoldMessenger.of(this.context).showSnackBar(const SnackBar(
                   content: Text('Thanks! Your admin has been notified.'),
                 ));
+                // If the server auto-invites, the invite lands within a few
+                // seconds — re-fetch so the card flips to "check your inbox".
+                Future.delayed(const Duration(seconds: 3), () {
+                  if (mounted) {
+                    ref.read(authProvider.notifier).refreshUser();
+                  }
+                });
               }
             } catch (_) {
               setDialogState(() {

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -37,6 +37,7 @@ import '../features/radarr/ui/radarr_wanted_screen.dart';
 import '../features/settings/ui/ai_tools_screen.dart';
 import '../features/settings/ui/credentials_screen.dart';
 import '../features/settings/ui/devices_screen.dart';
+import '../features/settings/ui/plex_settings_screen.dart';
 import '../features/settings/ui/instance_edit_screen.dart';
 import '../features/settings/ui/pending_requests_screen.dart';
 import '../features/settings/ui/request_settings_screen.dart';
@@ -474,6 +475,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         path: '/settings/devices',
         parentNavigatorKey: _rootNavigatorKey,
         builder: (_, __) => const DevicesScreen(),
+      ),
+      GoRoute(
+        path: '/settings/plex',
+        parentNavigatorKey: _rootNavigatorKey,
+        builder: (_, __) => const PlexSettingsScreen(),
       ),
       GoRoute(
         path: '/settings/notifications',

--- a/server/README.md
+++ b/server/README.md
@@ -133,6 +133,18 @@ DELETE /api/admin/users/{userID}
 POST   /api/admin/users/{userID}/test-push       # delivery diagnostics for one user
 GET|PUT /api/admin/users/{userID}/default-instances  # pin per-user default arr instances;
                                                      # for Chaptarr this doubles as the access grant
+POST   /api/admin/users/{userID}/plex-invite     # send the Plex invite for the user's shared email
+```
+
+### Plex invites (admin)
+```
+GET    /api/admin/plex/status              # linked account + invite config (never the token)
+POST   /api/admin/plex/link/begin          # start the PIN flow -> { pin_id, code, url }
+POST   /api/admin/plex/link/check          # poll the PIN; stores the token once approved
+DELETE /api/admin/plex/link                # unlink + forget invite settings
+GET    /api/admin/plex/servers             # linked account's owned Plex Media Servers
+GET    /api/admin/plex/servers/{machineID}/libraries  # sections for the library picker
+PUT    /api/admin/plex/settings            # server, shared libraries, auto-invite toggle
 ```
 
 ### Requests
@@ -252,7 +264,7 @@ WebSocket events:
 - `request_status_changed` -- `{ tmdb_id, media_type, status }` (queue polling **and** arr webhooks; status here is `available`, `partially_available`, `requested`, or `unavailable` -- note the longer spelling vs the REST `partial`)
 - `downloads_queue` -- full download-client queue snapshot `{ instance_id, paused, speed_bps, items }`, sent on change
 - `arr_queue_changed` -- `{ instance_id, service_type }` invalidation ping; clients refetch via REST
-- targeted events fanned out per user/admin: `request_pending`, `request_decision`, `issue_created`, `issue_updated`, `agent_action_pending`, `agent_action_decided`, `remediation_autodispatch_disabled`, `plex_access_request`
+- targeted events fanned out per user/admin: `request_pending`, `request_decision`, `issue_created`, `issue_updated`, `agent_action_pending`, `agent_action_decided`, `remediation_autodispatch_disabled`, `plex_access_request`, `plex_invite_sent`
 
 ## Architecture
 
@@ -324,9 +336,14 @@ Notification categories (per-user preferences; admin-scoped ones are enforced in
 | `new_episode` | on | everyone | new episode(s) import for a series |
 | `issue_created` | on | admins | a problem is reported/detected |
 | `agent_action_pending` | on | admins | the agent proposed a fix needing approval |
-| `plex_access_request` | on | admins | a user shared their Plex email for a server invite (collapse-keyed per user) |
+| `plex_access_request` | on | admins | a user shared their Plex email for a server invite (collapse-keyed per user; body says whether auto-invite already handled it) |
+| `plex_invite_sent` | on | requester | their Plex invite email went out (one-tap or auto) |
 
 Bodies are server-authored templates (untrusted text never hits the lock screen), sends are fire-and-forget with a 30s timeout, a 10-minute in-process dedupe window absorbs the overlap between queue polling and webhooks, and tokens the gateway reports dead are pruned automatically. Payloads carry deep-link data (`type`, `tmdb_id`/`issue_id`/`user_id`) the app routes on tap.
+
+### Plex invites
+
+Linking a Plex account (Settings > Plex Invites in the app) uses plex.tv's PIN flow: the server mints a PIN, the admin approves it in the browser, and the resulting token is stored AES-encrypted in the settings table (it never appears in any API response). With a server and libraries selected, `POST /api/admin/users/{id}/plex-invite` shares them with the user's email via plex.tv's `shared_servers` API — and with **auto-invite** on, the same happens with zero taps the moment a user shares their email from the Watch on Plex guide. A duplicate share (the account already has access) is treated as soft success. Sending an invite stamps `users.plex_invited_at` (a record of Cantinarr's action, not live Plex state) and pushes `plex_invite_sent` to the user; changing the email clears the stamp since the old invite went to the old address. The stable `X-Plex-Client-Identifier` survives unlink/relink.
 
 ### MCP server endpoint
 
@@ -390,7 +407,7 @@ SQLite (pure Go driver) with WAL mode. **The live schema is code**: `internal/db
 | Push | `push_tokens` (one per device), `notification_prefs` |
 | Remediation | `issues`, `issue_messages`, `agent_runs`, `agent_steps`, `agent_actions` (fingerprint-deduped) |
 | MCP OAuth | `oauth_clients`, `oauth_authorization_codes`, `oauth_refresh_tokens` |
-| Misc | `settings` (encrypted KV: JWT secret, push key, request policy), `tmdb_tvdb_cache` (30-day TTL) |
+| Misc | `settings` (encrypted KV: JWT secret, push key, request policy, Plex token + invite config), `tmdb_tvdb_cache` (30-day TTL) |
 
 ## Project Structure
 
@@ -414,6 +431,7 @@ server/
 │   ├── mcp/                  # The 26 tools, toggles, tool server (chat + MCP + agent share it)
 │   ├── mcpserver/            # MCP Streamable HTTP endpoint, prompts, agent guide (mcp-go)
 │   ├── nzbget/               # NZBGet JSON-RPC client
+│   ├── plex/                 # plex.tv PIN link + shared_servers invites (one-tap & auto)
 │   ├── proxy/                # Verbatim arr reverse proxy (read-only for users)
 │   ├── push/                 # Push gateway client, auto-enroll, prefs, notifier
 │   ├── qbittorrent/          # qBittorrent WebUI v2 client

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/downloads"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/mcp"
+	"github.com/windoze95/cantinarr-server/internal/plex"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/push"
 	"github.com/windoze95/cantinarr-server/internal/remediation"
@@ -168,9 +169,14 @@ func main() {
 	} else {
 		notifier = push.NewComposite(wsHub)
 	}
-	// The auth handler notifies admins when a user shares their Plex email
-	// (plex_access_request); wired late because the composite needs the hub.
-	authHandler.SetNotifier(notifier)
+	// Plex integration: linked-account invites (one-tap and auto). The auth
+	// handler's access-request hook routes "user shared their Plex email"
+	// through the plex service, which auto-invites when configured and
+	// notifies admins with the outcome; wired late because the composite
+	// needs the hub.
+	plexService := plex.NewService(database, cipher, plex.NewClient(), notifier, logger)
+	plexHandler := plex.NewHandler(plexService, logger)
+	authHandler.SetAccessRequestHook(plexService.OnAccessRequest)
 	requestService := request.NewService(database, registry, bridge, notifier)
 	requestHandler := request.NewHandler(requestService)
 
@@ -222,7 +228,7 @@ func main() {
 	webhookHandler := webhooks.NewHandler(instanceStore, registry, wsHub, requestService, contentNotifier)
 
 	// Router
-	router := api.NewRouter(cfg, authHandler, authService, requestHandler, remediationService, remediationHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler, webhookHandler)
+	router := api.NewRouter(cfg, authHandler, authService, requestHandler, remediationService, remediationHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler, webhookHandler, plexHandler)
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	log.Printf("Cantinarr server starting on %s", addr)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -17,6 +17,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/mcp"
 	"github.com/windoze95/cantinarr-server/internal/mcpserver"
+	"github.com/windoze95/cantinarr-server/internal/plex"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/push"
 	"github.com/windoze95/cantinarr-server/internal/remediation"
@@ -47,6 +48,7 @@ func NewRouter(
 	toolServer *mcp.ToolServer,
 	pushHandler *push.Handler,
 	webhookHandler *webhooks.Handler,
+	plexHandler *plex.Handler,
 ) http.Handler {
 	r := chi.NewRouter()
 
@@ -145,6 +147,18 @@ func NewRouter(
 			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Delete("/users/{userID}", authHandler.HandleDeleteUser)
 			// Send a test push to a specific user's devices (delivery diagnostics).
 			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Post("/users/{userID}/test-push", pushHandler.TestPushToUser)
+
+			// Plex integration: link the admin's Plex account (PIN flow), pick
+			// the server/libraries invites share, and send one-tap invites for
+			// a user's shared Plex email.
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Get("/plex/status", plexHandler.Status)
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Post("/plex/link/begin", plexHandler.BeginLink)
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Post("/plex/link/check", plexHandler.CheckLink)
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Delete("/plex/link", plexHandler.Unlink)
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Get("/plex/servers", plexHandler.Servers)
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Get("/plex/servers/{machineID}/libraries", plexHandler.Libraries)
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Put("/plex/settings", plexHandler.UpdateSettings)
+			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Post("/users/{userID}/plex-invite", plexHandler.InviteUser)
 
 			// Per-user default *arr instance overrides (admin-managed). Pins which
 			// instance is a given user's default source per service type, and —

--- a/server/internal/auth/handler.go
+++ b/server/internal/auth/handler.go
@@ -10,27 +10,26 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// AdminNotifier is the notification fan-out the handler uses for admin-scoped
-// events (currently only "plex_access_request"). Declared here so auth stays
-// free of a push dependency; *push.Composite satisfies it.
-type AdminNotifier interface {
-	NotifyAdmins(eventType string, data map[string]interface{})
-}
+// AccessRequestHook runs after a user shares a new or changed Plex email.
+// Wired by main to the plex service, which auto-invites when configured and
+// notifies admins with the outcome either way. A hook (not a notifier) so
+// auth stays free of both push and plex dependencies.
+type AccessRequestHook func(userID int64, username string)
 
 type Handler struct {
-	service  *Service
-	notifier AdminNotifier
+	service           *Service
+	accessRequestHook AccessRequestHook
 }
 
 func NewHandler(service *Service) *Handler {
 	return &Handler{service: service}
 }
 
-// SetNotifier wires the admin notification fan-out after construction: the
-// composite is built later in startup than the auth handler (it needs the
-// WebSocket hub, which needs this handler's service).
-func (h *Handler) SetNotifier(n AdminNotifier) {
-	h.notifier = n
+// SetAccessRequestHook wires the Plex access-request side effect after
+// construction: the plex service is built later in startup than the auth
+// handler (it needs the notifier composite, which needs the WebSocket hub).
+func (h *Handler) SetAccessRequestHook(hook AccessRequestHook) {
+	h.accessRequestHook = hook
 }
 
 func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
@@ -347,6 +346,7 @@ func (h *Handler) Me(w http.ResponseWriter, r *http.Request) {
 		"password_enabled": user.PasswordEnabled,
 		"passkey_enabled":  user.PasskeyEnabled,
 		"plex_email":       user.PlexEmail,
+		"plex_invited_at":  user.PlexInvitedAt,
 	})
 }
 
@@ -413,11 +413,8 @@ func (h *Handler) SetPlexEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if changed && h.notifier != nil {
-		h.notifier.NotifyAdmins("plex_access_request", map[string]interface{}{
-			"user_id":  claims.UserID,
-			"username": claims.Username,
-		})
+	if changed && h.accessRequestHook != nil {
+		h.accessRequestHook(claims.UserID, claims.Username)
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})

--- a/server/internal/auth/models.go
+++ b/server/internal/auth/models.go
@@ -14,9 +14,12 @@ type User struct {
 	PasswordEnabled bool `json:"password_enabled"`
 	PasskeyEnabled  bool `json:"passkey_enabled"`
 	// PlexEmail is the email the user shared so an admin can invite them to
-	// the Plex server. Empty until the user submits one.
-	PlexEmail string    `json:"plex_email"`
-	CreatedAt time.Time `json:"created_at"`
+	// the Plex server. Empty until the user submits one. PlexInvitedAt is
+	// when Cantinarr last sent their invite (one-tap or auto) — a record of
+	// our action, not a claim about current access in Plex.
+	PlexEmail     string     `json:"plex_email"`
+	PlexInvitedAt *time.Time `json:"plex_invited_at,omitempty"`
+	CreatedAt     time.Time  `json:"created_at"`
 }
 
 // UserSummary is an enriched view of a user for admin user-management screens.
@@ -34,6 +37,7 @@ type UserSummary struct {
 	PasskeyEnabled   bool         `json:"passkey_enabled"`
 	HasPendingInvite bool         `json:"has_pending_invite"`
 	PlexEmail        string       `json:"plex_email"`
+	PlexInvitedAt    *time.Time   `json:"plex_invited_at,omitempty"`
 }
 
 // UpdateUserRoleRequest changes a user's role.

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -337,8 +337,10 @@ func (s *Service) SetPlexEmail(userID int64, email string) (bool, error) {
 		return false, nil
 	}
 
+	// A changed address also clears the invited stamp: any invite already
+	// sent went to the OLD email, so the user is back to "waiting".
 	if _, err := s.db.Exec(
-		"UPDATE users SET plex_email = ? WHERE id = ?",
+		"UPDATE users SET plex_email = ?, plex_invited_at = NULL WHERE id = ?",
 		email, userID,
 	); err != nil {
 		return false, fmt.Errorf("update plex email: %w", err)
@@ -695,6 +697,7 @@ func (s *Service) ListUsers() ([]UserSummary, error) {
 			u.password_enabled,
 			u.passkey_enabled,
 			u.plex_email,
+			u.plex_invited_at,
 			(SELECT COUNT(*) FROM devices d WHERE d.user_id = u.id AND d.revoked_at IS NULL) AS device_count,
 			EXISTS(
 				SELECT 1 FROM connect_tokens ct
@@ -711,12 +714,16 @@ func (s *Service) ListUsers() ([]UserSummary, error) {
 	var users []UserSummary
 	for rows.Next() {
 		var u UserSummary
+		var invitedAt sql.NullTime
 		if err := rows.Scan(
 			&u.ID, &u.Username, &u.Role, &u.CreatedAt,
-			&u.HasPassword, &u.PasswordEnabled, &u.PasskeyEnabled, &u.PlexEmail,
+			&u.HasPassword, &u.PasswordEnabled, &u.PasskeyEnabled, &u.PlexEmail, &invitedAt,
 			&u.DeviceCount, &u.HasPendingInvite,
 		); err != nil {
 			return nil, fmt.Errorf("scan user: %w", err)
+		}
+		if invitedAt.Valid {
+			u.PlexInvitedAt = &invitedAt.Time
 		}
 		u.Permissions = PermissionsForRole(u.Role)
 		users = append(users, u)
@@ -874,6 +881,7 @@ func (s *Service) DeleteUser(actorID, userID int64) error {
 
 func (s *Service) userSummaryByID(userID int64) (*UserSummary, error) {
 	var u UserSummary
+	var invitedAt sql.NullTime
 	err := s.db.QueryRow(`
 		SELECT
 			u.id,
@@ -884,6 +892,7 @@ func (s *Service) userSummaryByID(userID int64) (*UserSummary, error) {
 			u.password_enabled,
 			u.passkey_enabled,
 			u.plex_email,
+			u.plex_invited_at,
 			(SELECT COUNT(*) FROM devices d WHERE d.user_id = u.id AND d.revoked_at IS NULL) AS device_count,
 			EXISTS(
 				SELECT 1 FROM connect_tokens ct
@@ -893,7 +902,7 @@ func (s *Service) userSummaryByID(userID int64) (*UserSummary, error) {
 		WHERE u.id = ?
 	`, time.Now(), userID).Scan(
 		&u.ID, &u.Username, &u.Role, &u.CreatedAt,
-		&u.HasPassword, &u.PasswordEnabled, &u.PasskeyEnabled, &u.PlexEmail,
+		&u.HasPassword, &u.PasswordEnabled, &u.PasskeyEnabled, &u.PlexEmail, &invitedAt,
 		&u.DeviceCount, &u.HasPendingInvite,
 	)
 	if err != nil {
@@ -901,6 +910,9 @@ func (s *Service) userSummaryByID(userID int64) (*UserSummary, error) {
 			return nil, ErrUserNotFound
 		}
 		return nil, fmt.Errorf("load user summary: %w", err)
+	}
+	if invitedAt.Valid {
+		u.PlexInvitedAt = &invitedAt.Time
 	}
 	u.Permissions = PermissionsForRole(u.Role)
 	return &u, nil
@@ -1052,22 +1064,30 @@ func userWithPermissions(user *User) User {
 
 func (s *Service) getUserByUsername(username string) (*User, error) {
 	var user User
+	var invitedAt sql.NullTime
 	err := s.db.QueryRow(
-		"SELECT id, username, password_hash, role, password_enabled, passkey_enabled, plex_email, created_at FROM users WHERE username = ?", username,
-	).Scan(&user.ID, &user.Username, &user.PasswordHash, &user.Role, &user.PasswordEnabled, &user.PasskeyEnabled, &user.PlexEmail, &user.CreatedAt)
+		"SELECT id, username, password_hash, role, password_enabled, passkey_enabled, plex_email, plex_invited_at, created_at FROM users WHERE username = ?", username,
+	).Scan(&user.ID, &user.Username, &user.PasswordHash, &user.Role, &user.PasswordEnabled, &user.PasskeyEnabled, &user.PlexEmail, &invitedAt, &user.CreatedAt)
 	if err != nil {
 		return nil, err
+	}
+	if invitedAt.Valid {
+		user.PlexInvitedAt = &invitedAt.Time
 	}
 	return &user, nil
 }
 
 func (s *Service) getUserByID(id int64) (*User, error) {
 	var user User
+	var invitedAt sql.NullTime
 	err := s.db.QueryRow(
-		"SELECT id, username, password_hash, role, password_enabled, passkey_enabled, plex_email, created_at FROM users WHERE id = ?", id,
-	).Scan(&user.ID, &user.Username, &user.PasswordHash, &user.Role, &user.PasswordEnabled, &user.PasskeyEnabled, &user.PlexEmail, &user.CreatedAt)
+		"SELECT id, username, password_hash, role, password_enabled, passkey_enabled, plex_email, plex_invited_at, created_at FROM users WHERE id = ?", id,
+	).Scan(&user.ID, &user.Username, &user.PasswordHash, &user.Role, &user.PasswordEnabled, &user.PasskeyEnabled, &user.PlexEmail, &invitedAt, &user.CreatedAt)
 	if err != nil {
 		return nil, err
+	}
+	if invitedAt.Valid {
+		user.PlexInvitedAt = &invitedAt.Time
 	}
 	return &user, nil
 }

--- a/server/internal/auth/service_test.go
+++ b/server/internal/auth/service_test.go
@@ -482,10 +482,23 @@ func TestSetPlexEmail_StoresTrimsAndReportsChange(t *testing.T) {
 		t.Fatal("identical resubmission should not report changed")
 	}
 
-	// A different address is a change again, and shows up in ListUsers.
+	// Simulate an invite having been sent to the first address.
+	if _, err := svc.db.Exec("UPDATE users SET plex_invited_at = CURRENT_TIMESTAMP WHERE id = ?", guestID); err != nil {
+		t.Fatalf("stamp invited: %v", err)
+	}
+
+	// A different address is a change again, shows up in ListUsers, and
+	// clears the invited stamp (that invite went to the old email).
 	changed, err = svc.SetPlexEmail(guestID, "corsair@example.com")
 	if err != nil || !changed {
 		t.Fatalf("expected changed update, got changed=%v err=%v", changed, err)
+	}
+	user, err = svc.GetUser(guestID)
+	if err != nil {
+		t.Fatalf("get user after change: %v", err)
+	}
+	if user.PlexInvitedAt != nil {
+		t.Fatal("changing the email must clear plex_invited_at")
 	}
 	users, err := svc.ListUsers()
 	if err != nil {

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS users (
     password_enabled BOOLEAN NOT NULL DEFAULT 0,
     passkey_enabled BOOLEAN NOT NULL DEFAULT 0,
     plex_email TEXT NOT NULL DEFAULT '',
+    plex_invited_at DATETIME,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -120,7 +121,8 @@ CREATE TABLE IF NOT EXISTS notification_prefs (
     new_episode      INTEGER NOT NULL DEFAULT 1,
     issue_created    INTEGER NOT NULL DEFAULT 1,
     agent_action_pending INTEGER NOT NULL DEFAULT 1,
-    plex_access_request INTEGER NOT NULL DEFAULT 1
+    plex_access_request INTEGER NOT NULL DEFAULT 1,
+    plex_invite_sent INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE TABLE IF NOT EXISTS connect_tokens (
@@ -391,6 +393,10 @@ func Open(dbPath string) (*sql.DB, error) {
 		// Admins are notified when a user shares their Plex email for an
 		// invite, on by default. New on existing databases.
 		{alter: "ALTER TABLE notification_prefs ADD COLUMN plex_access_request INTEGER NOT NULL DEFAULT 1"},
+		// When Cantinarr sends the user's Plex invite (one-tap or auto), the
+		// stamp records that it went out and the user is told to check email.
+		{alter: "ALTER TABLE users ADD COLUMN plex_invited_at DATETIME"},
+		{alter: "ALTER TABLE notification_prefs ADD COLUMN plex_invite_sent INTEGER NOT NULL DEFAULT 1"},
 	}
 	for _, m := range migrations {
 		if _, err := db.Exec(m.alter); err != nil {

--- a/server/internal/plex/client.go
+++ b/server/internal/plex/client.go
@@ -1,0 +1,263 @@
+// Package plex integrates with plex.tv: linking the admin's Plex account via
+// the PIN flow and sending library-share invites, so Cantinarr can turn a
+// user's "here's my Plex email" into an actual server invite without the
+// admin leaving the app.
+package plex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// ErrAlreadyShared reports that the invited account already has access to the
+// server (plex.tv answers 422 for duplicate shares). Callers treat it as a
+// soft success: the user is invited either way.
+var ErrAlreadyShared = errors.New("account already has access to this server")
+
+// Client is a minimal plex.tv API client. The admin token is passed per call
+// (it lives encrypted in the settings store, owned by the Service); the
+// client itself is stateless. baseURL is a field so tests can point it at a
+// fake plex.tv.
+type Client struct {
+	http    *http.Client
+	baseURL string
+	product string
+}
+
+func NewClient() *Client {
+	return &Client{
+		http:    &http.Client{Timeout: 15 * time.Second},
+		baseURL: "https://plex.tv",
+		product: "Cantinarr",
+	}
+}
+
+// Pin is a plex.tv link PIN. AuthToken stays empty until the admin approves
+// the link in their browser.
+type Pin struct {
+	ID        int64  `json:"id"`
+	Code      string `json:"code"`
+	AuthToken string `json:"authToken"`
+}
+
+// Account identifies the linked plex.tv account (display only).
+type Account struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+}
+
+// Server is an owned Plex Media Server visible to the linked account.
+// ClientIdentifier is what the sharing API calls the machine identifier.
+type Server struct {
+	Name             string `json:"name"`
+	ClientIdentifier string `json:"clientIdentifier"`
+	Provides         string `json:"provides"`
+	Owned            bool   `json:"owned"`
+}
+
+// Library is one library section on a server. ID is the plex.tv-global
+// section id the sharing API expects (NOT the server-local key).
+type Library struct {
+	ID    int64  `json:"id"`
+	Title string `json:"title"`
+	Type  string `json:"type"`
+}
+
+// CreatePin starts the PIN link flow.
+func (c *Client) CreatePin(ctx context.Context, clientID string) (*Pin, error) {
+	var pin Pin
+	if err := c.doJSON(ctx, http.MethodPost, "/api/v2/pins?strong=true", clientID, "", nil, &pin); err != nil {
+		return nil, fmt.Errorf("create pin: %w", err)
+	}
+	return &pin, nil
+}
+
+// CheckPin polls a PIN; AuthToken is non-empty once the admin approved it.
+func (c *Client) CheckPin(ctx context.Context, clientID string, id int64) (*Pin, error) {
+	var pin Pin
+	if err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("/api/v2/pins/%d", id), clientID, "", nil, &pin); err != nil {
+		return nil, fmt.Errorf("check pin: %w", err)
+	}
+	return &pin, nil
+}
+
+// AuthURL is the page the admin opens to approve the PIN. Always the real
+// plex.tv app, never baseURL: it is user-facing, not an API call.
+func (c *Client) AuthURL(clientID, code string) string {
+	v := url.Values{
+		"clientID":                {clientID},
+		"code":                    {code},
+		"context[device][product]": {c.product},
+	}
+	return "https://app.plex.tv/auth#?" + v.Encode()
+}
+
+// GetUser verifies a token and returns the account it belongs to.
+func (c *Client) GetUser(ctx context.Context, clientID, token string) (*Account, error) {
+	var acct Account
+	if err := c.doJSON(ctx, http.MethodGet, "/api/v2/user", clientID, token, nil, &acct); err != nil {
+		return nil, fmt.Errorf("get user: %w", err)
+	}
+	return &acct, nil
+}
+
+// ListServers returns the owned Plex Media Servers on the account.
+func (c *Client) ListServers(ctx context.Context, clientID, token string) ([]Server, error) {
+	var all []Server
+	if err := c.doJSON(ctx, http.MethodGet, "/api/v2/resources?includeHttps=1", clientID, token, nil, &all); err != nil {
+		return nil, fmt.Errorf("list servers: %w", err)
+	}
+	servers := make([]Server, 0, len(all))
+	for _, s := range all {
+		if s.Owned && strings.Contains(s.Provides, "server") {
+			servers = append(servers, s)
+		}
+	}
+	return servers, nil
+}
+
+// ListLibraries returns a server's library sections with their plex.tv-global
+// ids. This is the one v1/XML endpoint: /api/servers/{machineID} is where the
+// global section ids live (the JSON APIs only expose server-local keys).
+func (c *Client) ListLibraries(ctx context.Context, clientID, token, machineID string) ([]Library, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/api/servers/"+url.PathEscape(machineID), nil)
+	if err != nil {
+		return nil, err
+	}
+	c.setHeaders(req, clientID, token)
+	req.Header.Set("Accept", "application/xml")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list libraries: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("list libraries: plex.tv answered %d", resp.StatusCode)
+	}
+
+	var container struct {
+		Servers []struct {
+			Sections []struct {
+				ID    int64  `xml:"id,attr"`
+				Title string `xml:"title,attr"`
+				Type  string `xml:"type,attr"`
+			} `xml:"Section"`
+		} `xml:"Server"`
+	}
+	if err := xml.NewDecoder(resp.Body).Decode(&container); err != nil {
+		return nil, fmt.Errorf("list libraries: decode: %w", err)
+	}
+
+	var libs []Library
+	for _, srv := range container.Servers {
+		for _, sec := range srv.Sections {
+			libs = append(libs, Library{ID: sec.ID, Title: sec.Title, Type: sec.Type})
+		}
+	}
+	return libs, nil
+}
+
+// InviteEmail shares the server's selected libraries with an email address.
+// An empty sectionIDs list shares every library (plex.tv semantics). Returns
+// ErrAlreadyShared when the account already has access.
+func (c *Client) InviteEmail(ctx context.Context, clientID, token, machineID, email string, sectionIDs []int64) error {
+	if sectionIDs == nil {
+		sectionIDs = []int64{}
+	}
+	body := map[string]any{
+		"machineIdentifier": machineID,
+		"invitedEmail":      email,
+		"librarySectionIds": sectionIDs,
+		"settings":          map[string]any{},
+	}
+	err := c.doJSON(ctx, http.MethodPost, "/api/v2/shared_servers", clientID, token, body, nil)
+	if err != nil {
+		var apiErr *apiError
+		if errors.As(err, &apiErr) && apiErr.status == http.StatusUnprocessableEntity {
+			return ErrAlreadyShared
+		}
+		return fmt.Errorf("invite: %w", err)
+	}
+	return nil
+}
+
+// apiError is a non-2xx plex.tv answer, keeping the status for callers that
+// map specific codes (422 = duplicate share).
+type apiError struct {
+	status  int
+	message string
+}
+
+func (e *apiError) Error() string {
+	if e.message != "" {
+		return fmt.Sprintf("plex.tv answered %d: %s", e.status, e.message)
+	}
+	return fmt.Sprintf("plex.tv answered %d", e.status)
+}
+
+func (c *Client) setHeaders(req *http.Request, clientID, token string) {
+	req.Header.Set("X-Plex-Product", c.product)
+	req.Header.Set("X-Plex-Client-Identifier", clientID)
+	if token != "" {
+		req.Header.Set("X-Plex-Token", token)
+	}
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path, clientID, token string, body, out any) error {
+	var reader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	c.setHeaders(req, clientID, token)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		// plex.tv error bodies look like {"errors":[{"code":..,"message":".."}]}.
+		var parsed struct {
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		msg := ""
+		if data, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096)); readErr == nil {
+			if json.Unmarshal(data, &parsed) == nil && len(parsed.Errors) > 0 {
+				msg = parsed.Errors[0].Message
+			}
+		}
+		return &apiError{status: resp.StatusCode, message: msg}
+	}
+
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("decode response: %w", err)
+		}
+	}
+	return nil
+}

--- a/server/internal/plex/client_test.go
+++ b/server/internal/plex/client_test.go
@@ -1,0 +1,166 @@
+package plex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func testClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := NewClient()
+	c.baseURL = srv.URL
+	return c
+}
+
+func TestCreateAndCheckPin(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/pins", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("pins method = %s", r.Method)
+		}
+		if r.URL.Query().Get("strong") != "true" {
+			t.Error("expected strong=true")
+		}
+		if r.Header.Get("X-Plex-Client-Identifier") != "cid-1" {
+			t.Errorf("client id header = %q", r.Header.Get("X-Plex-Client-Identifier"))
+		}
+		if r.Header.Get("X-Plex-Product") == "" {
+			t.Error("missing X-Plex-Product")
+		}
+		json.NewEncoder(w).Encode(map[string]any{"id": 123, "code": "abcd"})
+	})
+	mux.HandleFunc("/api/v2/pins/123", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"id": 123, "code": "abcd", "authToken": "tok-9"})
+	})
+	c := testClient(t, mux)
+
+	pin, err := c.CreatePin(context.Background(), "cid-1")
+	if err != nil {
+		t.Fatalf("create pin: %v", err)
+	}
+	if pin.ID != 123 || pin.Code != "abcd" {
+		t.Fatalf("pin = %+v", pin)
+	}
+
+	checked, err := c.CheckPin(context.Background(), "cid-1", 123)
+	if err != nil {
+		t.Fatalf("check pin: %v", err)
+	}
+	if checked.AuthToken != "tok-9" {
+		t.Fatalf("auth token = %q", checked.AuthToken)
+	}
+}
+
+func TestAuthURLCarriesClientAndCode(t *testing.T) {
+	c := NewClient()
+	u := c.AuthURL("cid-1", "abcd")
+	if !strings.HasPrefix(u, "https://app.plex.tv/auth#?") {
+		t.Fatalf("auth url = %q", u)
+	}
+	for _, want := range []string{"clientID=cid-1", "code=abcd", "context%5Bdevice%5D%5Bproduct%5D=Cantinarr"} {
+		if !strings.Contains(u, want) {
+			t.Errorf("auth url missing %q: %s", want, u)
+		}
+	}
+}
+
+func TestListServersFiltersOwnedServers(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/resources", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Plex-Token") != "tok" {
+			t.Errorf("token header = %q", r.Header.Get("X-Plex-Token"))
+		}
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"name": "Cantina", "clientIdentifier": "m1", "provides": "server", "owned": true},
+			{"name": "Friend's", "clientIdentifier": "m2", "provides": "server", "owned": false},
+			{"name": "Apple TV", "clientIdentifier": "m3", "provides": "client,player", "owned": true},
+		})
+	})
+	c := testClient(t, mux)
+
+	servers, err := c.ListServers(context.Background(), "cid", "tok")
+	if err != nil {
+		t.Fatalf("list servers: %v", err)
+	}
+	if len(servers) != 1 || servers[0].ClientIdentifier != "m1" {
+		t.Fatalf("servers = %+v", servers)
+	}
+}
+
+func TestListLibrariesParsesSectionIDs(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/servers/m1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<MediaContainer friendlyName="myPlex" size="1">
+  <Server name="Cantina" machineIdentifier="m1">
+    <Section id="101" key="1" type="movie" title="Movies"/>
+    <Section id="102" key="2" type="show" title="TV Shows"/>
+  </Server>
+</MediaContainer>`))
+	})
+	c := testClient(t, mux)
+
+	libs, err := c.ListLibraries(context.Background(), "cid", "tok", "m1")
+	if err != nil {
+		t.Fatalf("list libraries: %v", err)
+	}
+	if len(libs) != 2 {
+		t.Fatalf("libraries = %+v", libs)
+	}
+	if libs[0].ID != 101 || libs[0].Title != "Movies" || libs[1].ID != 102 {
+		t.Fatalf("libraries = %+v", libs)
+	}
+}
+
+func TestInviteEmailSendsExpectedPayload(t *testing.T) {
+	var got map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/shared_servers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s", r.Method)
+		}
+		if r.Header.Get("X-Plex-Token") != "tok" {
+			t.Errorf("token header = %q", r.Header.Get("X-Plex-Token"))
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("{}"))
+	})
+	c := testClient(t, mux)
+
+	err := c.InviteEmail(context.Background(), "cid", "tok", "m1", "bob@example.com", []int64{101, 102})
+	if err != nil {
+		t.Fatalf("invite: %v", err)
+	}
+	if got["machineIdentifier"] != "m1" || got["invitedEmail"] != "bob@example.com" {
+		t.Fatalf("payload = %+v", got)
+	}
+	ids, ok := got["librarySectionIds"].([]any)
+	if !ok || len(ids) != 2 {
+		t.Fatalf("librarySectionIds = %+v", got["librarySectionIds"])
+	}
+}
+
+func TestInviteEmailMapsDuplicateShare(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/shared_servers", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		w.Write([]byte(`{"errors":[{"code":422,"message":"Account already has access to this server"}]}`))
+	})
+	c := testClient(t, mux)
+
+	err := c.InviteEmail(context.Background(), "cid", "tok", "m1", "bob@example.com", nil)
+	if !errors.Is(err, ErrAlreadyShared) {
+		t.Fatalf("expected ErrAlreadyShared, got %v", err)
+	}
+}

--- a/server/internal/plex/handler.go
+++ b/server/internal/plex/handler.go
@@ -1,0 +1,190 @@
+package plex
+
+import (
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// Handler exposes the admin Plex-integration API: PIN link flow, invite
+// configuration, and one-tap invites. All routes are mounted behind the
+// users:manage permission.
+type Handler struct {
+	svc    *Service
+	logger *slog.Logger
+}
+
+func NewHandler(svc *Service, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{svc: svc, logger: logger}
+}
+
+// Status returns whether an account is linked and how invites are configured.
+// Never includes the token.
+func (h *Handler) Status(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, h.svc.Status())
+}
+
+// BeginLink starts the PIN flow: the app opens `url` for the admin and polls
+// CheckLink with `pin_id`.
+func (h *Handler) BeginLink(w http.ResponseWriter, r *http.Request) {
+	pinID, code, authURL, err := h.svc.BeginLink(r.Context())
+	if err != nil {
+		h.logger.Error("plex: begin link", "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "could not reach plex.tv"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"pin_id": pinID,
+		"code":   code,
+		"url":    authURL,
+	})
+}
+
+type checkLinkRequest struct {
+	PinID int64 `json:"pin_id"`
+}
+
+// CheckLink polls the PIN; {linked:false} means keep waiting.
+func (h *Handler) CheckLink(w http.ResponseWriter, r *http.Request) {
+	var req checkLinkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.PinID == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "pin_id required"})
+		return
+	}
+	linked, account, err := h.svc.CheckLink(r.Context(), req.PinID)
+	if err != nil {
+		h.logger.Error("plex: check link", "err", err)
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "could not reach plex.tv"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"linked":  linked,
+		"account": account,
+	})
+}
+
+// Unlink forgets the linked account and invite configuration.
+func (h *Handler) Unlink(w http.ResponseWriter, r *http.Request) {
+	if err := h.svc.Unlink(); err != nil {
+		h.logger.Error("plex: unlink", "err", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to unlink"})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// Servers lists the linked account's owned servers for the picker.
+func (h *Handler) Servers(w http.ResponseWriter, r *http.Request) {
+	servers, err := h.svc.Servers(r.Context())
+	if err != nil {
+		h.writePlexError(w, err, "list servers")
+		return
+	}
+	out := make([]map[string]any, 0, len(servers))
+	for _, s := range servers {
+		out = append(out, map[string]any{
+			"name":               s.Name,
+			"machine_identifier": s.ClientIdentifier,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"servers": out})
+}
+
+// Libraries lists a server's sections for the picker.
+func (h *Handler) Libraries(w http.ResponseWriter, r *http.Request) {
+	machineID := chi.URLParam(r, "machineID")
+	libs, err := h.svc.Libraries(r.Context(), machineID)
+	if err != nil {
+		h.writePlexError(w, err, "list libraries")
+		return
+	}
+	out := make([]map[string]any, 0, len(libs))
+	for _, l := range libs {
+		out = append(out, map[string]any{
+			"id":    l.ID,
+			"title": l.Title,
+			"type":  l.Type,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"libraries": out})
+}
+
+type updateSettingsRequest struct {
+	MachineIdentifier string  `json:"machine_identifier"`
+	ServerName        string  `json:"server_name"`
+	LibrarySectionIDs []int64 `json:"library_section_ids"`
+	AutoInvite        bool    `json:"auto_invite"`
+}
+
+// UpdateSettings selects the server/libraries invites share and toggles
+// auto-invite.
+func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
+	var req updateSettingsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	err := h.svc.UpdateSettings(req.MachineIdentifier, req.ServerName, req.LibrarySectionIDs, req.AutoInvite)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrNotLinked):
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "link a Plex account first"})
+		case errors.Is(err, ErrNotConfigured):
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "machine_identifier required"})
+		default:
+			h.logger.Error("plex: update settings", "err", err)
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "failed to save settings"})
+		}
+		return
+	}
+	writeJSON(w, http.StatusOK, h.svc.Status())
+}
+
+// InviteUser sends the Plex invite for one user's shared email.
+func (h *Handler) InviteUser(w http.ResponseWriter, r *http.Request) {
+	userID, err := strconv.ParseInt(chi.URLParam(r, "userID"), 10, 64)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid user ID"})
+		return
+	}
+	outcome, err := h.svc.InviteUser(r.Context(), userID)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrNoEmail):
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "user has not shared a Plex email"})
+		case errors.Is(err, ErrNotLinked), errors.Is(err, ErrNotConfigured):
+			writeJSON(w, http.StatusConflict, map[string]string{"error": "Plex invites are not configured"})
+		default:
+			h.logger.Error("plex: invite user", "err", err, "user_id", userID)
+			writeJSON(w, http.StatusBadGateway, map[string]string{"error": "Plex invite failed"})
+		}
+		return
+	}
+	status := "invited"
+	if outcome.AlreadyShared {
+		status = "already_shared"
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": status, "email": outcome.Email})
+}
+
+func (h *Handler) writePlexError(w http.ResponseWriter, err error, op string) {
+	if errors.Is(err, ErrNotLinked) {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": "link a Plex account first"})
+		return
+	}
+	h.logger.Error("plex: "+op, "err", err)
+	writeJSON(w, http.StatusBadGateway, map[string]string{"error": "could not reach plex.tv"})
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}

--- a/server/internal/plex/service.go
+++ b/server/internal/plex/service.go
@@ -1,0 +1,366 @@
+package plex
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+// Settings-table keys. The token is the only secret and is stored encrypted;
+// the rest is plain configuration. The client identifier is generated once
+// and kept across unlink/relink so plex.tv sees one stable device.
+const (
+	settingClientID   = "plex_client_id"
+	settingToken      = "plex_token" // encrypted
+	settingAccount    = "plex_account"
+	settingMachineID  = "plex_machine_id"
+	settingServerName = "plex_server_name"
+	settingLibraryIDs = "plex_library_ids" // JSON array
+	settingAutoInvite = "plex_auto_invite" // "1" / "0"
+)
+
+var (
+	// ErrNotLinked: no Plex account has been linked yet.
+	ErrNotLinked = errors.New("no plex account linked")
+	// ErrNotConfigured: linked, but no server selected to invite to.
+	ErrNotConfigured = errors.New("plex invites are not configured")
+	// ErrNoEmail: the target user never shared a Plex email.
+	ErrNoEmail = errors.New("user has not shared a plex email")
+)
+
+// api is the plex.tv surface the service uses; *Client satisfies it. An
+// interface so service tests can fake plex.tv without HTTP.
+type api interface {
+	CreatePin(ctx context.Context, clientID string) (*Pin, error)
+	CheckPin(ctx context.Context, clientID string, id int64) (*Pin, error)
+	AuthURL(clientID, code string) string
+	GetUser(ctx context.Context, clientID, token string) (*Account, error)
+	ListServers(ctx context.Context, clientID, token string) ([]Server, error)
+	ListLibraries(ctx context.Context, clientID, token, machineID string) ([]Library, error)
+	InviteEmail(ctx context.Context, clientID, token, machineID, email string, sectionIDs []int64) error
+}
+
+// notifier is the WS+push fan-out (the push.Composite). Event types are the
+// push package's category strings, passed as literals to avoid the import.
+type notifier interface {
+	NotifyUser(userID int64, eventType string, data map[string]interface{})
+	NotifyAdmins(eventType string, data map[string]interface{})
+}
+
+// Service owns the linked Plex account (token encrypted at rest), the invite
+// configuration, and the invite flows: one-tap from the Users screen and
+// auto-invite when a user shares their email.
+type Service struct {
+	db       *sql.DB
+	cipher   *secrets.Cipher
+	api      api
+	notifier notifier
+	logger   *slog.Logger
+}
+
+func NewService(db *sql.DB, cipher *secrets.Cipher, api api, notifier notifier, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{db: db, cipher: cipher, api: api, notifier: notifier, logger: logger}
+}
+
+// Status is the admin-facing view of the integration. The token is never
+// included — linked/account are all a client learns about the credential.
+type Status struct {
+	Linked            bool    `json:"linked"`
+	Account           string  `json:"account,omitempty"`
+	MachineIdentifier string  `json:"machine_identifier,omitempty"`
+	ServerName        string  `json:"server_name,omitempty"`
+	LibrarySectionIDs []int64 `json:"library_section_ids"`
+	AutoInvite        bool    `json:"auto_invite"`
+	// Configured: invites can actually be sent (linked + server selected).
+	Configured bool `json:"configured"`
+}
+
+func (s *Service) Status() Status {
+	st := Status{LibrarySectionIDs: []int64{}}
+	_, linked := s.token()
+	st.Linked = linked
+	if !linked {
+		return st
+	}
+	st.Account, _ = s.getSetting(settingAccount)
+	st.MachineIdentifier, _ = s.getSetting(settingMachineID)
+	st.ServerName, _ = s.getSetting(settingServerName)
+	st.LibrarySectionIDs = s.libraryIDs()
+	if v, ok := s.getSetting(settingAutoInvite); ok && v == "1" {
+		st.AutoInvite = true
+	}
+	st.Configured = st.MachineIdentifier != ""
+	return st
+}
+
+// BeginLink starts the PIN flow: returns the PIN id the app polls with and
+// the plex.tv URL the admin opens to approve the link.
+func (s *Service) BeginLink(ctx context.Context) (pinID int64, code, authURL string, err error) {
+	clientID, err := s.clientID()
+	if err != nil {
+		return 0, "", "", err
+	}
+	pin, err := s.api.CreatePin(ctx, clientID)
+	if err != nil {
+		return 0, "", "", err
+	}
+	return pin.ID, pin.Code, s.api.AuthURL(clientID, pin.Code), nil
+}
+
+// CheckLink polls a PIN. Once approved it verifies the token, persists it
+// encrypted, and records the account name. linked=false with nil error means
+// "still waiting".
+func (s *Service) CheckLink(ctx context.Context, pinID int64) (linked bool, account string, err error) {
+	clientID, err := s.clientID()
+	if err != nil {
+		return false, "", err
+	}
+	pin, err := s.api.CheckPin(ctx, clientID, pinID)
+	if err != nil {
+		return false, "", err
+	}
+	if pin.AuthToken == "" {
+		return false, "", nil
+	}
+	acct, err := s.api.GetUser(ctx, clientID, pin.AuthToken)
+	if err != nil {
+		return false, "", fmt.Errorf("verify token: %w", err)
+	}
+	enc, err := s.cipher.Encrypt(pin.AuthToken)
+	if err != nil {
+		return false, "", fmt.Errorf("encrypt token: %w", err)
+	}
+	if err := s.setSetting(settingToken, enc); err != nil {
+		return false, "", err
+	}
+	if err := s.setSetting(settingAccount, acct.Username); err != nil {
+		return false, "", err
+	}
+	return true, acct.Username, nil
+}
+
+// Unlink forgets the token and invite configuration (keeps the client id so
+// plex.tv keeps seeing one stable device across relinks).
+func (s *Service) Unlink() error {
+	for _, key := range []string{settingToken, settingAccount, settingMachineID, settingServerName, settingLibraryIDs, settingAutoInvite} {
+		if _, err := s.db.Exec("DELETE FROM settings WHERE key = ?", key); err != nil {
+			return fmt.Errorf("unlink plex: %w", err)
+		}
+	}
+	return nil
+}
+
+// Servers lists the linked account's owned Plex Media Servers.
+func (s *Service) Servers(ctx context.Context) ([]Server, error) {
+	clientID, token, err := s.credentials()
+	if err != nil {
+		return nil, err
+	}
+	return s.api.ListServers(ctx, clientID, token)
+}
+
+// Libraries lists a server's sections (plex.tv-global ids) for the picker.
+func (s *Service) Libraries(ctx context.Context, machineID string) ([]Library, error) {
+	clientID, token, err := s.credentials()
+	if err != nil {
+		return nil, err
+	}
+	return s.api.ListLibraries(ctx, clientID, token, machineID)
+}
+
+// UpdateSettings selects the server and libraries invites share, and whether
+// invites go out automatically when a user shares their email. An empty
+// library list means "all libraries" (plex.tv semantics).
+func (s *Service) UpdateSettings(machineID, serverName string, libraryIDs []int64, autoInvite bool) error {
+	if _, linked := s.token(); !linked {
+		return ErrNotLinked
+	}
+	if machineID == "" {
+		return ErrNotConfigured
+	}
+	if libraryIDs == nil {
+		libraryIDs = []int64{}
+	}
+	encoded, err := json.Marshal(libraryIDs)
+	if err != nil {
+		return err
+	}
+	auto := "0"
+	if autoInvite {
+		auto = "1"
+	}
+	for key, value := range map[string]string{
+		settingMachineID:  machineID,
+		settingServerName: serverName,
+		settingLibraryIDs: string(encoded),
+		settingAutoInvite: auto,
+	} {
+		if err := s.setSetting(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// InviteOutcome reports what an invite attempt did.
+type InviteOutcome struct {
+	Email string
+	// AlreadyShared: plex.tv says the account already has access; treated as
+	// success (invited-at is stamped) but the user is not pushed "check your
+	// email" for an invite that never arrives.
+	AlreadyShared bool
+}
+
+// InviteUser shares the configured libraries with the user's Plex email and
+// stamps users.plex_invited_at. On a fresh invite the user gets a
+// "plex_invite_sent" push so they know to check their inbox.
+func (s *Service) InviteUser(ctx context.Context, userID int64) (*InviteOutcome, error) {
+	clientID, token, err := s.credentials()
+	if err != nil {
+		return nil, err
+	}
+	machineID, ok := s.getSetting(settingMachineID)
+	if !ok || machineID == "" {
+		return nil, ErrNotConfigured
+	}
+
+	var email string
+	if err := s.db.QueryRow("SELECT plex_email FROM users WHERE id = ?", userID).Scan(&email); err != nil {
+		return nil, fmt.Errorf("load user: %w", err)
+	}
+	if email == "" {
+		return nil, ErrNoEmail
+	}
+
+	outcome := &InviteOutcome{Email: email}
+	err = s.api.InviteEmail(ctx, clientID, token, machineID, email, s.libraryIDs())
+	switch {
+	case errors.Is(err, ErrAlreadyShared):
+		outcome.AlreadyShared = true
+	case err != nil:
+		return nil, err
+	}
+
+	if _, err := s.db.Exec("UPDATE users SET plex_invited_at = CURRENT_TIMESTAMP WHERE id = ?", userID); err != nil {
+		s.logger.Error("plex: stamp invited_at", "err", err, "user_id", userID)
+	}
+	if !outcome.AlreadyShared && s.notifier != nil {
+		s.notifier.NotifyUser(userID, "plex_invite_sent", map[string]interface{}{})
+	}
+	return outcome, nil
+}
+
+// OnAccessRequest runs after a user shares a new or changed Plex email (wired
+// to auth's access-request hook). Fire-and-forget: auto-invites when
+// configured, then notifies admins with the outcome so the push tells them
+// whether anything is left to do.
+func (s *Service) OnAccessRequest(userID int64, username string) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.logger.Error("plex: access request handling panicked", "err", fmt.Sprint(r))
+			}
+		}()
+		s.handleAccessRequest(userID, username)
+	}()
+}
+
+// handleAccessRequest is OnAccessRequest's synchronous body (split for tests).
+func (s *Service) handleAccessRequest(userID int64, username string) {
+	inviteState := "" // "" = needs a manual invite
+	st := s.Status()
+	if st.Configured && st.AutoInvite {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if _, err := s.InviteUser(ctx, userID); err != nil {
+			s.logger.Error("plex: auto-invite failed", "err", err, "user_id", userID)
+			inviteState = "failed"
+		} else {
+			inviteState = "sent"
+		}
+	}
+	if s.notifier != nil {
+		s.notifier.NotifyAdmins("plex_access_request", map[string]interface{}{
+			"user_id":      userID,
+			"username":     username,
+			"invite_state": inviteState,
+		})
+	}
+}
+
+// credentials returns the client id and decrypted token, or ErrNotLinked.
+func (s *Service) credentials() (clientID, token string, err error) {
+	clientID, err = s.clientID()
+	if err != nil {
+		return "", "", err
+	}
+	token, ok := s.token()
+	if !ok {
+		return "", "", ErrNotLinked
+	}
+	return clientID, token, nil
+}
+
+// clientID returns the stable X-Plex-Client-Identifier, creating and
+// persisting it on first use.
+func (s *Service) clientID() (string, error) {
+	if id, ok := s.getSetting(settingClientID); ok && id != "" {
+		return id, nil
+	}
+	id := uuid.NewString()
+	if err := s.setSetting(settingClientID, id); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+// token loads and decrypts the linked account token.
+func (s *Service) token() (string, bool) {
+	stored, ok := s.getSetting(settingToken)
+	if !ok || stored == "" {
+		return "", false
+	}
+	token, err := s.cipher.Decrypt(stored)
+	if err != nil {
+		s.logger.Error("plex: decrypt token", "err", err)
+		return "", false
+	}
+	return token, true
+}
+
+func (s *Service) libraryIDs() []int64 {
+	raw, ok := s.getSetting(settingLibraryIDs)
+	if !ok || raw == "" {
+		return []int64{}
+	}
+	var ids []int64
+	if err := json.Unmarshal([]byte(raw), &ids); err != nil {
+		return []int64{}
+	}
+	return ids
+}
+
+func (s *Service) getSetting(key string) (string, bool) {
+	var value string
+	if err := s.db.QueryRow("SELECT value FROM settings WHERE key = ?", key).Scan(&value); err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+func (s *Service) setSetting(key, value string) error {
+	if _, err := s.db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", key, value); err != nil {
+		return fmt.Errorf("store %s: %w", key, err)
+	}
+	return nil
+}

--- a/server/internal/plex/service_test.go
+++ b/server/internal/plex/service_test.go
@@ -1,0 +1,278 @@
+package plex
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+type inviteCall struct {
+	machineID  string
+	email      string
+	sectionIDs []int64
+}
+
+// fakeAPI is a canned plex.tv: tests set the fields they need.
+type fakeAPI struct {
+	pin       Pin
+	checked   Pin
+	account   Account
+	servers   []Server
+	libraries []Library
+	inviteErr error
+	invites   []inviteCall
+}
+
+func (f *fakeAPI) CreatePin(_ context.Context, _ string) (*Pin, error) { p := f.pin; return &p, nil }
+func (f *fakeAPI) CheckPin(_ context.Context, _ string, _ int64) (*Pin, error) {
+	p := f.checked
+	return &p, nil
+}
+func (f *fakeAPI) AuthURL(clientID, code string) string { return "https://app.plex.tv/auth#?code=" + code }
+func (f *fakeAPI) GetUser(_ context.Context, _, _ string) (*Account, error) {
+	a := f.account
+	return &a, nil
+}
+func (f *fakeAPI) ListServers(_ context.Context, _, _ string) ([]Server, error) {
+	return f.servers, nil
+}
+func (f *fakeAPI) ListLibraries(_ context.Context, _, _, _ string) ([]Library, error) {
+	return f.libraries, nil
+}
+func (f *fakeAPI) InviteEmail(_ context.Context, _, _, machineID, email string, sectionIDs []int64) error {
+	f.invites = append(f.invites, inviteCall{machineID: machineID, email: email, sectionIDs: sectionIDs})
+	return f.inviteErr
+}
+
+type notifyCall struct {
+	userID    int64
+	eventType string
+	data      map[string]interface{}
+}
+
+type fakeNotifier struct {
+	userCalls  []notifyCall
+	adminCalls []notifyCall
+}
+
+func (f *fakeNotifier) NotifyUser(userID int64, eventType string, data map[string]interface{}) {
+	f.userCalls = append(f.userCalls, notifyCall{userID: userID, eventType: eventType, data: data})
+}
+func (f *fakeNotifier) NotifyAdmins(eventType string, data map[string]interface{}) {
+	f.adminCalls = append(f.adminCalls, notifyCall{eventType: eventType, data: data})
+}
+
+func newTestService(t *testing.T) (*Service, *fakeAPI, *fakeNotifier) {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	cipher, err := secrets.NewCipher(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	api := &fakeAPI{}
+	notif := &fakeNotifier{}
+	return NewService(database, cipher, api, notif, nil), api, notif
+}
+
+// link walks the PIN flow so the service holds a stored (encrypted) token.
+func link(t *testing.T, svc *Service, api *fakeAPI) {
+	t.Helper()
+	api.pin = Pin{ID: 1, Code: "abcd"}
+	api.checked = Pin{ID: 1, Code: "abcd", AuthToken: "secret-token"}
+	api.account = Account{Username: "captain"}
+	if _, _, _, err := svc.BeginLink(context.Background()); err != nil {
+		t.Fatalf("begin link: %v", err)
+	}
+	linked, account, err := svc.CheckLink(context.Background(), 1)
+	if err != nil || !linked {
+		t.Fatalf("check link: linked=%v err=%v", linked, err)
+	}
+	if account != "captain" {
+		t.Fatalf("account = %q", account)
+	}
+}
+
+func seedUser(t *testing.T, svc *Service, id int64, username, plexEmail string) {
+	t.Helper()
+	if _, err := svc.db.Exec(
+		"INSERT INTO users (id, username, password_hash, role, plex_email) VALUES (?, ?, '', 'user', ?)",
+		id, username, plexEmail,
+	); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+}
+
+func TestLinkFlowStoresEncryptedTokenAndStatus(t *testing.T) {
+	svc, api, _ := newTestService(t)
+
+	// Pending PIN: not linked yet.
+	api.pin = Pin{ID: 1, Code: "abcd"}
+	api.checked = Pin{ID: 1, Code: "abcd"}
+	if _, _, _, err := svc.BeginLink(context.Background()); err != nil {
+		t.Fatalf("begin link: %v", err)
+	}
+	linked, _, err := svc.CheckLink(context.Background(), 1)
+	if err != nil || linked {
+		t.Fatalf("pending pin: linked=%v err=%v", linked, err)
+	}
+
+	link(t, svc, api)
+
+	// The stored row must be ciphertext, but token() must round-trip.
+	var stored string
+	if err := svc.db.QueryRow("SELECT value FROM settings WHERE key = ?", settingToken).Scan(&stored); err != nil {
+		t.Fatalf("load stored token: %v", err)
+	}
+	if stored == "secret-token" {
+		t.Fatal("token stored in plaintext")
+	}
+	if tok, ok := svc.token(); !ok || tok != "secret-token" {
+		t.Fatalf("token() = %q, %v", tok, ok)
+	}
+
+	st := svc.Status()
+	if !st.Linked || st.Account != "captain" || st.Configured {
+		t.Fatalf("status = %+v", st)
+	}
+
+	// Unlink forgets the token but keeps the stable client id.
+	if err := svc.Unlink(); err != nil {
+		t.Fatalf("unlink: %v", err)
+	}
+	if st := svc.Status(); st.Linked {
+		t.Fatalf("still linked after unlink: %+v", st)
+	}
+	if _, ok := svc.getSetting(settingClientID); !ok {
+		t.Fatal("client id should survive unlink")
+	}
+}
+
+func TestUpdateSettingsRequiresLinkAndServer(t *testing.T) {
+	svc, api, _ := newTestService(t)
+
+	if err := svc.UpdateSettings("m1", "Cantina", []int64{1}, true); !errors.Is(err, ErrNotLinked) {
+		t.Fatalf("expected ErrNotLinked, got %v", err)
+	}
+
+	link(t, svc, api)
+	if err := svc.UpdateSettings("", "", nil, false); !errors.Is(err, ErrNotConfigured) {
+		t.Fatalf("expected ErrNotConfigured, got %v", err)
+	}
+
+	if err := svc.UpdateSettings("m1", "Cantina", []int64{101, 102}, true); err != nil {
+		t.Fatalf("update settings: %v", err)
+	}
+	st := svc.Status()
+	if !st.Configured || !st.AutoInvite || st.ServerName != "Cantina" || st.MachineIdentifier != "m1" {
+		t.Fatalf("status = %+v", st)
+	}
+	if len(st.LibrarySectionIDs) != 2 || st.LibrarySectionIDs[0] != 101 {
+		t.Fatalf("library ids = %v", st.LibrarySectionIDs)
+	}
+}
+
+func TestInviteUserSharesStampsAndNotifies(t *testing.T) {
+	svc, api, notif := newTestService(t)
+	seedUser(t, svc, 7, "bob", "bob@example.com")
+	seedUser(t, svc, 8, "nomail", "")
+
+	if _, err := svc.InviteUser(context.Background(), 7); !errors.Is(err, ErrNotLinked) {
+		t.Fatalf("expected ErrNotLinked, got %v", err)
+	}
+
+	link(t, svc, api)
+	if err := svc.UpdateSettings("m1", "Cantina", []int64{101}, false); err != nil {
+		t.Fatalf("update settings: %v", err)
+	}
+
+	outcome, err := svc.InviteUser(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("invite: %v", err)
+	}
+	if outcome.AlreadyShared || outcome.Email != "bob@example.com" {
+		t.Fatalf("outcome = %+v", outcome)
+	}
+	if len(api.invites) != 1 || api.invites[0].machineID != "m1" || api.invites[0].email != "bob@example.com" {
+		t.Fatalf("invites = %+v", api.invites)
+	}
+
+	var invitedAt any
+	if err := svc.db.QueryRow("SELECT plex_invited_at FROM users WHERE id = 7").Scan(&invitedAt); err != nil {
+		t.Fatalf("load invited_at: %v", err)
+	}
+	if invitedAt == nil {
+		t.Fatal("plex_invited_at not stamped")
+	}
+
+	if len(notif.userCalls) != 1 || notif.userCalls[0].userID != 7 || notif.userCalls[0].eventType != "plex_invite_sent" {
+		t.Fatalf("user pushes = %+v", notif.userCalls)
+	}
+
+	// No shared email → 409 material, nothing sent.
+	if _, err := svc.InviteUser(context.Background(), 8); !errors.Is(err, ErrNoEmail) {
+		t.Fatalf("expected ErrNoEmail, got %v", err)
+	}
+
+	// Duplicate share: soft success, but no "check your email" push.
+	api.inviteErr = ErrAlreadyShared
+	outcome, err = svc.InviteUser(context.Background(), 7)
+	if err != nil || !outcome.AlreadyShared {
+		t.Fatalf("duplicate share: outcome=%+v err=%v", outcome, err)
+	}
+	if len(notif.userCalls) != 1 {
+		t.Fatalf("duplicate share should not re-push, got %+v", notif.userCalls)
+	}
+}
+
+func TestHandleAccessRequestStates(t *testing.T) {
+	svc, api, notif := newTestService(t)
+	seedUser(t, svc, 7, "bob", "bob@example.com")
+
+	// Not configured: admins are told a manual invite is needed.
+	svc.handleAccessRequest(7, "bob")
+	if len(notif.adminCalls) != 1 || notif.adminCalls[0].data["invite_state"] != "" {
+		t.Fatalf("admin calls = %+v", notif.adminCalls)
+	}
+
+	// Configured with auto-invite: the invite goes out and admins hear "sent".
+	link(t, svc, api)
+	if err := svc.UpdateSettings("m1", "Cantina", nil, true); err != nil {
+		t.Fatalf("update settings: %v", err)
+	}
+	svc.handleAccessRequest(7, "bob")
+	if len(api.invites) != 1 {
+		t.Fatalf("expected auto-invite, got %+v", api.invites)
+	}
+	if got := notif.adminCalls[1].data["invite_state"]; got != "sent" {
+		t.Fatalf("invite_state = %v", got)
+	}
+
+	// Upstream failure: admins hear "failed" so they retry manually.
+	api.inviteErr = errors.New("plex.tv down")
+	svc.handleAccessRequest(7, "bob")
+	if got := notif.adminCalls[2].data["invite_state"]; got != "failed" {
+		t.Fatalf("invite_state = %v", got)
+	}
+
+	// Auto-invite off: no attempt, plain "waiting for an invite".
+	api.inviteErr = nil
+	if err := svc.UpdateSettings("m1", "Cantina", nil, false); err != nil {
+		t.Fatalf("update settings: %v", err)
+	}
+	before := len(api.invites)
+	svc.handleAccessRequest(7, "bob")
+	if len(api.invites) != before {
+		t.Fatal("auto-invite ran while disabled")
+	}
+	if got := notif.adminCalls[3].data["invite_state"]; got != "" {
+		t.Fatalf("invite_state = %v", got)
+	}
+}

--- a/server/internal/push/handler_test.go
+++ b/server/internal/push/handler_test.go
@@ -36,7 +36,7 @@ func TestGetPreferencesDefaults(t *testing.T) {
 	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true, IssueCreated: true, AgentActionPending: true, PlexAccessRequest: true}
+	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true, IssueCreated: true, AgentActionPending: true, PlexAccessRequest: true, PlexInviteSent: true}
 	if got != want {
 		t.Errorf("prefs = %+v, want %+v", got, want)
 	}

--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -52,24 +52,34 @@ func (n *Notifier) client() *Client {
 	return n.mgr.Client()
 }
 
-// NotifyUser pushes the outcome of a request decision to the requesting user.
-// Only "request_decision" events produce a notification, and only when the
-// requester has opted into that category (off by default).
+// NotifyUser pushes a per-user event to its recipient, gated on their opt-in
+// for the matching category. Two events produce a notification today:
+// "request_decision" (approval/denial outcome, off by default) and
+// "plex_invite_sent" ("check your email", fixed template, on by default).
+// Any other event type is a no-op here (WS-only).
 func (n *Notifier) NotifyUser(userID int64, eventType string, data map[string]interface{}) {
 	client := n.client()
-	if client == nil || eventType != CategoryRequestDecision {
+	if client == nil {
 		return
 	}
-	if !n.prefs.optedIn(userID, CategoryRequestDecision) {
-		return
+	switch eventType {
+	case CategoryRequestDecision:
+		if !n.prefs.optedIn(userID, CategoryRequestDecision) {
+			return
+		}
+		title, body := decisionMessage(data)
+		if title == "" {
+			return
+		}
+		n.send(client, []int64{userID}, title, body, passthrough(CategoryRequestDecision, data))
+	case CategoryPlexInviteSent:
+		if !n.prefs.optedIn(userID, CategoryPlexInviteSent) {
+			return
+		}
+		n.send(client, []int64{userID}, "Plex invite sent",
+			"Your Plex invite is on its way — check your email",
+			map[string]any{"type": CategoryPlexInviteSent})
 	}
-
-	title, body := decisionMessage(data)
-	if title == "" {
-		return
-	}
-
-	n.send(client, []int64{userID}, title, body, passthrough(CategoryRequestDecision, data))
 }
 
 // NotifyAdmins pushes an admin-scoped event to every admin opted into the
@@ -170,11 +180,13 @@ func (n *Notifier) notifyAgentActionPending(client *Client, data map[string]inte
 	n.sendWithOptions(client, recipients, "A fix needs your approval", "The assistant proposed a fix for a problem and needs you to approve it", out, opts)
 }
 
-// notifyPlexAccessRequested pushes "a user shared their Plex email, invite
-// them" to opted-in admins. The body is a FIXED template — the username and
-// email are user-controlled and never placed on the lock screen; user_id rides
-// along for tap deep-linking to the Users screen. A collapse id per user keeps
-// a user editing their email from stacking alerts.
+// notifyPlexAccessRequested pushes "a user shared their Plex email" to
+// opted-in admins. The body is one of three FIXED templates picked by the
+// invite_state enum ("" needs a manual invite, "sent" auto-invite went out,
+// "failed" auto-invite needs a retry) — the username and email are
+// user-controlled and never placed on the lock screen; user_id rides along
+// for tap deep-linking to the Users screen. A collapse id per user keeps a
+// user editing their email from stacking alerts.
 func (n *Notifier) notifyPlexAccessRequested(client *Client, data map[string]interface{}) {
 	recipients, err := n.prefs.usersOptedInto(CategoryPlexAccessRequest)
 	if err != nil {
@@ -184,6 +196,13 @@ func (n *Notifier) notifyPlexAccessRequested(client *Client, data map[string]int
 	if len(recipients) == 0 {
 		return
 	}
+	body := "Someone shared their Plex email and is waiting for an invite"
+	switch str(data["invite_state"]) {
+	case "sent":
+		body = "Someone shared their Plex email — their invite was sent automatically"
+	case "failed":
+		body = "Someone shared their Plex email — the automatic invite failed, send it from the Users screen"
+	}
 	out := map[string]any{"type": CategoryPlexAccessRequest}
 	if v, ok := data["user_id"]; ok {
 		out["user_id"] = v
@@ -192,7 +211,7 @@ func (n *Notifier) notifyPlexAccessRequested(client *Client, data map[string]int
 	if id, ok := intval(data["user_id"]); ok {
 		opts.CollapseID = fmt.Sprintf("%s:%d", CategoryPlexAccessRequest, id)
 	}
-	n.sendWithOptions(client, recipients, "Plex access request", "Someone shared their Plex email and is waiting for an invite", out, opts)
+	n.sendWithOptions(client, recipients, "Plex access request", body, out, opts)
 }
 
 // NotifyNewMovie pushes a "movie became available" alert to every user opted

--- a/server/internal/push/prefs.go
+++ b/server/internal/push/prefs.go
@@ -15,6 +15,7 @@ type Prefs struct {
 	IssueCreated       bool `json:"issue_created"`
 	AgentActionPending bool `json:"agent_action_pending"`
 	PlexAccessRequest  bool `json:"plex_access_request"`
+	PlexInviteSent     bool `json:"plex_invite_sent"`
 }
 
 // Notification categories. These are the wire values used by the preferences
@@ -33,6 +34,9 @@ const (
 	// CategoryPlexAccessRequest notifies admins that a user shared their Plex
 	// email and is waiting for a server invite. Admin-scoped, on by default.
 	CategoryPlexAccessRequest = "plex_access_request"
+	// CategoryPlexInviteSent tells a user their Plex invite went out (one-tap
+	// or auto) so they know to check their inbox. User-scoped, on by default.
+	CategoryPlexInviteSent = "plex_invite_sent"
 )
 
 // defaultPrefs is the preference set applied when a user has no row. It must
@@ -46,6 +50,7 @@ var defaultPrefs = Prefs{
 	IssueCreated:       true,
 	AgentActionPending: true,
 	PlexAccessRequest:  true,
+	PlexInviteSent:     true,
 }
 
 // categoryColumn maps a category to its notification_prefs column and the
@@ -62,6 +67,7 @@ var categoryColumn = map[string]struct {
 	CategoryIssueCreated:       {"issue_created", defaultPrefs.IssueCreated},
 	CategoryAgentActionPending: {"agent_action_pending", defaultPrefs.AgentActionPending},
 	CategoryPlexAccessRequest:  {"plex_access_request", defaultPrefs.PlexAccessRequest},
+	CategoryPlexInviteSent:     {"plex_invite_sent", defaultPrefs.PlexInviteSent},
 }
 
 // PrefsStore reads and writes per-user notification preferences. It is safe to
@@ -80,10 +86,10 @@ func NewPrefsStore(db *sql.DB) *PrefsStore {
 func (s *PrefsStore) Get(userID int64) (Prefs, error) {
 	p := defaultPrefs
 	err := s.db.QueryRow(
-		`SELECT request_decision, request_pending, new_movie, new_episode, issue_created, agent_action_pending, plex_access_request
+		`SELECT request_decision, request_pending, new_movie, new_episode, issue_created, agent_action_pending, plex_access_request, plex_invite_sent
 		 FROM notification_prefs WHERE user_id = ?`,
 		userID,
-	).Scan(&p.RequestDecision, &p.RequestPending, &p.NewMovie, &p.NewEpisode, &p.IssueCreated, &p.AgentActionPending, &p.PlexAccessRequest)
+	).Scan(&p.RequestDecision, &p.RequestPending, &p.NewMovie, &p.NewEpisode, &p.IssueCreated, &p.AgentActionPending, &p.PlexAccessRequest, &p.PlexInviteSent)
 	if err == sql.ErrNoRows {
 		return defaultPrefs, nil
 	}
@@ -97,8 +103,8 @@ func (s *PrefsStore) Get(userID int64) (Prefs, error) {
 func (s *PrefsStore) Set(userID int64, p Prefs) error {
 	_, err := s.db.Exec(
 		`INSERT INTO notification_prefs
-		   (user_id, request_decision, request_pending, new_movie, new_episode, issue_created, agent_action_pending, plex_access_request)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		   (user_id, request_decision, request_pending, new_movie, new_episode, issue_created, agent_action_pending, plex_access_request, plex_invite_sent)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT(user_id) DO UPDATE SET
 		   request_decision = excluded.request_decision,
 		   request_pending  = excluded.request_pending,
@@ -106,8 +112,9 @@ func (s *PrefsStore) Set(userID int64, p Prefs) error {
 		   new_episode      = excluded.new_episode,
 		   issue_created    = excluded.issue_created,
 		   agent_action_pending = excluded.agent_action_pending,
-		   plex_access_request  = excluded.plex_access_request`,
-		userID, p.RequestDecision, p.RequestPending, p.NewMovie, p.NewEpisode, p.IssueCreated, p.AgentActionPending, p.PlexAccessRequest,
+		   plex_access_request  = excluded.plex_access_request,
+		   plex_invite_sent     = excluded.plex_invite_sent`,
+		userID, p.RequestDecision, p.RequestPending, p.NewMovie, p.NewEpisode, p.IssueCreated, p.AgentActionPending, p.PlexAccessRequest, p.PlexInviteSent,
 	)
 	if err != nil {
 		return fmt.Errorf("upsert notification prefs: %w", err)

--- a/server/internal/push/prefs_test.go
+++ b/server/internal/push/prefs_test.go
@@ -18,7 +18,7 @@ func TestPrefsGetDefaultsForMissingRow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true, IssueCreated: true, AgentActionPending: true, PlexAccessRequest: true}
+	want := Prefs{RequestDecision: false, RequestPending: true, NewMovie: true, NewEpisode: true, IssueCreated: true, AgentActionPending: true, PlexAccessRequest: true, PlexInviteSent: true}
 	if got != want {
 		t.Errorf("default prefs = %+v, want %+v", got, want)
 	}


### PR DESCRIPTION
## What

Completes the Plex onboarding loop from #147. The admin was still leaving Cantinarr to paste an email into Plex — now Cantinarr sends the invite itself.

**Admin: link once, then never think about it.** Settings → **Plex Invites** links a Plex account via plex.tv's PIN flow (open the approval page, Cantinarr polls until approved; token AES-256-GCM encrypted in the settings table and never returned by any API). Pick which owned server and libraries invites share (none selected = all, per plex.tv semantics), and optionally flip **auto-invite**.

**One tap or zero taps.** With an account linked, the Users screen's action becomes **Send Plex invite** (resend supported; "already has access" is soft success) via plex.tv's `shared_servers` API. With auto-invite on, a user sharing their email in the guide is invited immediately — the admin's `plex_access_request` push now carries the outcome in its fixed body: *sent automatically*, *failed — send it from the Users screen*, or plain *waiting for an invite*. Copy-email-and-open-Plex remains the fallback when nothing is linked.

**User: the loop actually closes.** Sending an invite stamps `users.plex_invited_at`, pushes a new user-scoped `plex_invite_sent` notification ("check your email", taps to the guide), and the guide's invite card flips to *"Your invite has been sent! Check your inbox…"* (with a delayed profile re-fetch after submitting so fast auto-invites show up without reopening). Changing the email clears the stamp — the old invite went to the old address — and re-triggers the whole flow. Users also get a "Plex invite sent" toggle in notification preferences.

**Plumbing** — new `internal/plex` package (stateless plex.tv client with injectable base URL, service owning the encrypted config, HTTP handler); admin routes under `/api/admin/plex/*` + `POST /api/admin/users/{id}/plex-invite`; the auth handler's notifier wiring became an access-request hook pointed at the plex service; `plex_invited_at` flows through `/auth/me` and the users list. plex.tv surface verified against current docs: PIN flow, `/api/v2/resources` (owned servers), v1 `/api/servers/{id}` XML for global section IDs, `POST /api/v2/shared_servers` with `invitedEmail` (422 = duplicate).

## Verification

- Server: `go vet ./...` clean; `go test ./...` all pass — new `internal/plex` tests cover the PIN link flow (pending → approved, token stored encrypted, client-id survives unlink), settings validation, invite outcomes (fresh / no-email / duplicate-share, invited-at stamping, user push exactly once), and all four access-request notification states against a fake plex.tv; client tests assert the exact wire payloads via httptest
- App: `flutter analyze --no-fatal-infos` — no new issues (16 pre-existing infos); `flutter test` — all 200 pass
- Not run: a live end-to-end invite against real plex.tv (needs a real linked account; the wire format is asserted in client tests and matches the documented/battle-tested shape used by python-plexapi/Overseerr)

## Docs

- [x] `README.md` — pitch, feature list, configuration/env vars, quick start
- [x] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [x] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above

Root README gains the **Plex onboarding** feature bullet; server README gains the Plex invites route block, an architecture section, the two new notification-category rows, the WS event, the settings-KV mention, and the `plex/` package-tree entry; app README updates the Settings/Users/guide/notification bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)