### PR TITLE
Add admin "Open in Radarr/Sonarr" link on media detail

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -61,6 +61,7 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 
 ### Movies & TV management (admin)
 - **Drill-down** -- library → movie detail, or series → season → episode, with per-item download progress, quality/size, history, and messages, proxied verbatim to Radarr/Sonarr API v3.
+- **Open in Radarr/Sonarr** -- on a discovery detail page, admins get a jump into the matching arr item, shown only once the title actually exists there (it appears right after a request adds it). Movies link to Radarr, TV to Sonarr; books are out of scope.
 - **Sonarr episode power tools** -- long-press action menus, episode **multi-select with batch search** (quick-select All / Undownloaded), batch **delete files**, an **All Seasons** view, per-season/series monitor toggles, **Edit Series** (profile, type, path, tags, season folders), and external links (IMDb/TheTVDB/TMDB/Trakt).
 - **Interactive release search** -- per-episode, per-season, per-movie, and per-book: live indexer results with smart sorting, seeders/leechers, and rejection reasons; tap to grab.
 - **Import Doctor** -- any stuck queue item explains itself in plain English with the raw arr messages shown for transparency, then offers ordered one-click fixes (manual/force import with candidates preview, remove, blocklist + re-search, category hand-off, rescan). One shared rule engine drives Sonarr, Radarr, and Chaptarr, mirrored from the server's classifier.

--- a/app/lib/features/media_detail/logic/arr_deep_link.dart
+++ b/app/lib/features/media_detail/logic/arr_deep_link.dart
@@ -1,0 +1,59 @@
+import '../../radarr/data/radarr_models.dart';
+import '../../sonarr/data/sonarr_models.dart';
+
+/// A resolved deep link from a discovery detail screen into the backing *arr
+/// module. Carries the matched library object plus the instance id needed to
+/// push the (imperatively-navigated) arr detail screen.
+///
+/// Exactly one of [movie] / [series] is set — movies deep-link into Radarr, TV
+/// into Sonarr. Books are never resolved here: [MediaDetailScreen] only ever
+/// shows movies and TV, so Chaptarr is out of scope for this affordance.
+class ArrDeepLink {
+  final String instanceId;
+  final RadarrMovie? movie;
+  final SonarrSeries? series;
+
+  const ArrDeepLink({required this.instanceId, this.movie, this.series});
+
+  /// Human label for the owning module, used for "Open in Radarr" / "Open in
+  /// Sonarr".
+  String get moduleLabel => movie != null ? 'Radarr' : 'Sonarr';
+}
+
+/// Finds the Radarr movie in [movies] that corresponds to TMDB id [tmdbId], or
+/// null when the title isn't in the Radarr library yet. The TMDB id is Radarr's
+/// natural key for a movie, so this is an exact match.
+RadarrMovie? matchRadarrMovie(List<RadarrMovie> movies, int tmdbId) {
+  for (final m in movies) {
+    if (m.tmdbId == tmdbId) return m;
+  }
+  return null;
+}
+
+/// Finds the Sonarr series in [series] that corresponds to the show, or null
+/// when it isn't in the Sonarr library yet.
+///
+/// Matches on the TVDB id (Sonarr's natural key) when the discovery side
+/// supplies one; when it doesn't, falls back to a case-insensitive title match.
+/// A known [tvdbId] with no hit is treated as "not in the library" rather than
+/// falling through to a title match, which avoids linking two distinct shows
+/// that happen to share a title.
+SonarrSeries? matchSonarrSeries(
+  List<SonarrSeries> series, {
+  int? tvdbId,
+  String? title,
+}) {
+  if (tvdbId != null) {
+    for (final s in series) {
+      if (s.tvdbId == tvdbId) return s;
+    }
+    return null;
+  }
+  if (title != null && title.isNotEmpty) {
+    final lower = title.toLowerCase();
+    for (final s in series) {
+      if (s.title.toLowerCase() == lower) return s;
+    }
+  }
+  return null;
+}

--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
 import '../../../core/providers/library_refresh_provider.dart';
 import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
@@ -14,11 +15,16 @@ import '../../auth/logic/auth_provider.dart';
 import '../../discover/data/tmdb_models.dart';
 import '../../discover/data/discover_api_service.dart';
 import '../../issues/ui/report_problem_sheet.dart';
