### PR TITLE
Remove spotlight items from popular rows

### DIFF
--- a/app/lib/features/dashboard/ui/dashboard_movies_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_movies_tab.dart
@@ -145,7 +145,7 @@ class _DashboardMoviesTabState extends ConsumerState<DashboardMoviesTab>
           // Discovery rows
           CategoryRow(
             title: 'Popular Movies',
-            items: discover.popularMovies,
+            items: discover.popularMovies.skip(1).toList(growable: false),
             isLoading: discover.isLoadingPopular,
           ),
           if (discover.topRated.isNotEmpty)

--- a/app/lib/features/dashboard/ui/dashboard_tv_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_tv_tab.dart
@@ -133,7 +133,7 @@ class _DashboardTvTabState extends ConsumerState<DashboardTvTab>
             ),
           CategoryRow(
             title: 'Popular TV Shows',
-            items: discover.popularTV,
+            items: discover.popularTV.skip(1).toList(growable: false),
             isLoading: discover.isLoadingPopular,
           ),
           if (discover.anticipated.isNotEmpty)


### PR DESCRIPTION
## What

Keep the first popular movie and TV show as the dashboard Spotlight, while starting each Popular row at the second result. This removes the immediate duplicate card beneath each hero without changing discovery ordering or shared provider state.

## Verification

- `flutter analyze --no-fatal-infos`
- `flutter test` (326 tests passed)

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — this only removes duplicate cards from existing dashboard rows; documented screens and features are unchanged.
