### PR TITLE
Live setup checklist: derived wizard + admin reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Cantinarr makes it dead simple for your family and friends to discover and reque
 - **Tautulli** -- watch what's playing on Plex right now: active streams with quality/transcode badges, watch history, and top movies/shows/users stats.
 - **Secrets encrypted at rest** -- arr API keys, download-client passwords, webhook tokens, and external credentials are AES-256-GCM encrypted in the database.
 - **Household-friendly** -- Connect links, passwordless by default, role-based access, per-user default instances. Admins manage services; users just browse and request.
+- **Guided setup** -- a live checklist wizard derived from what's actually configured: every step opens the real settings screen, progress can't go stale, and newly shipped features appear on the list automatically.
 - **Single container** -- One Go binary, one port, serves API + web UI. Runs great on a Raspberry Pi or NAS.
 
 ## Quick Start

--- a/app/README.md
+++ b/app/README.md
@@ -78,7 +78,7 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 - **Report a problem** -- on any available title (admin-toggleable), scoped to a movie, series, or season; category chips plus free text.
 - **Issue threads** -- a chat-style thread per issue where the reporter, admins, and the AI agent converse; the agent's questions flip the issue to "Needs your reply".
 - **Agent fixes** -- proposed mutations render as safety-critical approval cards (typed summaries, quoted parameters, rationale as passive text); admins approve or deny inline or from a grouped queue, and every run has a read-only audit timeline with step ledger and cost.
-- **Live badges** -- Approvals / Issues / Agent fixes counts in the drawer, kept current over WebSocket. A **Plex invites** entry appears (with count) only while someone is waiting on a Plex invite -- the persistent surface behind the miss-able push -- and lands on the Users screen, where waiting users carry a "Needs Plex invite" tag.
+- **Live badges** -- Approvals / Issues / Agent fixes counts in the drawer, kept current over WebSocket. A **Plex invites** entry appears (with count) only while someone is waiting on a Plex invite -- the persistent surface behind the miss-able push -- and lands on the Users screen, where waiting users carry a "Needs Plex invite" tag. A **Setup checklist** entry (with unconfigured-feature count) appears for admins until everything is configured or they mute it from the checklist.
 
 ### AI assistant
 - **Multi-provider chat** (Anthropic, OpenAI, or Gemini -- server-configured) with SSE streaming, visible tool activity, and a poster carousel for results.
@@ -90,6 +90,7 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 - **Per-category preferences** -- request decisions, new movies, new episodes, Plex invite sent, and admin-only categories (new requests, issues, agent fixes, Plex access requests), plus a test-push diagnostic.
 
 ### Settings
+- **Setup Checklist** (admin) -- a live wizard at `/setup`: which features are configured and which aren't, derived by the server from actual configuration (never stored progress, so it's resumable and editable by construction). Each step opens the real settings screen and re-derives on return; unknown items from newer servers still render, which is how future features announce themselves. Surfaced as a Settings tile with an "X of Y configured" subtitle and a muteable drawer reminder with the remaining count.
 - **Instances** (admin) -- add/edit all eight service types; test connections; set the global default (single-default invariant with takeover confirmation) or per-user default pins; assign users to a Chaptarr instance (the Books access grant); assigning a user pinned to a sibling instance asks for confirmation before removing them from it; copy the per-instance **webhook URL** for Radarr/Sonarr > Connect.
 - **Users** (admin) -- roles, connect links / re-invites / device links, per-user password & passkey enablement (disabling is a real revoke), per-user request settings (tri-state inherit/on/off + default instances), test push. Shows each user's shared Plex email and invite state: with a linked Plex account it's a one-tap **Send Plex invite** (resend supported); otherwise **Invite in Plex…** copies the address and opens Plex's Manage Library Access page.
 - **Plex Invites** (admin) -- link a Plex account via the PIN flow, pick the server and libraries invites share, and toggle **auto-invite** (a user sharing their Plex email gets invited with zero admin taps).
@@ -173,7 +174,7 @@ app/lib/
 │   ├── radarr/                   # Movie management: library/queue/history/wanted/calendar
 │   ├── request/                  # Request buttons, options sheet, status sheet
 │   ├── settings/                 # Everything under Settings (see Features)
-│   ├── setup_wizard/             # Static onboarding walkthrough + Plex guide
+│   ├── setup_wizard/             # Live setup checklist wizard + Plex guide
 │   ├── shell/                    # App shell: drawer, search bar, inline AI
 │   ├── sonarr/                   # TV management + episode tools + import doctor engine
 │   └── tautulli/                 # Plex activity/history/stats