+import '../../radarr/data/radarr_api_service.dart';
+import '../../radarr/ui/radarr_movie_detail_screen.dart';
 import '../../request/data/request_service.dart';
 import '../../request/logic/request_provider.dart';
 import '../../request/ui/request_button.dart';
 import '../../request/ui/request_options_sheet.dart';
 import '../../request/ui/request_status_sheet.dart';
+import '../../sonarr/data/sonarr_api_service.dart';
+import '../../sonarr/ui/sonarr_series_detail_screen.dart';
+import '../logic/arr_deep_link.dart';
 import '../logic/media_detail_provider.dart';
 import 'season_table.dart';
 
@@ -52,6 +58,12 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
   /// silent no-op.
   RequestOptions? _requestOptions;
 
+  /// For admins, a resolved deep link into the backing *arr (Radarr for movies,
+  /// Sonarr for TV) when this title actually exists there. Null while loading,
+  /// for non-admins, or when the title has no destination in the arr yet — the
+  /// "Open in …" affordance is shown only when this is non-null.
+  ArrDeepLink? _arrLink;
+
   @override
   void initState() {
     super.initState();
@@ -68,7 +80,11 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
       mediaType: widget.mediaType,
     );
 
-    _detailNotifier.load();
+    // Resolve the arr deep link once the TMDB detail is in — Sonarr matching
+    // needs the show's TVDB id, which only lands after the detail loads.
+    _detailNotifier.load().then((_) {
+      if (mounted) _resolveArrLink();
+    });
     _requestNotifier.checkStatus();
     if (widget.mediaType == MediaType.tv) {
       _requestNotifier.fetchOptions().then((opts) {
@@ -94,6 +110,12 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
         _requestNotifier.checkStatus();
       }
     });
+    // A request just added the title to the arr (main or per-season request
+    // both bump this tick) — re-check so the admin "Open in …" link appears.
+    ref.listen(libraryRefreshTickProvider, (_, __) => _resolveArrLink());
+    // Resolve (or re-resolve) the admin link once auth settles — covers auth
+    // landing after the initial detail load (e.g. an optimistic reconnect).
+    ref.listen(authProvider, (_, __) => _resolveArrLink());
     return ListenableBuilder(
       listenable: _detailNotifier,
       builder: (context, _) {
@@ -215,6 +237,32 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                               );
                             },
                           ),
