### PR TITLE
Fix AAB path in the Play beta lane

### DIFF
--- a/app/android/fastlane/Fastfile
+++ b/app/android/fastlane/Fastfile
@@ -29,7 +29,7 @@ platform :android do
       package_name: PACKAGE_NAME,
       track: ENV["PLAY_TRACK"] || "beta",
       release_status: ENV["PLAY_RELEASE_STATUS"] || "completed",
-      aab: "../../build/app/outputs/bundle/release/app-release.aab",
+      aab: "../build/app/outputs/bundle/release/app-release.aab",
       json_key: ENV["PLAY_JSON_KEY_PATH"],
       skip_upload_metadata: true,
       skip_upload_changelogs: false,


### PR DESCRIPTION
## What

The first credentialed Play upload attempt failed at parameter validation: `aab: "../../build/..."` resolves from fastlane's working directory (`app/android`), which put it one level above the app dir. The iOS lane's `ipa: "../build/..."` (run from `app/ios`, works in every TestFlight deploy) establishes the convention — corrected to `../build/app/outputs/bundle/release/app-release.aab`.

Also confirmed by the same run: the service account authenticates fine ("Package not found" is the expected pre-first-upload response), version-code fallback worked (`next: 1`).

## Verification

- Path arithmetic verified against the working iOS lane; the artifact-upload step in the same workflow already reads the identical path from repo root (`app/build/...`).
- Proven properly by the next credentialed `Deploy to Play Store` run once the package binds.

## Docs

- [x] No docs impact — path fix inside an existing lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bmWvBeNZGZieuXaBWhL5y