### PR TITLE
Group nav drawer into sections; rename Dashboard → Discover

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -8,7 +8,7 @@ Built with Flutter; iOS, Android, and web are the shipping targets (web is embed
 ┌──────────────────────────────────────────────────────┐
 │                   Cantinarr App                      │
 │                                                      │
-│  Dashboard · Requests · Movies · TV · Books ·        │
+│  Discover · Requests · Movies · TV · Books ·         │
 │  Downloads · Tautulli · Issues · AI · Settings       │
 │                        │                             │
 │                        ▼                             │
@@ -48,7 +48,7 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 - **Ever-present search bar** -- debounced multi-search from anywhere in the shell. Results carry **requester-vocabulary availability chips** (Available / Partially Available / Requested -- never arr jargon), matched against the user's default library and kept fresh via WebSocket pings.
 - **Search-to-AI hand-off** -- a query that looks like a question (or returns nothing) lights up an AI affordance; the chat opens inline in the shell and shares one conversation with the full-screen assistant.
 
-### Dashboard
+### Discover
 - **Movies / TV tabs** -- discovery rows plus live library rows from the user's default instances: Downloading Soon, Recently Downloaded, Airing Next.
 - **Releases tab** -- a unified movie + episode release timeline with list and month-calendar views.
 - **Books tab** -- appears only for users with a Chaptarr grant: owned-aware book search with per-format request buttons (see Books).

--- a/app/lib/core/providers/module_provider.dart
+++ b/app/lib/core/providers/module_provider.dart
@@ -57,11 +57,13 @@ class ModuleNotifier extends Notifier<ModuleState> {
       {bool isAdmin = false}) {
     final modules = <AppModule>[];
 
-    // Dashboard is always available
+    // Discover (the browse/home surface) is always available. Kept internally
+    // as ModuleType.dashboard / the /dashboard/* routes; only the user-facing
+    // label reads "Discover".
     modules.add(const AppModule(
       type: ModuleType.dashboard,
-      label: 'Dashboard',
-      icon: Icons.dashboard,
+      label: 'Discover',
+      icon: Icons.explore,
     ));
 
     if (connection != null) {

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -901,6 +901,94 @@ class _AppShellState extends ConsumerState<AppShell>
     final showSetupReminder =
         setupRemaining > 0 && ref.watch(setupReminderEnabledProvider);
 
+    // AI Assistant is a tool, not a library, so it sits with the footer actions
+    // instead of under the "Libraries" header. It's always last in
+    // moduleState.modules, so pulling it out leaves the remaining indices (used
+    // by the active-highlight fallback below) unchanged.
+    AppModule? assistantModule;
+    final libraryModules = <AppModule>[];
+    for (final m in moduleState.modules) {
+      if (m.type == ModuleType.assistant) {
+        assistantModule = m;
+      } else {
+        libraryModules.add(m);
+      }
+    }
+
+    // Builds one module row (plus its desktop sub-pages when active). [index]
+    // is the module's position in moduleState.modules, used for the active-
+    // highlight fallback when the current route isn't itself a module path.
+    Widget buildModuleTile(int index, AppModule module) {
+      final isActive = pathModule != null
+          ? module.type == pathModule
+          : index == moduleState.activeIndex;
+      final selectorInstances = isAdmin
+          ? _instancesForModule(instanceState, module.type)
+          : const <ServiceInstance>[];
+      final activeInstance =
+          _activeInstanceForModule(instanceState, module.type);
+
+      final item = _DrawerItem(
+        icon: module.icon,
+        title: module.label,
+        selected: isActive,
+        trailing: selectorInstances.length > 1
+            ? _InstanceSelector(
+                appName: module.label,
+                instances: selectorInstances,
+                activeInstanceId: activeInstance?.id,
+                onSelected: (instanceId) {
+                  if (isOverlay) Navigator.pop(context);
+                  _navigateToModule(
+                    context,
+                    module,
+                    instanceId: instanceId,
+                  );
+                  if (module.type != ModuleType.assistant) {
+                    ref
+                        .read(moduleProvider.notifier)
+                        .setActiveModule(module.type);
+                  }
+                },
+              )
+            : null,
+        onTap: () {
+          if (isOverlay) Navigator.pop(context);
+          _navigateToModule(
+            context,
+            module,
+            instanceId: _defaultInstanceForModule(
+              instanceState,
+              module.type,
+            )?.id,
+          );
+          if (module.type != ModuleType.assistant) {
+            ref.read(moduleProvider.notifier).setActiveModule(
+                  module.type,
+                );
+          }
+        },
+      );
+
+      final pages = !isOverlay && isActive
+          ? modulePagesFor(module.type, includeBooks: hasChaptarrService)
+          : const <ModulePage>[];
+      if (pages.isEmpty) return item;
+
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          item,
+          for (final page in pages)
+            _DrawerSubItem(
+              page: page,
+              selected: widget.currentPath == page.route,
+              onTap: () => context.go(page.route),
+            ),
+        ],
+      );
+    }
+
     return SafeArea(
       child: Column(
         children: [
@@ -938,9 +1026,10 @@ class _AppShellState extends ConsumerState<AppShell>
           ),
           const Divider(color: AppTheme.border),
 
-          // Admin approval queue — kept above the modules so a waiting count is
+          // Admin action queues — kept above the modules so a waiting count is
           // the first thing an admin sees when the drawer opens.
           if (isAdmin) ...[
+            const _DrawerSectionHeader('Needs attention'),
             _DrawerItem(
               icon: Icons.fact_check_outlined,
               title: 'Approvals',
@@ -959,15 +1048,19 @@ class _AppShellState extends ConsumerState<AppShell>
                 context.push('/issues');
               },
             ),
-            _DrawerItem(
-              icon: Icons.build_circle_outlined,
-              title: 'Agent fixes',
-              badgeCount: pendingAgentActions,
-              onTap: () {
-                if (isOverlay) Navigator.pop(context);
-                context.push('/agent-actions');
-              },
-            ),
+            // Only while fixes await review: the screen is a pending queue
+            // (empty at zero), agent-run history stays reachable via Issues, and
+            // a push for a new proposal deep-links straight here.
+            if (pendingAgentActions > 0)
+              _DrawerItem(
+                icon: Icons.build_circle_outlined,
+                title: 'Agent fixes',
+                badgeCount: pendingAgentActions,
+                onTap: () {
+                  if (isOverlay) Navigator.pop(context);
+                  context.push('/agent-actions');
+                },
+              ),
             // Appears only while someone is waiting on a Plex invite (e.g.
             // the push was missed or an auto-invite failed); lands on the
             // Users screen where the invite is one tap.
@@ -996,90 +1089,37 @@ class _AppShellState extends ConsumerState<AppShell>
             const Divider(color: AppTheme.border),
           ],
 
-          // Scrollable module navigation items. On desktop the active module
-          // also expands into its pages — those replace the module shell's
-          // bottom nav there. The mobile drawer stays modules-only because
-          // the bottom nav covers page switching.
+          // Module navigation. Discover (the browse/home surface) leads on its
+          // own; the "Libraries" header groups the managed arr modules beneath
+          // it. On desktop the active module also expands into its pages — those
+          // replace the module shell's bottom nav there. The mobile drawer stays
+          // modules-only because the bottom nav covers page switching.
           Expanded(
             child: ListView(
               padding: EdgeInsets.zero,
-              children: moduleState.modules.asMap().entries.map((entry) {
-                final module = entry.value;
-                final isActive = pathModule != null
-                    ? module.type == pathModule
-                    : entry.key == moduleState.activeIndex;
-                final selectorInstances = isAdmin
-                    ? _instancesForModule(instanceState, module.type)
-                    : const <ServiceInstance>[];
-                final activeInstance =
-                    _activeInstanceForModule(instanceState, module.type);
-
-                final item = _DrawerItem(
-                  icon: module.icon,
-                  title: module.label,
-                  selected: isActive,
-                  trailing: selectorInstances.length > 1
-                      ? _InstanceSelector(
-                          appName: module.label,
-                          instances: selectorInstances,
-                          activeInstanceId: activeInstance?.id,
-                          onSelected: (instanceId) {
-                            if (isOverlay) Navigator.pop(context);
-                            _navigateToModule(
-                              context,
-                              module,
-                              instanceId: instanceId,
-                            );
-                            if (module.type != ModuleType.assistant) {
-                              ref
-                                  .read(moduleProvider.notifier)
-                                  .setActiveModule(module.type);
-                            }
-                          },
-                        )
-                      : null,
-                  onTap: () {
-                    if (isOverlay) Navigator.pop(context);
-                    _navigateToModule(
-                      context,
-                      module,
-                      instanceId: _defaultInstanceForModule(
-                        instanceState,
-                        module.type,
-                      )?.id,
-                    );
-                    if (module.type != ModuleType.assistant) {
-                      ref.read(moduleProvider.notifier).setActiveModule(
-                            module.type,
-                          );
-                    }
-                  },
-                );
-
-                final pages = !isOverlay && isActive
-                    ? modulePagesFor(module.type,
-                        includeBooks: hasChaptarrService)
-                    : const <ModulePage>[];
-                if (pages.isEmpty) return item;
-
-                return Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    item,
-                    for (final page in pages)
-                      _DrawerSubItem(
-                        page: page,
-                        selected: widget.currentPath == page.route,
-                        onTap: () => context.go(page.route),
-                      ),
-                  ],
-                );
-              }).toList(),
+              children: [
+                if (libraryModules.isNotEmpty)
+                  buildModuleTile(0, libraryModules.first),
+                if (libraryModules.length > 1) ...[
+                  const _DrawerSectionHeader('Libraries'),
+                  for (int i = 1; i < libraryModules.length; i++)
+                    buildModuleTile(i, libraryModules[i]),
+                ],
+              ],
             ),
           ),
 
           const Divider(color: AppTheme.border),
 