+
+                          // Admin-only jump into the backing *arr, shown only
+                          // when this title actually exists there (Radarr for
+                          // movies, Sonarr for TV). Non-admins never resolve a
+                          // link, so this stays hidden for them.
+                          if (_arrLink != null) ...[
+                            const SizedBox(height: 12),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
+                              child: OutlinedButton.icon(
+                                onPressed: _openInArr,
+                                icon: const Icon(Icons.open_in_new, size: 18),
+                                label:
+                                    Text('Open in ${_arrLink!.moduleLabel}'),
+                                style: OutlinedButton.styleFrom(
+                                  foregroundColor: AppTheme.textPrimary,
+                                  side:
+                                      const BorderSide(color: AppTheme.border),
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
                           const SizedBox(height: 16),
 
                           // Genres
@@ -456,6 +504,81 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
   /// the next search.
   void _bumpLibraryRefresh() {
     ref.read(libraryRefreshTickProvider.notifier).state++;
+  }
+
+  /// For admins, resolve whether this title already exists in the backing arr
+  /// (Radarr for movies, Sonarr for TV) and, when it does, capture the matched
+  /// library object + instance id so the "Open in …" affordance can push the
+  /// arr detail screen. Runs on load and again after a request (via
+  /// [libraryRefreshTickProvider]). Non-admins never resolve a link, and any
+  /// fetch error leaves the current link untouched (quietly hidden) rather than
+  /// surfacing — the affordance appears only when there's a real destination.
+  Future<void> _resolveArrLink() async {
+    final isAdmin = ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    if (!isAdmin) return;
+
+    final backendDio = ref.read(backendClientProvider);
+    final instances = ref.read(instanceProvider);
+    final connection = ref.read(authProvider).valueOrNull?.connection;
+
+    try {
+      if (widget.mediaType == MediaType.movie) {
+        final instanceId = instances.activeRadarrInstance?.id ??
+            connection?.defaultRadarrInstance?.id;
+        if (instanceId == null) return;
+        final movies = await RadarrApiService(
+          backendDio: backendDio,
+          instanceId: instanceId,
+        ).getMovies();
+        if (!mounted) return;
+        final match = matchRadarrMovie(movies, widget.id);
+        setState(() => _arrLink = match == null
+            ? null
+            : ArrDeepLink(instanceId: instanceId, movie: match));
+      } else {
+        final instanceId = instances.activeSonarrInstance?.id ??
+            connection?.defaultSonarrInstance?.id;
+        if (instanceId == null) return;
+        final series = await SonarrApiService(
+          backendDio: backendDio,
+          instanceId: instanceId,
+        ).getSeries();
+        if (!mounted) return;
+        final match = matchSonarrSeries(
+          series,
+          tvdbId: _detailNotifier.state.tvDetail?.externalIds?.tvdbId,
+          title: _detailNotifier.state.title,
+        );
+        setState(() => _arrLink = match == null
+            ? null
+            : ArrDeepLink(instanceId: instanceId, series: match));
+      }
+    } catch (_) {
+      // Leave any existing link as-is; a transient fetch failure shouldn't
+      // yank a working affordance.
+    }
+  }
+
+  /// Pushes the matched arr detail screen (movie → Radarr, TV → Sonarr) over
+  /// the root navigator, mirroring how the arr home screens open an item.
+  void _openInArr() {
+    final link = _arrLink;
+    if (link == null) return;
+    final movie = link.movie;
+    final series = link.series;
+    final Widget screen;
+    if (movie != null) {
+      screen =
+          RadarrMovieDetailScreen(instanceId: link.instanceId, movie: movie);
+    } else if (series != null) {
+      screen =
+          SonarrSeriesDetailScreen(instanceId: link.instanceId, series: series);
+    } else {
+      return;
+    }
+    Navigator.of(context, rootNavigator: true).push(
+      MaterialPageRoute(builder: (_) => screen),
+    );
   }
 
   /// Reporting is offered only once the title is at least partially in the

--- a/app/test/media_detail/arr_deep_link_test.dart
+++ b/app/test/media_detail/arr_deep_link_test.dart
@@ -1,0 +1,85 @@
+import 'package:cantinarr/features/media_detail/logic/arr_deep_link.dart';
+import 'package:cantinarr/features/radarr/data/radarr_models.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('matchRadarrMovie', () {
+    final movies = [
+      const RadarrMovie(id: 10, title: 'Alpha', year: 2001, tmdbId: 111),
+      const RadarrMovie(id: 20, title: 'Beta', year: 2002, tmdbId: 222),
+    ];
+
+    test('returns the movie whose tmdbId matches', () {
+      final match = matchRadarrMovie(movies, 222);
+      expect(match, isNotNull);
+      expect(match!.id, 20);
+    });
+
+    test('returns null when no movie has that tmdbId', () {
+      expect(matchRadarrMovie(movies, 999), isNull);
+    });
+
+    test('returns null for an empty library', () {
+      expect(matchRadarrMovie(const [], 111), isNull);
+    });
+  });
+
+  group('matchSonarrSeries', () {
+    final series = [
+      const SonarrSeries(id: 1, title: 'The Wire', tvdbId: 79126),
+      const SonarrSeries(id: 2, title: 'Breaking Bad', tvdbId: 81189),
+      // A library entry Sonarr couldn't stamp with a TVDB id.
+      const SonarrSeries(id: 3, title: 'Homegrown Show'),
+    ];
+
+    test('matches on tvdbId when the discovery side supplies one', () {
+      final match = matchSonarrSeries(series, tvdbId: 81189, title: 'Breaking Bad');
+      expect(match, isNotNull);
+      expect(match!.id, 2);
+    });
+
+    test('a known tvdbId with no hit is "not in library" (no title fallback)',
+        () {
+      // tvdbId is authoritative here: even though the title matches id 1, an
+      // unknown tvdbId must not link to a different show.
+      final match = matchSonarrSeries(series, tvdbId: 55555, title: 'The Wire');
+      expect(match, isNull);
+    });
+
+    test('falls back to a case-insensitive title match when tvdbId is null', () {
+      final match =
+          matchSonarrSeries(series, tvdbId: null, title: 'homegrown show');
+      expect(match, isNotNull);
+      expect(match!.id, 3);
+    });
+
+    test('returns null when neither tvdbId nor title matches', () {
+      final match =
+          matchSonarrSeries(series, tvdbId: null, title: 'Unknown Series');
+      expect(match, isNull);
+    });
+
+    test('returns null when tvdbId is null and title is empty', () {
+      expect(matchSonarrSeries(series, tvdbId: null, title: ''), isNull);
+    });
+  });
+
+  group('ArrDeepLink', () {
+    test('labels a movie link as Radarr', () {
+      const link = ArrDeepLink(
+        instanceId: 'r1',
+        movie: RadarrMovie(id: 1, title: 'A', year: 2000, tmdbId: 1),
+      );
+      expect(link.moduleLabel, 'Radarr');
+    });
+
+    test('labels a series link as Sonarr', () {
+      const link = ArrDeepLink(
+        instanceId: 's1',
+        series: SonarrSeries(id: 1, title: 'B', tvdbId: 1),
+      );
+      expect(link.moduleLabel, 'Sonarr');
+    });
+  });
+}

