### PR TITLE
fix: restore OpenAI API key saves

### DIFF
--- a/app/test/ai_assistant/ai_settings_service_test.dart
+++ b/app/test/ai_assistant/ai_settings_service_test.dart
@@ -66,6 +66,28 @@ void main() {
       'model': 'gpt-5.4-mini',
     });
   });
+
+  test('combines a personal API key and model selection in one save', () async {
+    final adapter = _AiSettingsAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'https://cantinarr.example'))
+      ..httpClientAdapter = adapter;
+    final service = AiSettingsService(backendDio: dio);
+
+    await service.usePersonal(
+      provider: 'openai',
+      model: 'gpt-4.1-mini',
+      apiKey: 'synthetic-personal-key',
+    );
+
+    expect(adapter.requests, hasLength(1));
+    expect(adapter.requests.single.$1, 'PUT');
+    expect(adapter.requests.single.$2, '/api/ai/settings');
+    expect(adapter.requests.single.$3, {
+      'provider': 'openai',
+      'model': 'gpt-4.1-mini',
+      'api_key': 'synthetic-personal-key',
+    });
+  });
 }
 
 Map<String, dynamic> _settingsJson({

--- a/app/test/settings/credentials_screen_test.dart
+++ b/app/test/settings/credentials_screen_test.dart
@@ -55,6 +55,53 @@ void main() {
 
     expect(adapter.lastUpdate?['ai_health_check_enabled'], 'false');
   });
+
+  testWidgets('saves an OpenAI key with its selected shared model',
+      (tester) async {
+    final adapter = _CredentialsAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'https://cantinarr.example'))
+      ..httpClientAdapter = adapter;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [backendClientProvider.overrideWithValue(dio)],
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: const CredentialsScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('ai-provider-codex')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('OpenAI').last);
+    await tester.pumpAndSettle();
+
+    await tester.drag(
+      find.byType(Scrollable).first,
+      const Offset(0, -900),
+    );
+    await tester.pumpAndSettle();
+    final openAIKey = find.byWidgetPredicate(
+      (widget) =>
+          widget is TextField &&
+          widget.decoration?.hintText == 'OpenAI API key',
+    );
+    await tester.ensureVisible(openAIKey);
+    await tester.enterText(openAIKey, 'synthetic-shared-key');
+
+    final save = find.widgetWithText(ElevatedButton, 'Save');
+    await tester.ensureVisible(save);
+    await tester.tap(save);
+    await tester.pumpAndSettle();
+
+    expect(adapter.lastUpdate, {
+      'openai_key': 'synthetic-shared-key',
+      'ai_provider': 'openai',
+      'ai_model': 'gpt-4.1-mini',
+    });
+  });
 }
 
 class _CredentialsAdapter implements HttpClientAdapter {
@@ -93,6 +140,15 @@ class _CredentialsAdapter implements HttpClientAdapter {
               'credential_key': '',
               'models': [
                 {'id': 'gpt-5.4', 'label': 'GPT-5.4'},
+              ],
+            },
+            {
+              'id': 'openai',
+              'label': 'OpenAI',
+              'auth_type': 'api_key',
+              'credential_key': 'openai_key',
+              'models': [
+                {'id': 'gpt-4.1-mini', 'label': 'GPT-4.1 mini'},
               ],
             },
           ],

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -211,6 +211,8 @@ func main() {
 		log.Printf("OpenAI OAuth provider unavailable: %v", codexManager.AvailabilityError())
 	}
 	aiHandler := ai.NewHandler(creds, toolServer, codexManager)
+	aiHandler.SetPermissionAuthorizer(authService.AuthorizePermission)
+	credHandler.SetPermissionAuthorizer(authService.AuthorizePermission)
 	credHandler.SetSharedAIConfigured(aiHandler.ProviderConfigured)
 	aiHandler.SetSharedAIHealthIssueSink(remediationService)
 	credHandler.SetSharedAIValidator(aiHandler.ValidateSharedAISettings, aiHandler.SharedAISettingsValidated)

--- a/server/internal/ai/codex_handler.go
+++ b/server/internal/ai/codex_handler.go
@@ -209,7 +209,7 @@ func (h *Handler) CheckSharedCodexDeviceLogin(w http.ResponseWriter, r *http.Req
 			selected = true
 		}
 		if validateErr := h.ValidateSharedAISettings(r.Context(), credentials.AIProfile{Config: config, CredentialPresent: true}); validateErr != nil {
-			log.Printf("shared OpenAI OAuth validation failed model=%q: %s", config.Model, AIValidationDiagnostic(validateErr))
+			log.Printf("shared OpenAI OAuth validation failed: %s", AIValidationDiagnostic(validateErr))
 			writeCodexError(w, http.StatusUnprocessableEntity, AIValidationUserMessage(validateErr))
 			return
 		}

