### PR TITLE
Surface waiting Plex invites in the drawer, not just as a push

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -78,7 +78,7 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 - **Report a problem** -- on any available title (admin-toggleable), scoped to a movie, series, or season; category chips plus free text.
 - **Issue threads** -- a chat-style thread per issue where the reporter, admins, and the AI agent converse; the agent's questions flip the issue to "Needs your reply".
 - **Agent fixes** -- proposed mutations render as safety-critical approval cards (typed summaries, quoted parameters, rationale as passive text); admins approve or deny inline or from a grouped queue, and every run has a read-only audit timeline with step ledger and cost.
-- **Live badges** -- Approvals / Issues / Agent fixes counts in the drawer, kept current over WebSocket.
+- **Live badges** -- Approvals / Issues / Agent fixes counts in the drawer, kept current over WebSocket. A **Plex invites** entry appears (with count) only while someone is waiting on a Plex invite -- the persistent surface behind the miss-able push -- and lands on the Users screen, where waiting users carry a "Needs Plex invite" tag.
 
 ### AI assistant
 - **Multi-provider chat** (Anthropic, OpenAI, or Gemini -- server-configured) with SSE streaming, visible tool activity, and a poster carousel for results.

--- a/app/lib/features/settings/logic/plex_invites_provider.dart
+++ b/app/lib/features/settings/logic/plex_invites_provider.dart
@@ -1,0 +1,75 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/websocket_client.dart';
+import '../../../core/providers/realtime_provider.dart';
+import '../../auth/logic/auth_provider.dart';
+
+/// Tracks how many users shared a Plex email but have no invite sent yet,
+/// for admins only.
+///
+/// This is the persistent surface behind the miss-able `plex_access_request`
+/// push: the count drives a drawer "Plex invites" entry (shown only while
+/// someone is waiting) and the hamburger dot. Seeded from the admin users
+/// list and refreshed by `plex_access_request` websocket events — the server
+/// emits one for every state change (waiting, auto-sent, auto-failed), and
+/// stamps `plex_invited_at` before emitting, so a refetch always sees the
+/// settled state. Non-admin accounts always report 0 and never call the
+/// admin-only endpoint.
+class PlexInvitesWaitingNotifier extends StateNotifier<int> {
+  PlexInvitesWaitingNotifier(this._ref) : super(0) {
+    _bind();
+    // Re-bind on login/logout/role change without rebuilding the provider.
+    _ref.listen(authProvider, (_, __) => _bind());
+  }
+
+  final Ref _ref;
+  StreamSubscription<WsEvent>? _sub;
+  bool _isAdmin = false;
+
+  /// (Re)attaches to the live event stream when the admin status changes.
+  void _bind() {
+    final admin = _ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    if (admin == _isAdmin) return; // no change
+    _isAdmin = admin;
+    _sub?.cancel();
+    _sub = null;
+    if (!admin) {
+      state = 0;
+      return;
+    }
+    refresh();
+    _sub = _ref
+        .read(realtimeEventsProvider)
+        .where((e) => e.type == 'plex_access_request')
+        .listen((_) => refresh());
+  }
+
+  /// Re-counts waiting users from the backend. Call after sending an invite
+  /// so the badge clears immediately.
+  Future<void> refresh() async {
+    if (!_isAdmin) return;
+    try {
+      final users = await _ref.read(authProvider.notifier).listUsers();
+      if (!_isAdmin) return;
+      state = users
+          .where((u) => u.plexEmail.isNotEmpty && u.plexInvitedAt == null)
+          .length;
+    } catch (_) {
+      // Best-effort: keep the last known count on a transient failure.
+    }
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+}
+
+/// Users waiting for a Plex invite, for the signed-in admin (0 otherwise).
+final plexInvitesWaitingProvider =
+    StateNotifierProvider<PlexInvitesWaitingNotifier, int>(
+  PlexInvitesWaitingNotifier.new,
+);

--- a/app/lib/features/settings/ui/users_screen.dart
+++ b/app/lib/features/settings/ui/users_screen.dart
@@ -8,6 +8,7 @@ import '../../auth/data/auth_service.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../notifications/push_service.dart';
 import '../data/plex_admin_service.dart';
+import '../logic/plex_invites_provider.dart';
 
 /// Admin screen for managing user accounts: change roles, remove users, and
 /// see who still has an outstanding connect-link invite.
@@ -36,6 +37,9 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
     });
     try {
       final users = await ref.read(authProvider.notifier).listUsers();
+      // Keep the drawer's "Plex invites" badge in step with what this
+      // screen just learned (e.g. an invite sent here clears the count).
+      ref.read(plexInvitesWaitingProvider.notifier).refresh();
       setState(() {
         _users = users;
         _isLoading = false;
@@ -486,7 +490,9 @@ class _UserTile extends StatelessWidget {
             if (user.plexEmail.isNotEmpty)
               _Tag(label: user.plexEmail, color: AppTheme.textSecondary),
             if (user.plexInvitedAt != null)
-              const _Tag(label: 'Plex invite sent', color: AppTheme.available),
+              const _Tag(label: 'Plex invite sent', color: AppTheme.available)
+            else if (user.plexEmail.isNotEmpty)
+              const _Tag(label: 'Needs Plex invite', color: AppTheme.requested),
           ],
         ),
       ),

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -24,6 +24,7 @@ import '../../issues/logic/issues_provider.dart';
 import '../../radarr/data/radarr_api_service.dart';
 import '../../radarr/logic/radarr_movies_provider.dart';
 import '../../request/logic/pending_approvals_provider.dart';
+import '../../settings/logic/plex_invites_provider.dart';
 import '../../sonarr/data/sonarr_api_service.dart';
 import '../../sonarr/logic/sonarr_series_provider.dart';
 import '../logic/shell_search_provider.dart';
@@ -441,7 +442,11 @@ class _AppShellState extends ConsumerState<AppShell>
     // Agent-proposed fixes awaiting approval — drives the drawer "Agent fixes"
     // entry and the hamburger dot. Always 0 for non-admins.
     final pendingAgentActions = ref.watch(pendingAgentActionsProvider);
-    final menuBadgeCount = pendingApprovals + openIssues + pendingAgentActions;
+    // Users waiting for a Plex invite — drives the drawer "Plex invites"
+    // entry (only shown while someone waits) and the hamburger dot.
+    final plexInvitesWaiting = ref.watch(plexInvitesWaitingProvider);
+    final menuBadgeCount =
+        pendingApprovals + openIssues + pendingAgentActions + plexInvitesWaiting;
     final showSearchResults = searchState.searchMode == SearchMode.search ||
         searchState.searchMode == SearchMode.aiReady;
     final libraryStatus = searchState.isSearching && showSearchResults
@@ -845,6 +850,7 @@ class _AppShellState extends ConsumerState<AppShell>
     final pendingApprovals = ref.watch(pendingApprovalsProvider);
     final openIssues = ref.watch(openIssuesProvider);
     final pendingAgentActions = ref.watch(pendingAgentActionsProvider);
+    final plexInvitesWaiting = ref.watch(plexInvitesWaitingProvider);
 
     return SafeArea(
       child: Column(
@@ -913,6 +919,19 @@ class _AppShellState extends ConsumerState<AppShell>
                 context.push('/agent-actions');
               },
             ),
+            // Appears only while someone is waiting on a Plex invite (e.g.
+            // the push was missed or an auto-invite failed); lands on the
+            // Users screen where the invite is one tap.
+            if (plexInvitesWaiting > 0)
+              _DrawerItem(
+                icon: Icons.play_circle_outline,
+                title: 'Plex invites',
+                badgeCount: plexInvitesWaiting,
+                onTap: () {
+                  if (isOverlay) Navigator.pop(context);
+                  context.push('/settings/users');
+                },
+              ),
             const Divider(color: AppTheme.border),
           ],
 


### PR DESCRIPTION
## What

Answers "where do I see a Plex access request if I miss the push?" — previously nowhere persistent. Now:

- A **Plex invites** drawer entry with a live count appears whenever a user has shared a Plex email but has no invite sent (push missed, auto-invite off, or auto-invite **failed**). It follows the exact Approvals/Issues/Agent-fixes pattern: admin-only, seeded from the users list, refreshed on every `plex_access_request` WebSocket event (the server stamps `plex_invited_at` before emitting, so a refetch always sees settled state), and counted into the hamburger dot. It disappears entirely when nobody's waiting.
- Tapping it lands on Settings → Users, where waiting users now carry an explicit **"Needs Plex invite"** tag (previously implied only by the *absence* of the sent tag), and the screen keeps the badge in step as invites go out.

App-only change — the server already exposed everything needed.

## Verification

- `flutter analyze --no-fatal-infos` — no new issues (16 pre-existing infos)
- `flutter test` — all 200 pass

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [x] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above

Live-badges bullet updated with the conditional Plex invites entry and the Users-screen tag. No server surface changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)