--- a/app/test/media_detail/media_detail_arr_link_test.dart
+++ b/app/test/media_detail/media_detail_arr_link_test.dart
@@ -1,0 +1,176 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/network/websocket_client.dart';
+import 'package:cantinarr/core/providers/realtime_provider.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/discover/data/tmdb_models.dart';
+import 'package:cantinarr/features/media_detail/ui/media_detail_screen.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+// A movie whose TMDB id we render the detail for.
+const _tmdbId = 603;
+
+void main() {
+  Future<void> pumpDetail(
+    WidgetTester tester, {
+    required bool isAdmin,
+    required List<Map<String, dynamic>> radarrMovies,
+  }) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final router = GoRouter(
+      initialLocation: '/detail/movie/$_tmdbId',
+      routes: [
+        GoRoute(
+          path: '/detail/:type/:id',
+          builder: (_, state) => MediaDetailScreen(
+            id: int.parse(state.pathParameters['id']!),
+            mediaType: state.pathParameters['type'] == 'tv'
+                ? MediaType.tv
+                : MediaType.movie,
+          ),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith(() => _FakeAuthNotifier(_state(isAdmin))),
+          backendClientProvider.overrideWithValue(_fakeDio(radarrMovies)),
+          realtimeEventsProvider.overrideWithValue(const Stream<WsEvent>.empty()),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('admin sees "Open in Radarr" when the movie is in the library',
+      (tester) async {
+    await pumpDetail(
+      tester,
+      isAdmin: true,
+      radarrMovies: [
+        {'id': 5, 'title': 'The Matrix', 'year': 1999, 'tmdbId': _tmdbId},
+      ],
+    );
+
+    expect(find.text('Open in Radarr'), findsOneWidget);
+  });
+
+  testWidgets('admin sees no link when the movie is not in the library',
+      (tester) async {
+    await pumpDetail(
+      tester,
+      isAdmin: true,
+      // A different movie — no tmdbId match.
+      radarrMovies: [
+        {'id': 5, 'title': 'Some Other Film', 'year': 2010, 'tmdbId': 111},
+      ],
+    );
+
+    expect(find.text('Open in Radarr'), findsNothing);
+  });
+
+  testWidgets('non-admin never sees the link even when the movie is present',
+      (tester) async {
+    await pumpDetail(
+      tester,
+      isAdmin: false,
+      radarrMovies: [
+        {'id': 5, 'title': 'The Matrix', 'year': 1999, 'tmdbId': _tmdbId},
+      ],
+    );
+
+    expect(find.text('Open in Radarr'), findsNothing);
+  });
+}
+
+AuthState _state(bool isAdmin) => AuthState(
+      connection: const BackendConnection(
+        serverUrl: 'http://localhost',
+        accessToken: 'access',
+        refreshToken: 'refresh',
+        instances: [
+          ServiceInstance(
+            id: 'radarr-main',
+            serviceType: 'radarr',
+            name: 'Main Radarr',
+            isDefault: true,
+          ),
+        ],
+      ),
+      user: UserProfile(
+        id: 1,
+        username: isAdmin ? 'admin' : 'viewer',
+        role: isAdmin ? 'admin' : 'user',
+      ),
+    );
+
+class _FakeAuthNotifier extends AuthNotifier {
+  final AuthState authState;
+
+  _FakeAuthNotifier(this.authState);
+
+  @override
+  Future<AuthState> build() async => authState;
+}
+
+Dio _fakeDio(List<Map<String, dynamic>> radarrMovies) {
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+  dio.httpClientAdapter = _JsonAdapter(radarrMovies);
+  return dio;
+}
+
+/// Minimal backend stub: the TMDB detail load, the request-status check, and
+/// the Radarr library listing the "Open in Radarr" resolution depends on.
+class _JsonAdapter implements HttpClientAdapter {
+  final List<Map<String, dynamic>> radarrMovies;
+
+  _JsonAdapter(this.radarrMovies);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final path = options.path;
+    final Object body;
+    if (path.contains('/api/v3/movie')) {
+      body = radarrMovies; // Radarr library listing.
+    } else if (path.endsWith('/recommendations') || path.endsWith('/similar')) {
+      body = {'results': <dynamic>[]};
+    } else if (path.endsWith('/status')) {
+      body = {'status': 'unavailable', 'seasons': <dynamic>[]};
+    } else if (path.contains('/api/media/movie/')) {
+      body = {'id': _tmdbId, 'title': 'The Matrix'};
+    } else {
+      body = <dynamic>[];
+    }
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}


### PR DESCRIPTION
## What
On the discovery/request **media-detail screen**, admins now get an **Open in Radarr / Open in Sonarr** affordance that jumps straight to the matching item in the backing *arr module (movie → Radarr, TV → Sonarr). It renders only when the title actually exists in that arr, and it **appears right after an admin's request adds it**.

## Why
Admins triaging a request often want to hop from the requester-facing detail page into the full arr drill-down (queue, history, interactive search, Import Doctor) for that exact title. Today that means switching to the Radarr/Sonarr module and searching for it by hand.

## How existence is detected
The arr detail screens are pushed imperatively with a hydrated model + `instanceId` (they're not go_router routes), so we can't build a URL — we resolve the destination live:
- Resolve the active instance id (`instanceProvider.activeRadarr/SonarrInstance?.id`, falling back to `connection.defaultRadarr/SonarrInstance?.id`).
- Fetch that instance's arr library and match:
  - **Radarr:** `getMovies()` → first movie whose `tmdbId == widget.id`.
  - **Sonarr:** `getSeries()` → match on `tvdbId` (the show's TVDB id from `tvDetail.externalIds`); case-insensitive **title** fallback only when the discovery side has no `tvdbId`. A known `tvdbId` with no hit is treated as "not in library" (avoids linking two different shows that share a title).
- The matched `RadarrMovie` / `SonarrSeries` + `instanceId` are pushed onto the root navigator exactly as `RadarrHomeScreen`/`SonarrHomeScreen` open an item.

The lookup runs for **admins only** (non-admins never resolve a link and never have instances). Any fetch error leaves the current link untouched (quietly hidden). Match/visibility logic lives in a small, unit-tested helper (`arr_deep_link.dart`).

## "Appears after request" behavior
The re-check runs on initial load (after the TMDB detail lands, since Sonarr needs the TVDB id) and again whenever `libraryRefreshTickProvider` bumps — which every successful request does (the main Request button and per-season requests both call `_bumpLibraryRefresh`). For an admin's auto-approved request the arr add has already happened server-side by the time the tick fires, so the link surfaces on that re-check. It also re-resolves when auth settles (covers auth landing after the detail load, e.g. an optimistic reconnect).

## Out of scope
**Books / Chaptarr.** `MediaDetailScreen` only ever shows movies and TV, and books have no discovery-side id to match on — so there's nothing to link.

## Test plan
- `flutter analyze --no-fatal-infos` → 0 errors / 0 warnings (16 pre-existing info-level lints only).
- `flutter test` → all pass (225).
- New tests under `app/test/media_detail/`:
  - `arr_deep_link_test.dart` — unit tests for the Radarr/Sonarr match functions (tmdbId match, tvdbId match, title fallback, "known tvdbId, no hit ⇒ null", empty/no-match, `ArrDeepLink.moduleLabel`).
  - `media_detail_arr_link_test.dart` — widget tests via an admin auth override + fake Dio adapter: **admin + matching movie ⇒ "Open in Radarr" shows**; **admin + no match ⇒ absent**; **non-admin (even with the movie present) ⇒ absent**.

## Docs
- `app/README.md`: added a bullet under **Movies & TV management (admin)** describing the Open-in-arr jump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eZtcV6t8RZ1WaCURxmSRY