### PR TITLE
Retry deliver in the metadata lane: ASC intermittently returns empty bodies

### DIFF
--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -48,17 +48,31 @@ platform :ios do
       is_key_content_base64: false,
     )
 
-    deliver(
-      api_key: api_key,
-      app_identifier: "codes.julian.cantinarr",
-      app_version: ENV["APP_VERSION"],
-      metadata_path: "./fastlane/metadata",
-      screenshots_path: "./fastlane/screenshots",
-      skip_binary_upload: true,
-      overwrite_screenshots: true,
-      run_precheck_before_submit: false,
-      force: true,
-    )
+    # The ASC API intermittently returns empty bodies that spaceship surfaces
+    # as "No data". Everything deliver does here is an idempotent PATCH/upload,
+    # so retrying the whole call is safe.
+    attempts = 0
+    begin
+      attempts += 1
+      deliver(
+        api_key: api_key,
+        app_identifier: "codes.julian.cantinarr",
+        app_version: ENV["APP_VERSION"],
+        metadata_path: "./fastlane/metadata",
+        screenshots_path: "./fastlane/screenshots",
+        skip_binary_upload: true,
+        overwrite_screenshots: true,
+        run_precheck_before_submit: false,
+        force: true,
+      )
+    rescue => e
+      if attempts < 3
+        UI.important("deliver attempt #{attempts} failed (#{e.message.to_s.lines.first&.strip}); retrying in 30s")
+        sleep 30
+        retry
+      end
+      raise
+    end
   end
 
   desc "Submit the latest TestFlight build of APP_VERSION for App Store review"


### PR DESCRIPTION
## What

The listing sync's three runs hit the same metadata-upload path with different outcomes — one clean pass through version + App Info metadata, two `No data` crashes (spaceship's wrapper for an empty 200 body from the App Store Connect API). Classic ASC flakiness rather than a config problem: App Info and version metadata are already confirmed synced from the successful pass.

Everything the `metadata` lane does is an idempotent PATCH/upload, so the lane now retries the whole `deliver` call up to 3 times with a 30s backoff, logging the failed attempt's first error line.

## Verification

- Fastlane-only change; the post-merge `Sync Store Listings` run re-exercises the exact path and will be watched to green (screenshot upload is the remaining unproven step).

## Docs

- [x] No docs impact — retry behavior inside an existing lane; pipeline docs in `docs/store-release.md` remain accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bmWvBeNZGZieuXaBWhL5y