### PR TITLE
Add admin update-available banner and server version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,6 +67,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          build-args: |
+            VERSION=${{ steps.meta.outputs.version }}
           platforms: ${{ (startsWith(github.ref, 'refs/tags/v') || inputs.multi-arch) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN go mod download
 COPY server/ .
 # Copy Flutter web build into the Go embed directory
 COPY --from=flutter-builder /app/build/web/ ./internal/web/dist/
-RUN CGO_ENABLED=0 go build -o cantinarr ./cmd/server
+ARG VERSION=dev
+RUN CGO_ENABLED=0 go build -ldflags "-X github.com/windoze95/cantinarr-server/internal/version.Version=${VERSION}" -o cantinarr ./cmd/server
 
 # Stage 3: Final image
 FROM alpine:3.19

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: all flutter-web copy-web server run clean
 
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+
 all: flutter-web copy-web server
 
 flutter-web:
@@ -10,7 +12,7 @@ copy-web: flutter-web
 	cp -r app/build/web/* server/internal/web/dist/
 
 server: copy-web
-	cd server && CGO_ENABLED=0 go build -o cantinarr-server ./cmd/server
+	cd server && CGO_ENABLED=0 go build -ldflags "-X github.com/windoze95/cantinarr-server/internal/version.Version=$(VERSION)" -o cantinarr-server ./cmd/server
 
 run: all
 	./server/cantinarr-server

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Optional server env vars for deployment tuning:
 | `CANTINARR_ANDROID_PACKAGE_NAME` | `codes.julian.cantinarr` | Android package name for native passkeys |
 | `CANTINARR_ANDROID_CERT_SHA256_FINGERPRINTS` | unset | Android signing cert fingerprints for `/.well-known/assetlinks.json` |
 | `CANTINARR_WEBAUTHN_EXTRA_ORIGINS` | unset | Additional WebAuthn origins to trust |
+| `CANTINARR_DISABLE_UPDATE_CHECK` | unset | Set to `1` to disable the periodic GitHub release check behind the admin "update available" banner |
 
 Native app passkeys require a public HTTPS server domain associated with the app (AASA for Apple, Digital Asset Links for Android). Browser passkey setup remains available when native association isn't possible. See [`server/README.md`](server/README.md#configuration) for details.
 
@@ -169,6 +170,7 @@ By default, users are passwordless and passkeyless: a connect link starts a perm
 4. Optionally require approval for requests -- pending ones arrive as push notifications
 5. Copy each instance's webhook URL into Radarr/Sonarr > Connect so external changes sync instantly
 6. Manage everything from the app -- queues, stuck imports, issues, agent fixes. No config files.
+7. When a newer release ships, an in-app banner points you to it; optionally set an **Update Portal** link (**Settings > Admin**) to jump straight to your container manager. See [`docs/updating.md`](docs/updating.md).
 
 ### ID Bridge (TMDB-to-TVDB)
 

--- a/app/README.md
+++ b/app/README.md
@@ -99,6 +99,7 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 - **Credentials** (admin, write-only) -- TMDB, Trakt, and AI provider keys + provider/model selection.
 - **AI tools** (admin) -- per-tool toggles for chat + MCP, and a one-hour debug-logging switch.
 - **AI remediation** (admin) -- master switch, auto-dispatch, reporting affordance, autonomy tier, provider/model, and run budgets.
+- **Update Portal** (admin) -- optional link to your own container-management portal (e.g. an Unraid or Portainer page). When the server sees a newer published release, an admin-only banner appears app-wide and links here (or to the update guide when unset); it's dismissible per release. The About sheet also shows the running server version.
 - **Notifications, Passkeys, Password** -- self-service (passkey/password screens appear when admin-enabled).
 - **Watch on Plex guide** -- requester-focused walkthrough (install the Plex app, sign in, accept the invite, start watching) with a **Request your invite** step: the user shares their Plex email, admins get a push pointing at the Users screen, and once the invite goes out (one-tap or auto) the card flips to "check your inbox" and the user gets a push. Hideable from the guide itself or via a Settings toggle that also removes it from the menu.
 

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -4,6 +4,7 @@ import 'package:app_links/app_links.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
 import 'core/network/websocket_client.dart';
 import 'core/providers/realtime_provider.dart';
 import 'core/storage/preferences.dart';
@@ -12,6 +13,7 @@ import 'features/auth/logic/auth_provider.dart';
 import 'features/issues/logic/issues_provider.dart';
 import 'features/notifications/push_service.dart';
 import 'features/request/logic/pending_approvals_provider.dart';
+import 'features/settings/logic/update_status_provider.dart';
 import 'navigation/app_router.dart';
 
 class CantinarrApp extends ConsumerStatefulWidget {
@@ -51,6 +53,8 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
       ref.read(pendingApprovalsProvider.notifier).refresh();
       // Same for the open-issues badge.
       ref.read(openIssuesProvider.notifier).refresh();
+      // And re-check for a newer server release (no-op for non-admins).
+      ref.read(updateStatusProvider.notifier).refresh();
     }
   }
 
@@ -134,7 +138,8 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
     final data = event.data;
     final approved = data['decision'] == 'approved';
     final rawTitle = (data['title'] as String?)?.trim();
-    final label = rawTitle == null || rawTitle.isEmpty ? 'Your request' : rawTitle;
+    final label =
+        rawTitle == null || rawTitle.isEmpty ? 'Your request' : rawTitle;
     final reason = (data['reason'] as String?)?.trim();
     final text = approved
         ? 'Approved: $label'
@@ -216,8 +221,9 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
       debugShowCheckedModeBanner: false,
       scaffoldMessengerKey: _scaffoldMessengerKey,
       routerConfig: router,
-      builder: (context, child) =>
-          _ReconnectingBanner(child: child ?? const SizedBox.shrink()),
+      builder: (context, child) => _UpdateBanner(
+        child: _ReconnectingBanner(child: child ?? const SizedBox.shrink()),
+      ),
     );
   }
 }
@@ -318,6 +324,124 @@ class _ReconnectingBar extends StatelessWidget {
           Text(
             'Reconnecting…',
             style: TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A persistent, admin-only banner shown at the top of the app when a newer
+/// Cantinarr release is available. Its action links to the admin's configured
+/// management portal (if set) or the update guide otherwise, and it is
+/// dismissible per release — dismissing silences only the offered version.
+class _UpdateBanner extends ConsumerWidget {
+  const _UpdateBanner({required this.child});
+
+  final Widget child;
+
+  static const _updateGuideUrl =
+      'https://github.com/windoze95/cantinarr/blob/main/docs/updating.md';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isAdmin = ref.watch(
+      authProvider.select((s) => s.valueOrNull?.user?.isAdmin ?? false),
+    );
+    final status = ref.watch(updateStatusProvider);
+    final dismissed = ref.watch(dismissedUpdateVersionProvider);
+
+    final update = status?.update;
+    if (!isAdmin ||
+        update == null ||
+        !update.available ||
+        update.latest.isEmpty ||
+        dismissed == update.latest) {
+      return child;
+    }
+
+    return Column(
+      children: [
+        Material(
+          color: AppTheme.surfaceVariant,
+          child: SafeArea(
+            bottom: false,
+            child: _UpdateBannerBar(
+              latest: update.latest,
+              releaseUrl: update.url,
+              managementUrl: status?.managementUrl ?? '',
+              guideUrl: _updateGuideUrl,
+              onDismiss: () => ref
+                  .read(dismissedUpdateVersionProvider.notifier)
+                  .set(update.latest),
+            ),
+          ),
+        ),
+        Expanded(child: child),
+      ],
+    );
+  }
+}
+
+/// The update banner's visual content: a short message plus a "Notes" link, the
+/// primary update action, and a dismiss button.
+class _UpdateBannerBar extends StatelessWidget {
+  const _UpdateBannerBar({
+    required this.latest,
+    required this.releaseUrl,
+    required this.managementUrl,
+    required this.guideUrl,
+    required this.onDismiss,
+  });
+
+  final String latest;
+  final String releaseUrl;
+  final String managementUrl;
+  final String guideUrl;
+  final VoidCallback onDismiss;
+
+  void _open(String url) {
+    if (url.isEmpty) return;
+    final uri = Uri.tryParse(url);
+    if (uri == null) return;
+    launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasPortal = managementUrl.isNotEmpty;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 4, 4, 4),
+      child: Row(
+        children: [
+          const Icon(Icons.system_update, size: 18, color: AppTheme.accent),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              'Cantinarr $latest is available',
+              style: const TextStyle(
+                color: AppTheme.textPrimary,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          if (releaseUrl.isNotEmpty)
+            TextButton(
+              onPressed: () => _open(releaseUrl),
+              child: const Text('Notes'),
+            ),
+          TextButton(
+            onPressed: () => _open(hasPortal ? managementUrl : guideUrl),
+            child: Text(hasPortal ? 'Update' : 'How to update'),
+          ),
+          IconButton(
+            onPressed: onDismiss,
+            icon: const Icon(Icons.close, size: 18),
+            color: AppTheme.textSecondary,
+            tooltip: 'Dismiss',
+            visualDensity: VisualDensity.compact,
           ),
         ],
       ),

--- a/app/lib/core/models/backend_connection.dart
+++ b/app/lib/core/models/backend_connection.dart
@@ -34,6 +34,9 @@ class BackendConnection {
   final String accessToken;
   final String refreshToken;
   final String? serverName;
+
+  /// The running server version, reported by /api/config.
+  final String? serverVersion;
   final AvailableServices services;
   final List<ServiceInstance> instances;
 
@@ -48,6 +51,7 @@ class BackendConnection {
     required this.accessToken,
     required this.refreshToken,
     this.serverName,
+    this.serverVersion,
     this.services = const AvailableServices(),
     this.instances = const [],
     this.issuesEnabled = false,
@@ -59,6 +63,7 @@ class BackendConnection {
     String? accessToken,
     String? refreshToken,
     String? serverName,
+    String? serverVersion,
     AvailableServices? services,
     List<ServiceInstance>? instances,
     bool? issuesEnabled,
@@ -69,6 +74,7 @@ class BackendConnection {
         accessToken: accessToken ?? this.accessToken,
         refreshToken: refreshToken ?? this.refreshToken,
         serverName: serverName ?? this.serverName,
+        serverVersion: serverVersion ?? this.serverVersion,
         services: services ?? this.services,
         instances: instances ?? this.instances,
         issuesEnabled: issuesEnabled ?? this.issuesEnabled,

--- a/app/lib/core/storage/preferences.dart
+++ b/app/lib/core/storage/preferences.dart
@@ -55,8 +55,7 @@ class PlexGuideNotifier extends StateNotifier<bool> {
   }
 }
 
-final plexGuideEnabledProvider =
-    StateNotifierProvider<PlexGuideNotifier, bool>(
+final plexGuideEnabledProvider = StateNotifierProvider<PlexGuideNotifier, bool>(
   (ref) => PlexGuideNotifier(),
 );
 
@@ -85,4 +84,31 @@ class SetupReminderNotifier extends StateNotifier<bool> {
 final setupReminderEnabledProvider =
     StateNotifierProvider<SetupReminderNotifier, bool>(
   (ref) => SetupReminderNotifier(),
+);
+
+const _dismissedUpdateVersionKey = 'dismissed_update_version';
+
+/// The server version the admin last dismissed the "update available" banner
+/// for. Stored locally per device; the banner reappears once a newer version
+/// than this is offered, so a dismissal only silences the release it was for.
+class DismissedUpdateNotifier extends StateNotifier<String?> {
+  DismissedUpdateNotifier() : super(null) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    state = prefs.getString(_dismissedUpdateVersionKey);
+  }
+
+  Future<void> set(String version) async {
+    state = version;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_dismissedUpdateVersionKey, version);
+  }
+}
+
+final dismissedUpdateVersionProvider =
+    StateNotifierProvider<DismissedUpdateNotifier, String?>(
+  (ref) => DismissedUpdateNotifier(),
 );

--- a/app/lib/features/auth/data/auth_service.dart
+++ b/app/lib/features/auth/data/auth_service.dart
@@ -480,6 +480,9 @@ class UserSummary {
 /// Server-provided configuration returned after authentication.
 class ServerConfig {
   final String serverName;
+
+  /// The running server version, from the `version` field of /api/config.
+  final String? serverVersion;
   final AvailableServices services;
   final List<ServiceInstance> instances;
 
@@ -491,6 +494,7 @@ class ServerConfig {
 
   const ServerConfig({
     required this.serverName,
+    this.serverVersion,
     required this.services,
     this.instances = const [],
     this.issuesEnabled = false,
@@ -505,6 +509,7 @@ class ServerConfig {
 
     return ServerConfig(
       serverName: json['server_name'] as String? ?? 'Cantinarr',
+      serverVersion: json['version'] as String?,
       services: AvailableServices.fromJson(
           json['services'] as Map<String, dynamic>? ?? {}),
       instances: instancesList,

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -195,12 +195,13 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         accessToken: accessToken,
         refreshToken: refreshToken,
         serverName: meta['server_name'] as String?,
+        serverVersion: meta['version'] as String?,
         services: services is Map<String, dynamic>
             ? AvailableServices.fromJson(services)
             : const AvailableServices(),
         instances: (meta['instances'] as List<dynamic>?)
-                ?.map((e) =>
-                    ServiceInstance.fromJson(e as Map<String, dynamic>))
+                ?.map(
+                    (e) => ServiceInstance.fromJson(e as Map<String, dynamic>))
                 .toList() ??
             const [],
         issuesEnabled: meta['issues_enabled'] as bool? ?? false,
@@ -273,6 +274,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
           accessToken: authResp.accessToken,
           refreshToken: authResp.refreshToken,
           serverName: config.serverName,
+          serverVersion: config.serverVersion,
           services: config.services,
           instances: config.instances,
           issuesEnabled: config.issuesEnabled,
@@ -351,6 +353,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         accessToken: authResp.accessToken,
         refreshToken: authResp.refreshToken,
         serverName: config.serverName,
+        serverVersion: config.serverVersion,
         services: config.services,
         instances: config.instances,
         issuesEnabled: config.issuesEnabled,
@@ -446,6 +449,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         accessToken: authResp.accessToken,
         refreshToken: authResp.refreshToken,
         serverName: config.serverName,
+        serverVersion: config.serverVersion,
         services: config.services,
         instances: config.instances,
         issuesEnabled: config.issuesEnabled,
@@ -496,6 +500,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         accessToken: authResp.accessToken,
         refreshToken: authResp.refreshToken,
         serverName: config.serverName,
+        serverVersion: config.serverVersion,
         services: config.services,
         instances: config.instances,
         issuesEnabled: config.issuesEnabled,
@@ -541,6 +546,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         accessToken: authResp.accessToken,
         refreshToken: authResp.refreshToken,
         serverName: config.serverName,
+        serverVersion: config.serverVersion,
         services: config.services,
         instances: config.instances,
         issuesEnabled: config.issuesEnabled,
@@ -580,6 +586,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         await _authService.fetchConfig(conn.serverUrl, conn.accessToken);
     final updatedConn = conn.copyWith(
       serverName: config.serverName,
+      serverVersion: config.serverVersion,
       services: config.services,
       instances: config.instances,
       issuesEnabled: config.issuesEnabled,
@@ -782,6 +789,7 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
         accessToken: authResp.accessToken,
         refreshToken: authResp.refreshToken,
         serverName: config.serverName,
+        serverVersion: config.serverVersion,
         services: config.services,
         instances: config.instances,
         issuesEnabled: config.issuesEnabled,
@@ -833,8 +841,8 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
     // A successful refresh means we reached the server — clear any reconnecting
     // hold and stop the retry loop.
     _stopReconnect();
-    state = AsyncData(
-        current.copyWith(connection: updated, isReconnecting: false));
+    state =
+        AsyncData(current.copyWith(connection: updated, isReconnecting: false));
   }
 
   /// Called when the server has *rejected* our refresh token (a genuine 401):
@@ -907,14 +915,14 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   /// Cache the non-secret parts of an authenticated session (user profile +
   /// server config) so a later cold start can restore an optimistic, usable
   /// session before the server is reachable. Tokens are stored separately.
-  Future<void> _persistSession(
-      BackendConnection conn, UserProfile user) async {
+  Future<void> _persistSession(BackendConnection conn, UserProfile user) async {
     await _storage.write(
         key: StorageKeys.sessionUser, value: jsonEncode(user.toJson()));
     await _storage.write(
       key: StorageKeys.sessionConnection,
       value: jsonEncode({
         'server_name': conn.serverName,
+        'version': conn.serverVersion,
         'services': conn.services.toJson(),
         'instances': conn.instances.map((i) => i.toJson()).toList(),
         'issues_enabled': conn.issuesEnabled,

--- a/app/lib/features/settings/data/update_status_service.dart
+++ b/app/lib/features/settings/data/update_status_service.dart
@@ -1,0 +1,65 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+
+/// The latest-release comparison the server computed for the running version.
+class UpdateInfo {
+  final String current;
+  final String latest;
+  final bool available;
+  final String url;
+
+  const UpdateInfo({
+    required this.current,
+    required this.latest,
+    required this.available,
+    required this.url,
+  });
+
+  factory UpdateInfo.fromJson(Map<String, dynamic> json) => UpdateInfo(
+        current: json['current'] as String? ?? '',
+        latest: json['latest'] as String? ?? '',
+        available: json['available'] as bool? ?? false,
+        url: json['url'] as String? ?? '',
+      );
+}
+
+/// Admin-only update state: the release comparison plus the optional
+/// management-portal URL the banner's action button links to.
+class UpdateStatus {
+  final UpdateInfo update;
+  final String managementUrl;
+
+  const UpdateStatus({required this.update, required this.managementUrl});
+
+  factory UpdateStatus.fromJson(Map<String, dynamic> json) => UpdateStatus(
+        update: UpdateInfo.fromJson(
+            json['update'] as Map<String, dynamic>? ?? const {}),
+        managementUrl: json['management_url'] as String? ?? '',
+      );
+}
+
+class UpdateStatusService {
+  final Dio _dio;
+
+  UpdateStatusService({required Dio backendDio}) : _dio = backendDio;
+
+  Future<UpdateStatus> fetch() async {
+    final resp = await _dio.get('/api/admin/update-status');
+    return UpdateStatus.fromJson(resp.data as Map<String, dynamic>);
+  }
+
+  /// Sets the management-portal URL (empty clears it) and returns the updated
+  /// status. Throws on a non-2xx response so callers can surface the error.
+  Future<UpdateStatus> setManagementUrl(String url) async {
+    final resp = await _dio.put(
+      '/api/admin/update-status',
+      data: {'management_url': url},
+    );
+    return UpdateStatus.fromJson(resp.data as Map<String, dynamic>);
+  }
+}
+
+final updateStatusServiceProvider = Provider<UpdateStatusService>(
+  (ref) => UpdateStatusService(backendDio: ref.watch(backendClientProvider)),
+);

--- a/app/lib/features/settings/logic/update_status_provider.dart
+++ b/app/lib/features/settings/logic/update_status_provider.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../auth/logic/auth_provider.dart';
+import '../data/update_status_service.dart';
+
+/// Admin-only update status, null while unknown (loading, or not an admin).
+///
+/// Mirrors [setupStatusProvider]: there is no websocket event for a new
+/// release, so the banner and Settings refresh on login and on app resume.
+class UpdateStatusNotifier extends StateNotifier<UpdateStatus?> {
+  UpdateStatusNotifier(this._ref) : super(null) {
+    _bind();
+    // Re-bind on login/logout/role change without rebuilding the provider.
+    _ref.listen(authProvider, (_, __) => _bind());
+  }
+
+  final Ref _ref;
+  bool _isAdmin = false;
+
+  void _bind() {
+    final admin = _ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    if (admin == _isAdmin) return; // no change
+    _isAdmin = admin;
+    if (!admin) {
+      state = null;
+      return;
+    }
+    refresh();
+  }
+
+  /// Re-fetches the update status from the backend. No-op for non-admins.
+  Future<void> refresh() async {
+    if (!_isAdmin) return;
+    try {
+      final status = await _ref.read(updateStatusServiceProvider).fetch();
+      if (_isAdmin) state = status;
+    } catch (_) {
+      // Best-effort: keep the last known status on a transient failure.
+    }
+  }
+
+  /// Persists the management-portal URL and updates state. Rethrows on failure
+  /// so the Settings screen can show the error.
+  Future<void> setManagementUrl(String url) async {
+    final status =
+        await _ref.read(updateStatusServiceProvider).setManagementUrl(url);
+    state = status;
+  }
+}
+
+final updateStatusProvider =
+    StateNotifierProvider<UpdateStatusNotifier, UpdateStatus?>(
+  UpdateStatusNotifier.new,
+);

--- a/app/lib/features/settings/ui/about_sheet.dart
+++ b/app/lib/features/settings/ui/about_sheet.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../auth/logic/auth_provider.dart';
 
-class AboutSheet extends StatelessWidget {
+class AboutSheet extends ConsumerWidget {
   const AboutSheet({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final serverVersion =
+        ref.watch(authProvider).valueOrNull?.connection?.serverVersion;
     return Container(
       padding: const EdgeInsets.all(24),
       decoration: const BoxDecoration(
@@ -67,12 +71,24 @@ class AboutSheet extends StatelessWidget {
               ),
               const SizedBox(height: 4),
               Text(
-                build.isNotEmpty ? 'Version $version ($build)' : 'Version $version',
+                build.isNotEmpty
+                    ? 'Version $version ($build)'
+                    : 'Version $version',
                 style: const TextStyle(
                   color: AppTheme.textSecondary,
                   fontSize: 14,
                 ),
               ),
+              if (serverVersion != null && serverVersion.isNotEmpty) ...[
+                const SizedBox(height: 2),
+                Text(
+                  'Server $serverVersion',
+                  style: const TextStyle(
+                    color: AppTheme.textSecondary,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
 
               const SizedBox(height: 24),
             ],

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -8,6 +8,7 @@ import '../../../core/storage/preferences.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../logic/setup_status_provider.dart';
+import '../logic/update_status_provider.dart';
 import 'about_sheet.dart';
 
 /// Simplified settings screen for backend-connected architecture.
@@ -34,6 +35,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       ref.read(authProvider.notifier).refreshUser();
       ref.read(setupStatusProvider.notifier).refresh();
+      ref.read(updateStatusProvider.notifier).refresh();
     });
   }
 
@@ -45,6 +47,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final user = auth?.user;
     final instances = connection?.instances ?? [];
     final setupStatus = ref.watch(setupStatusProvider);
+    final updateStatus = ref.watch(updateStatusProvider);
 
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
@@ -227,6 +230,17 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               subtitle: 'Manage all connected devices',
               onTap: () => context.push('/settings/devices'),
             ),
+            _SettingsTile(
+              icon: Icons.open_in_new,
+              title: 'Update Portal',
+              subtitle: (updateStatus?.managementUrl.isNotEmpty ?? false)
+                  ? updateStatus!.managementUrl
+                  : 'Link your container manager for the update banner',
+              onTap: () => _showManagementUrlDialog(
+                context,
+                updateStatus?.managementUrl ?? '',
+              ),
+            ),
           ],
 
           const SizedBox(height: 16),
@@ -395,6 +409,78 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 icon: const Icon(Icons.copy, size: 18),
                 label: const Text('Copy'),
               ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showManagementUrlDialog(BuildContext context, String current) {
+    final controller = TextEditingController(text: current);
+    bool saving = false;
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (context, setDialogState) => AlertDialog(
+          title: const Text('Update Portal'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                'Optional. When set, the "update available" banner links here so '
+                'you can apply the update in your own container manager (e.g. an '
+                'Unraid Docker page or Portainer). Leave blank to clear.',
+                style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: controller,
+                decoration: const InputDecoration(
+                  labelText: 'Portal URL',
+                  hintText: 'http://tower.local/Docker',
+                  prefixIcon: Icon(Icons.open_in_new),
+                ),
+                keyboardType: TextInputType.url,
+                autocorrect: false,
+                textInputAction: TextInputAction.done,
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: saving
+                  ? null
+                  : () async {
+                      setDialogState(() => saving = true);
+                      try {
+                        await ref
+                            .read(updateStatusProvider.notifier)
+                            .setManagementUrl(controller.text.trim());
+                        if (dialogContext.mounted) {
+                          Navigator.of(dialogContext).pop();
+                        }
+                      } catch (e) {
+                        setDialogState(() => saving = false);
+                        if (dialogContext.mounted) {
+                          ScaffoldMessenger.of(dialogContext).showSnackBar(
+                            SnackBar(content: Text('Failed to save: $e')),
+                          );
+                        }
+                      }
+                    },
+              child: saving
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('Save'),
+            ),
           ],
         ),
       ),

--- a/app/test/settings/update_status_service_test.dart
+++ b/app/test/settings/update_status_service_test.dart
@@ -1,0 +1,32 @@
+import 'package:cantinarr/features/settings/data/update_status_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('UpdateStatus.fromJson', () {
+    test('parses a full payload', () {
+      final s = UpdateStatus.fromJson({
+        'update': {
+          'current': '1.2.3',
+          'latest': '1.3.0',
+          'available': true,
+          'url': 'https://example.com/releases/tag/v1.3.0',
+        },
+        'management_url': 'http://tower.local/Docker',
+      });
+      expect(s.update.current, '1.2.3');
+      expect(s.update.latest, '1.3.0');
+      expect(s.update.available, isTrue);
+      expect(s.update.url, 'https://example.com/releases/tag/v1.3.0');
+      expect(s.managementUrl, 'http://tower.local/Docker');
+    });
+
+    test('defaults missing fields', () {
+      final s = UpdateStatus.fromJson(const {});
+      expect(s.update.current, '');
+      expect(s.update.latest, '');
+      expect(s.update.available, isFalse);
+      expect(s.update.url, '');
+      expect(s.managementUrl, '');
+    });
+  });
+}

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,0 +1,54 @@
+# Updating Cantinarr
+
+Cantinarr ships as a Docker image at `ghcr.io/windoze95/cantinarr`. Updating means
+pulling the newer image and recreating the container — the exact steps depend on how
+you run it. Admins see an in-app banner when a newer release is available; it links
+here, or to your own management portal if you've set one
+(**Settings → Admin → Update Portal**).
+
+Your data lives in the `/config` volume, so recreating the container keeps your
+database and settings.
+
+## Docker Compose
+
+```sh
+docker compose pull
+docker compose up -d
+```
+
+## docker run
+
+```sh
+docker pull ghcr.io/windoze95/cantinarr:latest
+docker stop cantinarr && docker rm cantinarr
+# re-run your original `docker run …` command (same flags and volumes)
+```
+
+## Automatic updates (Watchtower)
+
+[Watchtower](https://containrrr.dev/watchtower/) pulls and recreates the container
+for you on a schedule:
+
+```sh
+docker run -d --name watchtower \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  containrrr/watchtower cantinarr
+```
+
+## Your platform's update action
+
+If you run Cantinarr through a NAS or container UI (Unraid, Portainer, TrueNAS,
+Dockge, …), use that platform's own "check for updates" / "apply update" action — it
+does the pull-and-recreate for you. Point the in-app banner straight at that page by
+setting **Settings → Admin → Update Portal** to its URL (e.g. `http://tower.local/Docker`).
+
+## Pinning a version
+
+Prefer to control upgrades explicitly? Pin a tag instead of `latest` — e.g.
+`ghcr.io/windoze95/cantinarr:1.4.0` — and bump it when you choose. The banner compares
+your running version against the latest published GitHub release.
+
+## Turning the check off
+
+The update check is best-effort and only runs on tagged release builds. To disable it
+entirely, set `CANTINARR_DISABLE_UPDATE_CHECK=1` in the container's environment.

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,7 +3,8 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o cantinarr ./cmd/server
+ARG VERSION=dev
+RUN CGO_ENABLED=0 go build -ldflags "-X github.com/windoze95/cantinarr-server/internal/version.Version=${VERSION}" -o cantinarr ./cmd/server
 
 FROM alpine:3.19
 RUN apk add --no-cache ca-certificates

--- a/server/README.md
+++ b/server/README.md
@@ -94,6 +94,7 @@ Optional env vars for deployment tuning (a `.env` file next to the binary is aut
 | `CANTINARR_ANDROID_PACKAGE_NAME` | `codes.julian.cantinarr` | Android package name for native passkeys |
 | `CANTINARR_ANDROID_CERT_SHA256_FINGERPRINTS` | unset | Comma-separated Android signing cert SHA-256 fingerprints for `/.well-known/assetlinks.json` and Android WebAuthn origins |
 | `CANTINARR_WEBAUTHN_EXTRA_ORIGINS` | unset | Additional WebAuthn origins to trust (e.g. non-standard HTTPS ports) |
+| `CANTINARR_DISABLE_UPDATE_CHECK` | unset | Set to `1` to disable the periodic GitHub release check behind the admin "update available" banner |
 
 The database lives at `/config/cantinarr.db` (SQLite, WAL mode). Keep the `/config` volume -- it holds the DB and the auto-generated encryption key, and encrypted secrets are unrecoverable without that key.
 
@@ -152,6 +153,13 @@ PUT    /api/admin/plex/settings            # server, shared libraries, auto-invi
 GET    /api/admin/setup-status             # live-derived checklist of configured/unconfigured features
 ```
 Re-derived from actual configuration on every request (never stored), so the app's setup wizard is resumable and can't go stale. New features surface themselves by adding an item here; clients render unknown keys generically.
+
+### Update status (admin)
+```
+GET    /api/admin/update-status            # latest-release comparison + management-portal URL
+PUT    /api/admin/update-status            # set the management-portal URL ({ management_url })
+```
+Backs the app's "update available" banner. The server compares its own build version against the latest published GitHub release (`windoze95/cantinarr`), cached ~12h, best-effort and non-blocking; only real semver-tagged builds check (dev/`latest`/PR builds never contact GitHub), and `CANTINARR_DISABLE_UPDATE_CHECK=1` turns it off. `management_url` is an optional admin-set link to a container-management portal the banner points at. The running version is also surfaced to all clients (for the About screen) in `/api/config` as `version`.
 
 ### Requests
 ```

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -30,8 +30,11 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/remediation"
 	"github.com/windoze95/cantinarr-server/internal/request"
 	"github.com/windoze95/cantinarr-server/internal/secrets"
+	"github.com/windoze95/cantinarr-server/internal/serversettings"
 	"github.com/windoze95/cantinarr-server/internal/tautulli"
 	"github.com/windoze95/cantinarr-server/internal/tmdb"
+	"github.com/windoze95/cantinarr-server/internal/update"
+	"github.com/windoze95/cantinarr-server/internal/version"
 	"github.com/windoze95/cantinarr-server/internal/webhooks"
 	ws "github.com/windoze95/cantinarr-server/internal/websocket"
 )
@@ -227,8 +230,13 @@ func main() {
 	// events and content pushes the queue-poll witness emits.
 	webhookHandler := webhooks.NewHandler(instanceStore, registry, wsHub, requestService, contentNotifier)
 
+	// Update checker (GitHub release comparison) + server settings (the
+	// admin-configured management-portal URL the update banner links to).
+	updateChecker := update.NewChecker(version.Version, cfg.DisableUpdateCheck)
+	serverSettings := serversettings.NewService(database)
+
 	// Router
-	router := api.NewRouter(cfg, authHandler, authService, requestHandler, remediationService, remediationHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler, webhookHandler, plexHandler, plexService)
+	router := api.NewRouter(cfg, authHandler, authService, requestHandler, remediationService, remediationHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler, webhookHandler, plexHandler, plexService, updateChecker, serverSettings)
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	log.Printf("Cantinarr server starting on %s", addr)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -22,7 +22,10 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/push"
 	"github.com/windoze95/cantinarr-server/internal/remediation"
 	"github.com/windoze95/cantinarr-server/internal/request"
+	"github.com/windoze95/cantinarr-server/internal/serversettings"
 	"github.com/windoze95/cantinarr-server/internal/tautulli"
+	"github.com/windoze95/cantinarr-server/internal/update"
+	"github.com/windoze95/cantinarr-server/internal/version"
 	"github.com/windoze95/cantinarr-server/internal/web"
 	"github.com/windoze95/cantinarr-server/internal/webhooks"
 	ws "github.com/windoze95/cantinarr-server/internal/websocket"
@@ -50,6 +53,8 @@ func NewRouter(
 	webhookHandler *webhooks.Handler,
 	plexHandler *plex.Handler,
 	plexService *plex.Service,
+	updateChecker *update.Checker,
+	serverSettings *serversettings.Service,
 ) http.Handler {
 	r := chi.NewRouter()
 
@@ -152,6 +157,12 @@ func NewRouter(
 			// Setup checklist: which features are configured, derived live on
 			// every request (drives the app's setup wizard + reminders).
 			r.With(auth.RequirePermission(auth.PermissionInstancesManage)).Get("/setup-status", setupStatusHandler(cfg, instanceStore, creds, plexService))
+
+			// Update availability + the admin-configured management-portal URL that
+			// backs the "update available" banner. GET returns both; PUT sets the
+			// management URL.
+			r.With(auth.RequirePermission(auth.PermissionInstancesManage)).Get("/update-status", updateStatusHandler(updateChecker, serverSettings))
+			r.With(auth.RequirePermission(auth.PermissionInstancesManage)).Put("/update-status", updateServerSettingsHandler(updateChecker, serverSettings))
 
 			// Plex integration: link the admin's Plex account (PIN flow), pick
 			// the server/libraries invites share, and send one-tap invites for
@@ -493,6 +504,7 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"server_name":     cfg.ServerName,
+			"version":         version.Version,
 			"services":        services,
 			"instances":       instances,
 			"issues_enabled":  remSettings.Enabled,

--- a/server/internal/api/update_status.go
+++ b/server/internal/api/update_status.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/windoze95/cantinarr-server/internal/serversettings"
+	"github.com/windoze95/cantinarr-server/internal/update"
+)
+
+// updateStatusResponse is the admin-only payload behind the "update available"
+// banner: the latest-release comparison plus the optional management-portal URL
+// an admin can point the banner's action button at.
+type updateStatusResponse struct {
+	Update        update.Status `json:"update"`
+	ManagementURL string        `json:"management_url"`
+}
+
+// updateStatusHandler serves GET /api/admin/update-status.
+func updateStatusHandler(checker *update.Checker, settings *serversettings.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(updateStatusResponse{
+			Update:        checker.Status(),
+			ManagementURL: settings.Get().ManagementURL,
+		})
+	}
+}
+
+// updateServerSettingsHandler serves PUT /api/admin/update-status. It sets the
+// management-portal URL and returns the full status in one round-trip.
+func updateServerSettingsHandler(checker *update.Checker, settings *serversettings.Service) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var body struct {
+			ManagementURL string `json:"management_url"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "invalid request body"})
+			return
+		}
+		saved, err := settings.Set(serversettings.Settings{ManagementURL: body.ManagementURL})
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(updateStatusResponse{
+			Update:        checker.Status(),
+			ManagementURL: saved.ManagementURL,
+		})
+	}
+}

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -37,6 +37,9 @@ type Config struct {
 	PushGatewayURL  string
 	PushAPIKey      string
 	PushEnrollToken string
+	// DisableUpdateCheck turns off the periodic GitHub release check that powers
+	// the admin "update available" banner (CANTINARR_DISABLE_UPDATE_CHECK).
+	DisableUpdateCheck bool
 }
 
 func Load() (*Config, error) {
@@ -59,6 +62,8 @@ func Load() (*Config, error) {
 		PushAPIKey:         os.Getenv("CANTINARR_PUSH_API_KEY"),
 		PushEnrollToken:    os.Getenv("CANTINARR_PUSH_ENROLL_TOKEN"),
 	}
+
+	cfg.DisableUpdateCheck = envBool(os.Getenv("CANTINARR_DISABLE_UPDATE_CHECK"))
 
 	if cfg.ServerName == "" {
 		cfg.ServerName = "Cantinarr"
@@ -110,6 +115,17 @@ func splitEnvList(value string) []string {
 		}
 	}
 	return result
+}
+
+// envBool parses a boolean environment variable. It accepts 1/true/yes/on
+// (case-insensitive) as true; everything else (including empty) is false.
+func envBool(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizeAndroidFingerprints(values []string) ([]string, error) {

--- a/server/internal/serversettings/serversettings.go
+++ b/server/internal/serversettings/serversettings.go
@@ -1,0 +1,74 @@
+// Package serversettings stores small, admin-editable, server-wide preferences
+// in the settings key/value table (mirroring the remediation/request settings
+// pattern). Today it holds only the optional management-portal URL that the
+// "update available" banner links to.
+package serversettings
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+const settingsKey = "server_settings"
+
+// Settings is the server-wide admin preferences blob. It is stored as JSON and
+// unmarshalled over the zero value, so adding a field later is migration-free.
+type Settings struct {
+	// ManagementURL is an optional link to the admin's own container-management
+	// portal (e.g. an Unraid or Portainer page). Empty means "not configured".
+	ManagementURL string `json:"management_url"`
+}
+
+// Service reads and writes the server settings blob.
+type Service struct {
+	db *sql.DB
+}
+
+// NewService returns a settings service backed by the given database.
+func NewService(db *sql.DB) *Service {
+	return &Service{db: db}
+}
+
+// Get returns the stored settings, or the zero value when none are saved.
+func (s *Service) Get() Settings {
+	var out Settings
+	var v string
+	if err := s.db.QueryRow("SELECT value FROM settings WHERE key = ?", settingsKey).Scan(&v); err == nil && v != "" {
+		_ = json.Unmarshal([]byte(v), &out)
+	}
+	out.ManagementURL = strings.TrimSpace(out.ManagementURL)
+	return out
+}
+
+// Set validates and persists the settings, returning the stored value.
+func (s *Service) Set(in Settings) (Settings, error) {
+	in.ManagementURL = strings.TrimSpace(in.ManagementURL)
+	if err := validateURL(in.ManagementURL); err != nil {
+		return Settings{}, err
+	}
+	data, err := json.Marshal(in)
+	if err != nil {
+		return Settings{}, fmt.Errorf("encode server settings: %w", err)
+	}
+	if _, err := s.db.Exec("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", settingsKey, string(data)); err != nil {
+		return Settings{}, fmt.Errorf("save server settings: %w", err)
+	}
+	return in, nil
+}
+
+// validateURL accepts an empty string (clears the setting) or an absolute
+// http(s) URL; anything else is rejected so the banner never links somewhere
+// unusable.
+func validateURL(raw string) error {
+	if raw == "" {
+		return nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return fmt.Errorf("management_url must be an http(s) URL")
+	}
+	return nil
+}

--- a/server/internal/serversettings/serversettings_test.go
+++ b/server/internal/serversettings/serversettings_test.go
@@ -1,0 +1,29 @@
+package serversettings
+
+import "testing"
+
+func TestValidateURL(t *testing.T) {
+	valid := []string{
+		"", // empty clears the setting
+		"http://tower.local/Docker",
+		"https://portainer.example.com",
+		"http://192.168.1.10:9000/#/containers",
+	}
+	for _, u := range valid {
+		if err := validateURL(u); err != nil {
+			t.Errorf("validateURL(%q) = %v, want nil", u, err)
+		}
+	}
+
+	invalid := []string{
+		"tower.local/Docker", // no scheme
+		"ftp://host/path",    // wrong scheme
+		"http://",            // no host
+		"just some text",
+	}
+	for _, u := range invalid {
+		if err := validateURL(u); err == nil {
+			t.Errorf("validateURL(%q) = nil, want error", u)
+		}
+	}
+}

--- a/server/internal/update/update.go
+++ b/server/internal/update/update.go
@@ -1,0 +1,194 @@
+// Package update reports whether a newer Cantinarr release is available.
+//
+// It compares the running server version against the latest published GitHub
+// release. The check is best-effort and never blocks the request path: callers
+// get the last cached result immediately, and a stale cache triggers a
+// background refresh. The checker makes no outbound request at all unless the
+// running version is a real semver tag, so dev, "latest", and PR builds never
+// contact GitHub.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// repoSlug is the GitHub "owner/repo" whose releases are checked.
+const repoSlug = "windoze95/cantinarr"
+
+const (
+	// checkInterval is how long a successful result is cached.
+	checkInterval = 12 * time.Hour
+	// errorBackoff is how long to wait before retrying after a failed check, so
+	// a GitHub outage can't turn every /api/config call into a fetch attempt.
+	errorBackoff = 1 * time.Hour
+)
+
+// Status is the update state surfaced to admin clients.
+type Status struct {
+	Current   string `json:"current"`
+	Latest    string `json:"latest"`
+	Available bool   `json:"available"`
+	URL       string `json:"url"`
+}
+
+// Checker holds the running version and a cached view of the latest release.
+// The zero value is not usable; construct one with NewChecker.
+type Checker struct {
+	current  string
+	disabled bool
+	client   *http.Client
+
+	mu        sync.Mutex
+	cached    Status
+	nextCheck time.Time
+	checking  bool
+}
+
+// NewChecker returns a checker for the given running version. It is disabled
+// (never contacts GitHub) when disable is true or when current is not a
+// comparable semver — there is nothing to compare a "dev"/"latest"/PR build to.
+func NewChecker(current string, disable bool) *Checker {
+	_, ok := parseVersion(current)
+	return &Checker{
+		current:  current,
+		disabled: disable || !ok,
+		client:   &http.Client{Timeout: 15 * time.Second},
+		cached:   Status{Current: current},
+	}
+}
+
+// Status returns the latest known update status without blocking. When the
+// cached result is stale it kicks off a background refresh and returns the
+// current (possibly stale) snapshot.
+func (c *Checker) Status() Status {
+	if c == nil {
+		return Status{}
+	}
+	if c.disabled {
+		return Status{Current: c.current}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.checking && time.Now().After(c.nextCheck) {
+		c.checking = true
+		go c.refresh()
+	}
+	return c.cached
+}
+
+// refresh fetches the latest release and updates the cache. It runs in its own
+// goroutine and swallows all errors (best-effort): on failure the previous
+// cache is kept and the next attempt is delayed by errorBackoff.
+func (c *Checker) refresh() {
+	tag, url, err := c.fetchLatest()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.checking = false
+	if err != nil {
+		c.nextCheck = time.Now().Add(errorBackoff)
+		return
+	}
+	c.cached = Status{
+		Current:   c.current,
+		Latest:    strings.TrimPrefix(tag, "v"),
+		Available: isNewer(c.current, tag),
+		URL:       url,
+	}
+	c.nextCheck = time.Now().Add(checkInterval)
+}
+
+// fetchLatest asks GitHub for the latest published (non-prerelease) release.
+func (c *Checker) fetchLatest() (tag, url string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	endpoint := "https://api.github.com/repos/" + repoSlug + "/releases/latest"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", "", err
+	}
+	// GitHub requires a User-Agent and recommends an explicit API version.
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "cantinarr-update-check")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("github releases/latest: unexpected status %d", resp.StatusCode)
+	}
+	var body struct {
+		TagName string `json:"tag_name"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", "", err
+	}
+	if body.TagName == "" {
+		return "", "", fmt.Errorf("github releases/latest: empty tag_name")
+	}
+	return body.TagName, body.HTMLURL, nil
+}
+
+type semver struct{ major, minor, patch int }
+
+// parseVersion parses a lenient "vMAJOR.MINOR.PATCH" (the v is optional, and
+// any -prerelease/+build suffix is ignored). It returns ok=false for anything
+// non-numeric like "dev", "latest", or "pr-42".
+func parseVersion(s string) (semver, bool) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	s = strings.TrimPrefix(s, "V")
+	if i := strings.IndexAny(s, "-+"); i >= 0 {
+		s = s[:i]
+	}
+	if s == "" {
+		return semver{}, false
+	}
+	var out semver
+	for i, part := range strings.Split(s, ".") {
+		if i > 2 {
+			break
+		}
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			return semver{}, false
+		}
+		switch i {
+		case 0:
+			out.major = n
+		case 1:
+			out.minor = n
+		case 2:
+			out.patch = n
+		}
+	}
+	return out, true
+}
+
+// isNewer reports whether latest is a strictly greater semver than current. If
+// either side is not comparable, it returns false (never nag on ambiguity).
+func isNewer(current, latest string) bool {
+	c, ok1 := parseVersion(current)
+	l, ok2 := parseVersion(latest)
+	if !ok1 || !ok2 {
+		return false
+	}
+	if l.major != c.major {
+		return l.major > c.major
+	}
+	if l.minor != c.minor {
+		return l.minor > c.minor
+	}
+	return l.patch > c.patch
+}

--- a/server/internal/update/update_test.go
+++ b/server/internal/update/update_test.go
@@ -1,0 +1,71 @@
+package update
+
+import "testing"
+
+func TestIsNewer(t *testing.T) {
+	cases := []struct {
+		name            string
+		current, latest string
+		want            bool
+	}{
+		{"patch bump", "1.2.3", "1.2.4", true},
+		{"minor bump", "1.2.3", "1.3.0", true},
+		{"major bump", "1.2.3", "2.0.0", true},
+		{"same version", "1.2.3", "1.2.3", false},
+		{"older patch", "1.2.3", "1.2.2", false},
+		{"older minor", "1.2.3", "1.1.9", false},
+		{"v prefix tolerated", "v1.2.3", "v1.2.4", true},
+		{"mixed prefix", "1.2.3", "v1.2.4", true},
+		{"prerelease suffix ignored", "1.2.3", "1.2.4-rc1", true},
+		{"two-component latest", "1.2.0", "1.3", true},
+		{"current not comparable", "dev", "1.2.3", false},
+		{"latest not comparable", "1.2.3", "latest", false},
+		{"latest tag build", "latest", "1.2.3", false},
+		{"pr build", "pr-42", "1.2.3", false},
+		{"empty current", "", "1.2.3", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNewer(tc.current, tc.latest); got != tc.want {
+				t.Fatalf("isNewer(%q, %q) = %v, want %v", tc.current, tc.latest, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNewCheckerDisabledForNonSemver(t *testing.T) {
+	c := NewChecker("dev", false)
+	if !c.disabled {
+		t.Fatal("checker should be disabled for a non-semver running version")
+	}
+	st := c.Status()
+	if st.Available {
+		t.Fatal("a dev build must never report an update available")
+	}
+	if st.Current != "dev" {
+		t.Fatalf("Status().Current = %q, want %q", st.Current, "dev")
+	}
+}
+
+func TestNewCheckerDisabledExplicitly(t *testing.T) {
+	c := NewChecker("1.2.3", true)
+	if !c.disabled {
+		t.Fatal("checker should be disabled when disable=true")
+	}
+	if got := c.Status(); got.Available {
+		t.Fatal("a disabled checker must never report an update available")
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	if _, ok := parseVersion("1.2.3"); !ok {
+		t.Fatal("1.2.3 should parse")
+	}
+	if _, ok := parseVersion("garbage"); ok {
+		t.Fatal("garbage should not parse")
+	}
+	v, ok := parseVersion("v2.5")
+	if !ok || v.major != 2 || v.minor != 5 || v.patch != 0 {
+		t.Fatalf("v2.5 parsed as %+v ok=%v", v, ok)
+	}
+}

--- a/server/internal/version/version.go
+++ b/server/internal/version/version.go
@@ -1,0 +1,11 @@
+// Package version exposes the build-time version of the Cantinarr server.
+package version
+
+// Version is the running server version. It defaults to "dev" for local and
+// untagged builds and is overridden at build time via:
+//
+//	-ldflags "-X github.com/windoze95/cantinarr-server/internal/version.Version=$VERSION"
+//
+// Release images bake the git tag here so the server can report its own version
+// and compare it against the latest published GitHub release.
+var Version = "dev"


### PR DESCRIPTION
## What

Adds an admin-facing "update available" banner and gives the server a runtime version.

**Server**
- `internal/version`: build version stamped via `-ldflags -X` (root Dockerfile, `server/Dockerfile`, Makefile, plus a `VERSION` build-arg from the tag `docker.yml` already computes). Exposed as `version` in `/api/config` (all clients, for the About screen).
- `internal/update`: compares the running build against the latest published GitHub release using a small in-package semver compare (no new dependency). 12h cache, non-blocking (returns cached, refreshes in the background). **Only real semver-tagged builds check** — dev / `latest` / PR builds never contact GitHub. Opt out with `CANTINARR_DISABLE_UPDATE_CHECK=1`.
- `GET/PUT /api/admin/update-status` (gated by `instances:manage`): returns `{update, management_url}`; PUT sets the validated (http/https) management-portal URL, stored in a new `internal/serversettings` blob.

**App**
- Dismissible, per-release, admin-only banner mounted app-wide (beside `_ReconnectingBanner`). Its action links to the admin's configured **management portal** if set, otherwise `docs/updating.md`; a "Notes" link opens the GitHub release.
- **Update Portal** field in Settings → Admin (deployment-agnostic — Unraid/Portainer/whatever).
- About sheet shows the running server version.
- `update_status` service/provider mirroring `setup_status`; refreshes on app resume.

**Docs**
- New `docs/updating.md` (compose / docker run / Watchtower / your platform's update action).
- README + server/README + app/README updated (env var, new route, Settings entry).

## Why not a self-updater

Updating a container from inside itself needs host-level access (the Docker socket) — effectively root on the host for an admin-exposed app. Instead the banner **points** at the update: the admin's own management portal, or the guide. On Unraid/Portainer/etc. their native "apply update" does the pull-and-recreate.

## Test plan

- `go vet ./...` + `go test ./...` — green (new tests: semver compare, URL validation).
- `flutter analyze --no-fatal-infos` — no new issues; `flutter test` — 212 pass (new: update-status parse).
- Verified `ldflags` stamping bakes the version into the binary.
- Not locally runnable: the live banner render (needs a server reporting an update) and the Docker build's `VERSION` build-arg — both exercised in CI.

## Docs checklist

- [x] Updated the owning docs in this PR (README, server/README, app/README, docs/updating.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