--- a/app/lib/core/storage/preferences.dart
+++ b/app/lib/core/storage/preferences.dart
@@ -59,3 +59,30 @@ final plexGuideEnabledProvider =
     StateNotifierProvider<PlexGuideNotifier, bool>(
   (ref) => PlexGuideNotifier(),
 );
+
+const _setupReminderKey = 'setup_reminder_enabled';
+
+/// Whether the drawer shows a "Setup checklist" reminder while features
+/// remain unconfigured. Admins who have deliberately skipped features can
+/// mute it from the wizard; the Settings tile always remains.
+class SetupReminderNotifier extends StateNotifier<bool> {
+  SetupReminderNotifier() : super(true) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = prefs.getBool(_setupReminderKey) ?? true;
+  }
+
+  Future<void> set(bool value) async {
+    state = value;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_setupReminderKey, value);
+  }
+}
+
+final setupReminderEnabledProvider =
+    StateNotifierProvider<SetupReminderNotifier, bool>(
+  (ref) => SetupReminderNotifier(),
+);

--- a/app/lib/features/settings/data/setup_status_service.dart
+++ b/app/lib/features/settings/data/setup_status_service.dart
@@ -1,0 +1,71 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+
+/// One entry in the admin setup checklist. The server derives the list live
+/// from actual configuration, so "configured" can never go stale. Unknown
+/// keys from newer servers still render (generically), which is how future
+/// features surface themselves without an app update.
+class SetupItem {
+  final String key;
+  final String title;
+  final String description;
+  final bool configured;
+  final bool optional;
+
+  const SetupItem({
+    required this.key,
+    required this.title,
+    required this.description,
+    required this.configured,
+    required this.optional,
+  });
+
+  factory SetupItem.fromJson(Map<String, dynamic> json) => SetupItem(
+        key: json['key'] as String? ?? '',
+        title: json['title'] as String? ?? '',
+        description: json['description'] as String? ?? '',
+        configured: json['configured'] as bool? ?? false,
+        optional: json['optional'] as bool? ?? false,
+      );
+}
+
+class SetupStatus {
+  final List<SetupItem> items;
+  final int configured;
+  final int total;
+
+  const SetupStatus({
+    required this.items,
+    required this.configured,
+    required this.total,
+  });
+
+  int get remaining => total - configured;
+
+  factory SetupStatus.fromJson(Map<String, dynamic> json) {
+    final items = (json['items'] as List? ?? [])
+        .map((e) => SetupItem.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return SetupStatus(
+      items: items,
+      configured: json['configured'] as int? ?? 0,
+      total: json['total'] as int? ?? items.length,
+    );
+  }
+}
+
+class SetupStatusService {
+  final Dio _dio;
+
+  SetupStatusService({required Dio backendDio}) : _dio = backendDio;
+
+  Future<SetupStatus> fetch() async {
+    final resp = await _dio.get('/api/admin/setup-status');
+    return SetupStatus.fromJson(resp.data as Map<String, dynamic>);
+  }
+}
+
+final setupStatusServiceProvider = Provider<SetupStatusService>(
+  (ref) => SetupStatusService(backendDio: ref.watch(backendClientProvider)),
+);

--- a/app/lib/features/settings/logic/setup_status_provider.dart
+++ b/app/lib/features/settings/logic/setup_status_provider.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../auth/logic/auth_provider.dart';
+import '../data/setup_status_service.dart';
+
+/// The admin setup checklist, null while unknown (loading, or not an admin).
+///
+/// Drives the settings "Setup Checklist" tile subtitle, the wizard screen,
+/// and the drawer reminder entry. There is no websocket event for config
+/// changes; instead the wizard and the settings screen call [refresh] on
+/// load/return, which covers every in-app path that changes configuration.
+class SetupStatusNotifier extends StateNotifier<SetupStatus?> {
+  SetupStatusNotifier(this._ref) : super(null) {
+    _bind();
+    // Re-bind on login/logout/role change without rebuilding the provider.
+    _ref.listen(authProvider, (_, __) => _bind());
+  }
+
+  final Ref _ref;
+  bool _isAdmin = false;
+
+  void _bind() {
+    final admin = _ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    if (admin == _isAdmin) return; // no change
+    _isAdmin = admin;
+    if (!admin) {
+      state = null;
+      return;
+    }
+    refresh();
+  }
+
+  /// Re-derives the checklist from the backend. Cheap (one small request);
+  /// call whenever a screen that can change configuration comes or goes.
+  Future<void> refresh() async {
+    if (!_isAdmin) return;
+    try {
+      final status = await _ref.read(setupStatusServiceProvider).fetch();
+      if (_isAdmin) state = status;
+    } catch (_) {
+      // Best-effort: keep the last known status on a transient failure.
+    }
+  }
+}
+
+final setupStatusProvider =
+    StateNotifierProvider<SetupStatusNotifier, SetupStatus?>(
+  SetupStatusNotifier.new,
+);

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import '../../../core/storage/preferences.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
+import '../logic/setup_status_provider.dart';
 import 'about_sheet.dart';
 
 /// Simplified settings screen for backend-connected architecture.
@@ -27,9 +28,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       setState(() => _appVersion =
           build.isNotEmpty ? '${info.version} ($build)' : info.version);
     });