--- a/server/internal/ai/handler.go
+++ b/server/internal/ai/handler.go
@@ -20,15 +20,16 @@ import (
 
 // Handler provides HTTP handlers for AI chat endpoints.
 type Handler struct {
-	creds           *credentials.Registry
-	toolServer      *mcp.ToolServer
-	codex           *codexapp.Manager
-	conversations   *conversationStore
-	validationProbe func(context.Context, credentials.AIProfile, codexapp.AccountRef) error
-	healthIssueSink SharedAIHealthIssueSink
-	settingsMu      sync.Mutex
-	admissionOnce   sync.Once
-	admission       *chatAdmission
+	creds               *credentials.Registry
+	toolServer          *mcp.ToolServer
+	codex               *codexapp.Manager
+	conversations       *conversationStore
+	validationProbe     func(context.Context, credentials.AIProfile, codexapp.AccountRef) error
+	healthIssueSink     SharedAIHealthIssueSink
+	authorizePermission auth.PermissionAuthorizer
+	settingsMu          sync.Mutex
+	admissionOnce       sync.Once
+	admission           *chatAdmission
 }
 
 func (h *Handler) chatAdmission() *chatAdmission {
@@ -39,6 +40,12 @@ func (h *Handler) chatAdmission() *chatAdmission {
 // NewHandler creates a new AI handler.
 func NewHandler(creds *credentials.Registry, toolServer *mcp.ToolServer, codex *codexapp.Manager) *Handler {
 	return &Handler{creds: creds, toolServer: toolServer, codex: codex, conversations: newConversationStore()}
+}
+
+// SetPermissionAuthorizer supplies the live user/device permission check used
+// after provider validation and immediately before settings persistence.
+func (h *Handler) SetPermissionAuthorizer(authorize auth.PermissionAuthorizer) {
+	h.authorizePermission = authorize
 }
 
 type chatRequest struct {

--- a/server/internal/ai/http_providers.go
+++ b/server/internal/ai/http_providers.go
@@ -54,15 +54,7 @@ func (s *openAIService) SendMessage(ctx context.Context, history transcript, cha
 	finalHistory := cloneTranscript(history)
 
 	for iteration := 0; iteration < maxToolIterations; iteration++ {
-		params := openai.ChatCompletionNewParams{
-			Model:               s.model,
-			Messages:            messages,
-			MaxCompletionTokens: openai.Int(httpProviderMaxOutputTokens),
-			Tools:               tools,
-		}
-		if iteration == maxToolIterations-1 {
-			params.ToolChoice.OfAuto = openai.String(string(openai.ChatCompletionToolChoiceOptionAutoNone))
-		}
+		params := openAIInteractiveParams(s.model, messages, tools, iteration == maxToolIterations-1)
 
 		message, finishReason, err := s.chatStream(ctx, params, cb)
 		if err != nil {
@@ -99,6 +91,24 @@ func (s *openAIService) SendMessage(ctx context.Context, history transcript, cha
 	}
 
 	return finalHistory, fmt.Errorf("agent loop exceeded %d iterations", maxToolIterations)
+}
+
+func openAIInteractiveParams(
+	model openai.ChatModel,
+	messages []openai.ChatCompletionMessageParamUnion,
+	tools []openai.ChatCompletionToolUnionParam,
+	forceText bool,
+) openai.ChatCompletionNewParams {
+	params := openai.ChatCompletionNewParams{
+		Model:               model,
+		Messages:            messages,
+		MaxCompletionTokens: openai.Int(httpProviderMaxOutputTokens),
+		Tools:               tools,
+	}
+	if forceText && len(tools) > 0 {
+		params.ToolChoice.OfAuto = openai.String(string(openai.ChatCompletionToolChoiceOptionAutoNone))
+	}
+	return params
 }
 
 func (s *openAIService) chatStream(ctx context.Context, params openai.ChatCompletionNewParams, cb StreamCallbacks) (openAIMessage, string, error) {

--- a/server/internal/ai/http_providers_test.go
+++ b/server/internal/ai/http_providers_test.go
@@ -219,6 +219,63 @@ func TestLiveAPIKeyInteractiveChat(t *testing.T) {
 	}
 }
 
+// TestLiveOpenAIInteractiveCatalog proves that every advertised OpenAI model
+// accepts Cantinarr's production interactive request shape, including the
+// requester tool catalog. It is intentionally opt-in because it spends real
+// API quota.
+func TestLiveOpenAIInteractiveCatalog(t *testing.T) {
+	if os.Getenv("CANTINARR_LIVE_AI_TESTS") != "1" {
+		t.Skip("set CANTINARR_LIVE_AI_TESTS=1 to run hosted-provider smoke tests")
+	}
+	if filter := strings.TrimSpace(os.Getenv("CANTINARR_LIVE_AI_PROVIDER")); filter != "" && filter != credentials.AIProviderOpenAI {
+		t.Skip("OpenAI is not selected by CANTINARR_LIVE_AI_PROVIDER")
+	}
+	key := os.Getenv("OPENAI_API_KEY")
+	if key == "" {
+		t.Skip("OPENAI_API_KEY is not set")
+	}
+
+	var models []credentials.AIModelOption
+	for _, provider := range credentials.AIProviders {
+		if provider.ID == credentials.AIProviderOpenAI {
+			models = provider.Models
+			break
+		}
+	}
+	if len(models) == 0 {
+		t.Fatal("advertised OpenAI model catalog is empty")
+	}
+
+	for _, model := range models {
+		model := model
+		t.Run(model.ID, func(t *testing.T) {
+			toolServer := mcp.NewToolServer(nil, nil, nil, nil)
+			toolServer.SetCallAuthorizer(func(context.Context, mcp.CallContext) (string, error) {
+				return auth.RoleUser, nil
+			})
+			history := transcript{textTranscriptMessage(agentRoleUser, "Reply with exactly LIVE_OK. Do not call a tool.")}
+			var streamed strings.Builder
+			final, err := NewOpenAIService(key, model.ID, toolServer).SendMessage(
+				context.Background(),
+				history,
+				ChatContext{UserID: 1, Role: auth.RoleUser, DeviceID: "live-openai-catalog-device"},
+				StreamCallbacks{OnText: func(value string) { streamed.WriteString(value) }},
+			)
+			if err != nil {
+				classified := newAIValidationFailure(err)
+				var failure *AIValidationFailure
+				if errors.As(classified, &failure) && (failure.Kind == AIValidationFailureUnsupportedModel || failure.Kind == AIValidationFailureQuota) {
+					t.Skip(AIValidationUserMessage(classified))
+				}
+				t.Fatal(AIValidationUserMessage(classified))
+			}
+			if strings.TrimSpace(streamed.String()) == "" || len(final) <= len(history) {
+				t.Fatalf("interactive chat returned no assistant response: messages=%d", len(final))
+			}
+		})
+	}
+}
+
 func TestProviderNeutralTranscriptConvertersPreserveToolContext(t *testing.T) {
 	history := transcript{
 		textTranscriptMessage(agentRoleUser, "find dune"),

--- a/server/internal/ai/provider_contract_test.go
+++ b/server/internal/ai/provider_contract_test.go
@@ -316,14 +316,41 @@ func TestOpenAIValidationProviderContract(t *testing.T) {
 	if got := req.body["reasoning_effort"]; got != "none" {
 		t.Fatalf("reasoning_effort=%v, want none", got)
 	}
-	if got := req.body["tool_choice"]; got != "none" {
-		t.Fatalf("tool_choice=%v, want none", got)
+	if _, found := req.body["tool_choice"]; found {
+		t.Fatalf("tool-free validation request unexpectedly included tool_choice: %#v", req.body)
 	}
 	if got := req.body["stream_options"].(map[string]any)["include_usage"]; got != true {
 		t.Fatalf("stream_options.include_usage=%v, want true", got)
 	}
 	if _, found := req.body["tools"]; found {
 		t.Fatal("validation request unexpectedly included tools")
+	}
+}
+
+func TestOpenAIInteractiveFinalIterationKeepsToolChoiceWithTools(t *testing.T) {
+	tools := toOpenAITools(mcp.NewToolServer(nil, nil, nil, nil).GetToolsForRole(auth.RoleUser))
+	if len(tools) == 0 {
+		t.Fatal("user tool catalog is empty")
+	}
+	params := openAIInteractiveParams(
+		"gpt-5.5",
+		[]openai.ChatCompletionMessageParamUnion{openai.UserMessage("hello")},
+		tools,
+		true,
+	)
+	body, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if got := decoded["tool_choice"]; got != "none" {
+		t.Fatalf("tool_choice=%v, want none", got)
+	}
+	if got, ok := decoded["tools"].([]any); !ok || len(got) == 0 {
+		t.Fatalf("final interactive request omitted tools: %#v", decoded)
 	}
 }
 

--- a/server/internal/ai/resolver_test.go
+++ b/server/internal/ai/resolver_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/windoze95/cantinarr-server/internal/auth"
 	"github.com/windoze95/cantinarr-server/internal/codexapp"
 	"github.com/windoze95/cantinarr-server/internal/credentials"
 	"github.com/windoze95/cantinarr-server/internal/db"
@@ -31,7 +32,12 @@ func newResolverTestHandler(t *testing.T) (*Handler, *credentials.Registry, *sql
 	}
 	userID, _ := result.LastInsertId()
 	registry := credentials.NewRegistry(database, cipher)
-	handler := &Handler{creds: registry}
+	handler := &Handler{
+		creds: registry,
+		authorizePermission: func(context.Context, int64, string, auth.Permission) error {
+			return nil
+		},
+	}
 	handler.validationProbe = func(context.Context, credentials.AIProfile, codexapp.AccountRef) error { return nil }
 	return handler, registry, database, userID
 }

--- a/server/internal/ai/settings_handler.go
+++ b/server/internal/ai/settings_handler.go
@@ -1,7 +1,9 @@
 package ai
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strings"
@@ -17,6 +19,8 @@ const (
 	maxAIModelLength  = 256
 	maxAIAPIKeyLength = 32 << 10
 )
+
+var errAISettingsAuthorizationUnavailable = errors.New("AI settings authorization is unavailable")
 
 type updatePersonalAISettingsRequest struct {
 	Provider string `json:"provider"`
@@ -83,8 +87,11 @@ func (h *Handler) UpdateAISettings(w http.ResponseWriter, r *http.Request) {
 		profile.APIKey, profile.CredentialPresent = key, found
 	}
 	if err := h.ValidatePersonalAISettings(r.Context(), claims.UserID, profile); err != nil {
-		log.Printf("personal AI validation failed user_id=%d provider=%q model=%q: %s", claims.UserID, req.Provider, req.Model, AIValidationDiagnostic(err))
+		log.Printf("personal AI validation failed user_id=%d provider=%q: %s", claims.UserID, req.Provider, AIValidationDiagnostic(err))
 		writeAISettingsError(w, http.StatusUnprocessableEntity, AIValidationUserMessage(err))
+		return
+	}
+	if !h.reauthorizePersonalAIWrite(w, r, claims) {
 		return
 	}
 	if err := h.creds.SetUserAIProfile(claims.UserID, req.Provider, req.Model, req.APIKey); err != nil {
@@ -150,8 +157,11 @@ func (h *Handler) UpdatePersonalAICredential(w http.ResponseWriter, r *http.Requ
 		CredentialPresent: true,
 	}
 	if err := h.ValidatePersonalAISettings(r.Context(), claims.UserID, profile); err != nil {
-		log.Printf("personal AI credential validation failed user_id=%d provider=%q model=%q: %s", claims.UserID, provider, req.Model, AIValidationDiagnostic(err))
+		log.Printf("personal AI credential validation failed user_id=%d provider=%q: %s", claims.UserID, provider, AIValidationDiagnostic(err))
 		writeAISettingsError(w, http.StatusUnprocessableEntity, AIValidationUserMessage(err))
+		return
+	}
+	if !h.reauthorizePersonalAIWrite(w, r, claims) {
 		return
 	}
 	setAINoStore(w)
@@ -160,6 +170,27 @@ func (h *Handler) UpdatePersonalAICredential(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) authorizeSettingsWrite(ctx context.Context, userID int64, deviceID string, permission auth.Permission) error {
+	if h.authorizePermission == nil {
+		return errAISettingsAuthorizationUnavailable
+	}
+	return h.authorizePermission(ctx, userID, deviceID, permission)
+}
+
+func (h *Handler) reauthorizePersonalAIWrite(w http.ResponseWriter, r *http.Request, claims *auth.Claims) bool {
+	err := h.authorizeSettingsWrite(r.Context(), claims.UserID, claims.DeviceID, auth.PermissionAIChat)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, auth.ErrAuthUnavailable) || errors.Is(err, errAISettingsAuthorizationUnavailable) ||
+		errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		writeAISettingsError(w, http.StatusServiceUnavailable, "AI settings authorization is temporarily unavailable")
+	} else {
+		writeAISettingsError(w, http.StatusForbidden, "permission denied")
+	}
+	return false
 }
 
 func (h *Handler) DeletePersonalAICredential(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/ai/settings_handler_test.go
+++ b/server/internal/ai/settings_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -144,6 +145,39 @@ func TestPersonalAIValidationFailureLeavesSettingsAndKeyUnchanged(t *testing.T) 
 	key, found, err := registry.UserAICredential(userID, credentials.AIProviderAnthropic)
 	if err != nil || !found || key != "old-secret" {
 		t.Fatalf("stored key=%q found=%t err=%v", key, found, err)
+	}
+}
+
+func TestPersonalAIValidationLogOmitsModelAndBareProviderKey(t *testing.T) {
+	h, _, _, userID := newResolverTestHandler(t)
+	const (
+		modelSecret = "sk-proj-SyntheticPersonalModel123456789"
+		keySecret   = "sk-ant-api03-SyntheticProviderEcho123456789"
+	)
+	h.validationProbe = func(context.Context, credentials.AIProfile, codexapp.AccountRef) error {
+		return errors.New("provider rejected " + keySecret)
+	}
+	var logs bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	req := httptest.NewRequest(http.MethodPut, "/api/ai/settings", strings.NewReader(
+		`{"provider":"openai","model":"`+modelSecret+`","api_key":"synthetic-personal-candidate"}`,
+	))
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{
+		UserID: userID, Role: auth.RoleUser, DeviceID: "personal-log-test-device",
+	}))
+	rec := httptest.NewRecorder()
+	h.UpdateAISettings(rec, req)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(logs.String(), modelSecret) || strings.Contains(logs.String(), keySecret) {
+		t.Fatalf("personal validation log leaked model or provider credential: %s", logs.String())
+	}
+	if !strings.Contains(logs.String(), secrets.RedactedValue) {
+		t.Fatalf("personal validation log did not retain a redaction marker: %s", logs.String())
 	}
 }
 

--- a/server/internal/ai/turn.go
+++ b/server/internal/ai/turn.go
@@ -103,8 +103,9 @@ type TurnParams struct {
 	Tools []mcp.Tool
 	// History is the provider-neutral transcript to continue from.
 	History Transcript
-	// ForceNoTools omits tools / sets tool_choice:none so the model must answer
-	// in text (used to coerce a final diagnosis when bounds are nearly spent).
+	// ForceNoTools uses each provider's compatible tool-free request shape so the
+	// model must answer in text (used to coerce a final diagnosis when bounds are
+	// nearly spent).
 	ForceNoTools bool
 	// DisableReasoning requests the provider's lowest supported reasoning mode.
 	// Validation probes use this so hidden reasoning cannot consume their small
@@ -447,8 +448,6 @@ func openAINextTurnParamsForAttempt(model openai.ChatModel, p TurnParams, attemp
 	}
 	if !p.ForceNoTools && len(p.Tools) > 0 {
 		params.Tools = toOpenAITools(p.Tools)
-	} else {
-		params.ToolChoice.OfAuto = openai.String(string(openai.ChatCompletionToolChoiceOptionAutoNone))
 	}
 	if attempt.effort != "" {
 		params.ReasoningEffort = attempt.effort

--- a/server/internal/ai/validation.go
+++ b/server/internal/ai/validation.go
@@ -306,7 +306,7 @@ func (h *Handler) runSharedAIHealthCheck(ctx context.Context, now time.Time) {
 		log.Printf("ai health: record scheduled check: %v", err)
 	}
 	if probeErr != nil {
-		log.Printf("ai health: shared provider=%q model=%q failed: %s", config.Provider, config.Model, AIValidationDiagnostic(probeErr))
+		log.Printf("ai health: shared provider=%q failed: %s", config.Provider, AIValidationDiagnostic(probeErr))
 	}
 	if h.healthIssueSink != nil {
 		if err := h.healthIssueSink.RecordSharedAIHealth(config.Provider, config.Model, probeErr == nil); err != nil {

--- a/server/internal/api/ai_settings_reauthorization_test.go
+++ b/server/internal/api/ai_settings_reauthorization_test.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/credentials"
+)
+
+func TestSharedAIKeySaveReauthorizesAfterValidation(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		revoke func(*testing.T, *rbacRouterHarness)
+	}{
+		{
+			name: "admin demoted",
+			revoke: func(t *testing.T, harness *rbacRouterHarness) {
+				t.Helper()
+				if _, err := harness.database.Exec(`UPDATE users SET role = ? WHERE id = ?`, auth.RoleUser, harness.adminID); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "admin device revoked",
+			revoke: func(t *testing.T, harness *rbacRouterHarness) {
+				t.Helper()
+				if err := harness.authService.RevokeDevice(harness.adminDeviceID); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			upstream, started, release := newBlockingOpenAIValidationUpstream(t)
+			t.Setenv("OPENAI_BASE_URL", upstream.URL+"/v1")
+			harness := newRBACRouterHarness(t, false)
+			const candidate = "sk-test-shared-reauthorization"
+			result := make(chan *httptest.ResponseRecorder, 1)
+			go func() {
+				result <- serveRBACRequestWithBody(
+					harness.router,
+					http.MethodPut,
+					"/api/admin/credentials",
+					harness.adminToken,
+					`{"openai_key":"`+candidate+`","ai_provider":"openai","ai_model":"gpt-4.1-mini"}`,
+				)
+			}()
+
+			awaitBlockedValidation(t, started)
+			test.revoke(t, harness)
+			release()
+			recorder := awaitBlockedResponse(t, result)
+			if recorder.Code != http.StatusForbidden {
+				t.Fatalf("save after authority revocation status=%d, want 403; body=%s", recorder.Code, recorder.Body.String())
+			}
+			if strings.Contains(recorder.Body.String(), candidate) {
+				t.Fatalf("authorization failure exposed candidate credential: %s", recorder.Body.String())
+			}
+			if harness.registry.IsConfigured(credentials.KeyOpenAIKey) {
+				t.Fatal("shared OpenAI credential persisted after authority revocation")
+			}
+			if got := harness.registry.GetAIConfig(); got.Provider == credentials.AIProviderOpenAI {
+				t.Fatalf("shared OpenAI selection persisted after authority revocation: %#v", got)
+			}
+		})
+	}
+}
+
+func TestPersonalAIKeySaveAndRotationReauthorizeAfterValidation(t *testing.T) {
+	t.Run("combined save after device revocation", func(t *testing.T) {
+		upstream, started, release := newBlockingOpenAIValidationUpstream(t)
+		t.Setenv("OPENAI_BASE_URL", upstream.URL+"/v1")
+		harness := newRBACRouterHarness(t, false)
+		const candidate = "sk-test-personal-reauthorization"
+		result := make(chan *httptest.ResponseRecorder, 1)
+		go func() {
+			result <- serveRBACRequestWithBody(
+				harness.router,
+				http.MethodPut,
+				"/api/ai/settings",
+				harness.requesterToken,
+				`{"provider":"openai","model":"gpt-4.1-mini","api_key":"`+candidate+`"}`,
+			)
+		}()
+
+		awaitBlockedValidation(t, started)
+		if err := harness.authService.RevokeDevice(harness.requesterDeviceID); err != nil {
+			t.Fatal(err)
+		}
+		release()
+		recorder := awaitBlockedResponse(t, result)
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf("personal save after device revocation status=%d, want 403; body=%s", recorder.Code, recorder.Body.String())
+		}
+		if strings.Contains(recorder.Body.String(), candidate) {
+			t.Fatalf("authorization failure exposed candidate credential: %s", recorder.Body.String())
+		}
+		if _, found, err := harness.registry.LoadUserAIProfile(t.Context(), harness.requesterID); err != nil || found {
+			t.Fatalf("personal profile persisted after device revocation: found=%t err=%v", found, err)
+		}
+	})
+
+	t.Run("key rotation after role disabled", func(t *testing.T) {
+		upstream, started, release := newBlockingOpenAIValidationUpstream(t)
+		t.Setenv("OPENAI_BASE_URL", upstream.URL+"/v1")
+		harness := newRBACRouterHarness(t, false)
+		const (
+			oldKey    = "sk-test-personal-old"
+			candidate = "sk-test-personal-new"
+		)
+		if err := harness.registry.SetUserAIConfig(harness.requesterID, credentials.AIProviderOpenAI, "gpt-4.1-mini"); err != nil {
+			t.Fatal(err)
+		}
+		if err := harness.registry.SetUserAICredential(harness.requesterID, credentials.AIProviderOpenAI, oldKey); err != nil {
+			t.Fatal(err)
+		}
+		result := make(chan *httptest.ResponseRecorder, 1)
+		go func() {
+			result <- serveRBACRequestWithBody(
+				harness.router,
+				http.MethodPut,
+				"/api/ai/credentials/openai",
+				harness.requesterToken,
+				`{"api_key":"`+candidate+`","model":"gpt-4.1-mini"}`,
+			)
+		}()
+
+		awaitBlockedValidation(t, started)
+		if _, err := harness.database.Exec(`UPDATE users SET role = 'disabled' WHERE id = ?`, harness.requesterID); err != nil {
+			t.Fatal(err)
+		}
+		release()
+		recorder := awaitBlockedResponse(t, result)
+		if recorder.Code != http.StatusForbidden {
+			t.Fatalf("personal rotation after role disable status=%d, want 403; body=%s", recorder.Code, recorder.Body.String())
+		}
+		key, found, err := harness.registry.UserAICredential(harness.requesterID, credentials.AIProviderOpenAI)
+		if err != nil || !found || key != oldKey {
+			t.Fatalf("personal rotation changed old key after authority revocation: found=%t err=%v", found, err)
+		}
+	})
+}
+
+func newBlockingOpenAIValidationUpstream(t *testing.T) (*httptest.Server, <-chan struct{}, func()) {
+	t.Helper()
+	started := make(chan struct{}, 1)
+	releaseChannel := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseChannel) }) }
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		started <- struct{}{}
+		select {
+		case <-releaseChannel:
+		case <-r.Context().Done():
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"id":"chatcmpl-reauth","object":"chat.completion.chunk","created":1,"model":"gpt-4.1-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"OK"},"finish_reason":"stop"}]}`+"\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(func() {
+		release()
+		server.Close()
+	})
+	return server, started, release
+}
+
+func awaitBlockedValidation(t *testing.T, started <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("provider validation did not reach the blocking upstream")
+	}
+}
+
+func awaitBlockedResponse(t *testing.T, result <-chan *httptest.ResponseRecorder) *httptest.ResponseRecorder {
+	t.Helper()
+	select {
+	case recorder := <-result:
+		return recorder
+	case <-time.After(2 * time.Second):
+		t.Fatal("credential save did not finish after provider validation was released")
+		return nil
+	}
+}

--- a/server/internal/api/openai_credential_save_test.go
+++ b/server/internal/api/openai_credential_save_test.go
@@ -1,0 +1,292 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/credentials"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+type strictOpenAISaveRequest struct {
+	path          string
+	authorization string
+	body          map[string]any
+}
+
+// TestOpenAIAPIKeySavesThroughAuthenticatedRouter covers the two public save
+// paths that must reach the same production OpenAI validation adapter. The fake
+// upstream reproduces OpenAI's hosted contract: tool_choice is rejected when a
+// request does not also contain tools.
+func TestOpenAIAPIKeySavesThroughAuthenticatedRouter(t *testing.T) {
+	upstream, requests := newStrictOpenAISaveUpstream(t)
+	t.Setenv("OPENAI_BASE_URL", upstream.URL+"/v1")
+
+	harness := newRBACRouterHarness(t, false)
+	const (
+		model        = "gpt-4.1-mini"
+		sharedKey    = "sk-test-shared-openai"
+		personalKey  = "sk-test-personal-openai"
+		sharedBody   = `{"openai_key":"sk-test-shared-openai","ai_provider":"openai","ai_model":"gpt-4.1-mini"}`
+		personalBody = `{"provider":"openai","model":"gpt-4.1-mini","api_key":"sk-test-personal-openai"}`
+	)
+
+	denied := serveRBACRequestWithBody(
+		harness.router,
+		http.MethodPut,
+		"/api/admin/credentials",
+		harness.requesterToken,
+		sharedBody,
+	)
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("requester shared save status=%d, want 403; body=%s", denied.Code, denied.Body.String())
+	}
+	assertNoStrictOpenAISaveRequest(t, requests)
+	if harness.registry.IsConfigured(credentials.KeyOpenAIKey) {
+		t.Fatal("denied requester shared save persisted an OpenAI key")
+	}
+
+	shared := serveRBACRequestWithBody(
+		harness.router,
+		http.MethodPut,
+		"/api/admin/credentials",
+		harness.adminToken,
+		sharedBody,
+	)
+	if shared.Code != http.StatusOK {
+		t.Fatalf("admin shared save status=%d, want 200; body=%s", shared.Code, shared.Body.String())
+	}
+	assertResponseOmitsSyntheticSecrets(t, shared.Body.String(), sharedKey, personalKey)
+	assertStrictOpenAISaveRequest(t, requests, sharedKey, model)
+	if got := harness.registry.GetCredential(credentials.KeyOpenAIKey); got != sharedKey {
+		t.Fatalf("stored shared credential=%q, want synthetic shared key", got)
+	}
+	if got := harness.registry.GetAIConfig(); got.Provider != credentials.AIProviderOpenAI || got.Model != model {
+		t.Fatalf("stored shared config=%#v", got)
+	}
+	assertEncryptedSetting(t, harness, credentials.KeyOpenAIKey, sharedKey)
+
+	personal := serveRBACRequestWithBody(
+		harness.router,
+		http.MethodPut,
+		"/api/ai/settings",
+		harness.requesterToken,
+		personalBody,
+	)
+	if personal.Code != http.StatusOK {
+		t.Fatalf("requester personal save status=%d, want 200; body=%s", personal.Code, personal.Body.String())
+	}
+	assertResponseOmitsSyntheticSecrets(t, personal.Body.String(), sharedKey, personalKey)
+	assertStrictOpenAISaveRequest(t, requests, personalKey, model)
+
+	profile, found, err := harness.registry.LoadUserAIProfile(t.Context(), harness.requesterID)
+	if err != nil || !found {
+		t.Fatalf("load requester personal profile: found=%t err=%v", found, err)
+	}
+	if profile.Config.Provider != credentials.AIProviderOpenAI || profile.Config.Model != model || profile.APIKey != personalKey {
+		t.Fatalf("requester personal profile=%#v", profile)
+	}
+	if _, found, err := harness.registry.LoadUserAIProfile(t.Context(), harness.adminID); err != nil || found {
+		t.Fatalf("requester save crossed into admin profile: found=%t err=%v", found, err)
+	}
+	assertEncryptedUserCredential(t, harness, harness.requesterID, credentials.AIProviderOpenAI, personalKey)
+	if got := harness.registry.GetCredential(credentials.KeyOpenAIKey); got != sharedKey {
+		t.Fatal("personal save changed the shared OpenAI credential")
+	}
+}
+
+func TestLiveOpenAIAPIKeySavesThroughAuthenticatedRouter(t *testing.T) {
+	if os.Getenv("CANTINARR_LIVE_AI_TESTS") != "1" {
+		t.Skip("set CANTINARR_LIVE_AI_TESTS=1 to run hosted-provider save tests")
+	}
+	key := strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+	if key == "" {
+		t.Skip("OPENAI_API_KEY is not set")
+	}
+	t.Setenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+	harness := newRBACRouterHarness(t, false)
+
+	var logs bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	sharedPayload, err := json.Marshal(map[string]string{
+		credentials.KeyOpenAIKey:  key,
+		credentials.KeyAIProvider: credentials.AIProviderOpenAI,
+		credentials.KeyAIModel:    "gpt-4.1-mini",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	shared := serveRBACRequestWithBody(
+		harness.router,
+		http.MethodPut,
+		"/api/admin/credentials",
+		harness.adminToken,
+		string(sharedPayload),
+	)
+	if strings.Contains(shared.Body.String(), key) {
+		t.Fatal("hosted shared save response exposed the OpenAI key")
+	}
+	if shared.Code != http.StatusOK {
+		t.Fatalf("hosted shared OpenAI save status=%d", shared.Code)
+	}
+	if got := harness.registry.GetCredential(credentials.KeyOpenAIKey); got != key {
+		t.Fatal("hosted shared save did not persist the exact OpenAI key")
+	}
+	assertEncryptedSetting(t, harness, credentials.KeyOpenAIKey, key)
+
+	personalPayload, err := json.Marshal(map[string]string{
+		"provider": credentials.AIProviderOpenAI,
+		"model":    "gpt-4.1-mini",
+		"api_key":  key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	personal := serveRBACRequestWithBody(
+		harness.router,
+		http.MethodPut,
+		"/api/ai/settings",
+		harness.requesterToken,
+		string(personalPayload),
+	)
+	if strings.Contains(personal.Body.String(), key) {
+		t.Fatal("hosted personal save response exposed the OpenAI key")
+	}
+	if personal.Code != http.StatusOK {
+		t.Fatalf("hosted personal OpenAI save status=%d", personal.Code)
+	}
+	profile, found, err := harness.registry.LoadUserAIProfile(t.Context(), harness.requesterID)
+	if err != nil || !found || profile.Config.Provider != credentials.AIProviderOpenAI ||
+		profile.Config.Model != "gpt-4.1-mini" || profile.APIKey != key {
+		t.Fatal("hosted personal save did not persist the exact isolated OpenAI profile")
+	}
+	if _, found, err := harness.registry.LoadUserAIProfile(t.Context(), harness.adminID); err != nil || found {
+		t.Fatal("hosted requester save crossed into the admin personal profile")
+	}
+	assertEncryptedUserCredential(t, harness, harness.requesterID, credentials.AIProviderOpenAI, key)
+	if got := harness.registry.GetCredential(credentials.KeyOpenAIKey); got != key {
+		t.Fatal("hosted personal save changed the shared OpenAI credential")
+	}
+	if strings.Contains(logs.String(), key) {
+		t.Fatal("hosted OpenAI save wrote the API key to logs")
+	}
+}
+
+func newStrictOpenAISaveUpstream(t *testing.T) (*httptest.Server, <-chan strictOpenAISaveRequest) {
+	t.Helper()
+	requests := make(chan strictOpenAISaveRequest, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, `{"error":{"message":"read request"}}`, http.StatusBadRequest)
+			return
+		}
+		var body map[string]any
+		if err := json.Unmarshal(bodyBytes, &body); err != nil {
+			http.Error(w, `{"error":{"message":"invalid JSON"}}`, http.StatusBadRequest)
+			return
+		}
+		requests <- strictOpenAISaveRequest{
+			path:          r.URL.Path,
+			authorization: r.Header.Get("Authorization"),
+			body:          body,
+		}
+		if _, hasChoice := body["tool_choice"]; hasChoice {
+			if tools, ok := body["tools"].([]any); !ok || len(tools) == 0 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{
+					"message": "Tool choice is only allowed when tools are specified.",
+					"type":    "invalid_request_error",
+					"param":   "tool_choice",
+					"code":    nil,
+				}})
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"id":"chatcmpl-save","object":"chat.completion.chunk","created":1,"model":"gpt-4.1-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"OK"},"finish_reason":"stop"}]}`+"\n\n")
+		_, _ = io.WriteString(w, `data: {"id":"chatcmpl-save","object":"chat.completion.chunk","created":1,"model":"gpt-4.1-mini","choices":[],"usage":{"prompt_tokens":7,"completion_tokens":1,"total_tokens":8}}`+"\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	t.Cleanup(server.Close)
+	return server, requests
+}
+
+func assertNoStrictOpenAISaveRequest(t *testing.T, requests <-chan strictOpenAISaveRequest) {
+	t.Helper()
+	select {
+	case request := <-requests:
+		t.Fatalf("authorization failure reached OpenAI upstream: %#v", request.body)
+	default:
+	}
+}
+
+func assertStrictOpenAISaveRequest(t *testing.T, requests <-chan strictOpenAISaveRequest, key, model string) {
+	t.Helper()
+	select {
+	case request := <-requests:
+		if request.path != "/v1/chat/completions" {
+			t.Fatalf("OpenAI validation path=%q", request.path)
+		}
+		if request.authorization != "Bearer "+key {
+			t.Fatalf("OpenAI validation authorization did not use the expected synthetic key")
+		}
+		if request.body["model"] != model {
+			t.Fatalf("OpenAI validation model=%v, want %q", request.body["model"], model)
+		}
+		if _, found := request.body["tool_choice"]; found {
+			t.Fatalf("tool-free OpenAI save validation sent tool_choice: %#v", request.body)
+		}
+		if _, found := request.body["tools"]; found {
+			t.Fatalf("tool-free OpenAI save validation sent tools: %#v", request.body)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("OpenAI save validation did not reach the strict upstream")
+	}
+}
+
+func assertResponseOmitsSyntheticSecrets(t *testing.T, response string, secrets ...string) {
+	t.Helper()
+	for _, secret := range secrets {
+		if strings.Contains(response, secret) {
+			t.Fatalf("credential save response exposed a synthetic secret: %s", response)
+		}
+	}
+}
+
+func assertEncryptedSetting(t *testing.T, harness *rbacRouterHarness, key, plaintext string) {
+	t.Helper()
+	var stored string
+	if err := harness.database.QueryRow(`SELECT value FROM settings WHERE key = ?`, key).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored == plaintext || strings.Contains(stored, plaintext) || !secrets.IsEncrypted(stored) {
+		t.Fatal("shared credential was not encrypted at rest")
+	}
+}
+
+func assertEncryptedUserCredential(t *testing.T, harness *rbacRouterHarness, userID int64, provider, plaintext string) {
+	t.Helper()
+	var stored string
+	if err := harness.database.QueryRow(`
+		SELECT credential_blob FROM user_ai_credentials
+		WHERE user_id = ? AND provider = ?`, userID, provider).Scan(&stored); err != nil {
+		t.Fatal(err)
+	}
+	if stored == plaintext || strings.Contains(stored, plaintext) || !secrets.IsEncrypted(stored) {
+		t.Fatal("personal credential was not encrypted at rest")
+	}
+}

--- a/server/internal/api/rbac_integration_test.go
+++ b/server/internal/api/rbac_integration_test.go
@@ -324,14 +324,19 @@ func serveRBACRequestWithBody(router http.Handler, method, path, token, body str
 }
 
 type rbacRouterHarness struct {
-	router         http.Handler
-	database       *sql.DB
-	cipher         *secrets.Cipher
-	registry       *credentials.Registry
-	adminID        int64
-	requesterID    int64
-	adminToken     string
-	requesterToken string
+	router            http.Handler
+	database          *sql.DB
+	cipher            *secrets.Cipher
+	registry          *credentials.Registry
+	authService       *auth.Service
+	aiHandler         *ai.Handler
+	credentialHandler *credentials.Handler
+	adminID           int64
+	requesterID       int64
+	adminDeviceID     string
+	requesterDeviceID string
+	adminToken        string
+	requesterToken    string
 }
 
 func newRBACRouterHarness(t *testing.T, withCodex bool) *rbacRouterHarness {
@@ -394,8 +399,11 @@ func newRBACRouterHarness(t *testing.T, withCodex bool) *rbacRouterHarness {
 		}
 	}
 	aiHandler := ai.NewHandler(registry, toolServer, codexManager)
+	aiHandler.SetPermissionAuthorizer(authService.AuthorizePermission)
 	credentialHandler := credentials.NewHandler(registry)
+	credentialHandler.SetPermissionAuthorizer(authService.AuthorizePermission)
 	credentialHandler.SetSharedAIConfigured(aiHandler.ProviderConfigured)
+	credentialHandler.SetSharedAIValidator(aiHandler.ValidateSharedAISettings, aiHandler.SharedAISettingsValidated)
 	instanceHandler := instance.NewHandler(store, instanceRegistry, "http://cantinarr.test")
 	downloadsHandler := downloads.NewHandler(store, instanceRegistry)
 	tautulliHandler := tautulli.NewHandler(store, instanceRegistry)
@@ -441,14 +449,19 @@ func newRBACRouterHarness(t *testing.T, withCodex bool) *rbacRouterHarness {
 		serversettings.NewService(database),
 	)
 	return &rbacRouterHarness{
-		router:         router,
-		database:       database,
-		cipher:         cipher,
-		registry:       registry,
-		adminID:        admin.User.ID,
-		requesterID:    requester.User.ID,
-		adminToken:     admin.AccessToken,
-		requesterToken: requester.AccessToken,
+		router:            router,
+		database:          database,
+		cipher:            cipher,
+		registry:          registry,
+		authService:       authService,
+		aiHandler:         aiHandler,
+		credentialHandler: credentialHandler,
+		adminID:           admin.User.ID,
+		requesterID:       requester.User.ID,
+		adminDeviceID:     admin.DeviceID,
+		requesterDeviceID: requester.DeviceID,
+		adminToken:        admin.AccessToken,
+		requesterToken:    requester.AccessToken,
 	}
 }
 

--- a/server/internal/auth/permissions.go
+++ b/server/internal/auth/permissions.go
@@ -1,6 +1,9 @@
 package auth
 
-import "sort"
+import (
+	"context"
+	"sort"
+)
 
 const (
 	RoleAdmin = "admin"
@@ -8,6 +11,12 @@ const (
 )
 
 type Permission string
+
+// PermissionAuthorizer re-checks one live user/device session against an
+// authoritative permission immediately before a sensitive action commits.
+// Long-running handlers receive this narrow callback instead of retaining a
+// stale role snapshot from their initial HTTP middleware pass.
+type PermissionAuthorizer func(context.Context, int64, string, Permission) error
 
 const (
 	PermissionAdmin             Permission = "admin:*"

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -42,6 +42,7 @@ var (
 	ErrCannotModifyAdmin     = errors.New("cannot change sign-in methods for an admin")
 	ErrInvalidPlexEmail      = errors.New("invalid email address")
 	ErrSharedAIAccessRevoked = errors.New("shared AI access has been revoked")
+	ErrPermissionDenied      = errors.New("permission denied")
 	// ErrAuthUnavailable marks a failure to *evaluate* credentials (DB error,
 	// signing error) as opposed to a rejection of them. Handlers must map it to
 	// a 5xx, never a 401: clients treat a 401 as "this session is dead" and
@@ -1014,40 +1015,67 @@ func (s *Service) AuthorizeInteractiveToolCall(
 	deviceID string,
 	requireSharedAI bool,
 ) (string, error) {
-	if userID <= 0 || deviceID == "" {
+	snapshot, err := s.authoritativeSession(ctx, userID, deviceID)
+	if err != nil {
+		return "", err
+	}
+	if snapshot.role != RoleAdmin && snapshot.role != RoleUser {
 		return "", ErrInvalidCredentials
+	}
+	if requireSharedAI && !snapshot.sharedAIEnabled {
+		return "", ErrSharedAIAccessRevoked
+	}
+	return snapshot.role, nil
+}
+
+// AuthorizePermission re-checks the current database role and device state for
+// one already-authenticated request. It is intended for handlers that spend a
+// meaningful amount of time awaiting an external provider before committing a
+// credential or setting: middleware admission is not enough across that gap.
+func (s *Service) AuthorizePermission(ctx context.Context, userID int64, deviceID string, permission Permission) error {
+	snapshot, err := s.authoritativeSession(ctx, userID, deviceID)
+	if err != nil {
+		return err
+	}
+	if !HasPermission(snapshot.role, permission) {
+		return ErrPermissionDenied
+	}
+	return nil
+}
+
+type authoritativeSessionSnapshot struct {
+	role            string
+	sharedAIEnabled bool
+}
+
+func (s *Service) authoritativeSession(ctx context.Context, userID int64, deviceID string) (authoritativeSessionSnapshot, error) {
+	if userID <= 0 || deviceID == "" {
+		return authoritativeSessionSnapshot{}, ErrInvalidCredentials
 	}
 
 	var (
-		role            string
-		sharedAIEnabled bool
-		revokedAt       sql.NullTime
+		snapshot  authoritativeSessionSnapshot
+		revokedAt sql.NullTime
 	)
 	err := s.db.QueryRowContext(ctx, `
 		SELECT u.role, u.ai_shared_enabled, d.revoked_at
 		FROM users u
 		JOIN devices d ON d.user_id = u.id
 		WHERE u.id = ? AND d.id = ?
-	`, userID, deviceID).Scan(&role, &sharedAIEnabled, &revokedAt)
+	`, userID, deviceID).Scan(&snapshot.role, &snapshot.sharedAIEnabled, &revokedAt)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", ErrInvalidCredentials
+		return authoritativeSessionSnapshot{}, ErrInvalidCredentials
 	}
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return "", ctxErr
+			return authoritativeSessionSnapshot{}, ctxErr
 		}
-		return "", fmt.Errorf("%w: authorize interactive tool call: %v", ErrAuthUnavailable, err)
+		return authoritativeSessionSnapshot{}, fmt.Errorf("%w: authorize session: %v", ErrAuthUnavailable, err)
 	}
 	if revokedAt.Valid {
-		return "", ErrDeviceRevoked
+		return authoritativeSessionSnapshot{}, ErrDeviceRevoked
 	}
-	if role != RoleAdmin && role != RoleUser {
-		return "", ErrInvalidCredentials
-	}
-	if requireSharedAI && !sharedAIEnabled {
-		return "", ErrSharedAIAccessRevoked
-	}
-	return role, nil
+	return snapshot, nil
 }
 
 func hasAudience(claims *Claims, audience string) bool {

--- a/server/internal/auth/service_test.go
+++ b/server/internal/auth/service_test.go
@@ -204,6 +204,12 @@ func TestAuthorizeInteractiveToolCallRechecksRoleDeviceAndSharedGrant(t *testing
 	if err != nil || role != RoleUser {
 		t.Fatalf("authorize after demotion = role %q, err %v", role, err)
 	}
+	if err := svc.AuthorizePermission(ctx, adminLogin.User.ID, adminLogin.DeviceID, PermissionCredentialsManage); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("credential permission after demotion = %v, want ErrPermissionDenied", err)
+	}
+	if err := svc.AuthorizePermission(ctx, adminLogin.User.ID, adminLogin.DeviceID, PermissionAIChat); err != nil {
+		t.Fatalf("user AI permission after demotion = %v", err)
+	}
 
 	if _, err := svc.AuthorizeInteractiveToolCall(ctx, userLogin.User.ID, adminLogin.DeviceID, false); !errors.Is(err, ErrInvalidCredentials) {
 		t.Fatalf("cross-user device error = %v, want ErrInvalidCredentials", err)
@@ -216,6 +222,9 @@ func TestAuthorizeInteractiveToolCallRechecksRoleDeviceAndSharedGrant(t *testing
 	}
 	if _, err := svc.AuthorizeInteractiveToolCall(ctx, userLogin.User.ID, userLogin.DeviceID, false); !errors.Is(err, ErrDeviceRevoked) {
 		t.Fatalf("revoked device error = %v, want ErrDeviceRevoked", err)
+	}
+	if err := svc.AuthorizePermission(ctx, userLogin.User.ID, userLogin.DeviceID, PermissionAIChat); !errors.Is(err, ErrDeviceRevoked) {
+		t.Fatalf("revoked device permission error = %v, want ErrDeviceRevoked", err)
 	}
 }
 

--- a/server/internal/credentials/handler.go
+++ b/server/internal/credentials/handler.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/auth"
 	"github.com/windoze95/cantinarr-server/internal/secrets"
 )
 
@@ -24,11 +25,12 @@ const (
 
 // Handler provides admin-only REST endpoints for credential management.
 type Handler struct {
-	registry           *Registry
-	sharedAIConfigured func() bool
-	validateSharedAI   func(context.Context, AIProfile) error
-	sharedAIValidated  func(AIConfig)
-	updateMu           sync.Mutex
+	registry            *Registry
+	sharedAIConfigured  func() bool
+	validateSharedAI    func(context.Context, AIProfile) error
+	sharedAIValidated   func(AIConfig)
+	authorizePermission auth.PermissionAuthorizer
+	updateMu            sync.Mutex
 }
 
 // SetSharedAIConfigured supplies the runtime-aware shared readiness check after
@@ -42,6 +44,12 @@ func (h *Handler) SetSharedAIConfigured(check func() bool) {
 func (h *Handler) SetSharedAIValidator(validate func(context.Context, AIProfile) error, validated func(AIConfig)) {
 	h.validateSharedAI = validate
 	h.sharedAIValidated = validated
+}
+
+// SetPermissionAuthorizer supplies the authoritative user/device permission
+// check repeated after a provider probe and immediately before persistence.
+func (h *Handler) SetPermissionAuthorizer(authorize auth.PermissionAuthorizer) {
+	h.authorizePermission = authorize
 }
 
 // NewHandler creates a new credentials handler.
@@ -202,10 +210,13 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, profile := range profiles {
 		if err := h.validateSharedAI(r.Context(), profile); err != nil {
-			log.Printf("credentials: shared AI validation failed provider=%q model=%q: %s", profile.Config.Provider, profile.Config.Model, credentialValidationDiagnostic(err))
+			log.Printf("credentials: shared AI validation failed provider=%q: %s", profile.Config.Provider, credentialValidationDiagnostic(err))
 			writeCredentialValidationError(w, err)
 			return
 		}
+	}
+	if len(profiles) > 0 && !h.reauthorizeSharedAIWrite(w, r) {
+		return
 	}
 
 	if err := h.applyUpdate(body, candidate, providerSet || modelSet, healthEnabled, healthSet); err != nil {
@@ -220,6 +231,27 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (h *Handler) reauthorizeSharedAIWrite(w http.ResponseWriter, r *http.Request) bool {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+		return false
+	}
+	if h.authorizePermission == nil {
+		http.Error(w, `{"error":"credential authorization is temporarily unavailable"}`, http.StatusServiceUnavailable)
+		return false
+	}
+	if err := h.authorizePermission(r.Context(), claims.UserID, claims.DeviceID, auth.PermissionCredentialsManage); err != nil {
+		if errors.Is(err, auth.ErrAuthUnavailable) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			http.Error(w, `{"error":"credential authorization is temporarily unavailable"}`, http.StatusServiceUnavailable)
+		} else {
+			http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
+		}
+		return false
+	}
+	return true
 }
 
 func writeCredentialValidationError(w http.ResponseWriter, err error) {

--- a/server/internal/credentials/handler_test.go
+++ b/server/internal/credentials/handler_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/windoze95/cantinarr-server/internal/auth"
 	"github.com/windoze95/cantinarr-server/internal/db"
 	"github.com/windoze95/cantinarr-server/internal/secrets"
 )
@@ -27,13 +29,19 @@ func newCredentialHandlerTest(t *testing.T) (*Handler, *Registry) {
 		t.Fatal(err)
 	}
 	registry := NewRegistry(database, cipher)
-	return NewHandler(registry), registry
+	handler := NewHandler(registry)
+	handler.SetPermissionAuthorizer(func(context.Context, int64, string, auth.Permission) error { return nil })
+	return handler, registry
 }
 
 func updateCredentialSettings(t *testing.T, handler *Handler, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	recorder := httptest.NewRecorder()
-	handler.Update(recorder, httptest.NewRequest(http.MethodPut, "/api/admin/credentials", strings.NewReader(body)))
+	request := httptest.NewRequest(http.MethodPut, "/api/admin/credentials", strings.NewReader(body))
+	request = request.WithContext(context.WithValue(request.Context(), auth.ClaimsKey, &auth.Claims{
+		UserID: 1, Role: auth.RoleAdmin, DeviceID: "credential-test-device",
+	}))
+	handler.Update(recorder, request)
 	return recorder
 }
 
@@ -62,6 +70,32 @@ func TestAISettingsValidationReturnsSafeActionableFailure(t *testing.T) {
 	}
 	if strings.Contains(recorder.Body.String(), "must-not-escape") || strings.Contains(recorder.Body.String(), "candidate-secret") {
 		t.Fatalf("validation response leaked diagnostic or credential: %s", recorder.Body.String())
+	}
+}
+
+func TestAISettingsValidationLogOmitsModelAndBareProviderKey(t *testing.T) {
+	handler, _ := newCredentialHandlerTest(t)
+	const (
+		modelSecret = "sk-proj-SyntheticModelField123456789"
+		keySecret   = "sk-proj-SyntheticProviderEcho123456789"
+	)
+	handler.SetSharedAIValidator(func(context.Context, AIProfile) error {
+		return errors.New("upstream rejected " + keySecret)
+	}, nil)
+	var logs bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	recorder := updateCredentialSettings(t, handler, `{"openai_key":"synthetic-candidate","ai_provider":"openai","ai_model":"`+modelSecret+`"}`)
+	if recorder.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	if strings.Contains(logs.String(), modelSecret) || strings.Contains(logs.String(), keySecret) {
+		t.Fatalf("validation log leaked model or provider credential: %s", logs.String())
+	}
+	if !strings.Contains(logs.String(), secrets.RedactedValue) {
+		t.Fatalf("validation log did not retain a redaction marker: %s", logs.String())
 	}
 }
 

--- a/server/internal/secrets/redact.go
+++ b/server/internal/secrets/redact.go
@@ -17,8 +17,17 @@ import (
 const RedactedValue = "[REDACTED]"
 
 var (
-	urlCandidatePattern = regexp.MustCompile(`(?i)(?:[a-z][a-z0-9+.-]*:)?//[^\s<>"']+|/[^\s<>"']*\?[^\s<>"']+`)
-	assignmentPattern   = regexp.MustCompile(`(?i)[a-z][a-z0-9_.-]{0,80}["']?[ \t]*[:=][ \t]*`)
+	urlCandidatePattern            = regexp.MustCompile(`(?i)(?:[a-z][a-z0-9+.-]*:)?//[^\s<>"']+|/[^\s<>"']*\?[^\s<>"']+`)
+	assignmentPattern              = regexp.MustCompile(`(?i)[a-z][a-z0-9_.-]{0,80}["']?[ \t]*[:=][ \t]*`)
+	bareProviderCredentialPatterns = []*regexp.Regexp{
+		// OpenAI project/legacy keys and Anthropic sk-ant-* keys share the
+		// sk- prefix. Require a non-trivial suffix to avoid scrubbing prose.
+		regexp.MustCompile(`\bsk-[A-Za-z0-9_-]{8,}\b`),
+		// Google API keys use AIza..., while newer Gemini credentials may use
+		// the AQ. prefix.
+		regexp.MustCompile(`\bAIza[A-Za-z0-9_-]{12,}\b`),
+		regexp.MustCompile(`\bAQ\.[A-Za-z0-9_-]{12,}\b`),
+	}
 )
 
 // RedactText removes credentials from structured JSON and from free-form
@@ -124,7 +133,11 @@ func stringMapValue(value map[string]any, name string) (string, bool) {
 
 func redactFreeform(text string) string {
 	text = urlCandidatePattern.ReplaceAllStringFunc(text, redactURLCredentials)
-	return redactAssignments(text)
+	text = redactAssignments(text)
+	for _, pattern := range bareProviderCredentialPatterns {
+		text = pattern.ReplaceAllString(text, RedactedValue)
+	}
+	return text
 }
 
 // redactAssignments handles both headers and fragments embedded in a larger

--- a/server/internal/secrets/redact_test.go
+++ b/server/internal/secrets/redact_test.go
@@ -54,6 +54,26 @@ func TestRedactTextScrubsPrefixedErrorBodyAndHeaders(t *testing.T) {
 	}
 }
 
+func TestRedactTextScrubsBareProviderCredentials(t *testing.T) {
+	credentials := []string{
+		"sk-proj-Synthetic_OpenAI_Key_123456789",
+		"sk-SyntheticLegacyOpenAIKey123456789",
+		"sk-ant-api03-Synthetic_Anthropic_Key_123456789",
+		"AIzaSyntheticGoogleAPIKey1234567890",
+		"AQ.Synthetic_Gemini_Key_1234567890",
+	}
+	input := "provider rejected credentials: " + strings.Join(credentials, " | ") + " (request_id=req-safe)"
+	got := RedactText(input)
+	for _, credential := range credentials {
+		if strings.Contains(got, credential) {
+			t.Fatalf("redacted output leaked bare provider credential %q: %s", credential, got)
+		}
+	}
+	if strings.Count(got, RedactedValue) != len(credentials) || !strings.Contains(got, "request_id=req-safe") {
+		t.Fatalf("bare provider redaction lost diagnostic context: %s", got)
+	}
+}
+
 func TestRedactErrorDoesNotWrapCredentialBearingBody(t *testing.T) {
 	original := errors.New(`arr request failed: {"downloadUrl":"https://idx.invalid/get?token=error-secret"}`)
 	redacted := RedactError(original)


### PR DESCRIPTION
## What changed

- fix the OpenAI tool-free validation request so it omits both `tools` and `tool_choice`
- preserve `tool_choice: "none"` only for interactive final turns that still include a tool catalog
- cover shared-admin and requester-owned OpenAI key saves through the authenticated production router
- reauthorize role and device permissions after provider validation and immediately before shared or personal credential persistence
- redact bare OpenAI, Anthropic, and Gemini credential formats from diagnostics
- add Flutter contracts for the shared and personal OpenAI save payloads

## Root cause

The merged validation path sent `tool_choice: "none"` while omitting `tools`. OpenAI rejects that combination with HTTP 400, so both shared admin saves and requester personal saves returned 422 even though the API key and model were valid. The old fake-provider contract test incorrectly required the invalid request shape and therefore hid the regression.

## Impact

Valid OpenAI API keys can again be validated and saved for both shared admin configuration and requester-owned personal configuration. Failed authorization or provider validation cannot persist a key, cross account boundaries, expose plaintext credentials, or continue after an admin demotion/device revocation.

## Verification

- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./internal/ai ./internal/auth ./internal/credentials ./internal/api ./internal/secrets -count=1`
- `CGO_ENABLED=0 go build -o /tmp/cantinarr-server-openai-check ./cmd/server`
- `flutter analyze --no-fatal-infos`
- `flutter test` (324 tests)
- `flutter build web --release`
- 48-case API-key matrix across Anthropic/OpenAI/Gemini, admin/requester, personal/shared, credential readiness, and shared access grants
- hosted OpenAI validation and interactive requests passed for all six advertised models
- hosted OpenAI authenticated shared-admin and requester-personal saves passed, including encrypted-at-rest and response/log secrecy assertions
- hosted Anthropic/OpenAI/Gemini interactive chats passed; hosted catalog validation correctly classified account-specific Gemini quota/model-access limits
- reproduced the deployed build returning 422 for both admin and requester OpenAI saves, with requester admin access correctly returning 403

## Documentation

No documented API, route, environment variable, data model, or user-visible workflow changed.