### PR TITLE
Skip deliver's review-attachment step while no review-detail record exists

### DIFF
--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -48,6 +48,26 @@ platform :ios do
       is_key_content_base64: false,
     )
 
+    # deliver unconditionally fetches the App Store review-detail record while
+    # syncing metadata, and an app that has never had a review contact set has
+    # no such record - the API returns data:null, which fastlane surfaces as a
+    # hard "No data" crash (fastlane#20538). Creating the record via the API
+    # requires a contact phone we deliberately don't commit, so skip the
+    # review-attachment step until the record exists (one-time console step);
+    # once it does, the original behavior resumes.
+    require 'deliver'
+    unless Deliver::UploadMetadata.method_defined?(:cantinarr_orig_review_attachment_file)
+      Deliver::UploadMetadata.class_eval do
+        alias_method :cantinarr_orig_review_attachment_file, :review_attachment_file
+        def review_attachment_file(version)
+          cantinarr_orig_review_attachment_file(version)
+        rescue => e
+          raise unless e.message.to_s.include?("No data")
+          FastlaneCore::UI.important("No App Store review-detail record exists yet (set the review contact, incl. phone, once in App Store Connect); skipping review-attachment handling.")
+        end
+      end
+    end
+
     # The ASC API intermittently returns empty bodies that spaceship surfaces
     # as "No data". Everything deliver does here is an idempotent PATCH/upload,
     # so retrying the whole call is safe.


### PR DESCRIPTION
## What

Root cause of the listing-sync `No data` failures, pinned by the stack trace: `upload_metadata.rb:752 review_attachment_file` → `fetch_app_store_review_detail` → spaceship `parse` crash. deliver unconditionally fetches the App Store review-detail record; this app has never had a review contact set, so the record doesn't exist and the API returns `data: null`, which fastlane 2.236.1 doesn't nil-guard ([fastlane#20538](https://github.com/fastlane/fastlane/issues/20538)). The earlier "flaky PATCH" reading was wrong — deliver's threaded workers just interleave the log lines.

Creating the record via API requires a contact phone (deliberately not committed), so the `metadata` lane now wraps `review_attachment_file` to skip with a clear message until the record exists — which happens at the documented one-time console step (set review contact incl. phone). After that, the original code path resumes untouched.

## Verification

Full `fastlane metadata` run from the debug branch with this shim: **success** — version metadata, App Info, and all 18 screenshots (9× iPhone 6.9" 1320×2868, 9× iPad 13" 2064×2752) uploaded to App Store Connect. The listing is now populated in ASC.

## Docs

- [x] No docs impact — internal lane behavior; the review-contact console step is already step 1 of the App Store runbook in `docs/store-release.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bmWvBeNZGZieuXaBWhL5y