-    // Learn whether the account has a password so the Account tile reflects it.
+    // Learn whether the account has a password so the Account tile reflects
+    // it, and re-derive the setup checklist so its tile subtitle is current.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(authProvider.notifier).refreshUser();
+      ref.read(setupStatusProvider.notifier).refresh();
     });
   }
 
@@ -40,6 +43,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final connection = auth?.connection;
     final user = auth?.user;
     final instances = connection?.instances ?? [];
+    final setupStatus = ref.watch(setupStatusProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
@@ -165,6 +169,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           if (user?.isAdmin == true) ...[
             const SizedBox(height: 16),
             _SectionHeader(title: 'Admin'),
+            _SettingsTile(
+              icon: Icons.checklist_outlined,
+              title: 'Setup Checklist',
+              subtitle: setupStatus == null
+                  ? 'See which features are configured'
+                  : '${setupStatus.configured} of ${setupStatus.total} features configured',
+              onTap: () => context.push('/setup'),
+            ),
             _SettingsTile(
               icon: Icons.key_outlined,
               title: 'API Credentials',

--- a/app/lib/features/setup_wizard/ui/setup_wizard_screen.dart
+++ b/app/lib/features/setup_wizard/ui/setup_wizard_screen.dart
@@ -1,244 +1,229 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import '../../../core/storage/preferences.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../../settings/data/setup_status_service.dart';
+import '../../settings/logic/setup_status_provider.dart';
 
-/// Step-by-step setup wizard for new users.
-class SetupWizardScreen extends StatefulWidget {
+/// Live, resumable setup checklist for admins. Every step deep-links to the
+/// real settings screen for that feature and progress is re-derived from
+/// actual configuration on return — a step is "done" because the thing
+/// exists, not because a wizard said next. Items the server adds in future
+/// versions render automatically (unknown keys get a generic row).
+class SetupWizardScreen extends ConsumerStatefulWidget {
   const SetupWizardScreen({super.key});
 
   @override
-  State<SetupWizardScreen> createState() => _SetupWizardScreenState();
+  ConsumerState<SetupWizardScreen> createState() => _SetupWizardScreenState();
 }
 
-class _SetupWizardScreenState extends State<SetupWizardScreen> {
-  int _currentStep = 0;
+class _SetupWizardScreenState extends ConsumerState<SetupWizardScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(setupStatusProvider.notifier).refresh();
+    });
+  }
 
-  final _steps = const [
-    _SetupStep(
-      title: 'Welcome to Cantinarr',
-      icon: Icons.movie_filter,
-      description:
-          'Discover movies and TV shows, request them with a tap, and your media server handles the rest — adding them to Radarr or Sonarr automatically.',
-    ),
-    _SetupStep(
-      title: 'Connect TMDB',
-      icon: Icons.search,
-      description:
-          'TMDB powers our discovery engine. Get a free API key at themoviedb.org to unlock trending content, search, and recommendations.',
-      hasTextField: true,
-      textFieldHint: 'TMDB API Key',
-    ),
-    _SetupStep(
-      title: 'Add Radarr (Movies)',
-      icon: Icons.movie_outlined,
-      description:
-          'Connect your Radarr instance to request movies with one tap. They\'ll be automatically downloaded and added to your library.',
-      hasServerConfig: true,
-    ),
-    _SetupStep(
-      title: 'Add Sonarr (TV)',
-      icon: Icons.tv,
-      description:
-          'Connect your Sonarr instance to request TV shows. New episodes will be automatically downloaded as they air.',
-      hasServerConfig: true,
-    ),
-    _SetupStep(
-      title: 'AI Assistant (Optional)',
-      icon: Icons.smart_toy_outlined,
-      description:
-          'Add an Anthropic, OpenAI, or Gemini API key to unlock the AI assistant. It can help you discover content, get personalized recommendations, and guide you through setup.',
-      hasTextField: true,
-      textFieldHint: 'AI provider API key (optional)',
-    ),
-    _SetupStep(
-      title: 'You\'re All Set!',
-      icon: Icons.check_circle_outline,
-      description:
-          'You can always change these settings later. Start discovering and requesting movies and TV shows!',
-    ),
-  ];
+  /// Where each checklist item is configured. Unknown keys (a newer server)
+  /// return null and render as informational rows.
+  String? _routeFor(String key) {
+    switch (key) {
+      case 'radarr':
+      case 'sonarr':
+      case 'download_client':
+      case 'tautulli':
+      case 'books':
+        return '/settings/instance/new';
+      case 'tmdb':
+      case 'trakt':
+      case 'ai':
+        return '/settings/credentials';
+      case 'plex_invites':
+        return '/settings/plex';
+      default:
+        return null; // push = server env var; unknown keys = newer server
+    }
+  }
+
+  IconData _iconFor(String key) {
+    switch (key) {
+      case 'radarr':
+        return Icons.movie_outlined;
+      case 'sonarr':
+        return Icons.tv_outlined;
+      case 'tmdb':
+        return Icons.search;
+      case 'trakt':
+        return Icons.trending_up;
+      case 'download_client':
+        return Icons.download_outlined;
+      case 'tautulli':
+        return Icons.monitor_heart_outlined;
+      case 'push':
+        return Icons.notifications_outlined;
+      case 'plex_invites':
+        return Icons.play_circle_outline;
+      case 'books':
+        return Icons.menu_book;
+      case 'ai':
+        return Icons.smart_toy_outlined;
+      default:
+        return Icons.tune;
+    }
+  }
+
+  Future<void> _openItem(String? route) async {
+    if (route == null) return;
+    await context.push(route);
+    // Re-derive on return: whatever the admin just configured (or didn't)
+    // is reflected immediately.
+    ref.read(setupStatusProvider.notifier).refresh();
+  }
 
   @override
   Widget build(BuildContext context) {
-    final step = _steps[_currentStep];
-    final isLast = _currentStep == _steps.length - 1;
-    final isFirst = _currentStep == 0;
+    final isAdmin = ref.watch(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    final status = ref.watch(setupStatusProvider);
 
     return Scaffold(
-      body: SafeArea(
-        child: Column(
-          children: [
-            // Progress
-            Padding(
-              padding: const EdgeInsets.all(16),
-              child: Row(
-                children: List.generate(_steps.length, (i) {
-                  return Expanded(
-                    child: Container(
-                      height: 3,
-                      margin: const EdgeInsets.symmetric(horizontal: 2),
-                      decoration: BoxDecoration(
-                        color: i <= _currentStep
-                            ? AppTheme.accent
-                            : AppTheme.border,
-                        borderRadius: BorderRadius.circular(2),
-                      ),
-                    ),
-                  );
-                }),
-              ),
-            ),
-
-            // Skip
-            if (!isLast)
-              Align(
-                alignment: Alignment.centerRight,
-                child: TextButton(
-                  onPressed: () => Navigator.pop(context),
-                  child: const Text('Skip',
-                      style: TextStyle(color: AppTheme.textSecondary)),
-                ),
-              ),
-
-            // Content
-            Expanded(
+      appBar: AppBar(title: const Text('Setup Checklist')),
+      body: !isAdmin
+          ? const Center(
               child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 32),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    // Icon
-                    Container(
-                      width: 80,
-                      height: 80,
-                      decoration: BoxDecoration(
-                        color: AppTheme.accent.withValues(alpha: 0.12),
-                        shape: BoxShape.circle,
-                      ),
-                      child: Icon(step.icon, size: 40, color: AppTheme.accent),
-                    ),
-                    const SizedBox(height: 24),
-
-                    // Title
-                    Text(
-                      step.title,
-                      style: const TextStyle(
-                        color: AppTheme.textPrimary,
-                        fontSize: 26,
-                        fontWeight: FontWeight.bold,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 12),
-
-                    // Description
-                    Text(
-                      step.description,
-                      style: const TextStyle(
-                          color: AppTheme.textSecondary,
-                          fontSize: 16,
-                          height: 1.5),
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 32),
-
-                    // Text field
-                    if (step.hasTextField)
-                      TextField(
-                        decoration: InputDecoration(
-                          hintText: step.textFieldHint,
-                          prefixIcon: const Icon(Icons.key),
-                        ),
-                        obscureText: true,
-                      ),
-
-                    // Server config
-                    if (step.hasServerConfig) ...[
-                      const TextField(
-                        decoration: InputDecoration(
-                          hintText: 'Host (e.g. 192.168.1.100)',
-                          prefixIcon: Icon(Icons.dns),
-                        ),
-                      ),
-                      const SizedBox(height: 12),
-                      const TextField(
-                        decoration: InputDecoration(
-                          hintText: 'Port (e.g. 7878)',
-                          prefixIcon: Icon(Icons.numbers),
-                        ),
-                        keyboardType: TextInputType.number,
-                      ),
-                      const SizedBox(height: 12),
-                      const TextField(
-                        decoration: InputDecoration(
-                          hintText: 'API Key',
-                          prefixIcon: Icon(Icons.key),
-                        ),
-                        obscureText: true,
-                      ),
-                    ],
-                  ],
+                padding: EdgeInsets.all(24),
+                child: Text(
+                  'The setup checklist is for server admins.',
+                  style: TextStyle(color: AppTheme.textSecondary),
+                  textAlign: TextAlign.center,
                 ),
               ),
-            ),
+            )
+          : status == null
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : RefreshIndicator(
+                  onRefresh: () =>
+                      ref.read(setupStatusProvider.notifier).refresh(),
+                  child: _buildChecklist(status),
+                ),
+    );
+  }
 
-            // Navigation buttons
-            Padding(
-              padding: const EdgeInsets.all(24),
-              child: Row(
-                children: [
-                  if (!isFirst)
-                    Expanded(
-                      child: OutlinedButton(
-                        onPressed: () => setState(() => _currentStep--),
-                        style: OutlinedButton.styleFrom(
-                          foregroundColor: AppTheme.textPrimary,
-                          side: const BorderSide(color: AppTheme.border),
-                          padding: const EdgeInsets.symmetric(vertical: 14),
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                        ),
-                        child: const Text('Back'),
-                      ),
-                    ),
-                  if (!isFirst) const SizedBox(width: 12),
-                  Expanded(
-                    flex: isFirst ? 1 : 1,
-                    child: ElevatedButton(
-                      onPressed: () {
-                        if (isLast) {
-                          Navigator.pop(context);
-                        } else {
-                          setState(() => _currentStep++);
-                        }
-                      },
-                      child: Text(isLast ? 'Get Started' : 'Continue'),
-                    ),
-                  ),
-                ],
+  Widget _buildChecklist(SetupStatus status) {
+    final essentials =
+        status.items.where((i) => !i.optional).toList(growable: false);
+    final optional =
+        status.items.where((i) => i.optional).toList(growable: false);
+    final progress = status.total == 0 ? 0.0 : status.configured / status.total;
+
+    return ListView(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '${status.configured} of ${status.total} features configured',
+                style: const TextStyle(
+                  color: AppTheme.textPrimary,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                ),
               ),
-            ),
-          ],
+              const SizedBox(height: 8),
+              ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: progress,
+                  minHeight: 6,
+                  backgroundColor: AppTheme.border,
+                  color: AppTheme.accent,
+                ),
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                'Each step opens the real settings screen, and progress '
+                'reflects what\'s actually configured — come back anytime, '
+                'nothing here is one-shot.',
+                style: TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 13, height: 1.4),
+              ),
+            ],
+          ),
         ),
