### PR TITLE
Desktop-adaptive layout: sidebar page navigation + readable content widths

### DIFF
--- a/app/.claude/skills/verify/SKILL.md
+++ b/app/.claude/skills/verify/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: verify
+description: Drive the Cantinarr Flutter app in a browser to verify UI changes at runtime — no backend required. Use when a change to app/lib needs visual/behavioral verification (layout, navigation, theming).
+---
+
+# Verifying the Cantinarr app at runtime
+
+The app normally needs a Cantinarr server to get past login. `DBPath` is
+hardcoded to `/config/` in the Go server, so it won't boot on macOS, and the
+published Docker image needs a working Docker daemon. For UI verification,
+skip the server entirely:
+
+## Preview harness (no backend)
+
+`test/preview/preview_main.dart` boots the REAL app (router, shell, screens,
+theme) with a faked authenticated admin (all modules + two Radarr instances)
+and a stub Dio adapter. Data screens show their empty/error states; chrome,
+navigation, and layout are the real code paths.
+
+```bash
+cd app
+flutter run -d web-server -t test/preview/preview_main.dart \
+  --web-port 7777 --web-hostname 127.0.0.1
+# wait for "is being served at", then drive http://127.0.0.1:7777 in Chrome
+```
+
+Drive with the claude-in-chrome tools. Gotchas learned the hard way:
+
+- **Debug-web page transitions are slow (2–4s)** — a screenshot right after a
+  click captures a mid-transition frame that looks like two screens layered
+  (e.g. login ghosting behind the shell on first load). Always `wait` 3–4s and
+  re-screenshot before judging layout.
+- **`resize_window` may not change the CSS viewport** (window managers /
+  non-100% zoom). Confirm with `javascript_tool`:
+  `window.innerWidth` — the app's breakpoints key off CSS px (desktop ≥ 900).
+  If you can't get below 900, cover mobile via the widget tests instead
+  (`test/shell/adaptive_layout_test.dart` pumps 390x844 and 1400x900).
+- The stub adapter returns `[]` for unknown paths; screens expecting a map
+  shape (e.g. Radarr queue) show their error state — that's the stub, not a
+  bug. Extend `_StubAdapter` in preview_main.dart if a screen's shape matters.
+- Real-server slice: the auth screen can be pointed at
+  `https://demo.cantinarr.com` to exercise the server-status flow (no creds,
+  so stop at the login view).
+
+## What to check for layout changes
+
+Desktop (≥900 CSS px): persistent sidebar (no hamburger), active module
+expanded into its pages, NO BottomNavigationBar, search bar/results/chat
+capped via `AppBreakpoints.readableContentWidth`. Mobile (<900): hamburger
+drawer, per-module bottom nav. The adaptive widget tests assert both.

--- a/app/README.md
+++ b/app/README.md
@@ -183,7 +183,7 @@ app/lib/
 
 ## Navigation
 
-An outer shell (drawer + persistent search bar; permanent rail on wide screens) hosts per-module bottom-tab shells:
+An outer shell (persistent search bar + navigation chrome) hosts per-module page shells. The chrome adapts at 900px: below it, a hamburger drawer lists modules and each module shows its pages as a bottom nav; at 900px+ the drawer becomes a persistent sidebar whose active module expands into its pages, and the bottom nav disappears. Line-length-sensitive surfaces (search results, chat, detail pages, settings forms) cap and center their content on desktop; modal bottom sheets cap at 640px.
 
 | Module | Tabs | Access |
 |---|---|---|

--- a/app/lib/core/layout/adaptive.dart
+++ b/app/lib/core/layout/adaptive.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/widgets.dart';
+
+/// Shared responsive breakpoints and desktop content-width helpers.
+///
+/// The app is mobile-first; at [desktopMinWidth] and up the chrome adapts:
+/// [AppShell] swaps the hamburger drawer for a persistent sidebar whose active
+/// module expands into per-page items, and the module shells drop their bottom
+/// nav (the sidebar covers page switching). Keep every desktop check on this
+/// class so the whole app flips layout at the same width.
+abstract final class AppBreakpoints {
+  static const double desktopMinWidth = 900;
+
+  /// Width of the persistent desktop sidebar in AppShell.
+  static const double sidebarWidth = 280;
+
+  /// Readable column width for line-length-sensitive surfaces (search
+  /// results, chat transcripts, forms) on desktop.
+  static const double readableContentWidth = 800;
+
+  static bool isDesktop(BuildContext context) =>
+      MediaQuery.sizeOf(context).width >= desktopMinWidth;
+
+  /// Phone-shaped screens (drives e.g. the collapse-on-scroll search bar).
+  static bool isMobile(BuildContext context) =>
+      MediaQuery.sizeOf(context).shortestSide < 600;
+
+  /// Horizontal padding that keeps content at most [maxContentWidth] wide and
+  /// centered within [totalWidth], never dropping below [minPadding]. Use as
+  /// scrollable padding so the scroll surface stays full width (wheel and
+  /// drag scrolling keep working in the side gutters) while the content
+  /// column stays readable on wide windows.
+  static double centeredContentPadding(
+    double totalWidth, {
+    double maxContentWidth = readableContentWidth,
+    double minPadding = 16,
+  }) {
+    final padding = (totalWidth - maxContentWidth) / 2;
+    return padding > minPadding ? padding : minPadding;
+  }
+}
+
+/// Caps [child] at [maxWidth] and centers it horizontally — a no-op on
+/// layouts already narrower than that. Wrap page bodies (forms, detail
+/// content) with this so they read as a column instead of stretching across
+/// a desktop window. For long infinite-scroll surfaces prefer padding-based
+/// centering ([AppBreakpoints.centeredContentPadding]) so wheel scrolling
+/// keeps working in the side gutters.
+class CenteredContent extends StatelessWidget {
+  final double maxWidth;
+  final Widget child;
+
+  const CenteredContent({
+    super.key,
+    this.maxWidth = AppBreakpoints.readableContentWidth,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: maxWidth),
+        child: child,
+      ),
+    );
+  }
+}

--- a/app/lib/core/models/app_module.dart
+++ b/app/lib/core/models/app_module.dart
@@ -1,7 +1,15 @@
 import 'package:flutter/material.dart';
 
 /// Types of modules available in the app.
-enum ModuleType { dashboard, radarr, sonarr, chaptarr, downloads, tautulli, assistant }
+enum ModuleType {
+  dashboard,
+  radarr,
+  sonarr,
+  chaptarr,
+  downloads,
+  tautulli,
+  assistant
+}
 
 /// Represents a navigable module in the app (shown in drawer).
 class AppModule {
@@ -18,4 +26,189 @@ class AppModule {
     this.instanceId,
     this.instanceName,
   });
+}
+
+/// One page (tab) within a module. Renders as a bottom-nav item on
+/// mobile/tablet and as a sidebar sub-item on desktop.
+class ModulePage {
+  final String label;
+  final IconData icon;
+  final IconData activeIcon;
+  final String route;
+
+  const ModulePage({
+    required this.label,
+    required this.icon,
+    required this.activeIcon,
+    required this.route,
+  });
+}
+
+/// Pages for [type], in the same order as the module's StatefulShellRoute
+/// branches in app_router.dart (bottom-nav index == branch index).
+/// [includeBooks] adds the dashboard Books tab, which exists only for users
+/// with Chaptarr access (services.chaptarr); it is last so its presence never
+/// shifts the other tabs' indices.
+List<ModulePage> modulePagesFor(ModuleType type, {bool includeBooks = false}) {
+  switch (type) {
+    case ModuleType.dashboard:
+      return [
+        const ModulePage(
+          label: 'Movies',
+          icon: Icons.movie_outlined,
+          activeIcon: Icons.movie,
+          route: '/dashboard/movies',
+        ),
+        const ModulePage(
+          label: 'TV Shows',
+          icon: Icons.tv_outlined,
+          activeIcon: Icons.tv,
+          route: '/dashboard/tv',
+        ),
+        const ModulePage(
+          label: 'Releases',
+          icon: Icons.event_outlined,
+          activeIcon: Icons.event,
+          route: '/dashboard/releases',
+        ),
+        if (includeBooks)
+          const ModulePage(
+            label: 'Books',
+            icon: Icons.menu_book_outlined,
+            activeIcon: Icons.menu_book,
+            route: '/dashboard/books',
+          ),
+      ];
+    case ModuleType.radarr:
+      return const [
+        ModulePage(
+          label: 'Library',
+          icon: Icons.video_library_outlined,
+          activeIcon: Icons.video_library,
+          route: '/radarr/library',
+        ),
+        ModulePage(
+          label: 'Queue',
+          icon: Icons.downloading_outlined,
+          activeIcon: Icons.downloading,
+          route: '/radarr/queue',
+        ),
+        ModulePage(
+          label: 'History',
+          icon: Icons.history_outlined,
+          activeIcon: Icons.history,
+          route: '/radarr/history',
+        ),
+        ModulePage(
+          label: 'Wanted',
+          icon: Icons.report_gmailerrorred_outlined,
+          activeIcon: Icons.report_gmailerrorred,
+          route: '/radarr/wanted',
+        ),
+        ModulePage(
+          label: 'Calendar',
+          icon: Icons.calendar_month_outlined,
+          activeIcon: Icons.calendar_month,
+          route: '/radarr/calendar',
+        ),
+      ];
+    case ModuleType.sonarr:
+      return const [
+        ModulePage(
+          label: 'Library',
+          icon: Icons.video_library_outlined,
+          activeIcon: Icons.video_library,
+          route: '/sonarr/library',
+        ),
+        ModulePage(
+          label: 'Queue',
+          icon: Icons.downloading_outlined,
+          activeIcon: Icons.downloading,
+          route: '/sonarr/queue',
+        ),
+        ModulePage(
+          label: 'History',
+          icon: Icons.history_outlined,
+          activeIcon: Icons.history,
+          route: '/sonarr/history',
+        ),
+        ModulePage(
+          label: 'Wanted',
+          icon: Icons.report_gmailerrorred_outlined,
+          activeIcon: Icons.report_gmailerrorred,
+          route: '/sonarr/wanted',
+        ),
+        ModulePage(
+          label: 'Calendar',
+          icon: Icons.calendar_month_outlined,
+          activeIcon: Icons.calendar_month,
+          route: '/sonarr/calendar',
+        ),
+      ];
+    case ModuleType.chaptarr:
+      return const [
+        ModulePage(
+          label: 'Library',
+          icon: Icons.menu_book_outlined,
+          activeIcon: Icons.menu_book,
+          route: '/chaptarr/library',
+        ),
+        ModulePage(
+          label: 'Queue',
+          icon: Icons.downloading_outlined,
+          activeIcon: Icons.downloading,
+          route: '/chaptarr/queue',
+        ),
+        ModulePage(
+          label: 'History',
+          icon: Icons.history_outlined,
+          activeIcon: Icons.history,
+          route: '/chaptarr/history',
+        ),
+        ModulePage(
+          label: 'Wanted',
+          icon: Icons.warning_amber_outlined,
+          activeIcon: Icons.warning_amber,
+          route: '/chaptarr/wanted',
+        ),
+      ];
+    case ModuleType.downloads:
+      return const [
+        ModulePage(
+          label: 'Queue',
+          icon: Icons.downloading_outlined,
+          activeIcon: Icons.downloading,
+          route: '/downloads/queue',
+        ),
+        ModulePage(
+          label: 'History',
+          icon: Icons.history_outlined,
+          activeIcon: Icons.history,
+          route: '/downloads/history',
+        ),
+      ];
+    case ModuleType.tautulli:
+      return const [
+        ModulePage(
+          label: 'Activity',
+          icon: Icons.play_circle_outline,
+          activeIcon: Icons.play_circle,
+          route: '/tautulli/activity',
+        ),
+        ModulePage(
+          label: 'History',
+          icon: Icons.history_outlined,
+          activeIcon: Icons.history,
+          route: '/tautulli/history',
+        ),
+        ModulePage(
+          label: 'Stats',
+          icon: Icons.insights_outlined,
+          activeIcon: Icons.insights,
+          route: '/tautulli/stats',
+        ),
+      ];
+    case ModuleType.assistant:
+      return const [];
+  }
 }

--- a/app/lib/core/theme/app_theme.dart
+++ b/app/lib/core/theme/app_theme.dart
@@ -55,6 +55,12 @@ class AppTheme {
           unselectedItemColor: textSecondary,
           type: BottomNavigationBarType.fixed,
         ),
