### PR TITLE
fix: restore Codex assistant responses

### DIFF
--- a/server/internal/ai/resolver_test.go
+++ b/server/internal/ai/resolver_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"os"
 	"testing"
 
 	"github.com/windoze95/cantinarr-server/internal/codexapp"
 	"github.com/windoze95/cantinarr-server/internal/credentials"
 	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/mcp"
 	"github.com/windoze95/cantinarr-server/internal/secrets"
 )
 
@@ -153,5 +155,181 @@ func TestResolveAICorruptCredentialPreservesSelectedSource(t *testing.T) {
 	resolved = h.resolveAI(context.Background(), userID)
 	if resolved.Available || resolved.Source != aiSourceShared || resolved.Provider != credentials.AIProviderOpenAI || resolved.Reason != "storage_error" {
 		t.Fatalf("shared corrupt resolved = %#v", resolved)
+	}
+}
+
+func TestResolveAIProviderScopeReadinessAndGrantMatrix(t *testing.T) {
+	providers := []string{
+		credentials.AIProviderAnthropic,
+		credentials.AIProviderOpenAI,
+		credentials.AIProviderGemini,
+		credentials.AIProviderCodex,
+	}
+
+	for _, provider := range providers {
+		provider := provider
+		for _, scope := range []string{aiSourcePersonal, aiSourceShared} {
+			scope := scope
+			for _, ready := range []bool{false, true} {
+				ready := ready
+				t.Run(provider+"/"+scope+"/ready="+boolName(ready), func(t *testing.T) {
+					h, registry, database, userID := newResolverTestHandler(t)
+					cipher := enableResolverCodexManager(t, h, registry, database)
+					model := provider + "-model"
+
+					if scope == aiSourcePersonal {
+						// A usable included provider makes this an explicit proof that
+						// a broken personal choice fails closed instead of spending it.
+						grantResolverSharedAccess(t, database, userID, true)
+						configureResolverProfile(t, registry, database, cipher, userID, aiSourceShared, credentials.AIProviderOpenAI, true)
+						configureResolverProfile(t, registry, database, cipher, userID, scope, provider, ready)
+					} else {
+						grantResolverSharedAccess(t, database, userID, true)
+						configureResolverProfile(t, registry, database, cipher, userID, scope, provider, ready)
+					}
+
+					resolved := h.resolveAI(context.Background(), userID)
+					wantReason := ""
+					if !ready {
+						if provider == credentials.AIProviderCodex {
+							wantReason = scope + "_codex_disconnected"
+						} else {
+							wantReason = scope + "_credential_missing"
+						}
+					}
+					if resolved.Available != ready || resolved.Source != scope || resolved.Provider != provider || resolved.Model != model || resolved.Reason != wantReason {
+						t.Fatalf("resolved = %#v, want available=%t source=%q provider=%q model=%q reason=%q", resolved, ready, scope, provider, model, wantReason)
+					}
+					if provider != credentials.AIProviderCodex {
+						wantKey := ""
+						if ready {
+							wantKey = scope + "-" + provider + "-secret"
+						}
+						if resolved.APIKey != wantKey {
+							t.Fatalf("API key = %q, want %q", resolved.APIKey, wantKey)
+						}
+					}
+				})
+			}
+		}
+
+		t.Run(provider+"/shared/grant=false", func(t *testing.T) {
+			h, registry, database, userID := newResolverTestHandler(t)
+			cipher := enableResolverCodexManager(t, h, registry, database)
+			configureResolverProfile(t, registry, database, cipher, userID, aiSourceShared, provider, true)
+			resolved := h.resolveAI(context.Background(), userID)
+			if resolved.Available || resolved.Source != aiSourceNone || resolved.Reason != "shared_access_disabled" || resolved.Provider != "" || resolved.APIKey != "" {
+				t.Fatalf("ungranted shared profile escaped its grant: %#v", resolved)
+			}
+		})
+
+		t.Run(provider+"/personal/grant=false", func(t *testing.T) {
+			h, registry, database, userID := newResolverTestHandler(t)
+			cipher := enableResolverCodexManager(t, h, registry, database)
+			configureResolverProfile(t, registry, database, cipher, userID, aiSourcePersonal, provider, true)
+			resolved := h.resolveAI(context.Background(), userID)
+			if !resolved.Available || resolved.Source != aiSourcePersonal || resolved.Provider != provider {
+				t.Fatalf("personal profile incorrectly depended on shared grant: %#v", resolved)
+			}
+		})
+	}
+
+	for _, scope := range []string{aiSourcePersonal, aiSourceShared} {
+		scope := scope
+		t.Run("codex/"+scope+"/runtime_unavailable", func(t *testing.T) {
+			h, registry, database, userID := newResolverTestHandler(t)
+			cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x27}, 32))
+			if err != nil {
+				t.Fatal(err)
+			}
+			grantResolverSharedAccess(t, database, userID, true)
+			configureResolverProfile(t, registry, database, cipher, userID, scope, credentials.AIProviderCodex, true)
+			resolved := h.resolveAI(context.Background(), userID)
+			if resolved.Available || resolved.Source != scope || resolved.Provider != credentials.AIProviderCodex || resolved.Reason != "codex_unavailable" {
+				t.Fatalf("unavailable Codex runtime resolved = %#v", resolved)
+			}
+		})
+	}
+}
+
+func boolName(value bool) string {
+	if value {
+		return "true"
+	}
+	return "false"
+}
+
+func enableResolverCodexManager(t *testing.T, h *Handler, registry *credentials.Registry, database *sql.DB) *secrets.Cipher {
+	t.Helper()
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x27}, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeDir := t.TempDir()
+	if err := os.Chmod(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	h.codex = codexapp.NewManager(database, cipher, mcp.NewToolServer(registry, nil, nil, nil), codexapp.Options{
+		Binary:                   os.Args[0],
+		RuntimeDir:               runtimeDir,
+		AllowDiskRuntimeForTests: true,
+	})
+	if !h.codex.Available() {
+		t.Fatal("test Codex manager is unavailable")
+	}
+	return cipher
+}
+
+func grantResolverSharedAccess(t *testing.T, database *sql.DB, userID int64, enabled bool) {
+	t.Helper()
+	if _, err := database.Exec(`UPDATE users SET ai_shared_enabled = ? WHERE id = ?`, enabled, userID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func configureResolverProfile(
+	t *testing.T,
+	registry *credentials.Registry,
+	database *sql.DB,
+	cipher *secrets.Cipher,
+	userID int64,
+	scope string,
+	provider string,
+	ready bool,
+) {
+	t.Helper()
+	model := provider + "-model"
+	if scope == aiSourcePersonal {
+		if err := registry.SetUserAIConfig(userID, provider, model); err != nil {
+			t.Fatal(err)
+		}
+	} else if err := registry.SetAIConfig(provider, model); err != nil {
+		t.Fatal(err)
+	}
+	if !ready {
+		return
+	}
+	if provider != credentials.AIProviderCodex {
+		secret := scope + "-" + provider + "-secret"
+		if scope == aiSourcePersonal {
+			if err := registry.SetUserAICredential(userID, provider, secret); err != nil {
+				t.Fatal(err)
+			}
+		} else if err := registry.SetCredential(credentials.AIKeyCredentialKey(provider), secret); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	authBlob, err := cipher.Encrypt(`{"tokens":{"access_token":"test-access","refresh_token":"test-refresh"}}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope == aiSourcePersonal {
+		_, err = database.Exec(`INSERT INTO user_codex_accounts (user_id, auth_blob) VALUES (?, ?)`, userID, authBlob)
+	} else {
+		_, err = database.Exec(`INSERT INTO shared_codex_account (singleton, auth_blob) VALUES (1, ?)`, authBlob)
+	}
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/server/internal/api/rbac_integration_test.go
+++ b/server/internal/api/rbac_integration_test.go
@@ -1,0 +1,545 @@
+package api
+
+import (
+	"bufio"
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/ai"
+	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/cache"
+	"github.com/windoze95/cantinarr-server/internal/codexapp"
+	"github.com/windoze95/cantinarr-server/internal/config"
+	"github.com/windoze95/cantinarr-server/internal/credentials"
+	projectdb "github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/discover"
+	"github.com/windoze95/cantinarr-server/internal/downloads"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+	"github.com/windoze95/cantinarr-server/internal/mcp"
+	"github.com/windoze95/cantinarr-server/internal/plex"
+	"github.com/windoze95/cantinarr-server/internal/proxy"
+	"github.com/windoze95/cantinarr-server/internal/push"
+	"github.com/windoze95/cantinarr-server/internal/remediation"
+	requestsvc "github.com/windoze95/cantinarr-server/internal/request"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+	"github.com/windoze95/cantinarr-server/internal/serversettings"
+	"github.com/windoze95/cantinarr-server/internal/tautulli"
+	"github.com/windoze95/cantinarr-server/internal/tmdb"
+	"github.com/windoze95/cantinarr-server/internal/update"
+	"github.com/windoze95/cantinarr-server/internal/webhooks"
+	ws "github.com/windoze95/cantinarr-server/internal/websocket"
+)
+
+func TestRouterRBACMatrixWithAdminAndRequesterTokens(t *testing.T) {
+	harness := newRBACRouterHarness(t, false)
+	routes := privilegedRoutes(t, harness.router)
+	if len(routes) < 50 {
+		t.Fatalf("privileged route inventory unexpectedly small: got %d", len(routes))
+	}
+
+	for _, route := range routes {
+		route := route
+		t.Run(route.method+" "+route.pattern, func(t *testing.T) {
+			path := concreteRBACPath(route.pattern)
+			requester := serveRBACRequest(harness.router, route.method, path, harness.requesterToken)
+			if requester.Code != http.StatusForbidden {
+				t.Fatalf("requester status = %d, want 403; body=%s", requester.Code, requester.Body.String())
+			}
+
+			anonymous := serveRBACRequest(harness.router, route.method, path, "")
+			if anonymous.Code != http.StatusUnauthorized {
+				t.Fatalf("anonymous status = %d, want 401; body=%s", anonymous.Code, anonymous.Body.String())
+			}
+		})
+	}
+
+	// Exercise one non-mutating route for every admin permission surface. These
+	// are real authenticated API requests; a backend-specific 404/5xx is fine in
+	// the empty harness, but auth must admit the admin and never return 401/403.
+	adminRoutes := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/admin/users"},
+		{http.MethodGet, "/api/admin/credentials"},
+		{http.MethodGet, "/api/admin/ai-tools"},
+		{http.MethodGet, "/api/admin/requests"},
+		{http.MethodGet, "/api/admin/issues"},
+		{http.MethodGet, "/api/admin/setup-status"},
+		{http.MethodGet, "/api/instances"},
+		{http.MethodGet, "/api/downloads/missing/queue"},
+		{http.MethodGet, "/api/tautulli/missing/activity"},
+	}
+	for _, route := range adminRoutes {
+		recorder := serveRBACRequest(harness.router, route.method, route.path, harness.adminToken)
+		if recorder.Code == http.StatusUnauthorized || recorder.Code == http.StatusForbidden {
+			t.Errorf("admin %s %s was rejected with %d: %s", route.method, route.path, recorder.Code, recorder.Body.String())
+		}
+	}
+
+	// Interactive AI and caller-owned settings are intentionally available to
+	// both roles. With no provider configured, chat fails at availability (503),
+	// which proves the request passed auth and AI permission middleware.
+	for _, token := range []string{harness.adminToken, harness.requesterToken} {
+		for _, route := range []struct {
+			method string
+			path   string
+			body   string
+			want   int
+		}{
+			{http.MethodGet, "/api/ai/available", "", http.StatusOK},
+			{http.MethodGet, "/api/ai/settings", "", http.StatusOK},
+			{http.MethodPost, "/api/ai/chat", `{"messages":[{"role":"user","content":"hello"}]}`, http.StatusServiceUnavailable},
+		} {
+			recorder := serveRBACRequestWithBody(harness.router, route.method, route.path, token, route.body)
+			if recorder.Code != route.want {
+				t.Errorf("%s %s status = %d, want %d; body=%s", route.method, route.path, recorder.Code, route.want, recorder.Body.String())
+			}
+		}
+	}
+}
+
+func TestAIChatAPIScopeAndRoleMatrixWithCodexAppServer(t *testing.T) {
+	harness := newRBACRouterHarness(t, true)
+	if err := harness.registry.SetAIConfig(credentials.AIProviderCodex, "default"); err != nil {
+		t.Fatal(err)
+	}
+	storeAPICodexAccount(t, harness, 0, "shared")
+
+	// Setup grants the first admin shared AI access. A newly invited requester
+	// starts without it, so the same shared account is available only to the
+	// admin until an authorized grant is made.
+	assertSuccessfulAIChat(t, harness.router, harness.adminToken, "shared response")
+	assertUnavailableAIChat(t, harness.router, harness.requesterToken)
+
+	accessPath := "/api/admin/users/" + strconv.FormatInt(harness.requesterID, 10) + "/ai-access"
+	denied := serveRBACRequestWithBody(harness.router, http.MethodPut, accessPath, harness.requesterToken, `{"shared_ai_enabled":true}`)
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("requester changed own shared grant: status=%d body=%s", denied.Code, denied.Body.String())
+	}
+	setSharedAIAccess(t, harness, accessPath, true)
+	assertSuccessfulAIChat(t, harness.router, harness.requesterToken, "shared response")
+
+	// Revoking the shared grant takes effect immediately. A caller-owned Codex
+	// account remains usable and is selected through the real settings API,
+	// including its mandatory test turn.
+	setSharedAIAccess(t, harness, accessPath, false)
+	assertUnavailableAIChat(t, harness.router, harness.requesterToken)
+	storeAPICodexAccount(t, harness, harness.requesterID, "requester-personal")
+	updatePersonalCodexSettings(t, harness.router, harness.requesterToken)
+	assertSuccessfulAIChat(t, harness.router, harness.requesterToken, "requester-personal response")
+
+	// A selected but disconnected personal profile is fail-closed even when the
+	// administrator grants a healthy shared fallback. Deleting the personal
+	// selection through the caller-owned endpoint deliberately restores shared.
+	setSharedAIAccess(t, harness, accessPath, true)
+	if _, err := harness.database.Exec(`DELETE FROM user_codex_accounts WHERE user_id = ?`, harness.requesterID); err != nil {
+		t.Fatal(err)
+	}
+	assertUnavailableAIChat(t, harness.router, harness.requesterToken)
+	storeAPICodexAccount(t, harness, harness.requesterID, "requester-personal")
+	deletePersonalAISettings(t, harness.router, harness.requesterToken)
+	assertSuccessfulAIChat(t, harness.router, harness.requesterToken, "shared response")
+
+	// Admins have the same caller-owned personal boundary; their elevated role
+	// changes tool permissions, not whose AI credential the turn consumes.
+	storeAPICodexAccount(t, harness, harness.adminID, "admin-personal")
+	updatePersonalCodexSettings(t, harness.router, harness.adminToken)
+	assertSuccessfulAIChat(t, harness.router, harness.adminToken, "admin-personal response")
+	deletePersonalAISettings(t, harness.router, harness.adminToken)
+	assertSuccessfulAIChat(t, harness.router, harness.adminToken, "shared response")
+}
+
+// TestAPICodexHelperProcess is a subprocess-only JSONL app-server used by the
+// full router test above. It returns the non-secret test_scope from the
+// account-specific auth.json so the assertion proves which credential boundary
+// served each API request.
+func TestAPICodexHelperProcess(t *testing.T) {
+	if !hasProcessArg("--api-codex-helper") {
+		return
+	}
+	scope := readAPICodexScope(t)
+	encoder := json.NewEncoder(os.Stdout)
+	send := func(value any) {
+		if err := encoder.Encode(value); err != nil {
+			t.Fatalf("encode app-server response: %v", err)
+		}
+	}
+
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 64<<10), 8<<20)
+	for scanner.Scan() {
+		var message struct {
+			ID     any             `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &message); err != nil {
+			t.Fatalf("decode app-server request: %v", err)
+		}
+		if message.ID == nil {
+			continue
+		}
+		switch message.Method {
+		case "initialize":
+			send(map[string]any{"id": message.ID, "result": map[string]any{
+				"codexHome": os.Getenv("CODEX_HOME"), "platformFamily": "unix", "platformOs": "test", "userAgent": "codex-app-server/test",
+			}})
+		case "thread/start":
+			var params struct {
+				Config map[string]any `json:"config"`
+			}
+			if json.Unmarshal(message.Params, &params) != nil {
+				sendAPICodexError(send, message.ID, "invalid thread config")
+				continue
+			}
+			if _, invalid := params.Config["apps.enabled"]; invalid {
+				sendAPICodexError(send, message.ID, "apps.enabled is not a valid app-server config key")
+				continue
+			}
+			if apps, ok := params.Config["features.apps"].(bool); !ok || apps {
+				sendAPICodexError(send, message.ID, "features.apps must be disabled")
+				continue
+			}
+			send(map[string]any{"id": message.ID, "result": map[string]any{"thread": map[string]any{"id": "thread-1"}}})
+		case "turn/start":
+			send(map[string]any{"id": message.ID, "result": map[string]any{"turn": map[string]any{
+				"id": "turn-1", "status": "inProgress", "items": []any{},
+			}}})
+			send(map[string]any{"method": "item/agentMessage/delta", "params": map[string]any{
+				"threadId": "thread-1", "turnId": "turn-1", "itemId": "message-1", "delta": scope + " response",
+			}})
+			send(map[string]any{"method": "turn/completed", "params": map[string]any{
+				"threadId": "thread-1", "turn": map[string]any{"id": "turn-1", "status": "completed", "items": []any{}},
+			}})
+		default:
+			sendAPICodexError(send, message.ID, "unsupported test method")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("read app-server protocol: %v", err)
+	}
+}
+
+func sendAPICodexError(send func(any), id any, message string) {
+	send(map[string]any{"id": id, "error": map[string]any{"code": -32602, "message": message}})
+}
+
+func hasProcessArg(want string) bool {
+	for _, arg := range os.Args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func readAPICodexScope(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(os.Getenv("CODEX_HOME"), "auth.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var authJSON struct {
+		TestScope string `json:"test_scope"`
+	}
+	if json.Unmarshal(data, &authJSON) != nil || authJSON.TestScope == "" {
+		t.Fatal("auth.json did not contain a test scope")
+	}
+	return authJSON.TestScope
+}
+
+type rbacRoute struct {
+	method  string
+	pattern string
+}
+
+func privilegedRoutes(t *testing.T, router http.Handler) []rbacRoute {
+	t.Helper()
+	routes, ok := router.(chi.Routes)
+	if !ok {
+		t.Fatal("router does not expose chi routes")
+	}
+	var out []rbacRoute
+	err := chi.Walk(routes, func(method, pattern string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		privileged := strings.HasPrefix(pattern, "/api/admin/") ||
+			strings.HasPrefix(pattern, "/api/downloads/") ||
+			strings.HasPrefix(pattern, "/api/tautulli/") ||
+			(strings.HasPrefix(pattern, "/api/instances") && !strings.HasSuffix(pattern, "/*"))
+		if privileged {
+			out = append(out, rbacRoute{method: method, pattern: pattern})
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].pattern == out[j].pattern {
+			return out[i].method < out[j].method
+		}
+		return out[i].pattern < out[j].pattern
+	})
+	return out
+}
+
+var routeParameterPattern = regexp.MustCompile(`\{[^}]+\}`)
+
+func concreteRBACPath(pattern string) string {
+	path := routeParameterPattern.ReplaceAllString(pattern, "1")
+	if strings.HasSuffix(path, "/*") {
+		return strings.TrimSuffix(path, "/*") + "/api/v3/config/host"
+	}
+	return path
+}
+
+func serveRBACRequest(router http.Handler, method, path, token string) *httptest.ResponseRecorder {
+	return serveRBACRequestWithBody(router, method, path, token, `{}`)
+}
+
+func serveRBACRequestWithBody(router http.Handler, method, path, token, body string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(method, path, strings.NewReader(body))
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, request)
+	return recorder
+}
+
+type rbacRouterHarness struct {
+	router         http.Handler
+	database       *sql.DB
+	cipher         *secrets.Cipher
+	registry       *credentials.Registry
+	adminID        int64
+	requesterID    int64
+	adminToken     string
+	requesterToken string
+}
+
+func newRBACRouterHarness(t *testing.T, withCodex bool) *rbacRouterHarness {
+	t.Helper()
+	database, err := projectdb.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x4a}, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := credentials.NewRegistry(database, cipher)
+	authService := auth.NewService(database, "rbac-integration-jwt-secret")
+	authHandler := auth.NewHandler(authService)
+	admin, err := authService.Setup("admin", "correct-horse-battery-staple", "Admin Test", "admin-hardware")
+	if err != nil {
+		t.Fatal(err)
+	}
+	connect, err := authService.CreateConnectToken(admin.User.ID, "requester", "http://cantinarr.test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	link, err := url.Parse(connect.Link)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requester, err := authService.RedeemConnectToken(link.Query().Get("token"), "Requester Test", "requester-hardware")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := instance.NewStore(database, cipher)
+	instanceRegistry := instance.NewRegistry(store)
+	bridge := tmdb.NewBridge(registry, database)
+	requestService := requestsvc.NewService(database, instanceRegistry, bridge, nil)
+	requestHandler := requestsvc.NewHandler(requestService)
+	remediationService := remediation.NewService(database, instanceRegistry, bridge, nil)
+	remediationHandler := remediation.NewHandler(remediationService)
+	toolServer := mcp.NewToolServer(registry, requestService, instanceRegistry, bridge)
+	var codexManager *codexapp.Manager
+	if withCodex {
+		codexManager = codexapp.NewManager(database, cipher, toolServer, codexapp.Options{
+			Binary:                   os.Args[0],
+			RuntimeDir:               filepath.Join(t.TempDir(), "codex-runtime"),
+			Args:                     []string{"-test.run=TestAPICodexHelperProcess", "--", "--api-codex-helper"},
+			AllowDiskRuntimeForTests: true,
+		})
+		if !codexManager.Available() {
+			t.Fatalf("fake Codex manager unavailable: %v", codexManager.AvailabilityError())
+		}
+	}
+	aiHandler := ai.NewHandler(registry, toolServer, codexManager)
+	credentialHandler := credentials.NewHandler(registry)
+	credentialHandler.SetSharedAIConfigured(aiHandler.ProviderConfigured)
+	instanceHandler := instance.NewHandler(store, instanceRegistry, "http://cantinarr.test")
+	downloadsHandler := downloads.NewHandler(store, instanceRegistry)
+	tautulliHandler := tautulli.NewHandler(store, instanceRegistry)
+	proxyHandler := proxy.NewHandler(store)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pushHandler := push.NewHandler(database, nil, logger)
+	hub := ws.NewHub(authService, instanceRegistry, store, nil, nil)
+	plexService := plex.NewService(database, cipher, plex.NewClient(), nil, logger)
+	plexHandler := plex.NewHandler(plexService, logger)
+	webhookHandler := webhooks.NewHandler(store, instanceRegistry, hub, requestService, nil)
+	discoverCache := cache.New()
+	t.Cleanup(discoverCache.Close)
+	discoverHandler := discover.NewHandler(registry, discoverCache)
+
+	cfg := &config.Config{
+		PublicURL:          "http://cantinarr.test",
+		ServerName:         "RBAC Test",
+		DisableUpdateCheck: true,
+	}
+	router := NewRouter(
+		cfg,
+		authHandler,
+		authService,
+		requestHandler,
+		remediationService,
+		remediationHandler,
+		proxyHandler,
+		hub,
+		aiHandler,
+		discoverHandler,
+		instanceHandler,
+		store,
+		downloadsHandler,
+		tautulliHandler,
+		registry,
+		credentialHandler,
+		toolServer,
+		pushHandler,
+		webhookHandler,
+		plexHandler,
+		plexService,
+		update.NewChecker("dev", true),
+		serversettings.NewService(database),
+	)
+	return &rbacRouterHarness{
+		router:         router,
+		database:       database,
+		cipher:         cipher,
+		registry:       registry,
+		adminID:        admin.User.ID,
+		requesterID:    requester.User.ID,
+		adminToken:     admin.AccessToken,
+		requesterToken: requester.AccessToken,
+	}
+}
+
+func storeAPICodexAccount(t *testing.T, harness *rbacRouterHarness, userID int64, scope string) {
+	t.Helper()
+	authJSON, err := json.Marshal(map[string]string{"test_scope": scope})
+	if err != nil {
+		t.Fatal(err)
+	}
+	encrypted, err := harness.cipher.Encrypt(string(authJSON))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if userID == 0 {
+		_, err = harness.database.Exec(`
+			INSERT INTO shared_codex_account (singleton, auth_blob)
+			VALUES (1, ?)
+			ON CONFLICT(singleton) DO UPDATE SET auth_blob = excluded.auth_blob`, encrypted)
+	} else {
+		_, err = harness.database.Exec(`
+			INSERT INTO user_codex_accounts (user_id, auth_blob)
+			VALUES (?, ?)
+			ON CONFLICT(user_id) DO UPDATE SET auth_blob = excluded.auth_blob`, userID, encrypted)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setSharedAIAccess(t *testing.T, harness *rbacRouterHarness, path string, enabled bool) {
+	t.Helper()
+	body := `{"shared_ai_enabled":false}`
+	if enabled {
+		body = `{"shared_ai_enabled":true}`
+	}
+	recorder := serveRBACRequestWithBody(harness.router, http.MethodPut, path, harness.adminToken, body)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("set shared AI access to %t: status=%d body=%s", enabled, recorder.Code, recorder.Body.String())
+	}
+}
+
+func updatePersonalCodexSettings(t *testing.T, router http.Handler, token string) {
+	t.Helper()
+	recorder := serveRBACRequestWithBody(
+		router,
+		http.MethodPut,
+		"/api/ai/settings",
+		token,
+		`{"provider":"codex","model":"default"}`,
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("select personal Codex: status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if !strings.Contains(recorder.Body.String(), `"source":"personal"`) {
+		t.Fatalf("personal Codex was not effective: %s", recorder.Body.String())
+	}
+}
+
+func deletePersonalAISettings(t *testing.T, router http.Handler, token string) {
+	t.Helper()
+	recorder := serveRBACRequest(router, http.MethodDelete, "/api/ai/settings", token)
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("delete personal AI settings: status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+}
+
+func assertSuccessfulAIChat(t *testing.T, router http.Handler, token, wantText string) {
+	t.Helper()
+	recorder := serveRBACRequestWithBody(
+		router,
+		http.MethodPost,
+		"/api/ai/chat",
+		token,
+		`{"messages":[{"role":"user","content":"hello"}]}`,
+	)
+	body := recorder.Body.String()
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("AI chat status=%d body=%s", recorder.Code, body)
+	}
+	if !strings.Contains(body, `"text":"`+wantText+`"`) || !strings.Contains(body, "data: [DONE]") {
+		t.Fatalf("AI chat did not complete with %q: %s", wantText, body)
+	}
+	if strings.Contains(body, `"error"`) {
+		t.Fatalf("AI chat returned an error frame: %s", body)
+	}
+}
+
+func assertUnavailableAIChat(t *testing.T, router http.Handler, token string) {
+	t.Helper()
+	recorder := serveRBACRequestWithBody(
+		router,
+		http.MethodPost,
+		"/api/ai/chat",
+		token,
+		`{"messages":[{"role":"user","content":"hello"}]}`,
+	)
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unavailable AI chat status=%d, want 503; body=%s", recorder.Code, recorder.Body.String())
+	}
+	if strings.Contains(recorder.Body.String(), " response") {
+		t.Fatalf("unavailable AI chat reached a model account: %s", recorder.Body.String())
+	}
+}

--- a/server/internal/auth/permissions_test.go
+++ b/server/internal/auth/permissions_test.go
@@ -21,6 +21,70 @@ func TestHasPermission_UserAndAdmin(t *testing.T) {
 	}
 }
 
+func TestRolePermissionMatrixIsExact(t *testing.T) {
+	permissions := []Permission{
+		PermissionAdmin,
+		PermissionMediaDiscover,
+		PermissionMediaRequest,
+		PermissionAIChat,
+		PermissionMCPAccess,
+		PermissionUsersManage,
+		PermissionRequestsManage,
+		PermissionCredentialsManage,
+		PermissionAIToolsManage,
+		PermissionInstancesManage,
+		PermissionRemediationManage,
+		PermissionArrRead,
+		PermissionArrSearch,
+		PermissionArrBrowse,
+		PermissionDownloadsRead,
+		PermissionDownloadsManage,
+		PermissionMonitoringRead,
+		PermissionSystemRead,
+	}
+	registered := allPermissions()
+	if len(registered) != len(permissions) {
+		t.Fatalf("registered permission count = %d, want explicit matrix count %d", len(registered), len(permissions))
+	}
+	userAllowed := map[Permission]bool{
+		PermissionMediaDiscover: true,
+		PermissionMediaRequest:  true,
+		PermissionAIChat:        true,
+		PermissionMCPAccess:     true,
+		PermissionArrBrowse:     true,
+	}
+	for _, permission := range permissions {
+		if !registered[permission] {
+			t.Errorf("permission %q is missing from the registry", permission)
+		}
+		if !HasPermission(RoleAdmin, permission) {
+			t.Errorf("admin missing permission %q", permission)
+		}
+		if got := HasPermission(RoleUser, permission); got != userAllowed[permission] {
+			t.Errorf("user permission %q = %t, want %t", permission, got, userAllowed[permission])
+		}
+		if HasPermission("unknown", permission) {
+			t.Errorf("unknown role received permission %q", permission)
+		}
+	}
+
+	listedUser := make(map[Permission]bool)
+	for _, permission := range PermissionsForRole(RoleUser) {
+		listedUser[permission] = true
+	}
+	if len(listedUser) != len(userAllowed) {
+		t.Fatalf("listed user permission count = %d, want %d", len(listedUser), len(userAllowed))
+	}
+	for permission := range userAllowed {
+		if !listedUser[permission] {
+			t.Errorf("PermissionsForRole(user) omitted %q", permission)
+		}
+	}
+	if got := PermissionsForRole("unknown"); len(got) != 0 {
+		t.Fatalf("unknown role permission list = %v", got)
+	}
+}
+
 func TestAuthMiddleware_RehydratesCurrentUserRole(t *testing.T) {
 	svc := setupTestService(t)
 

--- a/server/internal/codexapp/manager_test.go
+++ b/server/internal/codexapp/manager_test.go
@@ -1494,6 +1494,7 @@ func assertAppServerCommandSurface(t *testing.T, path string, prefix []string) {
 	}
 	defer func() {
 		_ = stdin.Close()
+		_ = stdout.Close()
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
 	}()
@@ -1507,26 +1508,88 @@ func assertAppServerCommandSurface(t *testing.T, path string, prefix []string) {
 	}
 	scanner := bufio.NewScanner(stdout)
 	scanner.Buffer(make([]byte, 64<<10), maxProtocolBytes)
-	for scanner.Scan() {
-		var response rpcEnvelope
-		if json.Unmarshal(scanner.Bytes(), &response) != nil || string(response.ID) != "1" {
-			continue
+	replies := make(chan rpcEnvelope, 64)
+	scanDone := make(chan error, 1)
+	go func() {
+		defer close(replies)
+		for scanner.Scan() {
+			var response rpcEnvelope
+			if json.Unmarshal(scanner.Bytes(), &response) == nil {
+				replies <- response
+			}
 		}
-		if response.Error != nil {
-			t.Fatalf("app-server rejected initialize with production arguments: code %d", response.Error.Code)
+		scanDone <- scanner.Err()
+	}()
+	readReply := func(id string) rpcEnvelope {
+		t.Helper()
+		for {
+			select {
+			case response, ok := <-replies:
+				if !ok {
+					t.Fatalf("app-server exited before response %s: %v", id, <-scanDone)
+				}
+				if string(response.ID) == id {
+					return response
+				}
+			case <-ctx.Done():
+				t.Fatalf("app-server request %s timed out", id)
+			}
 		}
-		var result struct {
-			CodexHome string `json:"codexHome"`
-		}
-		if json.Unmarshal(response.Result, &result) != nil || !sameDirectory(result.CodexHome, home) {
-			t.Fatalf("app-server did not honor isolated CODEX_HOME: got %q, want %q", result.CodexHome, home)
-		}
-		return
 	}
-	if ctx.Err() != nil {
-		t.Fatalf("app-server initialize timed out with production arguments")
+
+	initialize := readReply("1")
+	if initialize.Error != nil {
+		t.Fatalf("app-server rejected initialize with production arguments: code %d", initialize.Error.Code)
 	}
-	t.Fatalf("app-server exited before initialize response: %v", scanner.Err())
+	var initializeResult struct {
+		CodexHome string `json:"codexHome"`
+	}
+	if json.Unmarshal(initialize.Result, &initializeResult) != nil || !sameDirectory(initializeResult.CodexHome, home) {
+		t.Fatalf("app-server did not honor isolated CODEX_HOME: got %q, want %q", initializeResult.CodexHome, home)
+	}
+
+	encoder := json.NewEncoder(stdin)
+	if err := encoder.Encode(map[string]any{"method": "initialized"}); err != nil {
+		t.Fatalf("write initialized notification: %v", err)
+	}
+	if err := encoder.Encode(map[string]any{
+		"id": 2, "method": "thread/start", "params": map[string]any{
+			"cwd":                     work,
+			"runtimeWorkspaceRoots":   []any{},
+			"approvalPolicy":          "never",
+			"sandbox":                 "read-only",
+			"baseInstructions":        "Cantinarr protocol smoke test",
+			"developerInstructions":   "Do not run a model turn.",
+			"ephemeral":               true,
+			"environments":            []any{},
+			"dynamicTools":            []any{},
+			"selectedCapabilityRoots": []any{},
+			"config":                  restrictedThreadConfig(),
+			"serviceName":             "Cantinarr",
+			"threadSource":            "cantinarr",
+		},
+	}); err != nil {
+		t.Fatalf("write thread/start request: %v", err)
+	}
+	threadStart := readReply("2")
+	if threadStart.Error != nil {
+		t.Fatalf("app-server rejected production thread/start config: code %d: %s", threadStart.Error.Code, threadStart.Error.Message)
+	}
+	var threadResult struct {
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+		ApprovalPolicy string `json:"approvalPolicy"`
+		Sandbox        struct {
+			Type string `json:"type"`
+		} `json:"sandbox"`
+	}
+	if err := json.Unmarshal(threadStart.Result, &threadResult); err != nil {
+		t.Fatalf("decode thread/start response: %v", err)
+	}
+	if threadResult.Thread.ID == "" || threadResult.ApprovalPolicy != "never" || threadResult.Sandbox.Type != "readOnly" {
+		t.Fatalf("unsafe or incomplete thread/start response: %#v", threadResult)
+	}
 }
 
 func TestPrepareRuntimeScrubsOnlyStaleAdapterSessions(t *testing.T) {
@@ -1813,7 +1876,7 @@ func assertRestrictedProtocol(t *testing.T, entries []fakeLogEntry) {
 	config := params["config"].(map[string]any)
 	for _, key := range []string{
 		"features.shell_tool", "features.unified_exec", "features.browser_use", "features.computer_use",
-		"features.image_generation", "apps.enabled", "features.plugins", "features.multi_agent",
+		"features.image_generation", "features.apps", "features.plugins", "features.multi_agent",
 		"features.shell_snapshot", "features.standalone_web_search", "features.request_permissions_tool",
 		"features.memories", "features.guardian_approval", "features.goals", "features.auth_elicitation",
 		"features.personality", "features.artifact", "features.realtime_conversation", "features.remote_compaction_v2",
@@ -1821,6 +1884,9 @@ func assertRestrictedProtocol(t *testing.T, entries []fakeLogEntry) {
 		if config[key] != false {
 			t.Fatalf("thread config did not disable %s: %#v", key, config[key])
 		}
+	}
+	if _, invalid := config["apps.enabled"]; invalid {
+		t.Fatal("thread config included invalid app-server key apps.enabled")
 	}
 	if config["web_search"] != "disabled" {
 		t.Fatalf("web search not disabled: %#v", config["web_search"])

--- a/server/internal/codexapp/run.go
+++ b/server/internal/codexapp/run.go
@@ -604,7 +604,6 @@ func restrictedThreadConfig() map[string]any {
 		"features.computer_use":                    false,
 		"features.image_generation":                false,
 		"features.apps":                            false,
-		"apps.enabled":                             false,
 		"features.plugins":                         false,
 		"features.remote_plugin":                   false,
 		"features.plugin_sharing":                  false,

--- a/server/internal/mcp/tools_test.go
+++ b/server/internal/mcp/tools_test.go
@@ -131,6 +131,67 @@ func TestToolDefinitionsDeclarePermissions(t *testing.T) {
 	}
 }
 
+func TestToolRBACMatrixCoversEveryDefinition(t *testing.T) {
+	server := NewToolServer(nil, nil, nil, nil)
+	listedByRole := map[string]map[string]bool{}
+	for _, role := range []string{auth.RoleAdmin, auth.RoleUser, "unknown"} {
+		listedByRole[role] = make(map[string]bool)
+		for _, tool := range server.GetToolsForRole(role) {
+			if listedByRole[role][tool.Name] {
+				t.Fatalf("role %q received duplicate tool %q", role, tool.Name)
+			}
+			listedByRole[role][tool.Name] = true
+		}
+	}
+
+	seen := make(map[string]bool, len(toolDefinitions))
+	for _, tool := range toolDefinitions {
+		if seen[tool.Name] {
+			t.Fatalf("duplicate tool definition %q", tool.Name)
+		}
+		seen[tool.Name] = true
+
+		for _, role := range []string{auth.RoleAdmin, auth.RoleUser, "unknown"} {
+			want := auth.HasPermission(role, tool.RequiredPermission())
+			if got := listedByRole[role][tool.Name]; got != want {
+				t.Errorf("role %q listed tool %q = %t, want %t for permission %q", role, tool.Name, got, want, tool.RequiredPermission())
+			}
+			if want {
+				continue
+			}
+
+			result, err := server.ExecuteTool(
+				context.Background(),
+				tool.Name,
+				json.RawMessage(`{}`),
+				CallContext{UserID: 1, Role: role},
+			)
+			if err != nil {
+				t.Errorf("role %q denied tool %q with error: %v", role, tool.Name, err)
+				continue
+			}
+			if result == nil || result.Text != "This action is not permitted for your role." {
+				t.Errorf("role %q tool %q denial = %#v", role, tool.Name, result)
+			}
+		}
+	}
+
+	if len(listedByRole[auth.RoleAdmin]) != len(toolDefinitions) {
+		t.Fatalf("admin tool count = %d, want all %d definitions", len(listedByRole[auth.RoleAdmin]), len(toolDefinitions))
+	}
+	if len(listedByRole["unknown"]) != 0 {
+		t.Fatalf("unknown role received %d tools", len(listedByRole["unknown"]))
+	}
+	for _, tool := range AgentTools() {
+		if tool.RequiredPermission() != auth.PermissionRemediationManage {
+			t.Errorf("agent-only tool %q permission = %q", tool.Name, tool.RequiredPermission())
+		}
+		if seen[tool.Name] || hasTool(server.GetToolsForRole(auth.RoleAdmin), tool.Name) || hasTool(server.GetToolsForRole(auth.RoleUser), tool.Name) {
+			t.Errorf("agent-only tool %q leaked into interactive chat tools", tool.Name)
+		}
+	}
+}
+
 func TestGetToolsForRoleFiltersOperationalTools(t *testing.T) {
 	server := NewToolServer(nil, nil, nil, nil)
 	userTools := server.GetToolsForRole(auth.RoleUser)


### PR DESCRIPTION
## Summary

- remove the invalid `apps.enabled=false` thread configuration that made every ChatGPT Codex turn fail before model execution
- extend the pinned app-server smoke test through the production-shaped `thread/start` boundary
- add full-router admin/requester chat coverage for shared grants, revocation, personal accounts, fail-closed overrides, and deliberate fallback
- add exhaustive AI provider/scope/readiness, REST RBAC, role-permission, and MCP tool-permission matrices

## Root cause

Codex app-server 0.144.3 interprets the root `apps` setting as a map of connector IDs. The dotted override `apps.enabled=false` therefore attempts to decode the boolean `false` as an app configuration object, and `thread/start` fails before a model turn begins. The earlier fake app-server accepted arbitrary configuration, while the real-binary smoke test stopped after `initialize`, so neither test reached the failing boundary.

The supported `features.apps=false` lockdown remains in place; only the invalid duplicate key is removed.

## Impact

Included ChatGPT and personal ChatGPT OAuth turns can start and stream responses again. The new integration tests prove which encrypted account scope serves admin and requester API calls, and prove that revoked shared access and broken personal overrides fail closed.

## Validation

- `go vet ./...`
- `go test ./... -count=1 -timeout=10m`
- `go test -race ./internal/ai ./internal/codexapp ./internal/api ./internal/mcp ./internal/auth ./internal/credentials -count=1 -timeout=10m`
- `CGO_ENABLED=0 go build -o /tmp/cantinarr-server-ai-rbac ./cmd/server`
- checksum-verified Codex app-server 0.144.3 production `thread/start` smoke
- `flutter analyze --no-fatal-infos`
- `flutter test` (322 tests)
- `flutter build web --release`

Dockerfile smoke tests were not run locally because the Docker daemon is unavailable; CI runs the repository's Docker verification.

## Documentation

No documented route, setting, provider, or user-facing behavior changed; this restores the already-documented assistant behavior.