### PR TITLE
Default delete-files on the arr remove confirmations

### DIFF
--- a/app/lib/features/chaptarr/ui/chaptarr_author_list.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_list.dart
@@ -9,7 +9,7 @@ class ChaptarrAuthorList extends StatelessWidget {
   final List<ChaptarrAuthor> authors;
   final void Function(ChaptarrAuthor) onTap;
   final void Function(ChaptarrAuthor)? onSearch;
-  final void Function(ChaptarrAuthor)? onDelete;
+  final void Function(ChaptarrAuthor, {bool deleteFiles})? onDelete;
   final bool embedded;
 
   const ChaptarrAuthorList({
@@ -53,31 +53,56 @@ class ChaptarrAuthorList extends StatelessWidget {
             padding: const EdgeInsets.only(right: 20),
             child: const Icon(Icons.delete, color: Colors.white),
           ),
-          confirmDismiss: (_) => _confirmDelete(context, author.authorName),
-          onDismissed: (_) => onDelete!(author),
+          confirmDismiss: (_) async {
+            final deleteFiles = await _confirmDelete(context, author.authorName);
+            if (deleteFiles == null) return false;
+            onDelete!(author, deleteFiles: deleteFiles);
+            return true;
+          },
           child: tile,
         );
       },
     );
   }
 
+  /// Delete confirmation with an "also delete files" choice (defaulted on).
+  /// Resolves to the delete-files flag, or null when cancelled.
   Future<bool?> _confirmDelete(BuildContext context, String name) {
+    var deleteFiles = true;
     return showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: AppTheme.surface,
-        title: const Text('Delete Author'),
-        content: Text('Remove "$name" from Chaptarr?'),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Cancel')),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: TextButton.styleFrom(foregroundColor: AppTheme.error),
-            child: const Text('Delete'),
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setState) => AlertDialog(
+          backgroundColor: AppTheme.surface,
+          title: const Text('Delete Author'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Remove "$name" from Chaptarr?'),
+              const SizedBox(height: 8),
+              CheckboxListTile(
+                value: deleteFiles,
+                onChanged: (v) => setState(() => deleteFiles = v ?? false),
+                title: const Text('Also delete files from disk',
+                    style: TextStyle(fontSize: 14)),
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
+                activeColor: AppTheme.error,
+              ),
+            ],
           ),
-        ],
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('Cancel')),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, deleteFiles),
+              style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+              child: const Text('Delete'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/features/chaptarr/ui/chaptarr_home_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_home_screen.dart
@@ -186,8 +186,8 @@ class _ChaptarrHomeScreenState extends ConsumerState<ChaptarrHomeScreen> {
                         authors: state.filtered,
                         onTap: _openAuthor,
                         onSearch: _triggerAutomaticSearch,
-                        onDelete: (author) => _notifier!
-                            .deleteAuthor(author.id, deleteFiles: false),
+                        onDelete: (author, {bool deleteFiles = true}) => _notifier!
+                            .deleteAuthor(author.id, deleteFiles: deleteFiles),
                       ),
                     ),
             ),