+        // Modal bottom sheets cap at the Material 3 standard width so they
+        // present as centered sheets on desktop instead of spanning the
+        // window; phone layouts are narrower than the cap and unaffected.
+        bottomSheetTheme: const BottomSheetThemeData(
+          constraints: BoxConstraints(maxWidth: 640),
+        ),
         inputDecorationTheme: InputDecorationTheme(
           filled: true,
           fillColor: surfaceVariant,

--- a/app/lib/core/widgets/module_scaffold.dart
+++ b/app/lib/core/widgets/module_scaffold.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import '../layout/adaptive.dart';
+import '../models/app_module.dart';
+import '../theme/app_theme.dart';
+
+/// Scaffold shared by the module shells: page content plus adaptive page
+/// navigation. Mobile/tablet gets the classic bottom nav; desktop drops it —
+/// the AppShell sidebar lists the same [pages] there.
+class ModuleScaffold extends StatelessWidget {
+  final PreferredSizeWidget? appBar;
+  final List<ModulePage> pages;
+  final int currentIndex;
+  final ValueChanged<int> onTabChanged;
+  final Widget child;
+
+  const ModuleScaffold({
+    super.key,
+    this.appBar,
+    required this.pages,
+    required this.currentIndex,
+    required this.onTabChanged,
+    required this.child,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: appBar,
+      body: child,
+      bottomNavigationBar: AppBreakpoints.isDesktop(context)
+          ? null
+          : Container(
+              decoration: const BoxDecoration(
+                border:
+                    Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
+              ),
+              child: BottomNavigationBar(
+                currentIndex: currentIndex.clamp(0, pages.length - 1),
+                onTap: onTabChanged,
+                items: [
+                  for (final page in pages)
+                    BottomNavigationBarItem(
+                      icon: Icon(page.icon),
+                      activeIcon: Icon(page.activeIcon),
+                      label: page.label,
+                    ),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/app/lib/features/ai_assistant/ui/ai_chat_screen.dart
+++ b/app/lib/features/ai_assistant/ui/ai_chat_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/models/app_module.dart';
 import '../../../core/providers/module_provider.dart';
 import '../../../core/theme/app_theme.dart';
@@ -92,30 +93,34 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
           ),
           title: const Text('AI Assistant'),
         ),
-        body: const Center(
+        body: Center(
           child: Padding(
-            padding: EdgeInsets.all(32),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.smart_toy_outlined,
-                    size: 64, color: AppTheme.accent),
-                SizedBox(height: 16),
-                Text(
-                  'AI Assistant',
-                  style: TextStyle(
-                    color: AppTheme.textPrimary,
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
+            padding: const EdgeInsets.all(32),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 480),
+              child: const Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.smart_toy_outlined,
+                      size: 64, color: AppTheme.accent),
+                  SizedBox(height: 16),
+                  Text(
+                    'AI Assistant',
+                    style: TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
-                ),
-                SizedBox(height: 12),
-                Text(
-                  'The AI assistant is not configured on this server. Ask your server admin to set up an AI provider.',
-                  style: TextStyle(color: AppTheme.textSecondary, fontSize: 15),
-                  textAlign: TextAlign.center,
-                ),
-              ],
+                  SizedBox(height: 12),
+                  Text(
+                    'The AI assistant is not configured on this server. Ask your server admin to set up an AI provider.',
+                    style:
+                        TextStyle(color: AppTheme.textSecondary, fontSize: 15),
+                    textAlign: TextAlign.center,
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -154,17 +159,22 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
             child: GestureDetector(
               behavior: HitTestBehavior.translucent,
               onTap: _dismissKeyboard,
-              child: Builder(builder: (context) {
+              child: LayoutBuilder(builder: (context, constraints) {
                 // Only show the typing indicator before the assistant bubble
                 // materializes (text, tool activity, or media arriving).
                 final showTyping = state.isLoading &&
                     (state.messages.isEmpty ||
                         state.messages.last.role != ChatRole.assistant);
+                // Full-width scroll surface; the transcript column is capped
+                // and centered so bubbles stay readable on desktop.
+                final hPad = AppBreakpoints.centeredContentPadding(
+                  constraints.maxWidth,
+                );
                 return ListView.builder(
                   controller: _scrollController,
                   keyboardDismissBehavior:
                       ScrollViewKeyboardDismissBehavior.onDrag,
-                  padding: const EdgeInsets.all(16),
+                  padding: EdgeInsets.fromLTRB(hPad, 16, hPad, 16),
                   itemCount: state.messages.length + (showTyping ? 1 : 0),
                   itemBuilder: (context, index) {
                     if (index >= state.messages.length) {
@@ -186,16 +196,19 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
 
           // Error
           if (state.error != null)
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-              child: Text(
-                state.error!,
-                style: const TextStyle(color: AppTheme.error, fontSize: 12),
-                maxLines: 2,
+            CenteredContent(
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                child: Text(
+                  state.error!,
+                  style: const TextStyle(color: AppTheme.error, fontSize: 12),
+                  maxLines: 2,
+                ),
               ),
             ),
 
-          // Input
+          // Input (capped to the transcript column width on desktop)
           Container(
             decoration: const BoxDecoration(
               color: AppTheme.surface,
@@ -204,45 +217,47 @@ class _AiChatScreenState extends ConsumerState<AiChatScreen> {
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
             child: SafeArea(
               top: false,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (state.messages.length <= 1) ...[
-                    _buildSuggestions(),
-                    const SizedBox(height: 8),
-                  ],
-                  Row(
-                    children: [
-                      Expanded(
-                        child: TextField(
-                          controller: _inputController,
-                          focusNode: _focusNode,
-                          keyboardType: TextInputType.multiline,
-                          textInputAction: TextInputAction.send,
-                          onSubmitted: (_) => _send(),
-                          onTapOutside: (_) => _dismissKeyboard(),
-                          decoration: const InputDecoration(
-                            hintText: 'Ask me anything...',
-                            border: InputBorder.none,
-                            contentPadding: EdgeInsets.symmetric(
-                                horizontal: 12, vertical: 10),
-                          ),
-                          maxLines: 4,
-                          minLines: 1,
-                        ),
-                      ),
-                      IconButton(
-                        onPressed: state.isLoading ? null : _send,
-                        icon: Icon(
-                          Icons.send_rounded,
-                          color: state.isLoading
-                              ? AppTheme.textSecondary
-                              : AppTheme.accent,
-                        ),
-                      ),
+              child: CenteredContent(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    if (state.messages.length <= 1) ...[
+                      _buildSuggestions(),
+                      const SizedBox(height: 8),
                     ],
-                  ),
-                ],
+                    Row(
+                      children: [
+                        Expanded(
+                          child: TextField(
+                            controller: _inputController,
+                            focusNode: _focusNode,
+                            keyboardType: TextInputType.multiline,
+                            textInputAction: TextInputAction.send,
+                            onSubmitted: (_) => _send(),
+                            onTapOutside: (_) => _dismissKeyboard(),
+                            decoration: const InputDecoration(
+                              hintText: 'Ask me anything...',
+                              border: InputBorder.none,
+                              contentPadding: EdgeInsets.symmetric(
+                                  horizontal: 12, vertical: 10),
+                            ),
+                            maxLines: 4,
+                            minLines: 1,
+                          ),
+                        ),
+                        IconButton(
+                          onPressed: state.isLoading ? null : _send,
+                          icon: Icon(
+                            Icons.send_rounded,
+                            color: state.isLoading
+                                ? AppTheme.textSecondary
+                                : AppTheme.accent,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/app/lib/features/auth/ui/auth_screen.dart
+++ b/app/lib/features/auth/ui/auth_screen.dart
@@ -110,67 +110,72 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
         child: Center(
           child: SingleChildScrollView(
             padding: const EdgeInsets.symmetric(horizontal: 32),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // Logo
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(20),
-                  child: Image.asset(
-                    'assets/logo.png',
-                    width: 72,
-                    height: 72,
-                    fit: BoxFit.cover,
+            // Login card: full-width buttons would otherwise stretch the
+            // column across a desktop window.
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 420),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  // Logo
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(20),
+                    child: Image.asset(
+                      'assets/logo.png',
+                      width: 72,
+                      height: 72,
+                      fit: BoxFit.cover,
+                    ),
                   ),
-                ),
-                const SizedBox(height: 16),
-                const Text(
-                  'Cantinarr',
-                  style: TextStyle(
-                    color: AppTheme.textPrimary,
-                    fontSize: 28,
-                    fontWeight: FontWeight.bold,
+                  const SizedBox(height: 16),
+                  const Text(
+                    'Cantinarr',
+                    style: TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontSize: 28,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
-                ),
-                const SizedBox(height: 4),
-                Text(
-                  showPasskeyOffer ? 'Secure your account' : _subtitle,
-                  style: const TextStyle(
-                      color: AppTheme.textSecondary, fontSize: 15),
-                  textAlign: TextAlign.center,
-                ),
-                const SizedBox(height: 40),
+                  const SizedBox(height: 4),
+                  Text(
+                    showPasskeyOffer ? 'Secure your account' : _subtitle,
+                    style: const TextStyle(
+                        color: AppTheme.textSecondary, fontSize: 15),
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 40),
 
-                // Post-setup passkey offer takes priority
-                if (showPasskeyOffer)
-                  const _PasskeyOfferView()
-                else
-                  // View-specific content
-                  switch (_view) {
-                    _AuthView.serverUrl => _ServerUrlView(
-                        controller: _serverUrlController,
-                        isLoading: _isCheckingServer,
-                        error: _serverError,
-                        onCheck: _checkServer,
-                        onConnectLink: _showConnectLink,
-                      ),
-                    _AuthView.setup => _SetupView(
-                        serverUrl: _serverUrlController.text.trim(),
-                        serverStatus: _serverStatus!,
-                        onBack: _backToServerUrl,
-                      ),
-                    _AuthView.login => _LoginView(
-                        serverUrl: _serverUrlController.text.trim(),
-                        serverStatus: _serverStatus,
-                        onBack: _backToServerUrl,
-                        onConnectLink: _showConnectLink,
-                      ),
-                    _AuthView.connectLink => _ConnectLinkView(
-                        controller: _linkController,
-                        onBack: _backToServerUrl,
-                      ),
-                  },
-              ],
+                  // Post-setup passkey offer takes priority
+                  if (showPasskeyOffer)
+                    const _PasskeyOfferView()
+                  else
+                    // View-specific content
+                    switch (_view) {
+                      _AuthView.serverUrl => _ServerUrlView(
+                          controller: _serverUrlController,
+                          isLoading: _isCheckingServer,
+                          error: _serverError,
+                          onCheck: _checkServer,
+                          onConnectLink: _showConnectLink,
+                        ),
+                      _AuthView.setup => _SetupView(
+                          serverUrl: _serverUrlController.text.trim(),
+                          serverStatus: _serverStatus!,
+                          onBack: _backToServerUrl,
+                        ),
+                      _AuthView.login => _LoginView(
+                          serverUrl: _serverUrlController.text.trim(),
+                          serverStatus: _serverStatus,
+                          onBack: _backToServerUrl,
+                          onConnectLink: _showConnectLink,
+                        ),
+                      _AuthView.connectLink => _ConnectLinkView(
+                          controller: _linkController,
+                          onBack: _backToServerUrl,
+                        ),
+                    },
+                ],
+              ),
             ),
           ),
         ),

--- a/app/lib/features/auth/ui/passkey_create_screen.dart
+++ b/app/lib/features/auth/ui/passkey_create_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/passkey_service.dart';
 import '../logic/auth_provider.dart';
@@ -123,7 +124,8 @@ class _PasskeyCreateScreenState extends ConsumerState<PasskeyCreateScreen> {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Create Passkey')),
-      body: SafeArea(
+      body: CenteredContent(
+          child: SafeArea(
         child: ListView(
           padding: const EdgeInsets.all(20),
           children: [
@@ -180,7 +182,7 @@ class _PasskeyCreateScreenState extends ConsumerState<PasskeyCreateScreen> {
             ],
           ],
         ),
-      ),
+      )),
     );
   }
 

--- a/app/lib/features/auth/ui/passkey_management_screen.dart
+++ b/app/lib/features/auth/ui/passkey_management_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/auth_service.dart';
 import '../logic/auth_provider.dart';
@@ -100,22 +101,24 @@ class _PasskeyManagementScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Passkeys')),
-      body: _isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : _error != null
-              ? Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(_error!,
-                          style: const TextStyle(color: AppTheme.error)),
-                      const SizedBox(height: 16),
-                      ElevatedButton(
-                          onPressed: _loadPasskeys, child: const Text('Retry')),
-                    ],
-                  ),
-                )
-              : _buildList(),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : _error != null
+                  ? Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(_error!,
+                              style: const TextStyle(color: AppTheme.error)),
+                          const SizedBox(height: 16),
+                          ElevatedButton(
+                              onPressed: _loadPasskeys,
+                              child: const Text('Retry')),
+                        ],
+                      ),
+                    )
+                  : _buildList()),
       floatingActionButton: FloatingActionButton(
         onPressed: _addPasskey,
         backgroundColor: AppTheme.accent,

--- a/app/lib/features/auth/ui/set_password_screen.dart
+++ b/app/lib/features/auth/ui/set_password_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
 import '../logic/auth_provider.dart';
 
@@ -94,7 +95,8 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
     return Scaffold(
       appBar:
           AppBar(title: Text(isChange ? 'Change Password' : 'Create Password')),
-      body: SafeArea(
+      body: CenteredContent(
+          child: SafeArea(
         child: ListView(
           padding: const EdgeInsets.all(20),
           children: [
@@ -123,8 +125,8 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
                 labelText: 'New password',
                 prefixIcon: const Icon(Icons.lock_outline),
                 suffixIcon: IconButton(
-                  icon: Icon(
-                      _obscure ? Icons.visibility : Icons.visibility_off),
+                  icon:
+                      Icon(_obscure ? Icons.visibility : Icons.visibility_off),
                   onPressed: () => setState(() => _obscure = !_obscure),
                 ),
               ),
@@ -160,7 +162,7 @@ class _SetPasswordScreenState extends ConsumerState<SetPasswordScreen> {
             ),
           ],
         ),
-      ),
+      )),
     );
   }
 }

--- a/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/cached_image.dart';
@@ -194,39 +195,42 @@ class _ChaptarrAuthorDetailScreenState
           ),
         ],
       ),
-      body: _error != null && _author == null
-          ? FullScreenError(message: _error!, onRetry: _load)
-          : RefreshIndicator(
-              onRefresh: _load,
-              color: AppTheme.accent,
-              child: ListView(
-                padding: const EdgeInsets.symmetric(vertical: 12),
-                children: [
-                  if (_error != null)
-                    ErrorBanner(message: _error!, onRetry: _load),
-                  if (_author != null) _AuthorSummaryCard(author: _author!),
-                  const SizedBox(height: 4),
-                  ..._groupedBooks().map((records) => _BookCard(
-                        records: records,
-                        cover: chaptarrImageSource(
-                            ref, records.first.coverUrl, widget.instanceId),
-                        togglingIds: _togglingBooks,
-                        addingKeys: _addingFormats,
-                        onTap: () => _openBookGroup(records),
-                        onToggleRecord: _toggleBookMonitored,
-                        onAddFormat: (format) => _addFormat(records, format),
-                      )),
-                  if (_books.isEmpty && !_isLoading)
-                    const Padding(
-                      padding: EdgeInsets.all(32),
-                      child: Center(
-                        child: Text('No books',
-                            style: TextStyle(color: AppTheme.textSecondary)),
-                      ),
-                    ),
-                ],
-              ),
-            ),
+      body: CenteredContent(
+          child: _error != null && _author == null
+              ? FullScreenError(message: _error!, onRetry: _load)
+              : RefreshIndicator(
+                  onRefresh: _load,
+                  color: AppTheme.accent,
+                  child: ListView(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    children: [
+                      if (_error != null)
+                        ErrorBanner(message: _error!, onRetry: _load),
+                      if (_author != null) _AuthorSummaryCard(author: _author!),
+                      const SizedBox(height: 4),
+                      ..._groupedBooks().map((records) => _BookCard(
+                            records: records,
+                            cover: chaptarrImageSource(
+                                ref, records.first.coverUrl, widget.instanceId),
+                            togglingIds: _togglingBooks,
+                            addingKeys: _addingFormats,
+                            onTap: () => _openBookGroup(records),
+                            onToggleRecord: _toggleBookMonitored,
+                            onAddFormat: (format) =>
+                                _addFormat(records, format),
+                          )),
+                      if (_books.isEmpty && !_isLoading)
+                        const Padding(
+                          padding: EdgeInsets.all(32),
+                          child: Center(
+                            child: Text('No books',
+                                style:
+                                    TextStyle(color: AppTheme.textSecondary)),
+                          ),
+                        ),
+                    ],
+                  ),
+                )),
     );
   }
 }

--- a/app/lib/features/chaptarr/ui/chaptarr_book_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_book_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
@@ -146,7 +147,8 @@ class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
           ],
         ),
       ),
-      body: Column(
+      body: CenteredContent(
+          child: Column(
         children: [
           Expanded(child: _buildBody()),
           _ActionBar(
@@ -154,7 +156,7 @@ class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
             onInteractive: _interactiveSearch,
           ),
         ],
-      ),
+      )),
     );
   }
 

--- a/app/lib/features/chaptarr/ui/chaptarr_module_shell.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_module_shell.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/models/app_module.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/instance_dropdown.dart';
+import '../../../core/widgets/module_scaffold.dart';
 
-/// Chaptarr module shell with bottom nav: Library | Queue | History | Wanted.
-/// Calendar is intentionally omitted (books have no air schedule). Shows the
+/// Chaptarr module shell: Library | Queue | History | Wanted.
+/// Calendar is intentionally omitted (books have no air schedule). Pages
+/// render as a bottom nav on mobile and sidebar items on desktop. Shows the
 /// instance dropdown in the header when 2+ instances exist.
 class ChaptarrModuleShell extends ConsumerWidget {
   final int currentIndex;
@@ -23,7 +26,7 @@ class ChaptarrModuleShell extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final instanceState = ref.watch(instanceProvider);
 
-    return Scaffold(
+    return ModuleScaffold(
       appBar: instanceState.chaptarrInstances.length > 1
           ? AppBar(
               title: InstanceDropdown(
@@ -37,38 +40,10 @@ class ChaptarrModuleShell extends ConsumerWidget {
               elevation: 0,
             )
           : null,
-      body: child,
-      bottomNavigationBar: Container(
-        decoration: const BoxDecoration(
-          border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
-        ),
-        child: BottomNavigationBar(
-          currentIndex: currentIndex,
-          onTap: onTabChanged,
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.menu_book_outlined),
-              activeIcon: Icon(Icons.menu_book),
-              label: 'Library',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.downloading_outlined),
-              activeIcon: Icon(Icons.downloading),
-              label: 'Queue',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.history_outlined),
-              activeIcon: Icon(Icons.history),
-              label: 'History',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.warning_amber_outlined),
-              activeIcon: Icon(Icons.warning_amber),
-              label: 'Wanted',
-            ),
-          ],
-        ),
-      ),
+      pages: modulePagesFor(ModuleType.chaptarr),
+      currentIndex: currentIndex,
+      onTabChanged: onTabChanged,
+      child: child,
     );
   }
 }

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
@@ -198,7 +199,11 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
     }
     final ordered = <(ChaptarrBook, BookOwnership?, String?)>[
       for (final t in injected)
-        (_ownedTitleAsBook(t), t.ownership, t.cover.isNotEmpty ? t.cover : null),
+        (
+          _ownedTitleAsBook(t),
+          t.ownership,
+          t.cover.isNotEmpty ? t.cover : null
+        ),
       ...owned,
       ...rest,
     ];
@@ -230,20 +235,28 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
     final requestService =
         RequestService(backendDio: ref.read(backendClientProvider));
     final instanceId = ref.read(instanceProvider).activeChaptarrInstance?.id;
-    return ListView.separated(
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      itemCount: ordered.length,
-      separatorBuilder: (_, __) =>
-          const Divider(height: 1, color: AppTheme.border),
-      itemBuilder: (_, i) => _BookResultTile(
-        book: ordered[i].$1,
-        ownership: ordered[i].$2,
-        cover: instanceId == null
-            ? null
-            : chaptarrImageSource(ref, ordered[i].$3, instanceId),
-        requestService: requestService,
-      ),
-    );
+    // Full-width scroll surface; the result column is capped and centered so
+    // rows stay readable on desktop widths.
+    return LayoutBuilder(builder: (context, constraints) {
+      final hPad = AppBreakpoints.centeredContentPadding(
+        constraints.maxWidth,
+        minPadding: 0,
+      );
+      return ListView.separated(
+        padding: EdgeInsets.fromLTRB(hPad, 8, hPad, 8),
+        itemCount: ordered.length,
+        separatorBuilder: (_, __) =>
+            const Divider(height: 1, color: AppTheme.border),
+        itemBuilder: (_, i) => _BookResultTile(
+          book: ordered[i].$1,
+          ownership: ordered[i].$2,
+          cover: instanceId == null
+              ? null
+              : chaptarrImageSource(ref, ordered[i].$3, instanceId),
+          requestService: requestService,
+        ),
+      );
+    });
   }
 }
 
