### PR TITLE
Fix keyboard dismissal in lower form fields

### DIFF
--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -314,9 +314,17 @@ class _AppShellState extends ConsumerState<AppShell>
     final atTop =
         notification.metrics.pixels <= notification.metrics.minScrollExtent + 4;
 
-    if (notification is ScrollStartNotification ||
-        notification is ScrollUpdateNotification ||
-        notification is OverscrollNotification) {
+    // EditableText programmatically scrolls its focused field into view when
+    // the keyboard changes the viewport. Those notifications have no drag
+    // details; dismissing focus for them makes the keyboard immediately close
+    // again on fields near the bottom of long forms.
+    final isUserDrag = switch (notification) {
+      ScrollStartNotification(:final dragDetails) => dragDetails != null,
+      ScrollUpdateNotification(:final dragDetails) => dragDetails != null,
+      OverscrollNotification(:final dragDetails) => dragDetails != null,
+      _ => false,
+    };
+    if (isUserDrag) {
       _dismissKeyboard();
     }
 

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -21,6 +21,81 @@ import 'package:go_router/go_router.dart';
 
 void main() {
   testWidgets(
+      'programmatic form scrolling keeps focus while a user drag dismisses it',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final focusNode = FocusNode();
+    final scrollController = ScrollController();
+    addTearDown(focusNode.dispose);
+    addTearDown(scrollController.dispose);
+
+    final router = GoRouter(
+      initialLocation: '/settings/form',
+      routes: [
+        ShellRoute(
+          builder: (context, state, child) =>
+              AppShell(currentPath: state.uri.path, child: child),
+          routes: [
+            GoRoute(
+              path: '/settings/form',
+              builder: (_, __) => Scaffold(
+                body: ListView(
+                  controller: scrollController,
+                  children: [
+                    TextField(focusNode: focusNode),
+                    const SizedBox(height: 1200),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith(
+            () => _FakeAuthNotifier(_authenticatedAiState),
+          ),
+          backendClientProvider.overrideWithValue(_fakeDio()),
+          realtimeEventsProvider
+              .overrideWithValue(const Stream<WsEvent>.empty()),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(focusNode.hasFocus, isTrue);
+
+    scrollController.animateTo(
+      100,
+      duration: const Duration(milliseconds: 100),
+      curve: Curves.linear,
+    );
+    await tester.pumpAndSettle();
+    expect(
+      focusNode.hasFocus,
+      isTrue,
+      reason: 'automatic field reveal must not dismiss the keyboard',
+    );
+
+    await tester.drag(find.byType(ListView), const Offset(0, -100));
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isFalse);
+  });
+
+  testWidgets(
       'search-bar assistant submit opens route over previous shell content',
       (tester) async {
     tester.view.physicalSize = const Size(390, 844);


### PR DESCRIPTION
## What

Keep focused fields active when Flutter programmatically scrolls them into view after the mobile keyboard changes the viewport. Keyboard dismissal remains enabled for genuine user drag gestures.

Adds a shell regression test covering both programmatic scrolling and user-driven scrolling.

## Verification

- flutter analyze --no-fatal-infos
- flutter test
- flutter build web --release

## Docs

- [ ] README.md — pitch, feature list, configuration/env vars, quick start
- [ ] server/README.md — routes, MCP tools, DB tables, env vars, package tree
- [ ] app/README.md — screens/features, navigation, project structure
- [ ] AGENTS.md — workflow, verification, or convention changes
- [x] No docs impact — behavior-only bug fix with no route, feature list, configuration, or workflow changes.