### PR TITLE
feat(issues): read/unread status + "mark resolved as read" setting

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -78,6 +78,7 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 ### Issues & AI remediation
 - **Report a problem** -- on any available title (admin-toggleable), scoped to a movie, series, or season; category chips plus free text.
 - **Issue threads** -- a chat-style thread per issue where the reporter, admins, and the AI agent converse; the agent's questions flip the issue to "Needs your reply".
+- **Read/unread** -- the admin list flags unread issues with a dot: new issues and any non-admin status change (agent/system/reporter) show as unread, and opening the thread marks it read. Admin-toggleable "mark resolved issues as read" keeps a cleanly resolved issue from re-flagging.
 - **Agent fixes** -- proposed mutations render as safety-critical approval cards (typed summaries, quoted parameters, rationale as passive text); admins approve or deny inline or from a grouped queue, and every run has a read-only audit timeline with step ledger and cost.
 - **Live badges** -- Approvals / Issues / Agent fixes counts in the drawer, kept current over WebSocket. A **Plex invites** entry appears (with count) only while someone is waiting on a Plex invite -- the persistent surface behind the miss-able push -- and lands on the Users screen, where waiting users carry a "Needs Plex invite" tag. A **Setup checklist** entry (with unconfigured-feature count) appears for admins until everything is configured or they mute it from the checklist.
 
@@ -99,7 +100,7 @@ A single dark-first theme with warm gold accents, designed for couch browsing. S
 - **Devices** (admin) -- every connected device with hardware model, last-seen, "This device" badge, and revoke.
 - **Credentials** (admin, write-only) -- TMDB, Trakt, and AI provider keys + provider/model selection.
 - **AI tools** (admin) -- per-tool toggles for chat + MCP, and a one-hour debug-logging switch.
-- **AI remediation** (admin) -- master switch, auto-dispatch, reporting affordance, autonomy tier, provider/model, and run budgets.
+- **AI remediation** (admin) -- master switch, auto-dispatch, reporting affordance, mark-resolved-issues-as-read, autonomy tier, provider/model, and run budgets.
 - **Update Portal** (admin) -- optional link to your own container-management portal (e.g. an Unraid or Portainer page). When the server sees a newer published release, an admin-only banner appears app-wide and links here (or to the update guide when unset); it's dismissible per release. The About sheet also shows the running server version.
 - **Notifications, Passkeys, Password** -- self-service (passkey/password screens appear when admin-enabled).
 - **Watch on Plex guide** -- requester-focused walkthrough (install the Plex app, sign in, accept the invite, start watching) with a **Request your invite** step: the user shares their Plex email, admins get a push pointing at the Users screen, and once the invite goes out (one-tap or auto) the card flips to "check your inbox" and the user gets a push. Hideable from the guide itself or via a Settings toggle that also removes it from the menu.