@@ -472,9 +485,8 @@ class _BookRequestButtonState extends State<_BookRequestButton> {
   bool _isCovered(BookRequestFormat f) => _detail.isCovered(f);
 
   /// Requestable while at least one of ebook/audiobook hasn't been requested.
-  bool get _requestable =>
-      !(_isCovered(BookRequestFormat.ebook) &&
-          _isCovered(BookRequestFormat.audiobook));
+  bool get _requestable => !(_isCovered(BookRequestFormat.ebook) &&
+      _isCovered(BookRequestFormat.audiobook));
 
   String get _buttonText {
     if (!_requestable) {
@@ -631,7 +643,8 @@ class _FormatChoiceTile extends StatelessWidget {
     return ListTile(
       enabled: !covered,
       contentPadding: const EdgeInsets.symmetric(horizontal: 12),
-      leading: Icon(icon, color: covered ? AppTheme.textSecondary : AppTheme.accent),
+      leading:
+          Icon(icon, color: covered ? AppTheme.textSecondary : AppTheme.accent),
       title: Text(
         choice.label,
         style: TextStyle(

--- a/app/lib/features/dashboard/ui/dashboard_shell.dart
+++ b/app/lib/features/dashboard/ui/dashboard_shell.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import '../../../core/theme/app_theme.dart';
+import '../../../core/models/app_module.dart';
+import '../../../core/widgets/module_scaffold.dart';
 import '../../auth/logic/auth_provider.dart';
 
-/// Dashboard module shell with bottom nav: Movies | TV Shows | Releases, plus a
-/// Books tab when the user has Chaptarr access (services.chaptarr). Books is the
-/// LAST branch so showing/hiding it never shifts the other tabs' indices.
+/// Dashboard module shell: Movies | TV Shows | Releases, plus a Books tab when
+/// the user has Chaptarr access (services.chaptarr). Books is the LAST branch
+/// so showing/hiding it never shifts the other tabs' indices. Pages render as
+/// a bottom nav on mobile and sidebar items on desktop.
 class DashboardShell extends ConsumerWidget {
   final int currentIndex;
   final ValueChanged<int> onTabChanged;
@@ -26,42 +28,11 @@ class DashboardShell extends ConsumerWidget {
       ),
     );
 
-    final items = <BottomNavigationBarItem>[
-      const BottomNavigationBarItem(
-        icon: Icon(Icons.movie_outlined),
-        activeIcon: Icon(Icons.movie),
-        label: 'Movies',
-      ),
-      const BottomNavigationBarItem(
-        icon: Icon(Icons.tv_outlined),
-        activeIcon: Icon(Icons.tv),
-        label: 'TV Shows',
-      ),
-      const BottomNavigationBarItem(
-        icon: Icon(Icons.event_outlined),
-        activeIcon: Icon(Icons.event),
-        label: 'Releases',
-      ),
-      if (showBooks)
-        const BottomNavigationBarItem(
-          icon: Icon(Icons.menu_book_outlined),
-          activeIcon: Icon(Icons.menu_book),
-          label: 'Books',
-        ),
-    ];
-
-    return Scaffold(
-      body: child,
-      bottomNavigationBar: Container(
-        decoration: const BoxDecoration(
-          border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
-        ),
-        child: BottomNavigationBar(
-          currentIndex: currentIndex.clamp(0, items.length - 1),
-          onTap: onTabChanged,
-          items: items,
-        ),
-      ),
+    return ModuleScaffold(
+      pages: modulePagesFor(ModuleType.dashboard, includeBooks: showBooks),
+      currentIndex: currentIndex,
+      onTabChanged: onTabChanged,
+      child: child,
     );
   }
 }

--- a/app/lib/features/discover/ui/search_results_view.dart
+++ b/app/lib/features/discover/ui/search_results_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shimmer/shimmer.dart';
 import '../../../core/config/app_config.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/cached_image.dart';
 import '../../person/ui/person_detail_sheet.dart';
@@ -36,7 +37,10 @@ class SearchResultsView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (results.isEmpty && isLoading) {
-      return _buildLoadingList();
+      return LayoutBuilder(
+        builder: (context, constraints) =>
+            _buildLoadingList(_horizontalPadding(constraints)),
+      );
     }
 
     if (results.isEmpty && !isLoading && query.isNotEmpty) {
@@ -62,32 +66,40 @@ class SearchResultsView extends StatelessWidget {
       );
     }
 
-    return ListView.separated(
-      keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      itemCount: results.length + (isLoading ? 3 : 0),
-      separatorBuilder: (_, __) => const SizedBox.shrink(),
-      itemBuilder: (context, index) {
-        if (index >= results.length) {
-          return _buildShimmerRow();
-        }
-        final item = results[index];
-        if (onLoadMore != null && index >= results.length - 5) {
-          onLoadMore!(item);
-        }
-        return _SearchResultTile(
-          item: item,
-          status: libraryStatus[item.id],
-          onTap: onResultTap,
-        );
-      },
-    );
+    // Full-width scroll surface; the result column is capped and centered so
+    // rows stay readable on desktop widths.
+    return LayoutBuilder(builder: (context, constraints) {
+      final hPad = _horizontalPadding(constraints);
+      return ListView.separated(
+        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+        padding: EdgeInsets.symmetric(horizontal: hPad, vertical: 8),
+        itemCount: results.length + (isLoading ? 3 : 0),
+        separatorBuilder: (_, __) => const SizedBox.shrink(),
+        itemBuilder: (context, index) {
+          if (index >= results.length) {
+            return _buildShimmerRow();
+          }
+          final item = results[index];
+          if (onLoadMore != null && index >= results.length - 5) {
+            onLoadMore!(item);
+          }
+          return _SearchResultTile(
+            item: item,
+            status: libraryStatus[item.id],
+            onTap: onResultTap,
+          );
+        },
+      );
+    });
   }
 
-  Widget _buildLoadingList() {
+  double _horizontalPadding(BoxConstraints constraints) =>
+      AppBreakpoints.centeredContentPadding(constraints.maxWidth);
+
+  Widget _buildLoadingList(double horizontalPadding) {
     return ListView.separated(
       keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: EdgeInsets.symmetric(horizontal: horizontalPadding, vertical: 8),
       itemCount: 8,
       separatorBuilder: (_, __) => const SizedBox(height: 12),
       itemBuilder: (_, __) => _buildShimmerRow(),

--- a/app/lib/features/downloads/ui/downloads_module_shell.dart
+++ b/app/lib/features/downloads/ui/downloads_module_shell.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/models/app_module.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/instance_dropdown.dart';
+import '../../../core/widgets/module_scaffold.dart';
 
-/// Downloads module shell with bottom nav: Queue | History.
+/// Downloads module shell: Queue | History.
+/// Pages render as a bottom nav on mobile and sidebar items on desktop.
 /// Shows instance dropdown in the header when 2+ download clients exist.
 class DownloadsModuleShell extends ConsumerWidget {
   final int currentIndex;
@@ -22,7 +25,7 @@ class DownloadsModuleShell extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final instanceState = ref.watch(instanceProvider);
 
-    return Scaffold(
+    return ModuleScaffold(
       appBar: instanceState.downloadInstances.length > 1
           ? AppBar(
               title: InstanceDropdown(
@@ -36,28 +39,10 @@ class DownloadsModuleShell extends ConsumerWidget {
               elevation: 0,
             )
           : null,
-      body: child,
-      bottomNavigationBar: Container(
-        decoration: const BoxDecoration(
-          border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
-        ),
-        child: BottomNavigationBar(
-          currentIndex: currentIndex,
-          onTap: onTabChanged,
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.downloading_outlined),
-              activeIcon: Icon(Icons.downloading),
-              label: 'Queue',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.history_outlined),
-              activeIcon: Icon(Icons.history),
-              label: 'History',
-            ),
-          ],
-        ),
-      ),
+      pages: modulePagesFor(ModuleType.downloads),
+      currentIndex: currentIndex,
+      onTabChanged: onTabChanged,
+      child: child,
     );
   }
 }

--- a/app/lib/features/issues/ui/agent_run_screen.dart
+++ b/app/lib/features/issues/ui/agent_run_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
+import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/agent_action_models.dart';
 import '../logic/issues_provider.dart';
@@ -63,50 +64,51 @@ class _AgentRunScreenState extends ConsumerState<AgentRunScreen> {
     final detail = _detail;
     return Scaffold(
       appBar: AppBar(title: const Text('Agent activity')),
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : detail == null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(_friendlyError(_error ?? 'Could not load run'),
-                            style: const TextStyle(color: AppTheme.error),
-                            textAlign: TextAlign.center),
-                        const SizedBox(height: 12),
-                        ElevatedButton(
-                            onPressed: _load, child: const Text('Retry')),
-                      ],
-                    ),
-                  ),
-                )
-              : RefreshIndicator(
-                  color: AppTheme.accent,
-                  onRefresh: _load,
-                  child: ListView(
-                    physics: const AlwaysScrollableScrollPhysics(),
-                    padding: const EdgeInsets.all(16),
-                    children: [
-                      _RunSummary(run: detail.run),
-                      const SizedBox(height: 16),
-                      if (detail.steps.isEmpty)
-                        const Padding(
-                          padding: EdgeInsets.only(top: 24),
-                          child: Center(
-                            child: Text('No steps recorded.',
-                                style: TextStyle(
-                                    color: AppTheme.textSecondary)),
-                          ),
-                        )
-                      else
-                        for (final step in detail.steps)
-                          _StepTile(step: step),
-                    ],
-                  ),
-                ),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : detail == null
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(_friendlyError(_error ?? 'Could not load run'),
+                                style: const TextStyle(color: AppTheme.error),
+                                textAlign: TextAlign.center),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                                onPressed: _load, child: const Text('Retry')),
+                          ],
+                        ),
+                      ),
+                    )
+                  : RefreshIndicator(
+                      color: AppTheme.accent,
+                      onRefresh: _load,
+                      child: ListView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        padding: const EdgeInsets.all(16),
+                        children: [
+                          _RunSummary(run: detail.run),
+                          const SizedBox(height: 16),
+                          if (detail.steps.isEmpty)
+                            const Padding(
+                              padding: EdgeInsets.only(top: 24),
+                              child: Center(
+                                child: Text('No steps recorded.',
+                                    style: TextStyle(
+                                        color: AppTheme.textSecondary)),
+                              ),
+                            )
+                          else
+                            for (final step in detail.steps)
+                              _StepTile(step: step),
+                        ],
+                      ),
+                    )),
     );
   }
 }
@@ -146,8 +148,8 @@ class _RunSummary extends StatelessWidget {
             const SizedBox(height: 4),
             Text(
               'Started ${DateFormat('MMM d, h:mm a').format(run.startedAt!)}',
-              style: const TextStyle(
-                  color: AppTheme.textSecondary, fontSize: 12),
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
             ),
           ],
           const SizedBox(height: 10),
@@ -282,11 +284,7 @@ class _StepTile extends StatelessWidget {
           _toolHeading(s, 'Tool call')
         );
       case 'tool_result':
-        return (
-          Icons.south,
-          AppTheme.textSecondary,
-          _toolHeading(s, 'Result')
-        );
+        return (Icons.south, AppTheme.textSecondary, _toolHeading(s, 'Result'));
       case 'giveup':
         return (Icons.flag_outlined, AppTheme.error, 'Gave up');
       case 'system':

--- a/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
+++ b/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/issue_models.dart';
 import '../logic/issues_provider.dart';
@@ -105,27 +106,30 @@ class _AiRemediationSettingsScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('AI Remediation')),
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : _edited == null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(_friendlyError(_error ?? 'Something went wrong'),
-                            style: const TextStyle(color: AppTheme.error),
-                            textAlign: TextAlign.center),
-                        const SizedBox(height: 12),
-                        ElevatedButton(
-                            onPressed: _load, child: const Text('Retry')),
-                      ],
-                    ),
-                  ),
-                )
-              : _buildBody(_edited!),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : _edited == null
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                                _friendlyError(
+                                    _error ?? 'Something went wrong'),
+                                style: const TextStyle(color: AppTheme.error),
+                                textAlign: TextAlign.center),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                                onPressed: _load, child: const Text('Retry')),
+                          ],
+                        ),
+                      ),
+                    )
+                  : _buildBody(_edited!)),
     );
   }
 
@@ -215,7 +219,6 @@ class _AiRemediationSettingsScreenState
             },
           ),
         ),
-
         const _SectionLabel('Model'),
         _TextField(
           controller: _providerController,
@@ -229,7 +232,6 @@ class _AiRemediationSettingsScreenState
           help: "Leave blank to use the server's configured model.",
           hint: 'e.g. a model name',
         ),
-
         const _SectionLabel('Limits'),
         _NumberTile(
           label: 'Max steps per run',
@@ -260,7 +262,6 @@ class _AiRemediationSettingsScreenState
           onChanged: (v) =>
               setState(() => _edited = s.copyWith(dailyCostCeilingMicros: v)),
         ),
-
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
           child: SizedBox(

--- a/app/lib/features/issues/ui/issue_thread_screen.dart
+++ b/app/lib/features/issues/ui/issue_thread_screen.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 
 import 'package:go_router/go_router.dart';
 
+import '../../../core/layout/adaptive.dart';
 import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -203,42 +204,49 @@ class _IssueThreadScreenState extends ConsumerState<IssueThreadScreen> {
           child: RefreshIndicator(
             color: AppTheme.accent,
             onRefresh: _load,
-            child: ListView(
-              controller: _scrollController,
-              physics: const AlwaysScrollableScrollPhysics(),
-              padding: const EdgeInsets.all(16),
-              children: [
-                _IssueSummaryCard(issue: issue),
-                if (runId != null) ...[
-                  const SizedBox(height: 8),
-                  Align(
-                    alignment: Alignment.centerLeft,
-                    child: TextButton.icon(
-                      onPressed: () => context.push('/agent-runs/$runId'),
-                      icon: const Icon(Icons.timeline, size: 16),
-                      style: TextButton.styleFrom(
-                        foregroundColor: AppTheme.textSecondary,
-                        padding: EdgeInsets.zero,
-                        minimumSize: const Size(0, 32),
-                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            // Full-width scroll surface; the thread column is capped and
+            // centered so bubbles stay readable on desktop.
+            child: LayoutBuilder(builder: (context, constraints) {
+              final hPad = AppBreakpoints.centeredContentPadding(
+                constraints.maxWidth,
+              );
+              return ListView(
+                controller: _scrollController,
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: EdgeInsets.fromLTRB(hPad, 16, hPad, 16),
+                children: [
+                  _IssueSummaryCard(issue: issue),
+                  if (runId != null) ...[
+                    const SizedBox(height: 8),
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: TextButton.icon(
+                        onPressed: () => context.push('/agent-runs/$runId'),
+                        icon: const Icon(Icons.timeline, size: 16),
+                        style: TextButton.styleFrom(
+                          foregroundColor: AppTheme.textSecondary,
+                          padding: EdgeInsets.zero,
+                          minimumSize: const Size(0, 32),
+                          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        ),
+                        label: const Text('View agent activity'),
                       ),
-                      label: const Text('View agent activity'),
                     ),
-                  ),
+                  ],
+                  const SizedBox(height: 16),
+                  for (final msg in thread.messages) _MessageRow(message: msg),
+                  // Proposed-action cards surfaced inline so an admin can act from
+                  // the conversation. Each freezes on decide; the list reloads.
+                  for (final action in _actions)
+                    ProposedActionCard(
+                      key: ValueKey(action.id),
+                      action: action,
+                      onDecided: (_) => _load(),
+                    ),
+                  if (issue.status.isActive) const _WorkingIndicator(),
                 ],
-                const SizedBox(height: 16),
-                for (final msg in thread.messages) _MessageRow(message: msg),
-                // Proposed-action cards surfaced inline so an admin can act from
-                // the conversation. Each freezes on decide; the list reloads.
-                for (final action in _actions)
-                  ProposedActionCard(
-                    key: ValueKey(action.id),
-                    action: action,
-                    onDecided: (_) => _load(),
-                  ),
-                if (issue.status.isActive) const _WorkingIndicator(),
-              ],
-            ),
+              );
+            }),
           ),
         ),
         _ReplyBar(
@@ -279,8 +287,7 @@ class _IssueSummaryCard extends StatelessWidget {
         children: [
           Text(
             bits.join(' · '),
-            style: const TextStyle(
-                color: AppTheme.textSecondary, fontSize: 12),
+            style: const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
           ),
           const SizedBox(height: 6),
           Text(
@@ -352,8 +359,7 @@ class _Bubble extends StatelessWidget {
                 color: AppTheme.accent,
                 shape: BoxShape.circle,
               ),
-              child:
-                  const Icon(Icons.smart_toy, size: 18, color: Colors.white),
+              child: const Icon(Icons.smart_toy, size: 18, color: Colors.white),
             ),
             const SizedBox(width: 8),
           ],
@@ -371,8 +377,8 @@ class _Bubble extends StatelessWidget {
                     ),
                   ),
                 Container(
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 14, vertical: 10),
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
                   decoration: BoxDecoration(
                     color: isFromHuman
                         ? AppTheme.accent.withValues(alpha: 0.15)
@@ -439,8 +445,7 @@ class _SystemNotice extends StatelessWidget {
           child: SelectableText(
             message.body,
             textAlign: TextAlign.center,
-            style: const TextStyle(
-                color: AppTheme.textSecondary, fontSize: 12),
+            style: const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
           ),
         ),
       ),
@@ -504,46 +509,50 @@ class _ReplyBar extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       child: SafeArea(
         top: false,
-        child: enabled
-            ? Row(
-                children: [
-                  Expanded(
-                    child: TextField(
-                      controller: controller,
-                      keyboardType: TextInputType.multiline,
-                      textInputAction: TextInputAction.send,
-                      onSubmitted: (_) => onSend(),
-                      minLines: 1,
-                      maxLines: 4,
-                      style: const TextStyle(color: AppTheme.textPrimary),
-                      decoration: InputDecoration(
-                        hintText: hintText,
-                        hintStyle:
-                            const TextStyle(color: AppTheme.textSecondary),
-                        border: InputBorder.none,
-                        contentPadding: const EdgeInsets.symmetric(
-                            horizontal: 12, vertical: 10),
+        // Bar background spans the window; the input is capped to match the
+        // thread column on desktop.
+        child: CenteredContent(
+          child: enabled
+              ? Row(
+                  children: [
+                    Expanded(
+                      child: TextField(
+                        controller: controller,
+                        keyboardType: TextInputType.multiline,
+                        textInputAction: TextInputAction.send,
+                        onSubmitted: (_) => onSend(),
+                        minLines: 1,
+                        maxLines: 4,
+                        style: const TextStyle(color: AppTheme.textPrimary),
+                        decoration: InputDecoration(
+                          hintText: hintText,
+                          hintStyle:
+                              const TextStyle(color: AppTheme.textSecondary),
+                          border: InputBorder.none,
+                          contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 12, vertical: 10),
+                        ),
                       ),
                     ),
-                  ),
-                  IconButton(
-                    onPressed: sending ? null : onSend,
-                    icon: Icon(
-                      Icons.send_rounded,
-                      color:
-                          sending ? AppTheme.textSecondary : AppTheme.accent,
+                    IconButton(
+                      onPressed: sending ? null : onSend,
+                      icon: Icon(
+                        Icons.send_rounded,
+                        color:
+                            sending ? AppTheme.textSecondary : AppTheme.accent,
+                      ),
                     ),
+                  ],
+                )
+              : const Padding(
+                  padding: EdgeInsets.symmetric(vertical: 10, horizontal: 8),
+                  child: Text(
+                    'This issue is closed.',
+                    style:
+                        TextStyle(color: AppTheme.textSecondary, fontSize: 13),
                   ),
-                ],
-              )
-            : const Padding(
-                padding: EdgeInsets.symmetric(vertical: 10, horizontal: 8),
-                child: Text(
-                  'This issue is closed.',
-                  style:
-                      TextStyle(color: AppTheme.textSecondary, fontSize: 13),
                 ),
-              ),
+        ),
       ),
     );
   }

--- a/app/lib/features/issues/ui/issues_list_screen.dart
+++ b/app/lib/features/issues/ui/issues_list_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../core/layout/adaptive.dart';
 import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/issue_models.dart';
@@ -65,63 +66,64 @@ class _IssuesListScreenState extends ConsumerState<IssuesListScreen> {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Issues')),
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : _error != null && _issues == null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(_friendlyError(_error!),
-                            style: const TextStyle(color: AppTheme.error),
-                            textAlign: TextAlign.center),
-                        const SizedBox(height: 12),
-                        ElevatedButton(
-                            onPressed: _load, child: const Text('Retry')),
-                      ],
-                    ),
-                  ),
-                )
-              : RefreshIndicator(
-                  color: AppTheme.accent,
-                  onRefresh: _load,
-                  child: (_issues?.isEmpty ?? true)
-                      ? ListView(
-                          physics: const AlwaysScrollableScrollPhysics(),
-                          children: const [
-                            SizedBox(height: 120),
-                            Center(
-                              child: Text(
-                                'No reported problems.',
-                                style:
-                                    TextStyle(color: AppTheme.textSecondary),
-                              ),
-                            ),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : _error != null && _issues == null
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(_friendlyError(_error!),
+                                style: const TextStyle(color: AppTheme.error),
+                                textAlign: TextAlign.center),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                                onPressed: _load, child: const Text('Retry')),
                           ],
-                        )
-                      : ListView.separated(
-                          physics: const AlwaysScrollableScrollPhysics(),
-                          padding: const EdgeInsets.symmetric(vertical: 8),
-                          itemCount: _issues!.length,
-                          separatorBuilder: (_, __) =>
-                              const Divider(color: AppTheme.border, height: 1),
-                          itemBuilder: (context, index) {
-                            final issue = _issues![index];
-                            return _IssueTile(
-                              issue: issue,
-                              onTap: () async {
-                                await context.push('/issues/${issue.id}');
-                                // Returning from the thread may have changed
-                                // state (a reply, a dismiss) — refresh.
-                                if (mounted) _load();
-                              },
-                            );
-                          },
                         ),
-                ),
+                      ),
+                    )
+                  : RefreshIndicator(
+                      color: AppTheme.accent,
+                      onRefresh: _load,
+                      child: (_issues?.isEmpty ?? true)
+                          ? ListView(
+                              physics: const AlwaysScrollableScrollPhysics(),
+                              children: const [
+                                SizedBox(height: 120),
+                                Center(
+                                  child: Text(
+                                    'No reported problems.',
+                                    style: TextStyle(
+                                        color: AppTheme.textSecondary),
+                                  ),
+                                ),
+                              ],
+                            )
+                          : ListView.separated(
+                              physics: const AlwaysScrollableScrollPhysics(),
+                              padding: const EdgeInsets.symmetric(vertical: 8),
+                              itemCount: _issues!.length,
+                              separatorBuilder: (_, __) => const Divider(
+                                  color: AppTheme.border, height: 1),
+                              itemBuilder: (context, index) {
+                                final issue = _issues![index];
+                                return _IssueTile(
+                                  issue: issue,
+                                  onTap: () async {
+                                    await context.push('/issues/${issue.id}');
+                                    // Returning from the thread may have changed
+                                    // state (a reply, a dismiss) — refresh.
+                                    if (mounted) _load();
+                                  },
+                                );
+                              },
+                            ),
+                    )),
     );
   }
 }
