### PR TITLE
Library tiles: badge = airing status, bar = Sonarr's completeness colors

### DIFF
--- a/app/lib/features/chaptarr/ui/chaptarr_author_list.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_list.dart
@@ -159,9 +159,7 @@ class _AuthorTile extends StatelessWidget {
               child: LinearProgressIndicator(
                 value: percent,
                 backgroundColor: AppTheme.surfaceVariant,
-                valueColor: AlwaysStoppedAnimation(
-                  percent >= 1.0 ? AppTheme.available : AppTheme.accent,
-                ),
+                valueColor: AlwaysStoppedAnimation(_progressColor),
                 minHeight: 4,
               ),
             ),
@@ -194,17 +192,27 @@ class _AuthorTile extends StatelessWidget {
     );
   }
 
-  Color get _statusColor {
-    if (author.percentComplete >= 1.0) return AppTheme.available;
-    if (author.status == 'continuing') return AppTheme.downloading;
-    if (author.status == 'ended') return AppTheme.textSecondary;
-    return AppTheme.requested;
-  }
+  Color get _statusColor => switch (author.status) {
+        'continuing' => AppTheme.downloading,
+        'ended' => AppTheme.textSecondary,
+        _ => AppTheme.requested,
+      };
 
-  String get _statusText {
-    if (author.percentComplete >= 1.0) return 'Complete';
-    if (author.status == 'continuing') return 'Continuing';
-    if (author.status == 'ended') return 'Ended';
-    return 'Partial';
+  String get _statusText => switch (author.status) {
+        'continuing' => 'Continuing',
+        'ended' => 'Ended',
+        _ => 'Unknown',
+      };
+
+  /// Mirrors the Sonarr tile's progress grammar: green only when an ended
+  /// author's monitored books are all on disk, blue when merely caught up,
+  /// red/amber for monitored/unmonitored gaps.
+  Color get _progressColor {
+    if (author.percentComplete >= 1.0) {
+      return author.status == 'ended'
+          ? AppTheme.available
+          : AppTheme.downloading;
+    }
+    return author.monitored ? AppTheme.error : AppTheme.requested;
   }
 }

--- a/app/lib/features/sonarr/ui/sonarr_series_list.dart
+++ b/app/lib/features/sonarr/ui/sonarr_series_list.dart
@@ -176,9 +176,7 @@ class _SeriesTile extends StatelessWidget {
               child: LinearProgressIndicator(
                 value: percent,
                 backgroundColor: AppTheme.surfaceVariant,
-                valueColor: AlwaysStoppedAnimation(
-                  percent >= 1.0 ? AppTheme.available : AppTheme.accent,
-                ),
+                valueColor: AlwaysStoppedAnimation(_progressColor),
                 minHeight: 4,
               ),
             ),
@@ -225,17 +223,30 @@ class _SeriesTile extends StatelessWidget {
     );
   }
 
-  Color get _statusColor {
-    if (show.percentComplete >= 1.0) return AppTheme.available;
-    if (show.status == 'continuing') return AppTheme.downloading;
-    if (show.status == 'ended') return AppTheme.textSecondary;
-    return AppTheme.requested;
-  }
+  Color get _statusColor => switch (show.status) {
+        'continuing' => AppTheme.downloading,
+        'ended' => AppTheme.textSecondary,
+        'upcoming' => AppTheme.requested,
+        'deleted' => AppTheme.error,
+        _ => AppTheme.requested,
+      };
 
-  String get _statusText {
-    if (show.percentComplete >= 1.0) return 'Complete';
-    if (show.status == 'continuing') return 'Continuing';
-    if (show.status == 'ended') return 'Ended';
-    return 'Unknown';
+  String get _statusText => switch (show.status) {
+        'continuing' => 'Continuing',
+        'ended' => 'Ended',
+        'upcoming' => 'Upcoming',
+        'deleted' => 'Deleted',
+        _ => 'Unknown',
+      };
+
+  /// Sonarr's progress-bar grammar: green is reserved for ended series with
+  /// every monitored episode on disk. A continuing series that is merely
+  /// caught up shows blue (more episodes are coming), and gaps show red when
+  /// monitored or amber when the admin chose not to monitor them.
+  Color get _progressColor {
+    if (show.percentComplete >= 1.0) {
+      return show.status == 'ended' ? AppTheme.available : AppTheme.downloading;
+    }
+    return show.monitored ? AppTheme.error : AppTheme.requested;
   }
 }