+          if (assistantModule != null)
+            _DrawerItem(
+              icon: assistantModule.icon,
+              title: assistantModule.label,
+              onTap: () {
+                if (isOverlay) Navigator.pop(context);
+                context.push('/assistant');
+              },
+            ),
           if (ref.watch(plexGuideEnabledProvider))
             _DrawerItem(
               icon: Icons.play_circle_outline,
@@ -1232,6 +1272,30 @@ class _DrawerItem extends StatelessWidget {
       selectedTileColor: AppTheme.accent.withValues(alpha: 0.08),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
       onTap: onTap,
+    );
+  }
+}
+
+/// A small caps label that segments the drawer into scannable groups
+/// (e.g. "Needs attention", "Libraries"). Purely visual — not tappable.
+class _DrawerSectionHeader extends StatelessWidget {
+  final String label;
+
+  const _DrawerSectionHeader(this.label);
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
+      child: Text(
+        label.toUpperCase(),
+        style: const TextStyle(
+          color: AppTheme.textSecondary,
+          fontSize: 11,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.8,
+        ),
+      ),
     );
   }
 }

--- a/app/test/core/providers/module_provider_test.dart
+++ b/app/test/core/providers/module_provider_test.dart
@@ -22,7 +22,7 @@ void main() {
     await container.pump();
 
     final modules = container.read(moduleProvider).modules;
-    expect(_labels(modules), ['Dashboard']);
+    expect(_labels(modules), ['Discover']);
     expect(_labels(modules), isNot(contains('Main Radarr')));
     expect(_labels(modules), isNot(contains('4K Radarr')));
     expect(_labels(modules), isNot(contains('Radarr')));
@@ -49,7 +49,7 @@ void main() {
     expect(
       _labels(modules),
       containsAll([
-        'Dashboard',
+        'Discover',
         'Radarr',
         'Sonarr',
         'Chaptarr',

--- a/app/test/shell/adaptive_layout_test.dart
+++ b/app/test/shell/adaptive_layout_test.dart
@@ -89,7 +89,7 @@ void main() {
     await pumpShell(tester, size: const Size(1400, 900));
 
     // Persistent sidebar: module list visible without opening any drawer.
-    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.text('Discover'), findsOneWidget);
     expect(find.byIcon(Icons.menu), findsNothing);
 
     // Active module expands into its pages.
@@ -123,7 +123,7 @@ void main() {
     // 'Movies' exists only as a bottom-nav label, not a drawer entry.
     await tester.tap(find.byIcon(Icons.menu));
     await tester.pumpAndSettle();
-    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.text('Discover'), findsOneWidget);
   });
 }
 

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -125,7 +125,7 @@ void main() {
     await tester.tap(find.byIcon(Icons.menu));
     await tester.pumpAndSettle();
 
-    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.text('Discover'), findsOneWidget);
     expect(find.text('Radarr'), findsNothing);
     expect(find.text('Main Radarr'), findsNothing);
     expect(find.text('4K Radarr'), findsNothing);


### PR DESCRIPTION
## What & why

The nav drawer already separated its three zones (admin queues · modules · footer) with dividers, but faint hairlines and no labels made an admin's ~13 items read as one flat wall. This groups them with labels and fixes a couple of naming/placement issues — **no features removed** (requesters already see a short list; all the weight is admin-only).

### Changes
- **Section headers** on the two grouped zones:
  - `NEEDS ATTENTION` over the admin queues (Approvals, Issues, Agent fixes, …)
  - `LIBRARIES` over the managed arr modules
- **Hide "Agent fixes" when idle** — that screen is a *pending* queue (nothing to show at zero). Agent-run history stays reachable via Issues → thread, remediation settings via Settings, and a push for a new proposal deep-links straight to `/agent-actions`.
- **Move "AI Assistant" to the footer** (next to Watch on Plex / Settings) — it's a tool, not a library.
- **Rename "Dashboard" → "Discover"** and promote it above the `LIBRARIES` header. That screen is a discovery home (Popular / Top Rated / Coming Soon rows), not a metrics dashboard — "Discover" is the requester-app idiom (Overseerr/Jellyseerr). Routes and `ModuleType` stay `/dashboard` internally; only the user-facing label changes.

### Before → after (admin)
```
Approvals                     NEEDS ATTENTION
Issues                          Approvals · Issues · (Agent fixes)
Agent fixes                   ─────
Setup checklist          →      Discover
Dashboard  ← selected         LIBRARIES
Radarr · Sonarr · Chaptarr      Radarr · Sonarr · Chaptarr
AI Assistant                  ─────
Watch on Plex · Settings        AI Assistant · Watch on Plex · Settings
```

## Test plan
- `flutter analyze --no-fatal-infos` — 0 errors/warnings (16 pre-existing infos in untouched files).
- `flutter test` — 212 passing. Drawer/sidebar widget tests (admin + non-admin, mobile 390×844 + desktop 1400×900) and module-label tests updated for the new label.
- Docs: `app/README.md` app diagram + screen section renamed to match.
- ⚠️ No runtime screenshot — the Chrome extension isn't connected in my environment, so I couldn't drive the preview harness (`test/preview/preview_main.dart`). The adaptive/drawer widget tests exercise the real render paths in both layouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)