@@ -155,8 +157,7 @@ class _IssueTile extends StatelessWidget {
                 (issue.reporterName.isNotEmpty
                     ? ' · ${issue.reporterName}'
                     : ''),
-            style: const TextStyle(
-                color: AppTheme.textSecondary, fontSize: 13),
+            style: const TextStyle(color: AppTheme.textSecondary, fontSize: 13),
           ),
           const SizedBox(height: 6),
           Wrap(

--- a/app/lib/features/issues/ui/pending_agent_actions_screen.dart
+++ b/app/lib/features/issues/ui/pending_agent_actions_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../../core/layout/adaptive.dart';
 import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/agent_action_models.dart';
@@ -47,7 +48,8 @@ class _PendingAgentActionsScreenState
       _error = null;
     });
     try {
-      final actions = await ref.read(issuesServiceProvider).listPendingActions();
+      final actions =
+          await ref.read(issuesServiceProvider).listPendingActions();
       if (!mounted) return;
       setState(() {
         _actions = actions;
@@ -75,30 +77,31 @@ class _PendingAgentActionsScreenState
 
     return Scaffold(
       appBar: AppBar(title: const Text('Agent fixes')),
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : _error != null && _actions == null
-              ? _ErrorView(message: _friendlyError(_error!), onRetry: _load)
-              : RefreshIndicator(
-                  color: AppTheme.accent,
-                  onRefresh: _load,
-                  child: (_actions?.isEmpty ?? true)
-                      ? ListView(
-                          physics: const AlwaysScrollableScrollPhysics(),
-                          children: const [
-                            SizedBox(height: 120),
-                            Center(
-                              child: Text(
-                                'No fixes awaiting approval.',
-                                style:
-                                    TextStyle(color: AppTheme.textSecondary),
-                              ),
-                            ),
-                          ],
-                        )
-                      : _buildGroupedList(_actions!),
-                ),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : _error != null && _actions == null
+                  ? _ErrorView(message: _friendlyError(_error!), onRetry: _load)
+                  : RefreshIndicator(
+                      color: AppTheme.accent,
+                      onRefresh: _load,
+                      child: (_actions?.isEmpty ?? true)
+                          ? ListView(
+                              physics: const AlwaysScrollableScrollPhysics(),
+                              children: const [
+                                SizedBox(height: 120),
+                                Center(
+                                  child: Text(
+                                    'No fixes awaiting approval.',
+                                    style: TextStyle(
+                                        color: AppTheme.textSecondary),
+                                  ),
+                                ),
+                              ],
+                            )
+                          : _buildGroupedList(_actions!),
+                    )),
     );
   }
 

--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/library_refresh_provider.dart';
 import '../../../core/providers/realtime_provider.dart';
@@ -98,16 +99,23 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
       builder: (context, _) {
         final state = _detailNotifier.state;
 
-        if (state.isLoading && state.movieDetail == null && state.tvDetail == null) {
+        if (state.isLoading &&
+            state.movieDetail == null &&
+            state.tvDetail == null) {
           return const Scaffold(
-            body: Center(child: CircularProgressIndicator(color: AppTheme.accent)),
+            body: Center(
+                child: CircularProgressIndicator(color: AppTheme.accent)),
           );
         }
 
-        if (state.error != null && state.movieDetail == null && state.tvDetail == null) {
+        if (state.error != null &&
+            state.movieDetail == null &&
+            state.tvDetail == null) {
           return Scaffold(
             appBar: AppBar(),
-            body: Center(child: Text(state.error!, style: const TextStyle(color: AppTheme.error))),
+            body: Center(
+                child: Text(state.error!,
+                    style: const TextStyle(color: AppTheme.error))),
           );
         }
 
@@ -129,222 +137,243 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    // Header with backdrop + poster
+                    // Header with backdrop + poster (full-bleed; the detail
+                    // content below it reads as a centered column on desktop)
                     MediaHeader(
                       posterPath: state.posterPath,
                       backdropPath: state.backdropPath,
                       title: state.title,
                     ),
                     const SizedBox(height: 16),
-
-                    // Request button
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: ListenableBuilder(
-                        listenable: _requestNotifier,
-                        builder: (_, __) => RequestButton(
-                          status: _requestNotifier.state.status,
-                          isRequesting: _requestNotifier.state.isRequesting,
-                          error: _requestNotifier.state.error,
-                          onRequest: () => _onRequest(),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-
-                    // Status info tap target
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: ListenableBuilder(
-                        listenable: _requestNotifier,
-                        builder: (_, __) => GestureDetector(
-                          onTap: () => _showStatusSheet(context, state.title,
-                              _requestNotifier.state.status),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Icon(Icons.info_outline,
-                                  size: 14, color: AppTheme.textSecondary),
-                              const SizedBox(width: 4),
-                              Text(
-                                _requestNotifier.state.status.label,
-                                style: const TextStyle(
-                                    color: AppTheme.textSecondary,
-                                    fontSize: 13),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ),
-                    ),
-
-                    // Quiet "Report a problem" affordance — only once the
-                    // title is at least partially in the library and the
-                    // server allows reporting.
-                    ListenableBuilder(
-                      listenable: _requestNotifier,
-                      builder: (_, __) {
-                        if (!_canReport(_requestNotifier.state.status)) {
-                          return const SizedBox.shrink();
-                        }
-                        return Center(
-                          child: TextButton.icon(
-                            onPressed: () => _onReportProblem(state),
-                            icon: const Icon(Icons.flag_outlined, size: 14),
-                            label: const Text('Report a problem'),
-                            style: TextButton.styleFrom(
-                              foregroundColor: AppTheme.textSecondary,
-                              textStyle: const TextStyle(fontSize: 13),
-                            ),
-                          ),
-                        );
-                      },
-                    ),
-                    const SizedBox(height: 16),
-
-                    // Genres
-                    if (state.genres.isNotEmpty)
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: Wrap(
-                          spacing: 6,
-                          runSpacing: 6,
-                          children: state.genres
-                              .map((g) => Chip(
-                                    label: Text(g.name,
-                                        style: const TextStyle(fontSize: 12)),
-                                    backgroundColor: AppTheme.surfaceVariant,
-                                    side: const BorderSide(
-                                        color: AppTheme.border),
-                                    materialTapTargetSize:
-                                        MaterialTapTargetSize.shrinkWrap,
-                                    visualDensity: VisualDensity.compact,
-                                  ))
-                              .toList(),
-                        ),
-                      ),
-
-                    // Rating
-                    if (state.voteAverage != null && state.voteAverage! > 0) ...[
-                      const SizedBox(height: 12),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: Row(
-                          children: [
-                            const Icon(Icons.star,
-                                color: AppTheme.accent, size: 18),
-                            const SizedBox(width: 4),
-                            Text(
-                              state.voteAverage!.toStringAsFixed(1),
-                              style: const TextStyle(
-                                color: AppTheme.textPrimary,
-                                fontSize: 16,
-                                fontWeight: FontWeight.w600,
+                    CenteredContent(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // Request button
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 16),
+                            child: ListenableBuilder(
+                              listenable: _requestNotifier,
+                              builder: (_, __) => RequestButton(
+                                status: _requestNotifier.state.status,
+                                isRequesting:
+                                    _requestNotifier.state.isRequesting,
+                                error: _requestNotifier.state.error,
+                                onRequest: () => _onRequest(),
                               ),
                             ),
-                            const Text(' / 10',
-                                style: TextStyle(
-                                    color: AppTheme.textSecondary,
-                                    fontSize: 14)),
+                          ),
+                          const SizedBox(height: 8),
+
+                          // Status info tap target
+                          Padding(
+                            padding: const EdgeInsets.symmetric(horizontal: 16),
+                            child: ListenableBuilder(
+                              listenable: _requestNotifier,
+                              builder: (_, __) => GestureDetector(
+                                onTap: () => _showStatusSheet(context,
+                                    state.title, _requestNotifier.state.status),
+                                child: Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Icon(Icons.info_outline,
+                                        size: 14,
+                                        color: AppTheme.textSecondary),
+                                    const SizedBox(width: 4),
+                                    Text(
+                                      _requestNotifier.state.status.label,
+                                      style: const TextStyle(
+                                          color: AppTheme.textSecondary,
+                                          fontSize: 13),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+
+                          // Quiet "Report a problem" affordance — only once the
+                          // title is at least partially in the library and the
+                          // server allows reporting.
+                          ListenableBuilder(
+                            listenable: _requestNotifier,
+                            builder: (_, __) {
+                              if (!_canReport(_requestNotifier.state.status)) {
+                                return const SizedBox.shrink();
+                              }
+                              return Center(
+                                child: TextButton.icon(
+                                  onPressed: () => _onReportProblem(state),
+                                  icon:
+                                      const Icon(Icons.flag_outlined, size: 14),
+                                  label: const Text('Report a problem'),
+                                  style: TextButton.styleFrom(
+                                    foregroundColor: AppTheme.textSecondary,
+                                    textStyle: const TextStyle(fontSize: 13),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                          const SizedBox(height: 16),
+
+                          // Genres
+                          if (state.genres.isNotEmpty)
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
+                              child: Wrap(
+                                spacing: 6,
+                                runSpacing: 6,
+                                children: state.genres
+                                    .map((g) => Chip(
+                                          label: Text(g.name,
+                                              style: const TextStyle(
+                                                  fontSize: 12)),
+                                          backgroundColor:
+                                              AppTheme.surfaceVariant,
+                                          side: const BorderSide(
+                                              color: AppTheme.border),
+                                          materialTapTargetSize:
+                                              MaterialTapTargetSize.shrinkWrap,
+                                          visualDensity: VisualDensity.compact,
+                                        ))
+                                    .toList(),
+                              ),
+                            ),
+
+                          // Rating
+                          if (state.voteAverage != null &&
+                              state.voteAverage! > 0) ...[
+                            const SizedBox(height: 12),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
+                              child: Row(
+                                children: [
+                                  const Icon(Icons.star,
+                                      color: AppTheme.accent, size: 18),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    state.voteAverage!.toStringAsFixed(1),
+                                    style: const TextStyle(
+                                      color: AppTheme.textPrimary,
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                  const Text(' / 10',
+                                      style: TextStyle(
+                                          color: AppTheme.textSecondary,
+                                          fontSize: 14)),
+                                ],
+                              ),
+                            ),
                           ],
-                        ),
-                      ),
-                    ],
 
-                    // Tagline
-                    if (state.tagline.isNotEmpty) ...[
-                      const SizedBox(height: 16),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: Text(
-                          '"${state.tagline}"',
-                          style: const TextStyle(
-                            color: AppTheme.textSecondary,
-                            fontSize: 15,
-                            fontStyle: FontStyle.italic,
-                          ),
-                        ),
-                      ),
-                    ],
-
-                    // Overview
-                    if (state.overview.isNotEmpty) ...[
-                      const SizedBox(height: 12),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: Text(
-                          state.overview,
-                          style: const TextStyle(
-                              color: AppTheme.textPrimary,
-                              fontSize: 15,
-                              height: 1.5),
-                        ),
-                      ),
-                    ],
-
-                    // Watch Trailer button
-                    if (state.trailerKey != null) ...[
-                      const SizedBox(height: 16),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: OutlinedButton.icon(
-                          onPressed: () => _openTrailer(state.trailerKey!),
-                          icon: const Icon(Icons.play_arrow),
-                          label: const Text('Watch Trailer'),
-                          style: OutlinedButton.styleFrom(
-                            foregroundColor: AppTheme.textPrimary,
-                            side: const BorderSide(color: AppTheme.border),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(12),
+                          // Tagline
+                          if (state.tagline.isNotEmpty) ...[
+                            const SizedBox(height: 16),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
+                              child: Text(
+                                '"${state.tagline}"',
+                                style: const TextStyle(
+                                  color: AppTheme.textSecondary,
+                                  fontSize: 15,
+                                  fontStyle: FontStyle.italic,
+                                ),
+                              ),
                             ),
-                          ),
-                        ),
-                      ),
-                    ],
+                          ],
 
-                    // Seasons (TV only): interactive per-season request table
-                    // fed by live availability from the request notifier.
-                    if (state.seasons.isNotEmpty) ...[
-                      const SizedBox(height: 24),
-                      Padding(
-                        key: _seasonsKey,
-                        padding: const EdgeInsets.symmetric(horizontal: 16),
-                        child: const Text('Seasons',
-                            style: TextStyle(
-                                fontSize: 20,
-                                fontWeight: FontWeight.bold,
-                                color: AppTheme.textPrimary)),
-                      ),
-                      const SizedBox(height: 12),
-                      SeasonTable(
-                        seasons: state.seasons,
-                        notifier: _requestNotifier,
-                        title: state.title,
-                        tvdbId: state.tvDetail?.externalIds?.tvdbId,
-                        canRequest: _canChooseSeasons,
-                        onRequested: _bumpLibraryRefresh,
-                      ),
-                    ],
+                          // Overview
+                          if (state.overview.isNotEmpty) ...[
+                            const SizedBox(height: 12),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
+                              child: Text(
+                                state.overview,
+                                style: const TextStyle(
+                                    color: AppTheme.textPrimary,
+                                    fontSize: 15,
+                                    height: 1.5),
+                              ),
+                            ),
+                          ],
 
-                    // Recommendations
-                    if (state.recommendations.isNotEmpty) ...[
-                      const SizedBox(height: 24),
-                      _SectionRow(
-                        title: 'Recommended',
-                        items: state.recommendations,
-                      ),
-                    ],
+                          // Watch Trailer button
+                          if (state.trailerKey != null) ...[
+                            const SizedBox(height: 16),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
+                              child: OutlinedButton.icon(
+                                onPressed: () =>
+                                    _openTrailer(state.trailerKey!),
+                                icon: const Icon(Icons.play_arrow),
+                                label: const Text('Watch Trailer'),
+                                style: OutlinedButton.styleFrom(
+                                  foregroundColor: AppTheme.textPrimary,
+                                  side:
+                                      const BorderSide(color: AppTheme.border),
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
 
-                    // Similar
-                    if (state.similar.isNotEmpty) ...[
-                      const SizedBox(height: 24),
-                      _SectionRow(
-                        title: 'Similar',
-                        items: state.similar,
-                      ),
-                    ],
+                          // Seasons (TV only): interactive per-season request table
+                          // fed by live availability from the request notifier.
+                          if (state.seasons.isNotEmpty) ...[
+                            const SizedBox(height: 24),
+                            Padding(
+                              key: _seasonsKey,
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
+                              child: const Text('Seasons',
+                                  style: TextStyle(
+                                      fontSize: 20,
+                                      fontWeight: FontWeight.bold,
+                                      color: AppTheme.textPrimary)),
+                            ),
+                            const SizedBox(height: 12),
+                            SeasonTable(
+                              seasons: state.seasons,
+                              notifier: _requestNotifier,
+                              title: state.title,
+                              tvdbId: state.tvDetail?.externalIds?.tvdbId,
+                              canRequest: _canChooseSeasons,
+                              onRequested: _bumpLibraryRefresh,
+                            ),
+                          ],
 
-                    const SizedBox(height: 40),
+                          // Recommendations
+                          if (state.recommendations.isNotEmpty) ...[
+                            const SizedBox(height: 24),
+                            _SectionRow(
+                              title: 'Recommended',
+                              items: state.recommendations,
+                            ),
+                          ],
+
+                          // Similar
+                          if (state.similar.isNotEmpty) ...[
+                            const SizedBox(height: 24),
+                            _SectionRow(
+                              title: 'Similar',
+                              items: state.similar,
+                            ),
+                          ],
+
+                          const SizedBox(height: 40),
+                        ],
+                      ),
+                    ),
                   ],
                 ),
               ),
@@ -467,8 +496,7 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
   Future<ReportScope?> _pickTvScope(
       MediaDetailState state, String title, int? tvdbId) {
     // Real seasons only (drop a season 0 / specials placeholder when empty).
-    final seasons =
-        state.seasons.where((s) => s.seasonNumber > 0).toList();
+    final seasons = state.seasons.where((s) => s.seasonNumber > 0).toList();
     return showModalBottomSheet<ReportScope>(
       context: context,
       backgroundColor: AppTheme.surface,
@@ -492,8 +520,8 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                 ),
               ),
               ListTile(
-                leading:
-                    const Icon(Icons.tv_outlined, color: AppTheme.textSecondary),
+                leading: const Icon(Icons.tv_outlined,
+                    color: AppTheme.textSecondary),
                 title: const Text('The whole series',
                     style: TextStyle(color: AppTheme.textPrimary)),
                 onTap: () => Navigator.of(sheetContext).pop(

--- a/app/lib/features/notifications/ui/notification_preferences_screen.dart
+++ b/app/lib/features/notifications/ui/notification_preferences_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../notification_prefs.dart';
@@ -142,27 +143,28 @@ class _NotificationPreferencesScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Notification Preferences')),
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : _error != null && _prefs == null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(_error!,
-                            style: const TextStyle(color: AppTheme.error),
-                            textAlign: TextAlign.center),
-                        const SizedBox(height: 12),
-                        ElevatedButton(
-                            onPressed: _load, child: const Text('Retry')),
-                      ],
-                    ),
-                  ),
-                )
-              : _buildBody(),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : _error != null && _prefs == null
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(_error!,
+                                style: const TextStyle(color: AppTheme.error),
+                                textAlign: TextAlign.center),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                                onPressed: _load, child: const Text('Retry')),
+                          ],
+                        ),
+                      ),
+                    )
+                  : _buildBody()),
     );
   }
 