--- a/app/lib/features/radarr/ui/radarr_home_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_home_screen.dart
@@ -201,8 +201,8 @@ class _RadarrHomeScreenState extends ConsumerState<RadarrHomeScreen> {
                       color: AppTheme.accent,
                       child: RadarrMovieList(
                         movies: state.filtered,
-                        onDelete: (id) =>
-                            _notifier!.deleteMovie(id, deleteFiles: false),
+                        onDelete: (id, {bool deleteFiles = true}) =>
+                            _notifier!.deleteMovie(id, deleteFiles: deleteFiles),
                         onSearch: _triggerAutomaticSearch,
                         onInteractiveSearch: _openInteractiveSearch,
                         onOpen: _openMovie,

--- a/app/lib/features/radarr/ui/radarr_movie_list.dart
+++ b/app/lib/features/radarr/ui/radarr_movie_list.dart
@@ -6,7 +6,7 @@ import '../data/radarr_models.dart';
 /// List of Radarr movies with swipe actions.
 class RadarrMovieList extends StatelessWidget {
   final List<RadarrMovie> movies;
-  final void Function(int id) onDelete;
+  final void Function(int id, {bool deleteFiles}) onDelete;
   final void Function(int id) onSearch;
   final void Function(RadarrMovie movie)? onInteractiveSearch;
   final void Function(RadarrMovie movie)? onOpen;
@@ -48,8 +48,12 @@ class RadarrMovieList extends StatelessWidget {
             padding: const EdgeInsets.only(right: 20),
             child: const Icon(Icons.delete, color: Colors.white),
           ),
-          confirmDismiss: (_) => _confirmDelete(context, movie.title),
-          onDismissed: (_) => onDelete(movie.id),
+          confirmDismiss: (_) async {
+            final deleteFiles = await _confirmDelete(context, movie.title);
+            if (deleteFiles == null) return false;
+            onDelete(movie.id, deleteFiles: deleteFiles);
+            return true;
+          },
           child: _MovieTile(
             movie: movie,
             onSearch: () => onSearch(movie.id),
@@ -63,23 +67,44 @@ class RadarrMovieList extends StatelessWidget {
     );
   }
 
+  /// Delete confirmation with an "also delete files" choice (defaulted on).
+  /// Resolves to the delete-files flag, or null when cancelled.
   Future<bool?> _confirmDelete(BuildContext context, String title) {
+    var deleteFiles = true;
     return showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: AppTheme.surface,
-        title: const Text('Delete Movie'),
-        content: Text('Remove "$title" from Radarr?'),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Cancel')),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: TextButton.styleFrom(foregroundColor: AppTheme.error),
-            child: const Text('Delete'),
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setState) => AlertDialog(
+          backgroundColor: AppTheme.surface,
+          title: const Text('Delete Movie'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Remove "$title" from Radarr?'),
+              const SizedBox(height: 8),
+              CheckboxListTile(
+                value: deleteFiles,
+                onChanged: (v) => setState(() => deleteFiles = v ?? false),
+                title: const Text('Also delete files from disk',
+                    style: TextStyle(fontSize: 14)),
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
+                activeColor: AppTheme.error,
+              ),
+            ],
           ),
-        ],
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('Cancel')),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, deleteFiles),
+              style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+              child: const Text('Delete'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/app/lib/features/sonarr/ui/series_actions.dart
+++ b/app/lib/features/sonarr/ui/series_actions.dart
@@ -82,7 +82,7 @@ Future<void> showSeriesActions(
 /// Remove confirmation with a "delete files" choice. Resolves to the
 /// delete-files flag, or null when cancelled.
 Future<bool?> confirmRemoveSeries(BuildContext context, String title) {
-  var deleteFiles = false;
+  var deleteFiles = true;
   return showDialog<bool>(
     context: context,
     builder: (ctx) => StatefulBuilder(

--- a/app/lib/features/sonarr/ui/sonarr_home_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_home_screen.dart
@@ -254,8 +254,8 @@ class _SonarrHomeScreenState extends ConsumerState<SonarrHomeScreen> {
                       color: AppTheme.accent,
                       child: SonarrSeriesList(
                         series: state.filtered,
-                        onDelete: (id) =>
-                            _notifier!.deleteSeries(id, deleteFiles: false),
+                        onDelete: (id, {bool deleteFiles = true}) =>
+                            _notifier!.deleteSeries(id, deleteFiles: deleteFiles),
                         onSearch: _triggerAutomaticSearch,
                         onInteractiveSearch: _openInteractiveSearch,
                         onOpen: _openSeries,

--- a/app/lib/features/sonarr/ui/sonarr_series_list.dart
+++ b/app/lib/features/sonarr/ui/sonarr_series_list.dart
@@ -8,7 +8,7 @@ import '../data/sonarr_models.dart';
 /// wired.
 class SonarrSeriesList extends StatelessWidget {
   final List<SonarrSeries> series;
-  final void Function(int id) onDelete;
+  final void Function(int id, {bool deleteFiles}) onDelete;
   final void Function(int id) onSearch;
   final void Function(SonarrSeries show)? onInteractiveSearch;
   final void Function(SonarrSeries show)? onOpen;
@@ -52,8 +52,12 @@ class SonarrSeriesList extends StatelessWidget {
             padding: const EdgeInsets.only(right: 20),
             child: const Icon(Icons.delete, color: Colors.white),
           ),
-          confirmDismiss: (_) => _confirmDelete(context, show.title),
-          onDismissed: (_) => onDelete(show.id),
+          confirmDismiss: (_) async {
+            final deleteFiles = await _confirmDelete(context, show.title);
+            if (deleteFiles == null) return false;
+            onDelete(show.id, deleteFiles: deleteFiles);
+            return true;
+          },
           child: _SeriesTile(
             show: show,
             onSearch: () => onSearch(show.id),
@@ -68,23 +72,44 @@ class SonarrSeriesList extends StatelessWidget {
     );
   }
 
+  /// Delete confirmation with an "also delete files" choice (defaulted on).
+  /// Resolves to the delete-files flag, or null when cancelled.
   Future<bool?> _confirmDelete(BuildContext context, String title) {
+    var deleteFiles = true;
     return showDialog<bool>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: AppTheme.surface,
-        title: const Text('Delete Series'),
-        content: Text('Remove "$title" from Sonarr?'),
-        actions: [
-          TextButton(
-              onPressed: () => Navigator.pop(ctx, false),
-              child: const Text('Cancel')),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            style: TextButton.styleFrom(foregroundColor: AppTheme.error),
-            child: const Text('Delete'),
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setState) => AlertDialog(
+          backgroundColor: AppTheme.surface,
+          title: const Text('Delete Series'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Remove "$title" from Sonarr?'),
+              const SizedBox(height: 8),
+              CheckboxListTile(
+                value: deleteFiles,
+                onChanged: (v) => setState(() => deleteFiles = v ?? false),
+                title: const Text('Also delete files from disk',
+                    style: TextStyle(fontSize: 14)),
+                contentPadding: EdgeInsets.zero,
+                controlAffinity: ListTileControlAffinity.leading,
+                activeColor: AppTheme.error,
+              ),
+            ],
           ),
-        ],
+          actions: [
+            TextButton(
+                onPressed: () => Navigator.pop(ctx),
+                child: const Text('Cancel')),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, deleteFiles),
+              style: TextButton.styleFrom(foregroundColor: AppTheme.error),
+              child: const Text('Delete'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/app/test/chaptarr/author_swipe_delete_test.dart
+++ b/app/test/chaptarr/author_swipe_delete_test.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/features/chaptarr/data/chaptarr_api_service.dart';
+import 'package:cantinarr/features/chaptarr/data/chaptarr_models.dart';
+import 'package:cantinarr/features/chaptarr/ui/chaptarr_author_list.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fake Dio adapter: records every request (method, path, query) so the swipe
+/// tests can assert the DELETE and its deleteFiles flag. No GETs are issued.
+class _FakeAdapter implements HttpClientAdapter {
+  final List<({String method, String path, Map<String, dynamic> query})>
+      requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add((
+      method: options.method,
+      path: options.uri.path,
+      query: options.uri.queryParameters,
+    ));
+    return ResponseBody.fromString(
+      jsonEncode(<String, dynamic>{}),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+const _author = ChaptarrAuthor(id: 7, authorName: 'Example Author');
+
+void main() {
+  group('ChaptarrAuthorList swipe-to-delete', () {
+    late _FakeAdapter adapter;
+
+    Future<void> pumpList(WidgetTester tester) async {
+      adapter = _FakeAdapter();
+      final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+        ..httpClientAdapter = adapter;
+      final service = ChaptarrApiService(backendDio: dio, instanceId: 'inst1');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ChaptarrAuthorList(
+              authors: const [_author],
+              onTap: (_) {},
+              onDelete: (author, {bool deleteFiles = true}) =>
+                  service.deleteAuthor(author.id, deleteFiles: deleteFiles),
+            ),
+          ),
+        ),
+      );
+    }
+
+    List<({String method, String path, Map<String, dynamic> query})>
+        deletes() =>
+            adapter.requests.where((r) => r.method == 'DELETE').toList();
+
+    Future<void> swipe(WidgetTester tester) async {
+      await tester.drag(find.text('Example Author'), const Offset(-500, 0));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('swiping shows a confirmation with delete-files pre-checked',
+        (tester) async {
+      await pumpList(tester);
+      await swipe(tester);
+      expect(find.text('Delete Author'), findsOneWidget);
+      expect(find.text('Also delete files from disk'), findsOneWidget);
+      final box = tester.widget<CheckboxListTile>(find.byType(CheckboxListTile));
+      expect(box.value, isTrue);
+    });
+
+    testWidgets('cancelling sends no DELETE and keeps the tile',
+        (tester) async {
+      await pumpList(tester);
+      await swipe(tester);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      expect(deletes(), isEmpty);
+      expect(find.text('Example Author'), findsOneWidget);
+    });
+
+    testWidgets('confirming with the default deletes files from disk',
+        (tester) async {
+      await pumpList(tester);
+      await swipe(tester);
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      final d = deletes();
+      expect(d, hasLength(1));
+      expect(d.single.path, endsWith('/author/7'));
+      expect(d.single.query['deleteFiles'], 'true');
+    });
+
+    testWidgets('unchecking the box confirms without deleting files',
+        (tester) async {
+      await pumpList(tester);
+      await swipe(tester);
+      await tester.tap(find.text('Also delete files from disk'));
+      await tester.pump();
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      final d = deletes();
+      expect(d, hasLength(1));
+      expect(d.single.path, endsWith('/author/7'));
+      expect(d.single.query['deleteFiles'], 'false');
+    });
+  });
+}

--- a/app/test/radarr/movie_swipe_delete_test.dart
+++ b/app/test/radarr/movie_swipe_delete_test.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/features/radarr/data/radarr_api_service.dart';
+import 'package:cantinarr/features/radarr/data/radarr_models.dart';
+import 'package:cantinarr/features/radarr/ui/radarr_movie_list.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fake Dio adapter: records every request (method, path, query) so the swipe
+/// tests can assert the DELETE and its deleteFiles flag. No GETs are issued.
+class _FakeAdapter implements HttpClientAdapter {
+  final List<({String method, String path, Map<String, dynamic> query})>
+      requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add((
+      method: options.method,
+      path: options.uri.path,
+      query: options.uri.queryParameters,
+    ));
+    return ResponseBody.fromString(
+      jsonEncode(<String, dynamic>{}),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+const _movie = RadarrMovie(id: 7, title: 'Example Movie', year: 2020);
+
+void main() {
+  group('RadarrMovieList swipe-to-delete', () {
+    late _FakeAdapter adapter;
+
+    Future<void> pumpList(WidgetTester tester) async {
+      adapter = _FakeAdapter();
+      final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+        ..httpClientAdapter = adapter;
+      final service = RadarrApiService(backendDio: dio, instanceId: 'inst1');
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RadarrMovieList(
+              movies: const [_movie],
+              onDelete: (id, {bool deleteFiles = true}) =>
+                  service.deleteMovie(id, deleteFiles: deleteFiles),
+              onSearch: (_) {},
+            ),
+          ),
+        ),
+      );
+    }
+
+    List<({String method, String path, Map<String, dynamic> query})>
+        deletes() =>
+            adapter.requests.where((r) => r.method == 'DELETE').toList();
+
+    Future<void> swipe(WidgetTester tester) async {
+      await tester.drag(find.text('Example Movie'), const Offset(-500, 0));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('swiping shows a confirmation with delete-files pre-checked',
+        (tester) async {
+      await pumpList(tester);
+      await swipe(tester);
+      expect(find.text('Delete Movie'), findsOneWidget);
+      expect(find.text('Also delete files from disk'), findsOneWidget);
+      final box = tester.widget<CheckboxListTile>(find.byType(CheckboxListTile));
+      expect(box.value, isTrue);
+    });
+
+    testWidgets('cancelling sends no DELETE and keeps the tile',
+        (tester) async {
+      await pumpList(tester);
+      await swipe(tester);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+      expect(deletes(), isEmpty);
+      expect(find.text('Example Movie'), findsOneWidget);
+    });
+
+    testWidgets('confirming with the default deletes files from disk',
+        (tester) async {
+      await pumpList(tester);
+      await swipe(tester);
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      final d = deletes();
+      expect(d, hasLength(1));
+      expect(d.single.path, endsWith('/movie/7'));
+      expect(d.single.query['deleteFiles'], 'true');
+    });
+
+    testWidgets('unchecking the box confirms without deleting files',
+        (tester) async {
+      await pumpList(tester);
+      await swipe(tester);
+      await tester.tap(find.text('Also delete files from disk'));
+      await tester.pump();
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      final d = deletes();
+      expect(d, hasLength(1));
+      expect(d.single.path, endsWith('/movie/7'));
+      expect(d.single.query['deleteFiles'], 'false');
+    });
+  });
+}

--- a/app/test/sonarr/series_actions_test.dart
+++ b/app/test/sonarr/series_actions_test.dart
@@ -210,7 +210,7 @@ void main() {
       expect(changed, 1);
     });
 
-    testWidgets('Remove asks for confirmation and honors delete-files',
+    testWidgets('Remove asks for confirmation and defaults to deleting files',
         (tester) async {
       await pumpHarness(tester);
       await tester.tap(find.text('Remove Series'));
@@ -222,11 +222,28 @@ void main() {
       expect(ofMethod('DELETE'), isEmpty);
       expect(removed, 0);
 
-      // Again, this time deleting files too.
+      // Again, accepting the default — "delete files" is pre-checked.
       await tester.tap(find.text('open'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('Remove Series'));
       await tester.pumpAndSettle();
+      await tester.tap(find.text('Remove'));
+      await tester.pumpAndSettle();
+
+      final deletes = ofMethod('DELETE');
+      expect(deletes, hasLength(1));
+      expect(deletes.single.path, endsWith('/series/7'));
+      expect(deletes.single.query['deleteFiles'], 'true');
+      expect(removed, 1);
+    });
+
+    testWidgets('Remove can opt out of deleting files from disk',
+        (tester) async {
+      await pumpHarness(tester);
+      await tester.tap(find.text('Remove Series'));
+      await tester.pumpAndSettle();
+
+      // Uncheck the pre-checked "delete files" box, then confirm.
       await tester.tap(find.text('Delete files from disk'));
       await tester.pump();
       await tester.tap(find.text('Remove'));
@@ -235,7 +252,7 @@ void main() {
       final deletes = ofMethod('DELETE');
       expect(deletes, hasLength(1));
       expect(deletes.single.path, endsWith('/series/7'));
-      expect(deletes.single.query['deleteFiles'], 'true');
+      expect(deletes.single.query['deleteFiles'], 'false');
       expect(removed, 1);
     });
 

--- a/app/test/sonarr/series_tile_status_test.dart
+++ b/app/test/sonarr/series_tile_status_test.dart
@@ -29,7 +29,7 @@ Future<void> _pump(WidgetTester tester, SonarrSeries show) {
     home: Scaffold(
       body: SonarrSeriesList(
         series: [show],
-        onDelete: (_) {},
+        onDelete: (_, {bool deleteFiles = true}) {},
         onSearch: (_) {},
       ),
     ),


### PR DESCRIPTION
## What

Adds an **"Also delete files from disk"** checkbox — **defaulted ON** — to the swipe-to-remove confirmation dialogs for **Radarr movies**, **Sonarr series**, and **Chaptarr authors**, and threads the chosen value into the existing `deleteFiles` delete param. The Sonarr long-press remove (`confirmRemoveSeries`) also flips its existing checkbox default from OFF to ON, so every remove flow now defaults to deleting the data.

## Why

Removing a title from an *arr while leaving its files on disk is almost never what a user wants — it orphans the media and silently eats space. The confirmation already existed; this makes the destructive-but-expected choice the default while still letting the user opt out with one tap.

## Layers touched (app only)

- **List widgets** (`radarr_movie_list.dart`, `sonarr_series_list.dart`, `chaptarr_author_list.dart`): each delete dialog is wrapped in a `StatefulBuilder` with a pre-checked `CheckboxListTile`, and `_confirmDelete` now resolves to the chosen `bool` (or `null` when cancelled). Each `Dismissible` carries the flag through `confirmDismiss` and drops the separate `onDismissed` delete to avoid a double-delete. The `onDelete` callbacks widen to `(id, {bool deleteFiles})` (Chaptarr keeps its `ChaptarrAuthor` arg).
- **Home screens** (`radarr_home_screen.dart`, `sonarr_home_screen.dart`, `chaptarr_home_screen.dart`): pass the flag straight into the existing `delete*(…, deleteFiles: …)` notifier calls.
- **Sonarr long-press** (`series_actions.dart`): `confirmRemoveSeries` default `false` → `true`.

**Server: no change.** Its reverse proxy forwards `deleteFiles` verbatim, and the app's API services + providers already accept it.

The Sonarr season/episode file-delete flow was deliberately left untouched.

## Test plan

- `flutter analyze --no-fatal-infos` → **0 errors/warnings** (only pre-existing `info` lints in untouched files remain).
- `flutter test` → **all 221 pass.**
- Updated `series_actions_test.dart` for the new default: the default confirm now sends `deleteFiles=true` without tapping, plus a new case where unchecking sends `deleteFiles=false`.
- Added swipe widget tests `test/radarr/movie_swipe_delete_test.dart` and `test/chaptarr/author_swipe_delete_test.dart`: dialog appears with the box pre-checked, cancel sends no DELETE, default confirm calls delete with `deleteFiles=true`, unchecking then confirming calls with `deleteFiles=false` — captured via a fake Dio adapter.
- `season_selection_test.dart` remains green, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eZtcV6t8RZ1WaCURxmSRY