--- a/app/lib/features/issues/data/issue_models.dart
+++ b/app/lib/features/issues/data/issue_models.dart
@@ -83,6 +83,10 @@ class Issue {
   final int episodeNumber; // 0 = whole season / movie
   final String detail; // UNTRUSTED free text — render passively
   final int occurrences;
+
+  /// Whether an admin has seen the issue's current state. Any non-admin status
+  /// change re-flags it unread; an admin opening the thread marks it read.
+  final bool read;
   final DateTime? createdAt;
   final DateTime? updatedAt;
 
@@ -100,6 +104,7 @@ class Issue {
     required this.episodeNumber,
     required this.detail,
     required this.occurrences,
+    required this.read,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -138,6 +143,9 @@ class Issue {
         episodeNumber: json['episode_number'] as int? ?? 0,
         detail: json['detail'] as String? ?? '',
         occurrences: json['occurrences'] as int? ?? 1,
+        // Default true so an older server that omits the field doesn't paint the
+        // whole list unread.
+        read: json['read'] as bool? ?? true,
         createdAt:
             DateTime.tryParse(json['created_at'] as String? ?? '')?.toLocal(),
         updatedAt:
@@ -236,6 +244,10 @@ class RemediationSettings {
   final bool enabled;
   final bool autoDispatch;
   final bool allowReporting;
+
+  /// When on, an issue that transitions to resolved is marked read (overriding
+  /// the flip-to-unread that any non-admin status change otherwise triggers).
+  final bool markResolvedAsRead;
   final RemediationAutonomy autonomy;
 
   /// AI provider override (e.g. "anthropic", "openai"). Empty means "use the
@@ -257,6 +269,7 @@ class RemediationSettings {
     required this.enabled,
     required this.autoDispatch,
     required this.allowReporting,
+    required this.markResolvedAsRead,
     required this.autonomy,
     required this.provider,
     required this.model,
@@ -274,6 +287,8 @@ class RemediationSettings {
         enabled: json['enabled'] as bool? ?? false,
         autoDispatch: json['auto_dispatch'] as bool? ?? false,
         allowReporting: json['allow_reporting'] as bool? ?? false,
+        // Default true to match the server default when the field is absent.
+        markResolvedAsRead: json['mark_resolved_as_read'] as bool? ?? true,
         autonomy: RemediationAutonomy.fromValue(json['autonomy'] as String?),
         provider: json['provider'] as String? ?? '',
         model: json['model'] as String? ?? '',
@@ -290,6 +305,7 @@ class RemediationSettings {
         'enabled': enabled,
         'auto_dispatch': autoDispatch,
         'allow_reporting': allowReporting,
+        'mark_resolved_as_read': markResolvedAsRead,
         'autonomy': autonomy.value,
         'provider': provider,
         'model': model,
@@ -306,6 +322,7 @@ class RemediationSettings {
     bool? enabled,
     bool? autoDispatch,
     bool? allowReporting,
+    bool? markResolvedAsRead,
     RemediationAutonomy? autonomy,
     String? provider,
     String? model,
@@ -321,6 +338,7 @@ class RemediationSettings {
         enabled: enabled ?? this.enabled,
         autoDispatch: autoDispatch ?? this.autoDispatch,
         allowReporting: allowReporting ?? this.allowReporting,
+        markResolvedAsRead: markResolvedAsRead ?? this.markResolvedAsRead,
         autonomy: autonomy ?? this.autonomy,
         provider: provider ?? this.provider,
         model: model ?? this.model,

--- a/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
+++ b/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
@@ -191,6 +191,22 @@ class _AiRemediationSettingsScreenState
             style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
           ),
         ),
+        SwitchListTile(
+          value: s.markResolvedAsRead,
+          activeThumbColor: AppTheme.accent,
+          onChanged: (v) =>
+              setState(() => _edited = s.copyWith(markResolvedAsRead: v)),
+          title: const Text(
+            'Mark resolved issues as read',
+            style: TextStyle(
+                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+          ),
+          subtitle: const Text(
+            'Clear the unread dot when an issue resolves, instead of re-flagging '
+            'it for another look.',
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
         ListTile(
           title: const Text(
             'Autonomy',

--- a/app/lib/features/issues/ui/issues_list_screen.dart
+++ b/app/lib/features/issues/ui/issues_list_screen.dart
@@ -139,11 +139,23 @@ class _IssueTile extends StatelessWidget {
     final category = issue.category;
     return ListTile(
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      // Unread affordance: a small filled accent dot. The slot is reserved in
+      // both states (transparent when read) so titles stay aligned across rows.
+      leading: Container(
+        width: 8,
+        height: 8,
+        decoration: BoxDecoration(
+          color: issue.read ? Colors.transparent : AppTheme.accent,
+          shape: BoxShape.circle,
+        ),
+      ),
+      minLeadingWidth: 8,
+      horizontalTitleGap: 12,
       title: Text(
         issue.title.isEmpty ? 'Issue #${issue.id}' : issue.title,
-        style: const TextStyle(
+        style: TextStyle(
           color: AppTheme.textPrimary,
-          fontWeight: FontWeight.bold,
+          fontWeight: issue.read ? FontWeight.w600 : FontWeight.w800,
         ),
         maxLines: 1,
         overflow: TextOverflow.ellipsis,

--- a/app/test/issues/issue_models_test.dart
+++ b/app/test/issues/issue_models_test.dart
@@ -48,6 +48,16 @@ void main() {
       expect(tv.id, 7);
       expect(tv.category, IssueCategory.wrongAudio);
       expect(tv.scopeLabel, 'S2·E4');
+      expect(tv.read, isTrue); // absent 'read' defaults true (older server)
+
+      final unread = Issue.fromJson({
+        'id': 11,
+        'media_type': 'movie',
+        'status': 'open',
+        'tmdb_id': 1,
+        'read': false,
+      });
+      expect(unread.read, isFalse); // explicit false parses through
 
       final movie = Issue.fromJson({
         'id': 8,
@@ -87,6 +97,7 @@ void main() {
         enabled: true,
         autoDispatch: false,
         allowReporting: true,
+        markResolvedAsRead: false,
         autonomy: RemediationAutonomy.propose,
         provider: 'openai',
         model: 'gpt-5',
@@ -103,6 +114,7 @@ void main() {
       expect(back.model, 'gpt-5');
       expect(back.autonomy, RemediationAutonomy.propose);
       expect(back.maxCostMicros, 500000);
+      expect(back.markResolvedAsRead, isFalse); // explicit false round-trips
     });
 
     test('blank provider/model means "inherit server default"', () {
@@ -110,6 +122,7 @@ void main() {
       expect(s.provider, '');
       expect(s.model, '');
       expect(s.autonomy, RemediationAutonomy.propose); // tolerant default
+      expect(s.markResolvedAsRead, isTrue); // defaults on when absent
     });
   });
 }

--- a/server/README.md
+++ b/server/README.md
@@ -182,12 +182,12 @@ Request statuses: `unavailable`, `requested`, `pending` (awaiting approval), `de
 ### Issues & AI remediation
 ```
 POST   /api/issues                         # user: report a problem (gated by allow_reporting)
-GET    /api/issues/{id}                    # reporter or admin: issue thread
+GET    /api/issues/{id}                    # reporter or admin: issue thread (an admin viewing marks it read)
 POST   /api/issues/{id}/reply              # reporter or admin: reply (answers agent questions)
-GET    /api/admin/issues?status=           # admin: issue queue (user-reported + auto-detected)
+GET    /api/admin/issues?status=           # admin: issue queue (user-reported + auto-detected; each row carries read/unread)
 POST   /api/admin/issues/{id}/dismiss      # admin
 GET|PUT /api/admin/remediation-settings    # admin: master switch, auto-dispatch, reporting,
-                                           #   autonomy tier, provider/model, run budgets
+                                           #   mark-resolved-as-read, autonomy tier, provider/model, run budgets
 GET    /api/admin/agent-actions?status=    # admin: proposed-fix approval queue
 POST   /api/admin/agent-actions/{id}/approve   # admin: executes the stored proposal exactly once
 POST   /api/admin/agent-actions/{id}/deny      # admin: denial resumes the investigation
@@ -331,6 +331,8 @@ The issue system turns "my episode won't download" into a supervised agent workf
 5. **Audit** -- every run persists its full step ledger (`agent_runs`/`agent_steps`) with token counts and cost, viewable from the app.
 
 Auto-dispatch has a circuit breaker: repeated agent give-ups disable it and notify admins. Issue statuses: `open`, `investigating`, `awaiting_user`, `awaiting_approval`, `resolved`, `wont_fix`, `failed`, `dismissed`.
+
+Each issue also carries an admin **read/unread** flag: new issues start unread, any non-admin (agent/system/reporter) status change re-flags it unread, and an admin opening the thread (or dismissing it) marks it read. The `mark_resolved_as_read` setting (default on) keeps a cleanly resolved issue read instead of re-flagging it. The drawer's Issues badge still counts *open* issues, not unread ones.
 
 ### Import Doctor
 

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -220,6 +220,7 @@ CREATE TABLE IF NOT EXISTS issues (
     detail TEXT NOT NULL DEFAULT '',            -- user free-text reason OR doctor diagnosis summary (UNTRUSTED)
     dedupe_key TEXT,                           -- stable idempotency key (auto); NULL allowed (user reports)
     occurrences INTEGER NOT NULL DEFAULT 1,     -- bumped when a duplicate signal/report attaches
+    read INTEGER NOT NULL DEFAULT 0,            -- admin read/unread flag; any non-admin status change re-flags unread, an admin viewing marks read
     active_run_id INTEGER,                      -- CAS claim: at most one running run per issue
     resolution TEXT,                           -- short closing note on a terminal state
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
@@ -397,6 +398,16 @@ func Open(dbPath string) (*sql.DB, error) {
 		// stamp records that it went out and the user is told to check email.
 		{alter: "ALTER TABLE users ADD COLUMN plex_invited_at DATETIME"},
 		{alter: "ALTER TABLE notification_prefs ADD COLUMN plex_invite_sent INTEGER NOT NULL DEFAULT 1"},
+		{
+			// AI remediation: per-issue admin read/unread flag. New issues start
+			// unread (default 0); a non-admin status change re-flags unread, an
+			// admin viewing the thread marks read. Backfill the pre-existing
+			// backlog to read so it isn't a wall of unread on upgrade.
+			alter: "ALTER TABLE issues ADD COLUMN read INTEGER NOT NULL DEFAULT 0",
+			backfill: []string{
+				"UPDATE issues SET read = 1",
+			},
+		},
 	}
 	for _, m := range migrations {
 		if _, err := db.Exec(m.alter); err != nil {

--- a/server/internal/remediation/handler.go
+++ b/server/internal/remediation/handler.go
@@ -76,6 +76,14 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// An admin opening the thread marks the issue read (clears the unread dot);
+	// the reporter viewing their own issue must NOT. Reflect it in this payload
+	// too so the caller sees the new state immediately.
+	if auth.HasPermission(claims.Role, auth.PermissionRemediationManage) {
+		_ = h.service.MarkIssueRead(id)
+		issue.Read = true
+	}
+
 	thread, err := h.service.IssueThread(id)
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})

--- a/server/internal/remediation/issuestore.go
+++ b/server/internal/remediation/issuestore.go
@@ -44,10 +44,18 @@ func (s *Service) ConcludeIssue(ctx context.Context, issueID int64, status, reso
 	if status != IssueResolved && status != IssueWontFix {
 		status = IssueWontFix
 	}
+	// A conclude is always a non-admin (agent/system) status change, so it flips
+	// the issue back to unread — UNLESS it resolved and the admin opted to
+	// "mark resolved issues as read", which overrides the flip so a clean
+	// resolution doesn't nag the admin.
+	read := 0
+	if status == IssueResolved && s.Settings().MarkResolvedAsRead {
+		read = 1
+	}
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE issues SET status = ?, resolution = ?, closed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+		`UPDATE issues SET status = ?, resolution = ?, read = ?, closed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
 		 WHERE id = ? AND closed_at IS NULL`,
-		status, resolution, issueID,
+		status, resolution, read, issueID,
 	)
 	if err != nil {
 		return fmt.Errorf("conclude issue: %w", err)

--- a/server/internal/remediation/models.go
+++ b/server/internal/remediation/models.go
@@ -95,6 +95,7 @@ type Issue struct {
 	EpisodeNumber int       `json:"episode_number"` // 0 = whole season / movie
 	Detail        string    `json:"detail"`         // UNTRUSTED free text
 	Occurrences   int       `json:"occurrences"`
+	Read          bool      `json:"read"` // admin has seen the current state; any non-admin status change re-flags unread
 	CreatedAt     time.Time `json:"created_at"`
 	UpdatedAt     time.Time `json:"updated_at"`
 }

--- a/server/internal/remediation/read_test.go
+++ b/server/internal/remediation/read_test.go
@@ -1,0 +1,224 @@
+package remediation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/auth"
+)
+
+// movieReq builds a distinct-scope movie report so successive creates open
+// separate issues (dedupe is per reporter+scope+category) rather than bumping
+// occurrences.
+func movieReq(tmdbID int) *CreateIssueRequest {
+	return &CreateIssueRequest{MediaType: "movie", TmdbID: tmdbID, Category: CategoryOther, Reason: "x"}
+}
+
+func readFlag(t *testing.T, svc *Service, issueID int64) bool {
+	t.Helper()
+	iss, err := svc.GetIssue(issueID)
+	if err != nil {
+		t.Fatalf("GetIssue(%d): %v", issueID, err)
+	}
+	return iss.Read
+}
+
+// TestNewIssueStartsUnread confirms the column default: a freshly reported issue
+// is unread until an admin views it.
+func TestNewIssueStartsUnread(t *testing.T) {
+	svc, _, reporterID := setupTestService(t)
+	r, err := svc.CreateUserIssue(reporterID, movieReq(1))
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+	if readFlag(t, svc, r.IssueID) {
+		t.Fatal("a new issue should start unread")
+	}
+}
+
+// TestMarkIssueRead sets the read flag directly (the admin-view side effect).
+func TestMarkIssueRead(t *testing.T) {
+	svc, _, reporterID := setupTestService(t)
+	r, err := svc.CreateUserIssue(reporterID, movieReq(1))
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+	if err := svc.MarkIssueRead(r.IssueID); err != nil {
+		t.Fatalf("MarkIssueRead: %v", err)
+	}
+	if !readFlag(t, svc, r.IssueID) {
+		t.Fatal("MarkIssueRead should set read = 1")
+	}
+	// Idempotent + a no-op (no error) for a nonexistent issue.
+	if err := svc.MarkIssueRead(r.IssueID); err != nil {
+		t.Fatalf("MarkIssueRead (repeat): %v", err)
+	}
+	if err := svc.MarkIssueRead(999999); err != nil {
+		t.Fatalf("MarkIssueRead (missing): %v", err)
+	}
+}
+
+// TestDismissIssueMarksRead confirms an admin dismissal marks the issue read
+// (an admin status change never re-flags unread).
+func TestDismissIssueMarksRead(t *testing.T) {
+	svc, _, reporterID := setupTestService(t)
+	r, err := svc.CreateUserIssue(reporterID, movieReq(1))
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+	if err := svc.DismissIssue(r.IssueID); err != nil {
+		t.Fatalf("DismissIssue: %v", err)
+	}
+	if !readFlag(t, svc, r.IssueID) {
+		t.Fatal("dismiss (an admin action) should mark the issue read")
+	}
+}
+
+// TestConcludeIssueReadReflectsSetting drives the core rule: a conclude is a
+// non-admin (agent/system) status change, so it flips to unread — UNLESS it
+// resolved and "mark resolved issues as read" is on. wont_fix always flips
+// unread regardless of the setting.
+func TestConcludeIssueReadReflectsSetting(t *testing.T) {
+	svc, _, reporterID := setupTestService(t)
+	ctx := context.Background()
+
+	// Default setting is ON: resolving marks the issue read.
+	r1, err := svc.CreateUserIssue(reporterID, movieReq(1))
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+	if err := svc.ConcludeIssue(ctx, r1.IssueID, IssueResolved, "done"); err != nil {
+		t.Fatalf("ConcludeIssue resolved (setting on): %v", err)
+	}
+	if !readFlag(t, svc, r1.IssueID) {
+		t.Fatal("resolved issue should be read when mark_resolved_as_read is on")
+	}
+
+	// Setting OFF: resolving flips back to unread even if it was read.
+	if _, err := svc.SetSettings(Settings{MarkResolvedAsRead: false}); err != nil {
+		t.Fatalf("SetSettings off: %v", err)
+	}
+	r2, err := svc.CreateUserIssue(reporterID, movieReq(2))
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+	if err := svc.MarkIssueRead(r2.IssueID); err != nil {
+		t.Fatalf("MarkIssueRead: %v", err)
+	}
+	if err := svc.ConcludeIssue(ctx, r2.IssueID, IssueResolved, "done"); err != nil {
+		t.Fatalf("ConcludeIssue resolved (setting off): %v", err)
+	}
+	if readFlag(t, svc, r2.IssueID) {
+		t.Fatal("resolved issue should be unread when mark_resolved_as_read is off")
+	}
+
+	// wont_fix ignores the setting (never a "clean resolution"): setting back ON,
+	// concluding wont_fix on a read issue still flips it unread.
+	if _, err := svc.SetSettings(Settings{MarkResolvedAsRead: true}); err != nil {
+		t.Fatalf("SetSettings on: %v", err)
+	}
+	r3, err := svc.CreateUserIssue(reporterID, movieReq(3))
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+	if err := svc.MarkIssueRead(r3.IssueID); err != nil {
+		t.Fatalf("MarkIssueRead: %v", err)
+	}
+	if err := svc.ConcludeIssue(ctx, r3.IssueID, IssueWontFix, "nope"); err != nil {
+		t.Fatalf("ConcludeIssue wont_fix: %v", err)
+	}
+	if readFlag(t, svc, r3.IssueID) {
+		t.Fatal("wont_fix issue should be unread even when mark_resolved_as_read is on")
+	}
+}
+
+// TestReplyReadFlip separates the two actors that reach the awaiting_user resume
+// path: a reporter's reply re-flags the issue unread (a non-admin status change),
+// while an admin's reply on the same issue does not (an admin action).
+func TestReplyReadFlip(t *testing.T) {
+	svc, _, reporterID := setupTestService(t)
+	r, err := svc.CreateUserIssue(reporterID, movieReq(1))
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+	// Simulate the agent having asked the reporter a question and an admin having
+	// already viewed it: awaiting_user + read.
+	if _, err := svc.db.Exec("UPDATE issues SET status = ?, read = 1 WHERE id = ?", IssueAwaitingUser, r.IssueID); err != nil {
+		t.Fatalf("seed awaiting_user: %v", err)
+	}
+
+	// An admin reply (also routed through resumeOnReporterReply) must NOT re-flag.
+	if err := svc.PostReply(r.IssueID, AuthorAdmin, 0, "on it"); err != nil {
+		t.Fatalf("PostReply admin: %v", err)
+	}
+	if !readFlag(t, svc, r.IssueID) {
+		t.Fatal("an admin reply must not re-flag the issue unread")
+	}
+
+	// A reporter reply re-flags it unread so the admin sees the response.
+	if err := svc.PostReply(r.IssueID, AuthorUser, reporterID, "still broken"); err != nil {
+		t.Fatalf("PostReply reporter: %v", err)
+	}
+	if readFlag(t, svc, r.IssueID) {
+		t.Fatal("a reporter reply should re-flag the issue unread")
+	}
+}
+
+// getIssueDetail invokes the Get handler with injected claims + the {id} chi URL
+// param, mirroring how the real router would dispatch it.
+func getIssueDetail(t *testing.T, h *Handler, issueID int64, claims *auth.Claims) IssueDetail {
+	t.Helper()
+	id := strconv.FormatInt(issueID, 10)
+	req := httptest.NewRequest(http.MethodGet, "/api/issues/"+id, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", id)
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = context.WithValue(ctx, auth.ClaimsKey, claims)
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	h.Get(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Get status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var detail IssueDetail
+	if err := json.NewDecoder(rec.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode issue detail: %v", err)
+	}
+	return detail
+}
+
+// TestAdminGetMarksReadReporterDoesNot confirms the handler side effect: an admin
+// opening the thread marks the issue read (and the payload reflects it), while the
+// reporter viewing their own issue leaves it unread.
+func TestAdminGetMarksReadReporterDoesNot(t *testing.T) {
+	svc, _, reporterID := setupTestService(t)
+	h := NewHandler(svc)
+	r, err := svc.CreateUserIssue(reporterID, movieReq(1))
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+
+	// The reporter viewing their own issue must NOT mark it read.
+	reporterView := getIssueDetail(t, h, r.IssueID, &auth.Claims{UserID: reporterID, Role: auth.RoleUser})
+	if reporterView.Issue.Read {
+		t.Fatal("reporter view payload should report unread")
+	}
+	if readFlag(t, svc, r.IssueID) {
+		t.Fatal("reporter view must not mark the issue read")
+	}
+
+	// An admin opening the thread marks it read, reflected in the payload and DB.
+	adminView := getIssueDetail(t, h, r.IssueID, &auth.Claims{UserID: 9999, Role: auth.RoleAdmin})
+	if !adminView.Issue.Read {
+		t.Fatal("admin view payload should report read")
+	}
+	if !readFlag(t, svc, r.IssueID) {
+		t.Fatal("admin view must mark the issue read")
+	}
+}

--- a/server/internal/remediation/runner.go
+++ b/server/internal/remediation/runner.go
@@ -553,7 +553,9 @@ func (r *Runner) parkWith(issueID, runID int64, runStatus, stopReason, issueStat
 		log.Printf("remediation: park run %d (%s): %v", runID, runStatus, err)
 	}
 	if _, err := r.db.Exec(
-		"UPDATE issues SET status = ?, active_run_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND closed_at IS NULL",
+		// Parking for a human gate (awaiting_approval / awaiting_user) is an agent
+		// status change, so it flips the issue to unread for admins.
+		"UPDATE issues SET status = ?, read = 0, active_run_id = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND closed_at IS NULL",
 		issueStatus, issueID,
 	); err != nil {
 		log.Printf("remediation: park issue %d (%s): %v", issueID, issueStatus, err)
@@ -645,7 +647,10 @@ func (r *Runner) claim(issueID int64, model string) (runID int64, claimed bool, 
 	}
 
 	cas, err := r.db.Exec(
-		"UPDATE issues SET status = ?, active_run_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND active_run_id IS NULL AND closed_at IS NULL",
+		// A fresh claim moves the issue to investigating — a non-admin (agent)
+		// status change — so it flips to unread. (Resume's re-claim deliberately
+		// does NOT touch read: it may be reached from an admin approve/deny.)
+		"UPDATE issues SET status = ?, read = 0, active_run_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND active_run_id IS NULL AND closed_at IS NULL",
 		IssueInvestigating, runID, issueID,
 	)
 	if err != nil {

--- a/server/internal/remediation/service.go
+++ b/server/internal/remediation/service.go
@@ -279,7 +279,7 @@ func (s *Service) GetIssue(issueID int64) (*Issue, error) {
 	row := s.db.QueryRow(
 		`SELECT i.id, i.source, i.status, i.category, i.reporter_id, u.username,
 		        i.tmdb_id, i.media_type, i.title, i.season_number, i.episode_number,
-		        i.detail, i.occurrences, i.created_at, i.updated_at
+		        i.detail, i.occurrences, i.read, i.created_at, i.updated_at
 		 FROM issues i LEFT JOIN users u ON u.id = i.reporter_id
 		 WHERE i.id = ?`,
 		issueID,
@@ -370,6 +370,12 @@ func (s *Service) PostReply(issueID int64, authorKind string, authorID int64, bo
 	// to the run keyed to the ask tool_use, then enqueue the resume. (Defined in
 	// approvals.go alongside the W3 approval-resume helper, which it mirrors.)
 	if status == IssueAwaitingUser && (authorKind == AuthorUser || authorKind == AuthorAdmin) {
+		// A reporter's reply resumes the agent — a non-admin status change — so the
+		// issue flips back to unread for admins. An admin replying is an admin
+		// action (resumeOnReporterReply serves both), so it must NOT re-flag unread.
+		if authorKind == AuthorUser {
+			s.db.Exec("UPDATE issues SET read = 0 WHERE id = ?", issueID)
+		}
 		s.resumeOnReporterReply(issueID, body)
 	}
 	return nil
@@ -441,7 +447,7 @@ func (s *Service) SweepStaleAwaitingUser(ctx context.Context, maxWaitHours int) 
 func (s *Service) ListIssues(status string) ([]Issue, error) {
 	query := `SELECT i.id, i.source, i.status, i.category, i.reporter_id, u.username,
 	                 i.tmdb_id, i.media_type, i.title, i.season_number, i.episode_number,
-	                 i.detail, i.occurrences, i.created_at, i.updated_at
+	                 i.detail, i.occurrences, i.read, i.created_at, i.updated_at
 	          FROM issues i LEFT JOIN users u ON u.id = i.reporter_id`
 	var (
 		rows *sql.Rows
@@ -469,10 +475,12 @@ func (s *Service) ListIssues(status string) ([]Issue, error) {
 }
 
 // DismissIssue marks an open (non-terminal) issue dismissed and closes it. The
-// CAS on closed_at IS NULL makes a double-dismiss a no-op.
+// CAS on closed_at IS NULL makes a double-dismiss a no-op. Dismissal is an admin
+// action, so the issue is also marked read (an admin status change never re-flags
+// it unread).
 func (s *Service) DismissIssue(issueID int64) error {
 	res, err := s.db.Exec(
-		"UPDATE issues SET status = ?, closed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND closed_at IS NULL",
+		"UPDATE issues SET status = ?, read = 1, closed_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ? AND closed_at IS NULL",
 		IssueDismissed, issueID,
 	)
 	if err != nil {
@@ -485,6 +493,18 @@ func (s *Service) DismissIssue(issueID int64) error {
 		if qerr := s.db.QueryRow("SELECT 1 FROM issues WHERE id = ?", issueID).Scan(&exists); qerr == sql.ErrNoRows {
 			return fmt.Errorf("issue not found")
 		}
+	}
+	return nil
+}
+
+// MarkIssueRead clears the admin unread flag on an issue. It is a side effect of
+// an admin opening the issue thread (the Get handler calls it); a reporter
+// viewing their own issue does not mark it read. It deliberately leaves
+// updated_at untouched so "read" never re-sorts the issue as recently active.
+// Idempotent, and a harmless no-op for a nonexistent issue.
+func (s *Service) MarkIssueRead(issueID int64) error {
+	if _, err := s.db.Exec("UPDATE issues SET read = 1 WHERE id = ?", issueID); err != nil {
+		return fmt.Errorf("mark issue read: %w", err)
 	}
 	return nil
 }
@@ -517,7 +537,7 @@ func scanIssue(row rowScanner) (*Issue, error) {
 	if err := row.Scan(
 		&iss.ID, &iss.Source, &iss.Status, &category, &reporterID, &reporter,
 		&iss.TmdbID, &iss.MediaType, &iss.Title, &iss.SeasonNumber, &iss.EpisodeNumber,
-		&iss.Detail, &iss.Occurrences, &iss.CreatedAt, &iss.UpdatedAt,
+		&iss.Detail, &iss.Occurrences, &iss.Read, &iss.CreatedAt, &iss.UpdatedAt,
 	); err != nil {
 		return nil, err
 	}

--- a/server/internal/remediation/service_test.go
+++ b/server/internal/remediation/service_test.go
@@ -235,6 +235,9 @@ func TestSettingsRoundTrip(t *testing.T) {
 	if d.Enabled || d.AutoDispatch || !d.AllowReporting {
 		t.Fatalf("default switches = %+v, want enabled=false auto_dispatch=false allow_reporting=true", d)
 	}
+	if !d.MarkResolvedAsRead {
+		t.Fatalf("default mark_resolved_as_read = false, want true (resolved issues marked read by default)")
+	}
 	if d.Autonomy != AutonomyPropose {
 		t.Fatalf("default autonomy = %q, want propose", d.Autonomy)
 	}
@@ -253,6 +256,7 @@ func TestSettingsRoundTrip(t *testing.T) {
 		Enabled:                true,
 		AutoDispatch:           true,
 		AllowReporting:         false,
+		MarkResolvedAsRead:     false, // explicit false must override the true default and round-trip
 		Autonomy:               AutonomyInvestigateOnly,
 		Provider:               "openai",
 		Model:                  "gpt-x",

--- a/server/internal/remediation/settings.go
+++ b/server/internal/remediation/settings.go
@@ -35,6 +35,7 @@ type Settings struct {
 	Enabled                bool   `json:"enabled"`                   // master switch — ships OFF
 	AutoDispatch           bool   `json:"auto_dispatch"`             // poller may open auto issues — ships OFF
 	AllowReporting         bool   `json:"allow_reporting"`           // user-visible "Report a problem" affordance
+	MarkResolvedAsRead     bool   `json:"mark_resolved_as_read"`     // mark an issue read when it resolves (default ON)
 	Autonomy               string `json:"autonomy"`                  // investigate_only | propose | auto_safe
 	Provider               string `json:"provider"`                  // "" = inherit the configured AI provider
 	Model                  string `json:"model"`                     // "" = inherit the configured AI model
@@ -57,6 +58,7 @@ func Defaults() Settings {
 		Enabled:                false,
 		AutoDispatch:           false,
 		AllowReporting:         true,
+		MarkResolvedAsRead:     true,
 		Autonomy:               AutonomyPropose,
 		Provider:               "",
 		Model:                  "",


### PR DESCRIPTION
## What

Give issues an admin **read/unread** status, plus a default-on admin setting **"Mark resolved issues as read."**

- New issues start **unread**.
- Any **non-admin** status change re-flags an issue **unread**.
- **Admin** actions never re-flag unread; opening the thread as an admin (or dismissing) marks it **read**.
- When an issue resolves and "mark resolved as read" is on, it's marked **read** (overriding the flip).

## Why

The admin issue queue had no notion of "has anyone looked at this since it last changed?" A reporter reply, an agent parking for approval, or a give-up all move an issue's state, but nothing surfaced that to the admin. Read/unread makes "what changed and needs another look" glanceable, while the setting keeps clean auto-resolutions from nagging.

## Read-flip rules

| Transition | Actor | `read` |
|---|---|---|
| Issue created (user report / auto) | system | **0** (column default) |
| claim → `investigating` | agent | **0** |
| park → `awaiting_approval` / `awaiting_user` | agent | **0** |
| reporter reply on `awaiting_user` (resumes agent) | reporter | **0** |
| admin reply on `awaiting_user` (resumes agent) | admin | unchanged |
| conclude → `resolved`, setting **on** | agent/system | **1** |
| conclude → `resolved`, setting **off** | agent/system | **0** |
| conclude → `wont_fix` (incl. reply-TTL sweep) | agent/system | **0** |
| dismiss | admin | **1** |
| admin opens thread (`GET /api/issues/{id}`) | admin | **1** |
| reporter opens own thread | reporter | unchanged |
| approve / deny → resume (`Resume` re-claim) | admin | unchanged |

Intermediate agent transitions follow the literal **"non-admin status change → unread"** rule (e.g. an issue that goes park → resume → park flips unread each agent hop). The `Resume` re-claim deliberately does **not** touch `read` because it's reached from both admin approve/deny **and** reporter reply — the two actors are separated at their call sites instead (reporter flip lives in `PostReply`, gated on `AuthorUser`, since `resumeOnReporterReply` serves admin replies too).

The drawer **Issues badge still counts OPEN issues, not unread** — left as-is by design.

## Implementation

**Server**
- `db.go`: new `issues.read INTEGER NOT NULL DEFAULT 0` in `CREATE TABLE` + a tolerant `ALTER` with a one-time `UPDATE issues SET read = 1` backfill (so the pre-existing backlog isn't a wall of unread on upgrade).
- `Issue.Read` field; `read` added to the `GetIssue`/`ListIssues` SELECTs and `scanIssue`.
- New `MarkIssueRead` writer (leaves `updated_at` untouched so "read" never re-sorts). `Get` calls it for admins only.
- `ConcludeIssue` honors `MarkResolvedAsRead`; `DismissIssue`, `claim`, `parkWith`, and the reporter-reply path set `read`.
- `MarkResolvedAsRead` settings field (default **true**), stored in the `remediation_settings` blob (migration-free).

**App**
- `Issue.read` + `RemediationSettings.markResolvedAsRead` models (both default true when the server omits the field, so an older server doesn't paint everything unread).
- Unread dot + heavier title on the issues list tile (slot reserved in both states so rows stay aligned).
- "Mark resolved issues as read" switch in AI Remediation settings.
- The list already reloads on return from a thread, so the dot clears after an admin views an issue.

**Docs:** `server/README.md` (routes + remediation-agent section) and `app/README.md` (Issues feature + settings list).

## Test plan

- `server/`: `go vet ./...` ✅ · `go test ./...` ✅ (new `read_test.go` covers: new issue starts unread, `MarkIssueRead`, `DismissIssue` → read, `ConcludeIssue` read-per-setting for resolved/off/wont_fix, reporter-vs-admin reply flip, and an admin-`Get`-marks-read / reporter-`Get`-doesn't handler test; `TestSettingsRoundTrip` extended).
- `app/`: `flutter analyze --no-fatal-infos` ✅ (0 errors/warnings; only pre-existing infos in untouched files) · `flutter test` ✅ (model tests assert `read` default/parse and `markResolvedAsRead` round-trip/default).
- `flutter build web --release` / server `CGO_ENABLED=0` build: left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eZtcV6t8RZ1WaCURxmSRY