--- a/app/lib/features/radarr/ui/radarr_module_shell.dart
+++ b/app/lib/features/radarr/ui/radarr_module_shell.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/models/app_module.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/instance_dropdown.dart';
+import '../../../core/widgets/module_scaffold.dart';
 
-/// Radarr module shell with bottom nav:
-/// Library | Queue | History | Wanted | Calendar.
+/// Radarr module shell: Library | Queue | History | Wanted | Calendar.
+/// Pages render as a bottom nav on mobile and sidebar items on desktop.
 /// Shows instance dropdown in the header when 2+ instances exist.
 class RadarrModuleShell extends ConsumerWidget {
   final int currentIndex;
@@ -23,7 +25,7 @@ class RadarrModuleShell extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final instanceState = ref.watch(instanceProvider);
 
-    return Scaffold(
+    return ModuleScaffold(
       appBar: instanceState.radarrInstances.length > 1
           ? AppBar(
               title: InstanceDropdown(
@@ -37,43 +39,10 @@ class RadarrModuleShell extends ConsumerWidget {
               elevation: 0,
             )
           : null,
-      body: child,
-      bottomNavigationBar: Container(
-        decoration: const BoxDecoration(
-          border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
-        ),
-        child: BottomNavigationBar(
-          currentIndex: currentIndex,
-          onTap: onTabChanged,
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.video_library_outlined),
-              activeIcon: Icon(Icons.video_library),
-              label: 'Library',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.downloading_outlined),
-              activeIcon: Icon(Icons.downloading),
-              label: 'Queue',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.history_outlined),
-              activeIcon: Icon(Icons.history),
-              label: 'History',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.report_gmailerrorred_outlined),
-              activeIcon: Icon(Icons.report_gmailerrorred),
-              label: 'Wanted',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.calendar_month_outlined),
-              activeIcon: Icon(Icons.calendar_month),
-              label: 'Calendar',
-            ),
-          ],
-        ),
-      ),
+      pages: modulePagesFor(ModuleType.radarr),
+      currentIndex: currentIndex,
+      onTabChanged: onTabChanged,
+      child: child,
     );
   }
 }

--- a/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/cached_image.dart';
@@ -138,7 +139,8 @@ class _RadarrMovieDetailScreenState
           ),
         ],
       ),
-      body: Column(
+      body: CenteredContent(
+          child: Column(
         children: [
           Expanded(child: _buildBody()),
           _ActionBar(
@@ -146,7 +148,7 @@ class _RadarrMovieDetailScreenState
             onInteractive: _interactiveSearch,
           ),
         ],
-      ),
+      )),
     );
   }
 
@@ -353,7 +355,8 @@ class _FileCard extends StatelessWidget {
                   children: [
                     StatusPill(
                       text: file.quality ?? 'Downloaded',
-                      color: cutoffMet ? AppTheme.available : AppTheme.requested,
+                      color:
+                          cutoffMet ? AppTheme.available : AppTheme.requested,
                     ),
                     if (!cutoffMet) ...[
                       const SizedBox(width: 6),
@@ -458,12 +461,11 @@ class _HistoryTile extends StatelessWidget {
           ),
           const SizedBox(height: 2),
           Text(_historyTime(record.date),
-              style: const TextStyle(
-                  color: AppTheme.textSecondary, fontSize: 11)),
+              style:
+                  const TextStyle(color: AppTheme.textSecondary, fontSize: 11)),
           const SizedBox(height: 2),
           Text(_historyEventLabel(record),
-              style: const TextStyle(
-                  color: AppTheme.requested, fontSize: 12)),
+              style: const TextStyle(color: AppTheme.requested, fontSize: 12)),
         ],
       ),
     );
@@ -490,7 +492,8 @@ class _ActionBar extends StatelessWidget {
           Expanded(
             child: OutlinedButton.icon(
               onPressed: onAutomatic,
-              icon: const Icon(Icons.search, size: 18, color: AppTheme.available),
+              icon:
+                  const Icon(Icons.search, size: 18, color: AppTheme.available),
               label: const Text('Automatic',
                   style: TextStyle(color: AppTheme.textPrimary)),
               style: OutlinedButton.styleFrom(

--- a/app/lib/features/settings/ui/ai_tools_screen.dart
+++ b/app/lib/features/settings/ui/ai_tools_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/ai_tools_service.dart';
@@ -113,67 +114,70 @@ class _AiToolsScreenState extends ConsumerState<AiToolsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('AI Tools')),
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : _error != null && _tools == null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(_error!,
-                            style: const TextStyle(color: AppTheme.error),
-                            textAlign: TextAlign.center),
-                        const SizedBox(height: 12),
-                        ElevatedButton(
-                            onPressed: _loadTools, child: const Text('Retry')),
-                      ],
-                    ),
-                  ),
-                )
-              : RefreshIndicator(
-                  color: AppTheme.accent,
-                  onRefresh: _loadTools,
-                  child: ListView(
-                    physics: const AlwaysScrollableScrollPhysics(),
-                    padding: const EdgeInsets.symmetric(vertical: 8),
-                    children: [
-                      const Padding(
-                        padding: EdgeInsets.fromLTRB(16, 8, 16, 12),
-                        child: Text(
-                          'Control which tools the AI assistant can use. Disabled tools are hidden from the assistant entirely.',
-                          style: TextStyle(
-                              color: AppTheme.textSecondary, fontSize: 13),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : _error != null && _tools == null
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(_error!,
+                                style: const TextStyle(color: AppTheme.error),
+                                textAlign: TextAlign.center),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                                onPressed: _loadTools,
+                                child: const Text('Retry')),
+                          ],
                         ),
                       ),
-                      _DebugLoggingTile(
-                        status: _debug,
-                        pending: _debugPending,
-                        onToggle: (enabled) => _setDebug(enabled),
-                        onExtend: () => _setDebug(true),
-                      ),
-                      const Divider(color: AppTheme.border),
-                      if (_tools?.isEmpty ?? false)
-                        const Padding(
-                          padding: EdgeInsets.all(24),
-                          child: Center(
+                    )
+                  : RefreshIndicator(
+                      color: AppTheme.accent,
+                      onRefresh: _loadTools,
+                      child: ListView(
+                        physics: const AlwaysScrollableScrollPhysics(),
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        children: [
+                          const Padding(
+                            padding: EdgeInsets.fromLTRB(16, 8, 16, 12),
                             child: Text(
-                              'No AI tools reported by the server.',
-                              style: TextStyle(color: AppTheme.textSecondary),
+                              'Control which tools the AI assistant can use. Disabled tools are hidden from the assistant entirely.',
+                              style: TextStyle(
+                                  color: AppTheme.textSecondary, fontSize: 13),
                             ),
                           ),
-                        ),
-                      ...?_tools?.map((tool) => _ToolTile(
-                            tool: tool,
-                            pending: _pending.contains(tool.name),
-                            onChanged: (v) => _toggleTool(tool, v),
-                          )),
-                      const SizedBox(height: 32),
-                    ],
-                  ),
-                ),
+                          _DebugLoggingTile(
+                            status: _debug,
+                            pending: _debugPending,
+                            onToggle: (enabled) => _setDebug(enabled),
+                            onExtend: () => _setDebug(true),
+                          ),
+                          const Divider(color: AppTheme.border),
+                          if (_tools?.isEmpty ?? false)
+                            const Padding(
+                              padding: EdgeInsets.all(24),
+                              child: Center(
+                                child: Text(
+                                  'No AI tools reported by the server.',
+                                  style:
+                                      TextStyle(color: AppTheme.textSecondary),
+                                ),
+                              ),
+                            ),
+                          ...?_tools?.map((tool) => _ToolTile(
+                                tool: tool,
+                                pending: _pending.contains(tool.name),
+                                onChanged: (v) => _toggleTool(tool, v),
+                              )),
+                          const SizedBox(height: 32),
+                        ],
+                      ),
+                    )),
     );
   }
 }

--- a/app/lib/features/settings/ui/credentials_screen.dart
+++ b/app/lib/features/settings/ui/credentials_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -220,124 +221,128 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('API Credentials')),
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : _error != null
-              ? Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(_error!,
-                          style: const TextStyle(color: AppTheme.error)),
-                      const SizedBox(height: 12),
-                      ElevatedButton(
-                          onPressed: _loadStatus, child: const Text('Retry')),
-                    ],
-                  ),
-                )
-              : ListView(
-                  padding: const EdgeInsets.all(16),
-                  children: [
-                    const Text(
-                      'Credentials are write-only. Enter a new value to set or replace.',
-                      style: TextStyle(
-                          color: AppTheme.textSecondary, fontSize: 13),
-                    ),
-                    const SizedBox(height: 24),
-                    _AISelectionSection(
-                      providers: _status?.ai.providers ?? const [],
-                      selectedProvider: _selectedProvider,
-                      selectedModel: _selectedModel,
-                      customModelValue: _customModelValue,
-                      customModelController: _customModelController,
-                      isSelectedProviderConfigured: _status?.isConfigured(
-                            _providerFor(
-                                  _selectedProvider,
-                                  _status?.ai.providers ?? const [],
-                                )?.credentialKey ??
-                                'anthropic_key',
-                          ) ??
-                          false,
-                      onProviderChanged: _selectProvider,
-                      onModelChanged: (value) =>
-                          setState(() => _selectedModel = value),
-                    ),
-                    const SizedBox(height: 24),
-                    _CredentialSection(
-                      title: 'TMDB',
-                      description: 'Required for media discovery and search',
-                      isConfigured:
-                          _status?.isConfigured('tmdb_access_token') ?? false,
-                      controller: _tmdbController,
-                      hint: 'TMDB access token',
-                      onDelete: () =>
-                          _deleteCredential('tmdb_access_token', 'TMDB'),
-                    ),
-                    const SizedBox(height: 20),
-                    _CredentialSection(
-                      title: 'Anthropic (AI)',
-                      description: 'Claude model provider',
-                      isConfigured:
-                          _status?.isConfigured('anthropic_key') ?? false,
-                      controller: _anthropicController,
-                      hint: 'Anthropic API key',
-                      onDelete: () =>
-                          _deleteCredential('anthropic_key', 'Anthropic'),
-                    ),
-                    if (_status?.ai.providers.isNotEmpty ?? false) ...[
-                      const SizedBox(height: 20),
-                      _CredentialSection(
-                        title: 'OpenAI (AI)',
-                        description: 'GPT model provider',
-                        isConfigured:
-                            _status?.isConfigured('openai_key') ?? false,
-                        controller: _openAIController,
-                        hint: 'OpenAI API key',
-                        onDelete: () =>
-                            _deleteCredential('openai_key', 'OpenAI'),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : _error != null
+                  ? Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(_error!,
+                              style: const TextStyle(color: AppTheme.error)),
+                          const SizedBox(height: 12),
+                          ElevatedButton(
+                              onPressed: _loadStatus,
+                              child: const Text('Retry')),
+                        ],
                       ),
-                      const SizedBox(height: 20),
-                      _CredentialSection(
-                        title: 'Google Gemini (AI)',
-                        description: 'Gemini model provider',
-                        isConfigured:
-                            _status?.isConfigured('gemini_key') ?? false,
-                        controller: _geminiController,
-                        hint: 'Gemini API key',
-                        onDelete: () =>
-                            _deleteCredential('gemini_key', 'Google Gemini'),
-                      ),
-                    ],
-                    const SizedBox(height: 20),
-                    _CredentialSection(
-                      title: 'Trakt',
-                      description:
-                          'Enhances discovery with trending and popular lists',
-                      isConfigured:
-                          _status?.isConfigured('trakt_client_id') ?? false,
-                      controller: _traktIdController,
-                      hint: 'Trakt client ID',
-                      onDelete: () =>
-                          _deleteCredential('trakt_client_id', 'Trakt'),
-                    ),
-                    const SizedBox(height: 32),
-                    SizedBox(
-                      width: double.infinity,
-                      child: ElevatedButton(
-                        onPressed: _isSaving ? null : _save,
-                        child: _isSaving
-                            ? const SizedBox(
-                                width: 20,
-                                height: 20,
-                                child:
-                                    CircularProgressIndicator(strokeWidth: 2),
-                              )
-                            : const Text('Save'),
-                      ),
-                    ),
-                  ],
-                ),
+                    )
+                  : ListView(
+                      padding: const EdgeInsets.all(16),
+                      children: [
+                        const Text(
+                          'Credentials are write-only. Enter a new value to set or replace.',
+                          style: TextStyle(
+                              color: AppTheme.textSecondary, fontSize: 13),
+                        ),
+                        const SizedBox(height: 24),
+                        _AISelectionSection(
+                          providers: _status?.ai.providers ?? const [],
+                          selectedProvider: _selectedProvider,
+                          selectedModel: _selectedModel,
+                          customModelValue: _customModelValue,
+                          customModelController: _customModelController,
+                          isSelectedProviderConfigured: _status?.isConfigured(
+                                _providerFor(
+                                      _selectedProvider,
+                                      _status?.ai.providers ?? const [],
+                                    )?.credentialKey ??
+                                    'anthropic_key',
+                              ) ??
+                              false,
+                          onProviderChanged: _selectProvider,
+                          onModelChanged: (value) =>
+                              setState(() => _selectedModel = value),
+                        ),
+                        const SizedBox(height: 24),
+                        _CredentialSection(
+                          title: 'TMDB',
+                          description:
+                              'Required for media discovery and search',
+                          isConfigured:
+                              _status?.isConfigured('tmdb_access_token') ??
+                                  false,
+                          controller: _tmdbController,
+                          hint: 'TMDB access token',
+                          onDelete: () =>
+                              _deleteCredential('tmdb_access_token', 'TMDB'),
+                        ),
+                        const SizedBox(height: 20),
+                        _CredentialSection(
+                          title: 'Anthropic (AI)',
+                          description: 'Claude model provider',
+                          isConfigured:
+                              _status?.isConfigured('anthropic_key') ?? false,
+                          controller: _anthropicController,
+                          hint: 'Anthropic API key',
+                          onDelete: () =>
+                              _deleteCredential('anthropic_key', 'Anthropic'),
+                        ),
+                        if (_status?.ai.providers.isNotEmpty ?? false) ...[
+                          const SizedBox(height: 20),
+                          _CredentialSection(
+                            title: 'OpenAI (AI)',
+                            description: 'GPT model provider',
+                            isConfigured:
+                                _status?.isConfigured('openai_key') ?? false,
+                            controller: _openAIController,
+                            hint: 'OpenAI API key',
+                            onDelete: () =>
+                                _deleteCredential('openai_key', 'OpenAI'),
+                          ),
+                          const SizedBox(height: 20),
+                          _CredentialSection(
+                            title: 'Google Gemini (AI)',
+                            description: 'Gemini model provider',
+                            isConfigured:
+                                _status?.isConfigured('gemini_key') ?? false,
+                            controller: _geminiController,
+                            hint: 'Gemini API key',
+                            onDelete: () => _deleteCredential(
+                                'gemini_key', 'Google Gemini'),
+                          ),
+                        ],
+                        const SizedBox(height: 20),
+                        _CredentialSection(
+                          title: 'Trakt',
+                          description:
+                              'Enhances discovery with trending and popular lists',
+                          isConfigured:
+                              _status?.isConfigured('trakt_client_id') ?? false,
+                          controller: _traktIdController,
+                          hint: 'Trakt client ID',
+                          onDelete: () =>
+                              _deleteCredential('trakt_client_id', 'Trakt'),
+                        ),
+                        const SizedBox(height: 32),
+                        SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            onPressed: _isSaving ? null : _save,
+                            child: _isSaving
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(
+                                        strokeWidth: 2),
+                                  )
+                                : const Text('Save'),
+                          ),
+                        ),
+                      ],
+                    )),
     );
   }
 }