--- a/app/test/chaptarr/author_tile_status_test.dart
+++ b/app/test/chaptarr/author_tile_status_test.dart
@@ -1,0 +1,65 @@
+import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/features/chaptarr/data/chaptarr_models.dart';
+import 'package:cantinarr/features/chaptarr/ui/chaptarr_author_list.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Mirrors the Sonarr tile's grammar: the badge is the author's publishing
+/// status, and the bar carries completeness — green only for an ended author
+/// with every monitored book on disk, blue when merely caught up, red/amber
+/// for monitored/unmonitored gaps.
+ChaptarrAuthor _author({
+  String? status,
+  bool monitored = true,
+  int files = 0,
+  int count = 0,
+}) =>
+    ChaptarrAuthor(
+      id: 1,
+      authorName: 'Author',
+      status: status,
+      monitored: monitored,
+      statistics:
+          ChaptarrAuthorStatistics(bookFileCount: files, bookCount: count),
+    );
+
+Future<void> _pump(WidgetTester tester, ChaptarrAuthor author) {
+  return tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: ChaptarrAuthorList(
+        authors: [author],
+        onTap: (_) {},
+      ),
+    ),
+  ));
+}
+
+Color? _barColor(WidgetTester tester) {
+  final bar = tester
+      .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator));
+  return bar.valueColor?.value;
+}
+
+void main() {
+  testWidgets('caught-up continuing author stays Continuing with a blue bar',
+      (tester) async {
+    await _pump(tester, _author(status: 'continuing', files: 12, count: 12));
+    expect(find.text('Continuing'), findsOneWidget);
+    expect(find.text('Complete'), findsNothing);
+    expect(_barColor(tester), AppTheme.downloading);
+  });
+
+  testWidgets('complete ended author shows Ended with a green bar',
+      (tester) async {
+    await _pump(tester, _author(status: 'ended', files: 8, count: 8));
+    expect(find.text('Ended'), findsOneWidget);
+    expect(_barColor(tester), AppTheme.available);
+  });
+
+  testWidgets('monitored author with missing books shows a red bar',
+      (tester) async {
+    await _pump(tester, _author(status: 'continuing', files: 3, count: 9));
+    expect(find.text('Continuing'), findsOneWidget);
+    expect(_barColor(tester), AppTheme.error);
+  });
+}

--- a/app/test/sonarr/series_tile_status_test.dart
+++ b/app/test/sonarr/series_tile_status_test.dart
@@ -1,0 +1,80 @@
+import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:cantinarr/features/sonarr/ui/sonarr_series_list.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The library tile follows Sonarr's grammar: the badge is the airing status,
+/// and completeness lives in the progress bar — green only for an ended series
+/// with every monitored episode on disk, blue for a continuing series that is
+/// merely caught up, red for monitored gaps, amber for unmonitored gaps.
+SonarrSeries _series({
+  String? status,
+  bool monitored = true,
+  int files = 0,
+  int count = 0,
+}) =>
+    SonarrSeries(
+      id: 1,
+      title: 'Show',
+      year: 2020,
+      monitored: monitored,
+      status: status,
+      statistics:
+          SonarrStatistics(episodeFileCount: files, episodeCount: count),
+    );
+
+Future<void> _pump(WidgetTester tester, SonarrSeries show) {
+  return tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: SonarrSeriesList(
+        series: [show],
+        onDelete: (_) {},
+        onSearch: (_) {},
+      ),
+    ),
+  ));
+}
+
+Color? _barColor(WidgetTester tester) {
+  final bar = tester
+      .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator));
+  return bar.valueColor?.value;
+}
+
+void main() {
+  testWidgets('caught-up continuing series stays Continuing with a blue bar',
+      (tester) async {
+    await _pump(tester, _series(status: 'continuing', files: 33, count: 33));
+    expect(find.text('Continuing'), findsOneWidget);
+    expect(find.text('Complete'), findsNothing);
+    expect(_barColor(tester), AppTheme.downloading);
+  });
+
+  testWidgets('complete ended series shows Ended with a green bar',
+      (tester) async {
+    await _pump(tester, _series(status: 'ended', files: 62, count: 62));
+    expect(find.text('Ended'), findsOneWidget);
+    expect(_barColor(tester), AppTheme.available);
+  });
+
+  testWidgets('monitored series with missing episodes shows a red bar',
+      (tester) async {
+    await _pump(tester, _series(status: 'ended', files: 95, count: 96));
+    expect(find.text('Ended'), findsOneWidget);
+    expect(_barColor(tester), AppTheme.error);
+  });
+
+  testWidgets('unmonitored series with missing episodes shows an amber bar',
+      (tester) async {
+    await _pump(tester,
+        _series(status: 'continuing', monitored: false, files: 5, count: 10));
+    expect(_barColor(tester), AppTheme.requested);
+  });
+
+  testWidgets('upcoming series shows Upcoming and no bar', (tester) async {
+    await _pump(tester, _series(status: 'upcoming'));
+    expect(find.text('Upcoming'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsNothing);
+  });
+}


### PR DESCRIPTION
## What

The Sonarr library tile (and its Chaptarr author twin) answered two different questions with one badge: it said **Complete** whenever every monitored episode was on disk, and only fell back to the airing status otherwise. So America's Got Talent (0/5) read "Continuing" while American Dad! (33/33, still airing) read "Complete" — and a mid-run show that is merely caught up (A Knight of the Seven Kingdoms, 3/3 aired) claimed "Complete" too. Sonarr has no "Complete" label at all.

This adopts Sonarr's own grammar:

- **Badge = airing status**, always: Continuing (blue) / Ended (gray) / Upcoming (amber) / Deleted (red). `upcoming` previously rendered as "Unknown".
- **Progress bar = completeness**, using Sonarr's color rules (`getProgressBarKind`): green is reserved for an **ended** series with every monitored episode on disk; a continuing series that's caught up shows **blue** (more is coming); missing episodes show **red** when monitored, **amber** when unmonitored. The `x/y eps` text is unchanged.
- Chaptarr's author list mirrors the same rules (it was a copy of the old logic).

The library header stats (Total / Complete / Partial) are aggregates and are unchanged.

## Verification

- `flutter analyze --no-fatal-infos` — no issues in touched files (16 pre-existing infos elsewhere).
- `flutter test` — 208 passed, including 8 new widget tests covering the badge/bar mapping for both tiles.

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — explained above

The tile badges/colors aren't described in any README (checked for Complete/Continuing/Ended mentions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)