### PR TITLE
Store listings: acknowledge MCP server and zero-hassle iOS push

### DIFF
--- a/app/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/app/android/fastlane/metadata/android/en-US/full_description.txt
@@ -25,6 +25,7 @@ The management side goes as deep as you want:
 • Import Doctor: stuck downloads explain themselves in plain English, with one-click fixes
 • See what's playing through Tautulli — active streams, history, top stats
 • Plex invites, a guided setup checklist, per-user defaults, and device management
+• Your server is an MCP server too: connect Claude or any MCP client and manage your library with the same tools that power the built-in assistant
 
 PRIVACY
 

--- a/app/ios/fastlane/metadata/en-US/description.txt
+++ b/app/ios/fastlane/metadata/en-US/description.txt
@@ -25,6 +25,8 @@ The management side goes as deep as you want:
 • Import Doctor: stuck downloads explain themselves in plain English, with one-click fixes
 • See what's playing through Tautulli — active streams, history, top stats
 • Plex invites, a guided setup checklist, per-user defaults, and device management
+• Push notifications with a single line of server config — no Apple developer account, certificates, or Firebase project on your side
+• Your server is an MCP server too: connect Claude or any MCP client and manage your library with the same tools that power the built-in assistant
 
 Works on iPhone and iPad, with a sidebar layout on bigger screens.
 

--- a/app/ios/fastlane/metadata/en-US/keywords.txt
+++ b/app/ios/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-radarr,sonarr,plex,jellyfin,media,request,server,selfhosted,homelab,library,tv,movies
+radarr,sonarr,plex,jellyfin,media,request,server,selfhosted,homelab,library,tv,movies,mcp


### PR DESCRIPTION
## What

- **Both stores**: new admin bullet — the server is an MCP server; connect Claude or any MCP client to the same tools that power the built-in assistant (count deliberately omitted so the listing can't drift from the README's tool table).
- **App Store only**: bullet that push notifications need a single line of server config — no Apple developer account, certificates, or Firebase project. Also appends `mcp` to keywords (90/100 chars).
- **Play deliberately stays silent on push**: the Android app has no push implementation today (no FCM, no token registration, no notification plugin) — listings describe shipped reality. When Android push lands, the Play copy earns the same line.

## Why

MCP and credential-free push are two of the strongest differentiators and neither was mentioned. iOS push claims were already present (approval/ready notifications); this makes the zero-hassle setup explicit.

## Docs

Listing copy *is* the doc here (synced to both consoles by `storelisting.yml` on merge). No route/tool/env surfaces touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)