--- a/app/lib/features/settings/ui/devices_screen.dart
+++ b/app/lib/features/settings/ui/devices_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/storage/secure_storage.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/data/auth_service.dart';
@@ -97,7 +98,7 @@ class _DevicesScreenState extends ConsumerState<DevicesScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Connected Devices')),
-      body: _buildBody(),
+      body: CenteredContent(child: _buildBody()),
     );
   }
 
@@ -166,56 +167,55 @@ class _DevicesScreenState extends ConsumerState<DevicesScreen> {
               ...userDevices.map((device) {
                 final isCurrent = device.id == _currentDeviceId;
                 return Dismissible(
-                    key: Key(device.id),
-                    direction: DismissDirection.endToStart,
-                    background: Container(
-                      alignment: Alignment.centerRight,
-                      padding: const EdgeInsets.only(right: 20),
-                      color: AppTheme.error,
-                      child: const Icon(Icons.delete, color: Colors.white),
+                  key: Key(device.id),
+                  direction: DismissDirection.endToStart,
+                  background: Container(
+                    alignment: Alignment.centerRight,
+                    padding: const EdgeInsets.only(right: 20),
+                    color: AppTheme.error,
+                    child: const Icon(Icons.delete, color: Colors.white),
+                  ),
+                  confirmDismiss: (_) async {
+                    await _revokeDevice(device);
+                    return false; // We handle removal via _loadDevices
+                  },
+                  child: ListTile(
+                    leading: Icon(
+                      _deviceIcon(device.deviceName),
+                      color:
+                          isCurrent ? AppTheme.accent : AppTheme.textSecondary,
                     ),
-                    confirmDismiss: (_) async {
-                      await _revokeDevice(device);
-                      return false; // We handle removal via _loadDevices
-                    },
-                    child: ListTile(
-                      leading: Icon(
-                        _deviceIcon(device.deviceName),
-                        color: isCurrent
-                            ? AppTheme.accent
-                            : AppTheme.textSecondary,
-                      ),
-                      title: Row(
-                        children: [
-                          Flexible(
-                            child: Text(
-                              device.deviceName,
-                              style: const TextStyle(
-                                color: AppTheme.textPrimary,
-                                fontWeight: FontWeight.w500,
-                              ),
+                    title: Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            device.deviceName,
+                            style: const TextStyle(
+                              color: AppTheme.textPrimary,
+                              fontWeight: FontWeight.w500,
                             ),
                           ),
-                          if (isCurrent) ...[
-                            const SizedBox(width: 8),
-                            _thisDeviceBadge(),
-                          ],
-                        ],
-                      ),
-                      subtitle: Text(
-                        'Last seen ${_formatTime(device.lastSeenAt)}',
-                        style: const TextStyle(
-                          color: AppTheme.textSecondary,
-                          fontSize: 13,
                         ),
-                      ),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.close,
-                            color: AppTheme.textSecondary, size: 20),
-                        onPressed: () => _revokeDevice(device),
+                        if (isCurrent) ...[
+                          const SizedBox(width: 8),
+                          _thisDeviceBadge(),
+                        ],
+                      ],
+                    ),
+                    subtitle: Text(
+                      'Last seen ${_formatTime(device.lastSeenAt)}',
+                      style: const TextStyle(
+                        color: AppTheme.textSecondary,
+                        fontSize: 13,
                       ),
                     ),
-                  );
+                    trailing: IconButton(
+                      icon: const Icon(Icons.close,
+                          color: AppTheme.textSecondary, size: 20),
+                      onPressed: () => _revokeDevice(device),
+                    ),
+                  ),
+                );
               }),
             ],
           );

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/models/backend_connection.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
@@ -452,8 +453,7 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
           children: [
             Expanded(
               child: Text(_userSelectError!,
-                  style:
-                      const TextStyle(color: AppTheme.error, fontSize: 13)),
+                  style: const TextStyle(color: AppTheme.error, fontSize: 13)),
             ),
             TextButton(
               onPressed: _retryDirectory,
@@ -719,7 +719,8 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
             ),
         ],
       ),
-      body: ListView(
+      body: CenteredContent(
+          child: ListView(
         padding: const EdgeInsets.all(16),
         children: [
           // Service type (only for new instances)
@@ -964,7 +965,7 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
             ),
           ],
         ],
-      ),
+      )),
     );
   }
 }

--- a/app/lib/features/settings/ui/pending_requests_screen.dart
+++ b/app/lib/features/settings/ui/pending_requests_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/request_settings_service.dart';
@@ -305,58 +306,60 @@ class _PendingRequestsScreenState extends ConsumerState<PendingRequestsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Approvals')),
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : _error != null && _pending == null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(_error!,
-                            style: const TextStyle(color: AppTheme.error),
-                            textAlign: TextAlign.center),
-                        const SizedBox(height: 12),
-                        ElevatedButton(
-                            onPressed: _load, child: const Text('Retry')),
-                      ],
-                    ),
-                  ),
-                )
-              : RefreshIndicator(
-                  color: AppTheme.accent,
-                  onRefresh: _load,
-                  child: (_pending?.isEmpty ?? true)
-                      ? ListView(
-                          physics: const AlwaysScrollableScrollPhysics(),
-                          children: const [
-                            SizedBox(height: 120),
-                            Center(
-                              child: Text(
-                                'No pending requests.',
-                                style: TextStyle(color: AppTheme.textSecondary),
-                              ),
-                            ),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : _error != null && _pending == null
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(_error!,
+                                style: const TextStyle(color: AppTheme.error),
+                                textAlign: TextAlign.center),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                                onPressed: _load, child: const Text('Retry')),
                           ],
-                        )
-                      : ListView.separated(
-                          physics: const AlwaysScrollableScrollPhysics(),
-                          padding: const EdgeInsets.symmetric(vertical: 8),
-                          itemCount: _pending!.length,
-                          separatorBuilder: (_, __) =>
-                              const Divider(color: AppTheme.border, height: 1),
-                          itemBuilder: (context, index) {
-                            final item = _pending![index];
-                            return _PendingTile(
-                              item: item,
-                              onApprove: () => _approve(item),
-                              onDeny: () => _deny(item),
-                            );
-                          },
                         ),
-                ),
+                      ),
+                    )
+                  : RefreshIndicator(
+                      color: AppTheme.accent,
+                      onRefresh: _load,
+                      child: (_pending?.isEmpty ?? true)
+                          ? ListView(
+                              physics: const AlwaysScrollableScrollPhysics(),
+                              children: const [
+                                SizedBox(height: 120),
+                                Center(
+                                  child: Text(
+                                    'No pending requests.',
+                                    style: TextStyle(
+                                        color: AppTheme.textSecondary),
+                                  ),
+                                ),
+                              ],
+                            )
+                          : ListView.separated(
+                              physics: const AlwaysScrollableScrollPhysics(),
+                              padding: const EdgeInsets.symmetric(vertical: 8),
+                              itemCount: _pending!.length,
+                              separatorBuilder: (_, __) => const Divider(
+                                  color: AppTheme.border, height: 1),
+                              itemBuilder: (context, index) {
+                                final item = _pending![index];
+                                return _PendingTile(
+                                  item: item,
+                                  onApprove: () => _approve(item),
+                                  onDeny: () => _deny(item),
+                                );
+                              },
+                            ),
+                    )),
     );
   }
 }

--- a/app/lib/features/settings/ui/plex_settings_screen.dart
+++ b/app/lib/features/settings/ui/plex_settings_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/plex_admin_service.dart';
 
@@ -151,8 +152,8 @@ class _PlexSettingsScreenState extends ConsumerState<PlexSettingsScreen> {
         _linkUrl = null;
       });
       ref.invalidate(plexInviteConfiguredProvider);
-      ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Plex account linked!')));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Plex account linked!')));
       await _load();
     } catch (_) {
       if (!silent && mounted) {
@@ -206,8 +207,8 @@ class _PlexSettingsScreenState extends ConsumerState<PlexSettingsScreen> {
 
   Future<void> _save() async {
     if (_machineId.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Pick a server first')));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Pick a server first')));
       return;
     }
     setState(() => _saving = true);
@@ -237,23 +238,24 @@ class _PlexSettingsScreenState extends ConsumerState<PlexSettingsScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Plex Invites')),
-      body: _loading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : _error != null
-              ? Center(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(_error!,
-                          style: const TextStyle(color: AppTheme.error)),
-                      const SizedBox(height: 12),
-                      ElevatedButton(
-                          onPressed: _load, child: const Text('Retry')),
-                    ],
-                  ),
-                )
-              : _buildBody(),
+      body: CenteredContent(
+          child: _loading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : _error != null
+                  ? Center(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Text(_error!,
+                              style: const TextStyle(color: AppTheme.error)),
+                          const SizedBox(height: 12),
+                          ElevatedButton(
+                              onPressed: _load, child: const Text('Retry')),
+                        ],
+                      ),
+                    )
+                  : _buildBody()),
     );
   }
 

--- a/app/lib/features/settings/ui/request_settings_screen.dart
+++ b/app/lib/features/settings/ui/request_settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../data/request_settings_service.dart';
@@ -14,8 +15,7 @@ class RequestSettingsScreen extends ConsumerStatefulWidget {
       _RequestSettingsScreenState();
 }
 
-class _RequestSettingsScreenState
-    extends ConsumerState<RequestSettingsScreen> {
+class _RequestSettingsScreenState extends ConsumerState<RequestSettingsScreen> {
   late final RequestSettingsService _service;
 
   AdminRequestSettings? _admin;
@@ -90,27 +90,28 @@ class _RequestSettingsScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Request Defaults')),
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : (_admin == null || _edited == null)
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(_error ?? 'Something went wrong',
-                            style: const TextStyle(color: AppTheme.error),
-                            textAlign: TextAlign.center),
-                        const SizedBox(height: 12),
-                        ElevatedButton(
-                            onPressed: _load, child: const Text('Retry')),
-                      ],
-                    ),
-                  ),
-                )
-              : _buildBody(_admin!, _edited!),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : (_admin == null || _edited == null)
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(_error ?? 'Something went wrong',
+                                style: const TextStyle(color: AppTheme.error),
+                                textAlign: TextAlign.center),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                                onPressed: _load, child: const Text('Retry')),
+                          ],
+                        ),
+                      ),
+                    )
+                  : _buildBody(_admin!, _edited!)),
     );
   }
 
@@ -130,8 +131,8 @@ class _RequestSettingsScreenState
         SwitchListTile(
           value: edited.requireApproval,
           activeThumbColor: AppTheme.accent,
-          onChanged: (v) => setState(
-              () => _edited = edited.copyWith(requireApproval: v)),
+          onChanged: (v) =>
+              setState(() => _edited = edited.copyWith(requireApproval: v)),
           title: const Text(
             'Require approval for new requests',
             style: TextStyle(
@@ -146,8 +147,8 @@ class _RequestSettingsScreenState
         SwitchListTile(
           value: edited.allowSeasonChoice,
           activeThumbColor: AppTheme.accent,
-          onChanged: (v) => setState(
-              () => _edited = edited.copyWith(allowSeasonChoice: v)),
+          onChanged: (v) =>
+              setState(() => _edited = edited.copyWith(allowSeasonChoice: v)),
           title: const Text(
             'Let users choose seasons',
             style: TextStyle(
@@ -178,8 +179,7 @@ class _RequestSettingsScreenState
             ],
             onChanged: (v) {
               if (v == null) return;
-              setState(
-                  () => _edited = edited.copyWith(defaultSeasonScope: v));
+              setState(() => _edited = edited.copyWith(defaultSeasonScope: v));
             },
           ),
         ),
@@ -187,8 +187,8 @@ class _RequestSettingsScreenState
         SwitchListTile(
           value: edited.allowQualityChoice,
           activeThumbColor: AppTheme.accent,
-          onChanged: (v) => setState(
-              () => _edited = edited.copyWith(allowQualityChoice: v)),
+          onChanged: (v) =>
+              setState(() => _edited = edited.copyWith(allowQualityChoice: v)),
           title: const Text(
             'Let users choose quality',
             style: TextStyle(
@@ -248,8 +248,7 @@ class _RequestSettingsScreenState
     required ValueChanged<int> onChanged,
   }) {
     // Guard against a stored value that no longer matches a known profile.
-    final hasValue =
-        value == 0 || profiles.any((p) => p.id == value);
+    final hasValue = value == 0 || profiles.any((p) => p.id == value);
     return ListTile(
       title: Text(
         label,

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/storage/preferences.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -47,7 +48,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
-      body: ListView(
+      body: CenteredContent(
+          child: ListView(
         padding: const EdgeInsets.symmetric(vertical: 8),
         children: [
           // Server connection
@@ -295,7 +297,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 
           const SizedBox(height: 32),
         ],
-      ),
+      )),
     );
   }
 

--- a/app/lib/features/settings/ui/user_request_settings_screen.dart
+++ b/app/lib/features/settings/ui/user_request_settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/models/backend_connection.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
@@ -134,27 +135,28 @@ class _UserRequestSettingsScreenState
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text('User Settings — ${widget.username}')),
-      body: _isLoading
-          ? const Center(
-              child: CircularProgressIndicator(color: AppTheme.accent))
-          : _error != null && _global == null
-              ? Center(
-                  child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text(_error!,
-                            style: const TextStyle(color: AppTheme.error),
-                            textAlign: TextAlign.center),
-                        const SizedBox(height: 12),
-                        ElevatedButton(
-                            onPressed: _load, child: const Text('Retry')),
-                      ],
-                    ),
-                  ),
-                )
-              : _buildBody(),
+      body: CenteredContent(
+          child: _isLoading
+              ? const Center(
+                  child: CircularProgressIndicator(color: AppTheme.accent))
+              : _error != null && _global == null
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(_error!,
+                                style: const TextStyle(color: AppTheme.error),
+                                textAlign: TextAlign.center),
+                            const SizedBox(height: 12),
+                            ElevatedButton(
+                                onPressed: _load, child: const Text('Retry')),
+                          ],
+                        ),
+                      ),
+                    )
+                  : _buildBody()),
     );
   }
 

--- a/app/lib/features/settings/ui/users_screen.dart
+++ b/app/lib/features/settings/ui/users_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/data/auth_service.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -326,7 +327,7 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Users')),
-      body: _buildBody(),
+      body: CenteredContent(child: _buildBody()),
     );
   }
 

--- a/app/lib/features/setup_wizard/ui/plex_watch_guide.dart
+++ b/app/lib/features/setup_wizard/ui/plex_watch_guide.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/storage/preferences.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -33,7 +34,8 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Watch on Plex')),
-      body: ListView(
+      body: CenteredContent(
+          child: ListView(
         padding: const EdgeInsets.all(24),
         children: [
           const Text(
@@ -112,7 +114,7 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
             ),
           ),
         ],
-      ),
+      )),
     );
   }
 