-      ),
+        const _SectionHeader(title: 'Essentials'),
+        ...essentials.map(_buildItem),
+        if (optional.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          const _SectionHeader(title: 'Nice to have'),
+          ...optional.map(_buildItem),
+        ],
+        const SizedBox(height: 8),
+        const Divider(color: AppTheme.border),
+        SwitchListTile(
+          value: ref.watch(setupReminderEnabledProvider),
+          onChanged: (v) =>
+              ref.read(setupReminderEnabledProvider.notifier).set(v),
+          activeThumbColor: AppTheme.accent,
+          secondary: const Icon(Icons.notifications_outlined,
+              color: AppTheme.textSecondary),
+          title: const Text('Remind me in the menu',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
+          subtitle: const Text(
+              'Show this checklist in the menu while features remain unconfigured',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+        ),
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+
+  Widget _buildItem(SetupItem item) {
+    final route = _routeFor(item.key);
+    return ListTile(
+      leading: Icon(_iconFor(item.key),
+          color:
+              item.configured ? AppTheme.available : AppTheme.textSecondary),
+      title: Text(item.title,
+          style: const TextStyle(
+              color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
+      subtitle: Text(item.description,
+          style: const TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+      trailing: item.configured
+          ? const Icon(Icons.check_circle, color: AppTheme.available, size: 20)
+          : route != null
+              ? const Icon(Icons.chevron_right, color: AppTheme.textSecondary)
+              : null,
+      onTap: route != null ? () => _openItem(route) : null,
     );
   }
 }
 
-class _SetupStep {
+/// Small uppercase accent header, matching the settings screen sections.
+class _SectionHeader extends StatelessWidget {
   final String title;
-  final IconData icon;
-  final String description;
-  final bool hasTextField;
-  final String? textFieldHint;
-  final bool hasServerConfig;
+  const _SectionHeader({required this.title});
 
-  const _SetupStep({
-    required this.title,
-    required this.icon,
-    required this.description,
-    this.hasTextField = false,
-    this.textFieldHint,
-    this.hasServerConfig = false,
-  });
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Text(
+        title.toUpperCase(),
+        style: const TextStyle(
+          color: AppTheme.accent,
+          fontSize: 12,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 1.2,
+        ),
+      ),
+    );
+  }
 }

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -25,6 +25,7 @@ import '../../radarr/data/radarr_api_service.dart';
 import '../../radarr/logic/radarr_movies_provider.dart';
 import '../../request/logic/pending_approvals_provider.dart';
 import '../../settings/logic/plex_invites_provider.dart';
+import '../../settings/logic/setup_status_provider.dart';
 import '../../sonarr/data/sonarr_api_service.dart';
 import '../../sonarr/logic/sonarr_series_provider.dart';
 import '../logic/shell_search_provider.dart';
@@ -851,6 +852,11 @@ class _AppShellState extends ConsumerState<AppShell>
     final openIssues = ref.watch(openIssuesProvider);
     final pendingAgentActions = ref.watch(pendingAgentActionsProvider);
     final plexInvitesWaiting = ref.watch(plexInvitesWaitingProvider);
+    // Setup reminder: unconfigured-feature count, shown while the admin
+    // hasn't muted it from the checklist screen.
+    final setupRemaining = ref.watch(setupStatusProvider)?.remaining ?? 0;
+    final showSetupReminder =
+        setupRemaining > 0 && ref.watch(setupReminderEnabledProvider);
 
     return SafeArea(
       child: Column(
@@ -930,6 +936,18 @@ class _AppShellState extends ConsumerState<AppShell>
                 onTap: () {
                   if (isOverlay) Navigator.pop(context);
                   context.push('/settings/users');
+                },
+              ),
+            // Setup reminder: how many features are still unconfigured.
+            // Muteable from the checklist; the Settings tile always remains.
+            if (showSetupReminder)
+              _DrawerItem(
+                icon: Icons.checklist_outlined,
+                title: 'Setup checklist',
+                badgeCount: setupRemaining,
+                onTap: () {
+                  if (isOverlay) Navigator.pop(context);
+                  context.push('/setup');
                 },
               ),
             const Divider(color: AppTheme.border),

--- a/server/README.md
+++ b/server/README.md
@@ -147,6 +147,12 @@ GET    /api/admin/plex/servers/{machineID}/libraries  # sections for the library
 PUT    /api/admin/plex/settings            # server, shared libraries, auto-invite toggle
 ```
 
+### Setup status (admin)
+```
+GET    /api/admin/setup-status             # live-derived checklist of configured/unconfigured features
+```
+Re-derived from actual configuration on every request (never stored), so the app's setup wizard is resumable and can't go stale. New features surface themselves by adding an item here; clients render unknown keys generically.
+
 ### Requests
 ```
 POST   /api/requests                       # user: create (movie/tv by tmdb_id;

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -228,7 +228,7 @@ func main() {
 	webhookHandler := webhooks.NewHandler(instanceStore, registry, wsHub, requestService, contentNotifier)
 
 	// Router
-	router := api.NewRouter(cfg, authHandler, authService, requestHandler, remediationService, remediationHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler, webhookHandler, plexHandler)
+	router := api.NewRouter(cfg, authHandler, authService, requestHandler, remediationService, remediationHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler, webhookHandler, plexHandler, plexService)
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	log.Printf("Cantinarr server starting on %s", addr)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -49,6 +49,7 @@ func NewRouter(
 	pushHandler *push.Handler,
 	webhookHandler *webhooks.Handler,
 	plexHandler *plex.Handler,
+	plexService *plex.Service,
 ) http.Handler {
 	r := chi.NewRouter()
 
@@ -147,6 +148,10 @@ func NewRouter(
 			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Delete("/users/{userID}", authHandler.HandleDeleteUser)
 			// Send a test push to a specific user's devices (delivery diagnostics).
 			r.With(auth.RequirePermission(auth.PermissionUsersManage)).Post("/users/{userID}/test-push", pushHandler.TestPushToUser)
+
+			// Setup checklist: which features are configured, derived live on
+			// every request (drives the app's setup wizard + reminders).
+			r.With(auth.RequirePermission(auth.PermissionInstancesManage)).Get("/setup-status", setupStatusHandler(cfg, instanceStore, creds, plexService))
 
 			// Plex integration: link the admin's Plex account (PIN flow), pick
 			// the server/libraries invites share, and send one-tap invites for

--- a/server/internal/api/setup_status.go
+++ b/server/internal/api/setup_status.go
@@ -1,0 +1,159 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/windoze95/cantinarr-server/internal/config"
+	"github.com/windoze95/cantinarr-server/internal/credentials"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+	"github.com/windoze95/cantinarr-server/internal/plex"
+)
+
+// setupItem is one entry in the admin setup checklist. The list is DERIVED
+// live from actual configuration on every request — never stored — so the
+// setup wizard is resumable and editable for free and can never go stale.
+// New features grow the product by adding an item here; clients render
+// unknown keys generically, so old apps still show new items.
+type setupItem struct {
+	Key         string `json:"key"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Configured  bool   `json:"configured"`
+	// Optional separates "the app doesn't work without this" (Radarr/Sonarr/
+	// TMDB) from features an admin may deliberately skip.
+	Optional bool `json:"optional"`
+}
+
+// setupFacts are the booleans the checklist derives from, gathered by the
+// handler and kept separate so the item list itself is a pure function.
+type setupFacts struct {
+	HasRadarr         bool
+	HasSonarr         bool
+	HasChaptarr       bool
+	HasDownloadClient bool
+	HasTautulli       bool
+	TMDB              bool
+	Trakt             bool
+	AI                bool
+	Push              bool
+	PlexInvites       bool
+}
+
+// buildSetupItems maps configuration facts to the ordered checklist:
+// essentials first, then optional features in rough order of impact.
+func buildSetupItems(f setupFacts) []setupItem {
+	return []setupItem{
+		{
+			Key:         "radarr",
+			Title:       "Movies (Radarr)",
+			Description: "Connect Radarr so movie requests have somewhere to go.",
+			Configured:  f.HasRadarr,
+		},
+		{
+			Key:         "sonarr",
+			Title:       "TV (Sonarr)",
+			Description: "Connect Sonarr so TV requests have somewhere to go.",
+			Configured:  f.HasSonarr,
+		},
+		{
+			Key:         "tmdb",
+			Title:       "Discovery (TMDB)",
+			Description: "Browsing, search, and artwork are powered by TMDB.",
+			Configured:  f.TMDB,
+		},
+		{
+			Key:         "push",
+			Title:       "Push notifications",
+			Description: "Approval, issue, and new-content alerts on devices. Set CANTINARR_PUSH_GATEWAY_URL on the server.",
+			Configured:  f.Push,
+			Optional:    true,
+		},
+		{
+			Key:         "plex_invites",
+			Title:       "Plex invites",
+			Description: "Link a Plex account to send server invites with one tap — or automatically.",
+			Configured:  f.PlexInvites,
+			Optional:    true,
+		},
+		{
+			Key:         "download_client",
+			Title:       "Download activity",
+			Description: "See and manage the live download queue (SABnzbd, qBittorrent, NZBGet, or Transmission).",
+			Configured:  f.HasDownloadClient,
+			Optional:    true,
+		},
+		{
+			Key:         "tautulli",
+			Title:       "Plex monitoring (Tautulli)",
+			Description: "Watch live Plex streams, history, and stats from the app.",
+			Configured:  f.HasTautulli,
+			Optional:    true,
+		},
+		{
+			Key:         "trakt",
+			Title:       "Trakt discovery",
+			Description: "Adds trending, popular lists, and the release calendar to discovery.",
+			Configured:  f.Trakt,
+			Optional:    true,
+		},
+		{
+			Key:         "books",
+			Title:       "Books (Chaptarr)",
+			Description: "Let users request ebooks and audiobooks; access is granted per user.",
+			Configured:  f.HasChaptarr,
+			Optional:    true,
+		},
+		{
+			Key:         "ai",
+			Title:       "AI assistant",
+			Description: "Conversational discovery, requests, and server management. Bring an Anthropic, OpenAI, or Gemini key.",
+			Configured:  f.AI,
+			Optional:    true,
+		},
+	}
+}
+
+// setupStatusHandler answers the admin setup checklist: which features are
+// configured right now. Everything is re-derived per request.
+func setupStatusHandler(cfg *config.Config, store *instance.Store, creds *credentials.Registry, plexService *plex.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var facts setupFacts
+		if instances, err := store.ListAll(); err == nil {
+			for _, inst := range instances {
+				switch inst.ServiceType {
+				case "radarr":
+					facts.HasRadarr = true
+				case "sonarr":
+					facts.HasSonarr = true
+				case "chaptarr":
+					facts.HasChaptarr = true
+				case "tautulli":
+					facts.HasTautulli = true
+				case "sabnzbd", "qbittorrent", "nzbget", "transmission":
+					facts.HasDownloadClient = true
+				}
+			}
+		}
+		facts.TMDB = creds.IsConfigured(credentials.KeyTMDBAccessToken)
+		facts.Trakt = creds.IsConfigured(credentials.KeyTraktClientID)
+		facts.AI = creds.IsAIConfigured()
+		facts.Push = cfg.PushGatewayURL != ""
+		facts.PlexInvites = plexService.Status().Configured
+
+		items := buildSetupItems(facts)
+		configured := 0
+		for _, item := range items {
+			if item.Configured {
+				configured++
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"items":      items,
+			"configured": configured,
+			"total":      len(items),
+		})
+	}
+}

--- a/server/internal/api/setup_status_test.go
+++ b/server/internal/api/setup_status_test.go
@@ -1,0 +1,62 @@
+package api
+
+import "testing"
+
+func TestBuildSetupItemsNothingConfigured(t *testing.T) {
+	items := buildSetupItems(setupFacts{})
+	if len(items) != 10 {
+		t.Fatalf("items = %d, want 10", len(items))
+	}
+	for _, item := range items {
+		if item.Configured {
+			t.Errorf("%s: configured with empty facts", item.Key)
+		}
+		if item.Key == "" || item.Title == "" || item.Description == "" {
+			t.Errorf("item missing display fields: %+v", item)
+		}
+	}
+	// Essentials lead the list so the wizard shows them first.
+	for i, key := range []string{"radarr", "sonarr", "tmdb"} {
+		if items[i].Key != key {
+			t.Errorf("items[%d] = %s, want %s", i, items[i].Key, key)
+		}
+		if items[i].Optional {
+			t.Errorf("%s must not be optional", key)
+		}
+	}
+	for _, item := range items[3:] {
+		if !item.Optional {
+			t.Errorf("%s should be optional", item.Key)
+		}
+	}
+}
+
+func TestBuildSetupItemsMapsFacts(t *testing.T) {
+	items := buildSetupItems(setupFacts{
+		HasRadarr:         true,
+		HasDownloadClient: true,
+		TMDB:              true,
+		PlexInvites:       true,
+	})
+	got := map[string]bool{}
+	for _, item := range items {
+		got[item.Key] = item.Configured
+	}
+	want := map[string]bool{
+		"radarr":          true,
+		"sonarr":          false,
+		"tmdb":            true,
+		"push":            false,
+		"plex_invites":    true,
+		"download_client": true,
+		"tautulli":        false,
+		"trakt":           false,
+		"books":           false,
+		"ai":              false,
+	}
+	for key, expect := range want {
+		if got[key] != expect {
+			t.Errorf("%s configured = %v, want %v", key, got[key], expect)
+		}
+	}
+}


### PR DESCRIPTION
## What

The old `/setup` wizard was mock UI — text fields that saved nothing, reachable from nowhere. This replaces it with a real one built on one principle: **setup progress is derived, never stored** (the same philosophy as never trusting a stored copy of arr state).

- **`GET /api/admin/setup-status`** re-computes per request which features are configured: essentials (Radarr, Sonarr, TMDB) and optional (push, Plex invites, download clients, Tautulli, Trakt, books, AI). No wizard state exists anywhere, so the wizard is resumable and editable *by construction* and can never disagree with reality.
- **The wizard at `/setup`** shows live progress ("X of Y configured" + bar), groups essentials vs nice-to-have, and deep-links every step to the real settings screen (instances editor, credentials, Plex Invites). On return it re-derives, so the step checks itself off only if the thing actually got configured. Server-env items (push gateway) render as informational with the env var named. Unknown keys from newer servers render generically — **that's the groundwork for intelligently exposing future features: ship a feature, add one checklist item server-side, and even older apps surface it.**
- **Reminders in two spots**: Settings → **Setup Checklist** tile with a live progress subtitle (always present), and a drawer **Setup checklist** entry with the remaining-feature count that appears until everything is configured — muteable from the wizard ("Remind me in the menu") for admins who've deliberately skipped features.

## Verification

- Server: `go vet ./...` clean; `go test ./...` all pass (new tests cover the derivation: item order/flags with nothing configured, and fact→item mapping)
- App: `flutter analyze --no-fatal-infos` — no new issues (16 pre-existing infos); `flutter test` — all 200 pass

## Docs

- [x] `README.md` — pitch, feature list, configuration/env vars, quick start
- [x] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [x] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above

Root README gains the **Guided setup** bullet; server README gains the setup-status route block; app README gains the Setup Checklist settings bullet, the drawer-entry mention, and the corrected `setup_wizard/` tree comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)