@@ -134,8 +136,7 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
             decoration: BoxDecoration(
               color: AppTheme.accent.withValues(alpha: 0.08),
               borderRadius: BorderRadius.circular(12),
-              border:
-                  Border.all(color: AppTheme.accent.withValues(alpha: 0.2)),
+              border: Border.all(color: AppTheme.accent.withValues(alpha: 0.2)),
             ),
             child: plexEmail.isEmpty
                 ? Column(
@@ -220,7 +221,9 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
 
     // Mirrors the server's shape check: something@something, no whitespace.
     bool looksLikeEmail(String email) {
-      if (email.isEmpty || email.length > 254 || email.contains(RegExp(r'\s'))) {
+      if (email.isEmpty ||
+          email.length > 254 ||
+          email.contains(RegExp(r'\s'))) {
         return false;
       }
       final at = email.indexOf('@');
@@ -296,9 +299,8 @@ class _PlexWatchGuideState extends ConsumerState<PlexWatchGuide> {
             ),
             actions: [
               TextButton(
-                onPressed: saving
-                    ? null
-                    : () => Navigator.of(dialogContext).pop(),
+                onPressed:
+                    saving ? null : () => Navigator.of(dialogContext).pop(),
                 child: const Text('Cancel'),
               ),
               ElevatedButton(
@@ -424,8 +426,7 @@ class _TipCard extends StatelessWidget {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Icon(Icons.lightbulb_outline,
-              color: AppTheme.accent, size: 20),
+          const Icon(Icons.lightbulb_outline, color: AppTheme.accent, size: 20),
           const SizedBox(width: 12),
           Expanded(
             child: Column(
@@ -433,8 +434,7 @@ class _TipCard extends StatelessWidget {
               children: [
                 Text(title,
                     style: const TextStyle(
-                        color: AppTheme.accent,
-                        fontWeight: FontWeight.w600)),
+                        color: AppTheme.accent, fontWeight: FontWeight.w600)),
                 const SizedBox(height: 4),
                 Text(message,
                     style: const TextStyle(

--- a/app/lib/features/setup_wizard/ui/setup_wizard_screen.dart
+++ b/app/lib/features/setup_wizard/ui/setup_wizard_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/storage/preferences.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
@@ -91,25 +92,26 @@ class _SetupWizardScreenState extends ConsumerState<SetupWizardScreen> {
 
     return Scaffold(
       appBar: AppBar(title: const Text('Setup Checklist')),
-      body: !isAdmin
-          ? const Center(
-              child: Padding(
-                padding: EdgeInsets.all(24),
-                child: Text(
-                  'The setup checklist is for server admins.',
-                  style: TextStyle(color: AppTheme.textSecondary),
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            )
-          : status == null
+      body: CenteredContent(
+          child: !isAdmin
               ? const Center(
-                  child: CircularProgressIndicator(color: AppTheme.accent))
-              : RefreshIndicator(
-                  onRefresh: () =>
-                      ref.read(setupStatusProvider.notifier).refresh(),
-                  child: _buildChecklist(status),
-                ),
+                  child: Padding(
+                    padding: EdgeInsets.all(24),
+                    child: Text(
+                      'The setup checklist is for server admins.',
+                      style: TextStyle(color: AppTheme.textSecondary),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                )
+              : status == null
+                  ? const Center(
+                      child: CircularProgressIndicator(color: AppTheme.accent))
+                  : RefreshIndicator(
+                      onRefresh: () =>
+                          ref.read(setupStatusProvider.notifier).refresh(),
+                      child: _buildChecklist(status),
+                    )),
     );
   }
 
@@ -189,8 +191,7 @@ class _SetupWizardScreenState extends ConsumerState<SetupWizardScreen> {
     final route = _routeFor(item.key);
     return ListTile(
       leading: Icon(_iconFor(item.key),
-          color:
-              item.configured ? AppTheme.available : AppTheme.textSecondary),
+          color: item.configured ? AppTheme.available : AppTheme.textSecondary),
       title: Text(item.title,
           style: const TextStyle(
               color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/models/app_module.dart';
 import '../../../core/models/backend_connection.dart';
 import '../../../core/network/backend_client.dart';
@@ -30,13 +31,19 @@ import '../../sonarr/data/sonarr_api_service.dart';
 import '../../sonarr/logic/sonarr_series_provider.dart';
 import '../logic/shell_search_provider.dart';
 
-/// The root shell widget with persistent search bar and drawer.
-/// Each module provides its own bottom nav via inner StatefulShellRoutes.
+/// The root shell widget with persistent search bar and navigation chrome.
+/// On mobile/tablet that chrome is a hamburger drawer plus per-module bottom
+/// navs (inner StatefulShellRoutes); on desktop it is a persistent sidebar
+/// whose active module expands into its pages, replacing the bottom nav.
 class AppShell extends ConsumerStatefulWidget {
+  /// Current location inside the shell (e.g. `/radarr/queue`), used to
+  /// highlight the active module and page in the desktop sidebar.
+  final String currentPath;
   final Widget child;
 
   const AppShell({
     super.key,
+    required this.currentPath,
     required this.child,
   });
 
@@ -358,11 +365,16 @@ class _AppShellState extends ConsumerState<AppShell>
     return map;
   }
 
-  bool _isMobile(BuildContext context) =>
-      MediaQuery.sizeOf(context).shortestSide < 600;
-
-  bool _isDesktop(BuildContext context) =>
-      MediaQuery.sizeOf(context).width >= 900;
+  /// Module owning [path], or null for paths outside the module shells.
+  static ModuleType? _moduleTypeForPath(String path) {
+    if (path.startsWith('/dashboard')) return ModuleType.dashboard;
+    if (path.startsWith('/radarr')) return ModuleType.radarr;
+    if (path.startsWith('/sonarr')) return ModuleType.sonarr;
+    if (path.startsWith('/chaptarr')) return ModuleType.chaptarr;
+    if (path.startsWith('/downloads')) return ModuleType.downloads;
+    if (path.startsWith('/tautulli')) return ModuleType.tautulli;
+    return null;
+  }
 
   bool _handleScrollNotification(ScrollNotification notification) {
     final atTop =
@@ -446,16 +458,18 @@ class _AppShellState extends ConsumerState<AppShell>
     // Users waiting for a Plex invite — drives the drawer "Plex invites"
     // entry (only shown while someone waits) and the hamburger dot.
     final plexInvitesWaiting = ref.watch(plexInvitesWaitingProvider);
-    final menuBadgeCount =
-        pendingApprovals + openIssues + pendingAgentActions + plexInvitesWaiting;
+    final menuBadgeCount = pendingApprovals +
+        openIssues +
+        pendingAgentActions +
+        plexInvitesWaiting;
     final showSearchResults = searchState.searchMode == SearchMode.search ||
         searchState.searchMode == SearchMode.aiReady;
     final libraryStatus = searchState.isSearching && showSearchResults
         ? _buildLibraryStatus(searchState.searchResults)
         : const <int, LibraryStatus>{};
 
-    final mobile = _isMobile(context);
-    final desktop = _isDesktop(context);
+    final mobile = AppBreakpoints.isMobile(context);
+    final desktop = AppBreakpoints.isDesktop(context);
 
     // Drive animations from state changes
     _onSearchModeChanged(searchState.searchMode);
@@ -503,10 +517,18 @@ class _AppShellState extends ConsumerState<AppShell>
       ),
     );
 
-    // Top bar: hamburger + search on non-desktop, just search on desktop
+    // Top bar: hamburger + search on non-desktop; on desktop just the search
+    // bar, capped to a readable width (the results overlay centers to match).
     Widget topBar;
     if (desktop) {
-      topBar = searchBar;
+      topBar = Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            maxWidth: AppBreakpoints.readableContentWidth,
+          ),
+          child: searchBar,
+        ),
+      );
     } else {
       topBar = Row(
         children: [
@@ -671,7 +693,7 @@ class _AppShellState extends ConsumerState<AppShell>
       return Row(
         children: [
           SizedBox(
-            width: 280,
+            width: AppBreakpoints.sidebarWidth,
             child: Material(
               color: AppTheme.surface,
               child: _buildDrawerContent(context, isOverlay: false),
@@ -747,54 +769,62 @@ class _AppShellState extends ConsumerState<AppShell>
                     ),
                   ),
 
-                  // Chat messages
+                  // Chat messages: full-width scroll surface with the
+                  // transcript column capped for readability on desktop.
                   Expanded(
                     child: GestureDetector(
                       behavior: HitTestBehavior.translucent,
                       onTap: _dismissKeyboard,
-                      child: ListView.builder(
-                        controller: _chatScrollController,
-                        keyboardDismissBehavior:
-                            ScrollViewKeyboardDismissBehavior.onDrag,
-                        padding: const EdgeInsets.all(16),
-                        itemCount: messages.length +
-                            (isLoading &&
-                                    (messages.isEmpty ||
-                                        messages.last.role !=
-                                            ChatRole.assistant)
-                                ? 1
-                                : 0),
-                        itemBuilder: (context, index) {
-                          if (index >= messages.length) {
-                            return const _TypingIndicator();
-                          }
-                          // Skip the initial welcome message
-                          final msg = messages[index];
-                          if (index == 0 && msg.role == ChatRole.assistant) {
-                            return const SizedBox.shrink();
-                          }
-                          final isLast = index == messages.length - 1;
-                          return ChatBubble(
-                            message: msg,
-                            onRetry: isLast && msg.errorText != null
-                                ? _aiChatNotifier?.retryLast
-                                : null,
-                          );
-                        },
-                      ),
+                      child: LayoutBuilder(builder: (context, constraints) {
+                        final hPad = AppBreakpoints.centeredContentPadding(
+                          constraints.maxWidth,
+                        );
+                        return ListView.builder(
+                          controller: _chatScrollController,
+                          keyboardDismissBehavior:
+                              ScrollViewKeyboardDismissBehavior.onDrag,
+                          padding: EdgeInsets.fromLTRB(hPad, 16, hPad, 16),
+                          itemCount: messages.length +
+                              (isLoading &&
+                                      (messages.isEmpty ||
+                                          messages.last.role !=
+                                              ChatRole.assistant)
+                                  ? 1
+                                  : 0),
+                          itemBuilder: (context, index) {
+                            if (index >= messages.length) {
+                              return const _TypingIndicator();
+                            }
+                            // Skip the initial welcome message
+                            final msg = messages[index];
+                            if (index == 0 && msg.role == ChatRole.assistant) {
+                              return const SizedBox.shrink();
+                            }
+                            final isLast = index == messages.length - 1;
+                            return ChatBubble(
+                              message: msg,
+                              onRetry: isLast && msg.errorText != null
+                                  ? _aiChatNotifier?.retryLast
+                                  : null,
+                            );
+                          },
+                        );
+                      }),
                     ),
                   ),
 
                   // Error
                   if (chatState?.error != null)
-                    Padding(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 16, vertical: 4),
-                      child: Text(
-                        chatState!.error!,
-                        style: const TextStyle(
-                            color: AppTheme.error, fontSize: 12),
-                        maxLines: 2,
+                    CenteredContent(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 16, vertical: 4),
+                        child: Text(
+                          chatState!.error!,
+                          style: const TextStyle(
+                              color: AppTheme.error, fontSize: 12),
+                          maxLines: 2,
+                        ),
                       ),
                     ),
 
@@ -816,15 +846,22 @@ class _AppShellState extends ConsumerState<AppShell>
                     padding: const EdgeInsets.fromLTRB(12, 8, 12, 0),
                     child: SafeArea(
                       top: false,
-                      child: CantinarrSearchBar(
-                        controller: _searchController,
-                        focusNode: _searchFocusNode,
-                        hintText: 'Ask about movies, shows...',
-                        aiEnabled: true,
-                        multiline: true,
-                        onSend: _sendAiMessage,
-                        onChanged: (_) => setState(() {}),
-                        onClear: _exitAiMode,
+                      child: Center(
+                        child: ConstrainedBox(
+                          constraints: const BoxConstraints(
+                            maxWidth: AppBreakpoints.readableContentWidth,
+                          ),
+                          child: CantinarrSearchBar(
+                            controller: _searchController,
+                            focusNode: _searchFocusNode,
+                            hintText: 'Ask about movies, shows...',
+                            aiEnabled: true,
+                            multiline: true,
+                            onSend: _sendAiMessage,
+                            onChanged: (_) => setState(() {}),
+                            onClear: _exitAiMode,
+                          ),
+                        ),
                       ),
                     ),
                   ),
@@ -848,6 +885,12 @@ class _AppShellState extends ConsumerState<AppShell>
     final moduleState = ref.watch(moduleProvider);
     final instanceState = ref.watch(instanceProvider);
     final isAdmin = ref.watch(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    // Highlight the module that owns the current route; fall back to the
+    // last drawer selection for locations outside the module shells.
+    final pathModule = _moduleTypeForPath(widget.currentPath);
+    final hasChaptarrService =
+        ref.watch(authProvider).valueOrNull?.connection?.services.chaptarr ??
+            false;
     final pendingApprovals = ref.watch(pendingApprovalsProvider);
     final openIssues = ref.watch(openIssuesProvider);
     final pendingAgentActions = ref.watch(pendingAgentActionsProvider);
@@ -953,20 +996,25 @@ class _AppShellState extends ConsumerState<AppShell>
             const Divider(color: AppTheme.border),
           ],
 
-          // Scrollable module navigation items
+          // Scrollable module navigation items. On desktop the active module
+          // also expands into its pages — those replace the module shell's
+          // bottom nav there. The mobile drawer stays modules-only because
+          // the bottom nav covers page switching.
           Expanded(
             child: ListView(
               padding: EdgeInsets.zero,
               children: moduleState.modules.asMap().entries.map((entry) {
                 final module = entry.value;
-                final isActive = entry.key == moduleState.activeIndex;
+                final isActive = pathModule != null
+                    ? module.type == pathModule
+                    : entry.key == moduleState.activeIndex;
                 final selectorInstances = isAdmin
                     ? _instancesForModule(instanceState, module.type)
                     : const <ServiceInstance>[];
                 final activeInstance =
                     _activeInstanceForModule(instanceState, module.type);
 
-                return _DrawerItem(
+                final item = _DrawerItem(
                   icon: module.icon,
                   title: module.label,
                   selected: isActive,
@@ -1006,6 +1054,25 @@ class _AppShellState extends ConsumerState<AppShell>
                           );
                     }
                   },
+                );
+
+                final pages = !isOverlay && isActive
+                    ? modulePagesFor(module.type,
+                        includeBooks: hasChaptarrService)
+                    : const <ModulePage>[];
+                if (pages.isEmpty) return item;
+
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    item,
+                    for (final page in pages)
+                      _DrawerSubItem(
+                        page: page,
+                        selected: widget.currentPath == page.route,
+                        onTap: () => context.go(page.route),
+                      ),
+                  ],
                 );
               }).toList(),
             ),
@@ -1161,6 +1228,47 @@ class _DrawerItem extends StatelessWidget {
         ),
       ),
       trailing: badgeCount > 0 ? _CountPill(count: badgeCount) : trailing,
+      selected: selected,
+      selectedTileColor: AppTheme.accent.withValues(alpha: 0.08),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+      onTap: onTap,
+    );
+  }
+}
+
+/// A page entry nested under the active module in the desktop sidebar —
+/// the desktop counterpart of one bottom-nav tab.
+class _DrawerSubItem extends StatelessWidget {
+  final ModulePage page;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const _DrawerSubItem({
+    required this.page,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      dense: true,
+      contentPadding: const EdgeInsets.only(left: 36, right: 16),
+      minLeadingWidth: 0,
+      horizontalTitleGap: 14,
+      leading: Icon(
+        selected ? page.activeIcon : page.icon,
+        size: 20,
+        color: selected ? AppTheme.accent : AppTheme.textSecondary,
+      ),
+      title: Text(
+        page.label,
+        style: TextStyle(
+          fontSize: 14,
+          color: selected ? AppTheme.accent : AppTheme.textPrimary,
+          fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+        ),
+      ),
       selected: selected,
       selectedTileColor: AppTheme.accent.withValues(alpha: 0.08),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),

--- a/app/lib/features/sonarr/ui/edit_series_screen.dart
+++ b/app/lib/features/sonarr/ui/edit_series_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
@@ -264,7 +265,7 @@ class _EditSeriesScreenState extends ConsumerState<EditSeriesScreen> {
         backgroundColor: AppTheme.background,
         title: const Text('Edit Series'),
       ),
-      body: _buildBody(),
+      body: CenteredContent(child: _buildBody()),
     );
   }
 

--- a/app/lib/features/sonarr/ui/sonarr_module_shell.dart
+++ b/app/lib/features/sonarr/ui/sonarr_module_shell.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/models/app_module.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/instance_dropdown.dart';
+import '../../../core/widgets/module_scaffold.dart';
 
-/// Sonarr module shell with bottom nav:
-/// Library | Queue | History | Wanted | Calendar.
+/// Sonarr module shell: Library | Queue | History | Wanted | Calendar.
+/// Pages render as a bottom nav on mobile and sidebar items on desktop.
 /// Shows instance dropdown in the header when 2+ instances exist.
 class SonarrModuleShell extends ConsumerWidget {
   final int currentIndex;
@@ -23,7 +25,7 @@ class SonarrModuleShell extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final instanceState = ref.watch(instanceProvider);
 
-    return Scaffold(
+    return ModuleScaffold(
       appBar: instanceState.sonarrInstances.length > 1
           ? AppBar(
               title: InstanceDropdown(
@@ -37,43 +39,10 @@ class SonarrModuleShell extends ConsumerWidget {
               elevation: 0,
             )
           : null,
-      body: child,
-      bottomNavigationBar: Container(
-        decoration: const BoxDecoration(
-          border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
-        ),
-        child: BottomNavigationBar(
-          currentIndex: currentIndex,
-          onTap: onTabChanged,
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.video_library_outlined),
-              activeIcon: Icon(Icons.video_library),
-              label: 'Library',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.downloading_outlined),
-              activeIcon: Icon(Icons.downloading),
-              label: 'Queue',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.history_outlined),
-              activeIcon: Icon(Icons.history),
-              label: 'History',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.report_gmailerrorred_outlined),
-              activeIcon: Icon(Icons.report_gmailerrorred),
-              label: 'Wanted',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.calendar_month_outlined),
-              activeIcon: Icon(Icons.calendar_month),
-              label: 'Calendar',
-            ),
-          ],
-        ),
-      ),
+      pages: modulePagesFor(ModuleType.sonarr),
+      currentIndex: currentIndex,
+      onTabChanged: onTabChanged,
+      child: child,
     );
   }
 }

--- a/app/lib/features/sonarr/ui/sonarr_series_detail_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_series_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
+import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/action_sheet.dart';
@@ -229,8 +230,8 @@ class _SonarrSeriesDetailScreenState
       _toast('No external links available');
       return;
     }
-    final url =
-        await showActionSheet<String>(context, title: _series.title, actions: links);
+    final url = await showActionSheet<String>(context,
+        title: _series.title, actions: links);
     if (url == null) return;
     launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
   }
@@ -244,7 +245,8 @@ class _SonarrSeriesDetailScreenState
       backgroundColor: AppTheme.background,
       appBar: AppBar(
         backgroundColor: AppTheme.background,
-        title: Text(_series.title, maxLines: 1, overflow: TextOverflow.ellipsis),
+        title:
+            Text(_series.title, maxLines: 1, overflow: TextOverflow.ellipsis),
         actions: [
           IconButton(
             icon: const Icon(Icons.link, color: AppTheme.textPrimary),
@@ -263,36 +265,38 @@ class _SonarrSeriesDetailScreenState
           ),
         ],
       ),
-      body: _error != null && _series.seasons.isEmpty
-          ? FullScreenError(message: _error!, onRetry: _load)
-          : RefreshIndicator(
-              onRefresh: _load,
-              color: AppTheme.accent,
-              child: ListView(
-                padding: const EdgeInsets.symmetric(vertical: 12),
-                children: [
-                  if (_error != null)
-                    ErrorBanner(message: _error!, onRetry: _load),
-                  _AllSeasonsCard(series: _series, onTap: _openAllSeasons),
-                  const SizedBox(height: 4),
-                  ...seasons.map((s) => _SeasonCard(
-                        season: s,
-                        busy: _togglingSeasons.contains(s.seasonNumber),
-                        onTap: () => _openSeason(s),
-                        onLongPress: () => _showSeasonActions(s),
-                        onToggleMonitored: () => _toggleSeasonMonitored(s),
-                      )),
-                  if (seasons.isEmpty && !_isLoading)
-                    const Padding(
-                      padding: EdgeInsets.all(32),
-                      child: Center(
-                        child: Text('No seasons',
-                            style: TextStyle(color: AppTheme.textSecondary)),
-                      ),
-                    ),
-                ],
-              ),
-            ),
+      body: CenteredContent(
+          child: _error != null && _series.seasons.isEmpty
+              ? FullScreenError(message: _error!, onRetry: _load)
+              : RefreshIndicator(
+                  onRefresh: _load,
+                  color: AppTheme.accent,
+                  child: ListView(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    children: [
+                      if (_error != null)
+                        ErrorBanner(message: _error!, onRetry: _load),
+                      _AllSeasonsCard(series: _series, onTap: _openAllSeasons),
+                      const SizedBox(height: 4),
+                      ...seasons.map((s) => _SeasonCard(
+                            season: s,
+                            busy: _togglingSeasons.contains(s.seasonNumber),
+                            onTap: () => _openSeason(s),
+                            onLongPress: () => _showSeasonActions(s),
+                            onToggleMonitored: () => _toggleSeasonMonitored(s),
+                          )),
+                      if (seasons.isEmpty && !_isLoading)
+                        const Padding(
+                          padding: EdgeInsets.all(32),
+                          child: Center(
+                            child: Text('No seasons',
+                                style:
+                                    TextStyle(color: AppTheme.textSecondary)),
+                          ),
+                        ),
+                    ],
+                  ),
+                )),
     );
   }
 }
@@ -413,7 +417,9 @@ class _SeasonCard extends StatelessWidget {
               ),
               child: Icon(
                 Icons.video_library_outlined,
-                color: season.monitored ? AppTheme.available : AppTheme.unavailable,
+                color: season.monitored
+                    ? AppTheme.available
+                    : AppTheme.unavailable,
                 size: 22,
               ),
             ),
@@ -448,9 +454,7 @@ class _SeasonCard extends StatelessWidget {
                       child: CircularProgressIndicator(
                           strokeWidth: 2, color: AppTheme.accent))
                   : Icon(
-                      season.monitored
-                          ? Icons.bookmark
-                          : Icons.bookmark_border,
+                      season.monitored ? Icons.bookmark : Icons.bookmark_border,
                       color: season.monitored
                           ? AppTheme.accent
                           : AppTheme.textSecondary,

--- a/app/lib/features/tautulli/ui/tautulli_module_shell.dart
+++ b/app/lib/features/tautulli/ui/tautulli_module_shell.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/models/app_module.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/instance_dropdown.dart';
+import '../../../core/widgets/module_scaffold.dart';
 
-/// Tautulli module shell with bottom nav: Activity | History | Stats.
+/// Tautulli module shell: Activity | History | Stats.
+/// Pages render as a bottom nav on mobile and sidebar items on desktop.
 /// Shows instance dropdown in the header when 2+ Tautulli instances exist.
 class TautulliModuleShell extends ConsumerWidget {
   final int currentIndex;
@@ -22,7 +25,7 @@ class TautulliModuleShell extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final instanceState = ref.watch(instanceProvider);
 
-    return Scaffold(
+    return ModuleScaffold(
       appBar: instanceState.tautulliInstances.length > 1
           ? AppBar(
               title: InstanceDropdown(
@@ -36,33 +39,10 @@ class TautulliModuleShell extends ConsumerWidget {
               elevation: 0,
             )
           : null,
-      body: child,
-      bottomNavigationBar: Container(
-        decoration: const BoxDecoration(
-          border: Border(top: BorderSide(color: AppTheme.border, width: 0.5)),
-        ),
-        child: BottomNavigationBar(
-          currentIndex: currentIndex,
-          onTap: onTabChanged,
-          items: const [
-            BottomNavigationBarItem(
-              icon: Icon(Icons.play_circle_outline),
-              activeIcon: Icon(Icons.play_circle),
-              label: 'Activity',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.history_outlined),
-              activeIcon: Icon(Icons.history),
-              label: 'History',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.insights_outlined),
-              activeIcon: Icon(Icons.insights),
-              label: 'Stats',
-            ),
-          ],
-        ),
-      ),
+      pages: modulePagesFor(ModuleType.tautulli),
+      currentIndex: currentIndex,
+      onTabChanged: onTabChanged,
+      child: child,
     );
   }
 }

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -104,10 +104,10 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         builder: (_, __) => const AuthScreen(),
       ),
 
-      // Module shell (provides drawer + search bar, no bottom nav)
+      // Module shell (provides drawer/sidebar + search bar, no bottom nav)
       ShellRoute(
         builder: (context, state, child) {
-          return AppShell(child: child);
+          return AppShell(currentPath: state.uri.path, child: child);
         },
         routes: [
           // Dashboard module (Movies/TV tabs)

--- a/app/test/preview/preview_main.dart
+++ b/app/test/preview/preview_main.dart
@@ -1,0 +1,158 @@
+// Dev-only preview harness: boots the REAL app (router, shell, screens,
+// theme) with a faked authenticated admin session and a stubbed backend, so
+// the UI can be driven in a browser without standing up a server:
+//
+//   flutter run -d chrome -t test/preview/preview_main.dart
+//
+// Data-backed screens render their empty/error states (the stub returns empty
+// payloads); navigation chrome, layout, and theming are the real code paths.
+// Never ship or import this from lib/.
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/network/websocket_client.dart';
+import 'package:cantinarr/core/providers/realtime_provider.dart';
+import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/navigation/app_router.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  runApp(
+    ProviderScope(
+      overrides: [
+        authProvider.overrideWith(() => _FakeAuthNotifier(_adminState)),
+        backendClientProvider.overrideWithValue(_stubDio()),
+        realtimeEventsProvider.overrideWithValue(const Stream<WsEvent>.empty()),
+      ],
+      child: const _PreviewApp(),
+    ),
+  );
+}
+
+class _PreviewApp extends ConsumerWidget {
+  const _PreviewApp();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // Same composition as CantinarrApp's authenticated branch (app.dart),
+    // minus deep links and push which need native plumbing.
+    return MaterialApp.router(
+      title: 'Cantinarr Preview',
+      theme: AppTheme.dark,
+      debugShowCheckedModeBanner: false,
+      routerConfig: ref.watch(appRouterProvider),
+    );
+  }
+}
+
+/// Admin with every module lit up: two Radarr instances (exercises the
+/// sidebar instance selector), Sonarr, Chaptarr, a download client, Tautulli,
+/// plus AI + Chaptarr services for the assistant module and Books tab.
+const _adminState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost:8585',
+    accessToken: 'preview-access',
+    refreshToken: 'preview-refresh',
+    services: AvailableServices(
+      radarr: true,
+      sonarr: true,
+      chaptarr: true,
+      ai: true,
+      tmdb: true,
+    ),
+    instances: [
+      ServiceInstance(
+        id: 'radarr-main',
+        serviceType: 'radarr',
+        name: 'Main Radarr',
+        isDefault: true,
+      ),
+      ServiceInstance(
+        id: 'radarr-4k',
+        serviceType: 'radarr',
+        name: '4K Radarr',
+      ),
+      ServiceInstance(
+        id: 'sonarr-main',
+        serviceType: 'sonarr',
+        name: 'Sonarr',
+        isDefault: true,
+      ),
+      ServiceInstance(
+        id: 'chaptarr-main',
+        serviceType: 'chaptarr',
+        name: 'Chaptarr',
+        isDefault: true,
+      ),
+      ServiceInstance(
+        id: 'sab-main',
+        serviceType: 'sabnzbd',
+        name: 'SABnzbd',
+        isDefault: true,
+      ),
+      ServiceInstance(
+        id: 'tautulli-main',
+        serviceType: 'tautulli',
+        name: 'Tautulli',
+        isDefault: true,
+      ),
+    ],
+  ),
+  user: UserProfile(id: 1, username: 'preview-admin', role: 'admin'),
+);
+
+class _FakeAuthNotifier extends AuthNotifier {
+  final AuthState authState;
+
+  _FakeAuthNotifier(this.authState);
+
+  @override
+  Future<AuthState> build() async => authState;
+}
+
+Dio _stubDio() {
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost:8585'));
+  dio.httpClientAdapter = _StubAdapter();
+  return dio;
+}
+
+/// Empty-but-well-shaped responses so providers settle into their empty
+/// states instead of erroring where the shape matters.
+class _StubAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final path = options.path;
+    final Object body;
+    if (path.contains('/discover') || path.contains('/search')) {
+      body = {'results': [], 'page': 1, 'total_pages': 1, 'total_results': 0};
+    } else if (path.contains('/issues')) {
+      body = {'issues': []};
+    } else if (path.contains('/agent-actions')) {
+      body = {'actions': []};
+    } else if (path.contains('/requests')) {
+      body = {'requests': []};
+    } else {
+      body = <Object>[];
+    }
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/app/test/shell/adaptive_layout_test.dart
+++ b/app/test/shell/adaptive_layout_test.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/network/websocket_client.dart';
+import 'package:cantinarr/core/providers/realtime_provider.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/dashboard/ui/dashboard_shell.dart';
+import 'package:cantinarr/features/shell/ui/app_shell.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+/// The desktop layout flips at 900px: persistent sidebar with the active
+/// module's pages instead of a hamburger drawer, and no module bottom nav.
+/// Narrower layouts must keep the mobile chrome untouched.
+void main() {
+  GoRouter buildRouter() {
+    return GoRouter(
+      initialLocation: '/dashboard/movies',
+      routes: [
+        ShellRoute(
+          builder: (context, state, child) =>
+              AppShell(currentPath: state.uri.path, child: child),
+          routes: [
+            StatefulShellRoute.indexedStack(
+              builder: (context, state, navigationShell) => DashboardShell(
+                currentIndex: navigationShell.currentIndex,
+                onTabChanged: navigationShell.goBranch,
+                child: navigationShell,
+              ),
+              branches: [
+                StatefulShellBranch(routes: [
+                  GoRoute(
+                    path: '/dashboard/movies',
+                    builder: (_, __) =>
+                        const Scaffold(body: Text('Movies tab')),
+                  ),
+                ]),
+                StatefulShellBranch(routes: [
+                  GoRoute(
+                    path: '/dashboard/tv',
+                    builder: (_, __) => const Scaffold(body: Text('TV tab')),
+                  ),
+                ]),
+                StatefulShellBranch(routes: [
+                  GoRoute(
+                    path: '/dashboard/releases',
+                    builder: (_, __) =>
+                        const Scaffold(body: Text('Releases tab')),
+                  ),
+                ]),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Future<void> pumpShell(WidgetTester tester, {required Size size}) async {
+    tester.view.physicalSize = size;
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith(() => _FakeAuthNotifier(_userState)),
+          backendClientProvider.overrideWithValue(_fakeDio()),
+          realtimeEventsProvider
+              .overrideWithValue(const Stream<WsEvent>.empty()),
+        ],
+        child: MaterialApp.router(routerConfig: buildRouter()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('desktop shows sidebar with module pages and no bottom nav',
+      (tester) async {
+    await pumpShell(tester, size: const Size(1400, 900));
+
+    // Persistent sidebar: module list visible without opening any drawer.
+    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.byIcon(Icons.menu), findsNothing);
+
+    // Active module expands into its pages.
+    expect(find.text('Movies'), findsOneWidget);
+    expect(find.text('TV Shows'), findsOneWidget);
+    expect(find.text('Releases'), findsOneWidget);
+    // No Chaptarr grant -> no Books page.
+    expect(find.text('Books'), findsNothing);
+
+    // The mobile bottom nav is gone on desktop.
+    expect(find.byType(BottomNavigationBar), findsNothing);
+
+    // Sidebar page items navigate between branches.
+    await tester.tap(find.text('TV Shows'));
+    await tester.pumpAndSettle();
+    expect(find.text('TV tab'), findsOneWidget);
+  });
+
+  testWidgets('phone keeps hamburger drawer and bottom nav', (tester) async {
+    await pumpShell(tester, size: const Size(390, 844));
+
+    expect(find.byIcon(Icons.menu), findsOneWidget);
+    expect(find.byType(BottomNavigationBar), findsOneWidget);
+
+    // Bottom nav still switches tabs.
+    await tester.tap(find.text('Releases'));
+    await tester.pumpAndSettle();
+    expect(find.text('Releases tab'), findsOneWidget);
+
+    // Drawer lists modules but not per-module pages (bottom nav covers them):
+    // 'Movies' exists only as a bottom-nav label, not a drawer entry.
+    await tester.tap(find.byIcon(Icons.menu));
+    await tester.pumpAndSettle();
+    expect(find.text('Dashboard'), findsOneWidget);
+  });
+}
+
+const _userState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+  ),
+  user: UserProfile(id: 1, username: 'viewer', role: 'user'),
+);
+
+class _FakeAuthNotifier extends AuthNotifier {
+  final AuthState authState;
+
+  _FakeAuthNotifier(this.authState);
+
+  @override
+  Future<AuthState> build() async => authState;
+}
+
+Dio _fakeDio() {
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+  dio.httpClientAdapter = _JsonAdapter();
+  return dio;
+}
+
+class _JsonAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    return ResponseBody.fromString(
+      jsonEncode([]),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -34,7 +34,8 @@ void main() {
       initialLocation: '/dashboard/movies',
       routes: [
         ShellRoute(
-          builder: (context, state, child) => AppShell(child: child),
+          builder: (context, state, child) =>
+              AppShell(currentPath: state.uri.path, child: child),
           routes: [
             GoRoute(
               path: '/dashboard/movies',
@@ -96,7 +97,8 @@ void main() {
       initialLocation: '/dashboard/movies',
       routes: [
         ShellRoute(
-          builder: (context, state, child) => AppShell(child: child),
+          builder: (context, state, child) =>
+              AppShell(currentPath: state.uri.path, child: child),
           routes: [
             GoRoute(
               path: '/dashboard/movies',
@@ -154,7 +156,8 @@ void main() {
       initialLocation: '/dashboard/movies',
       routes: [
         ShellRoute(
-          builder: (context, state, child) => AppShell(child: child),
+          builder: (context, state, child) =>
+              AppShell(currentPath: state.uri.path, child: child),
           routes: [
             GoRoute(
               path: '/dashboard/movies',


### PR DESCRIPTION
## Why

The app was mobile-first and large screens got a raw scale-up: each module's bottom nav stretched across the window, chat bubbles and settings forms ran full-bleed (2000px text lines on a big monitor), and nothing capped content width anywhere.

## What

**Adaptive navigation (flips at 900px, one shared breakpoint):**
- Per-module pages (Library / Queue / History / …) are now defined once in `modulePagesFor` (`app_module.dart`). On mobile they render as the exact same bottom nav as before; on desktop the persistent sidebar expands the **active module into its pages** and the bottom nav disappears.
- New shared `ModuleScaffold` replaces the six copy-pasted module-shell scaffolds; `AppShell` gets the current route (`currentPath`) so sidebar module/page highlighting is derived from the URL (also fixes stale highlight after deep links).
- Instance selectors, admin badges, drawer behavior on mobile: unchanged.

**Readable content widths on desktop (`AppBreakpoints` + `CenteredContent` in `core/layout/adaptive.dart`):**
- Shell search bar + search results overlay, inline AI chat overlay, full-screen assistant, and issue threads cap at 800px and center. Long scroll surfaces stay full-width and center via scrollable *padding*, so wheel scrolling still works in the gutters.
- Media detail keeps its full-bleed hero; the content column below it centers.
- All full-screen route bodies (settings ×10, issues ×4, auth ×3, setup ×2, arr detail ×4, edit series, notification prefs) wrap in `CenteredContent`.
- Login card caps at 420px; modal bottom sheets cap at the M3-standard 640px via `bottomSheetTheme`.

**Left as-is intentionally:** dashboard poster rows (full-bleed horizontal carousels are correct on desktop), the weekday calendar grid, and admin library/queue/history list rows inside modules (Gmail-style full-width data rows; can cap later if desired).

## Verification

- `flutter analyze --no-fatal-infos`: no new issues (16 pre-existing infos).
- `flutter test`: 210/210 pass, including new `adaptive_layout_test.dart` pinning both chromes (desktop: sidebar pages + no bottom nav + sidebar navigation works; phone at 390×844: hamburger + bottom nav + tab switching unchanged).
- Driven live in Chrome via a new dev-only preview harness (`test/preview/preview_main.dart`, boots the real app with a faked admin session — documented in `app/.claude/skills/verify/SKILL.md`): sidebar navigation across Dashboard/Radarr pages, URL-synced highlighting, capped search bar with the aiReady shimmer hugging it, centered settings column, centered assistant transcript/input.

Docs: `app/README.md` navigation section updated in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)