### PR TITLE
Add master regression catalog and alignment enforcement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,17 @@
 ## Verification
 
 <!-- Paste the checks you ran (server: `go test ./...`; app: `flutter analyze`, `flutter test`).
-     Note anything that could not be run and why. -->
+     List catalog case IDs exercised and note relevant cases/checks that could not be run and why. -->
+
+## Regression catalog
+
+Reconcile this change with the [master regression catalog](/windoze95/cantinarr/blob/main/docs/testing/README.md). List affected IDs and select exactly one option.
+
+Affected case IDs: <!-- IDs or PREFIX-001..PREFIX-009 ranges added/updated/retired/confirmed accurate; or "no change — <specific reason>" -->
+
+- [ ] Updated, added, or retired affected cases, counts, and automation references
+- [ ] Existing catalog cases already describe the affected behavior and remain accurate
+- [ ] No catalog impact — explained in **What**
 
 ## Docs
 
@@ -14,5 +24,6 @@ Docs are part of the change, not a follow-up. Tick what you updated, or tick the
 - [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
 - [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
 - [ ] `app/README.md` — screens/features, navigation, project structure
+- [ ] `docs/testing/` — behavioral contracts, stable case IDs, fixtures, counts, release scope
 - [ ] `AGENTS.md` — workflow, verification, or convention changes
 - [ ] No docs impact — explained above

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -18,6 +19,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate regression catalog
+        working-directory: ${{ github.workspace }}
+        run: python3 docs/testing/check_catalog.py --base-ref "${{ github.event.pull_request.base.sha }}"
+
+      - name: Validate PR catalog declaration
+        working-directory: ${{ github.workspace }}
+        run: python3 docs/testing/check_pr_catalog.py
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ Operating manual for AI agents and human contributors. `CLAUDE.md` imports this 
 
 - Server changes: run `go vet ./...` and `go test ./...` from `server/`.
 - App changes: run `flutter analyze --no-fatal-infos` and `flutter test` from `app/`.
-- CI runs exactly those on every PR, plus a `CGO_ENABLED=0` server build and a `flutter build web --release`. A PR is not done if any of them fail.
+- Catalog changes: run `python3 docs/testing/check_catalog.py` from the repository root.
+- CI validates the regression catalog and runs the server/app checks above on every PR, plus a `CGO_ENABLED=0` server build and a `flutter build web --release`. A PR is not done if any of them fail.
 - Codex integration changes are also proved against the checksum-verified pinned app-server in CI. The Docker workflow builds and smoke-tests both Dockerfiles, including bundled license notices, before publishing the root image to GHCR.
 - iOS release builds happen only in CI (`testflight.yml`, auto-deploys on `main` when iOS-relevant `app/**` paths change — web/android/desktop subdirs and store-listing metadata/screenshots are excluded; listing copy syncs via `storelisting.yml` instead). Don't assume a local iOS toolchain; when one isn't available, sanity-check Swift with `swiftc -parse` and let CI prove the build.
 - iOS signing is manual, via the `IOS_PROVISIONING_PROFILE_BASE64` secret. Changing app capabilities/entitlements invalidates the profile — regenerate it and update the secret.
@@ -29,6 +30,21 @@ Operating manual for AI agents and human contributors. `CLAUDE.md` imports this 
 - Merges to `main` publish `ghcr.io/windoze95/cantinarr` (`latest`; version tags on `v*` releases).
 - Site changes (`site/`, plain static HTML/CSS, no build step): merges to `main` deploy `site/` to Cloudflare Pages via `site.yml` when the `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID` secrets are set; manual deploy is `npx wrangler pages deploy site --project-name=cantinarr`.
 - Mention any tests or checks that could not be run.
+
+## Regression test catalog
+
+[`docs/testing/README.md`](docs/testing/README.md) is the canonical behavioral regression catalog. Treat it as part of implementation, not release-only paperwork or a replacement for unit/integration tests.
+
+- Before changing user-visible behavior, an API or route, screen, setting, schema, event, permission boundary, integration, deployment path, or workflow, search the catalog for affected case IDs. Reconcile those cases before declaring the change complete.
+- Update the catalog in the same PR as the behavior. Update an existing case when its setup, action, or expected result intentionally changes. Add a case for new behavior, for a defect that exposed missing regression coverage, or for a materially different boundary or failure mode. A bug fix must identify an existing case that would have caught it, or add/strengthen one when none does.
+- For every new or changed behavior, cover all applicable dimensions: happy path; empty/minimum/maximum/invalid input; anonymous/requester/admin authorization; persistence and restart/upgrade; cancellation, timeout, retry, idempotency, duplicate submission, concurrency, and partial failure; cache freshness, realtime, and cross-device behavior; external source-of-truth verification; backward compatibility; and secret/privacy/logging containment. Explain intentionally inapplicable high-risk dimensions in the PR.
+- Never weaken an expected result merely to match broken implementation. Record the defect. A `GAP` case requires a linked, accepted issue or decision in `docs/testing/known-gaps.md`; it records required but unshipped behavior and is never a release waiver. GAP ledger rows are permanent: when behavior ships or is deliberately withdrawn, remove the tag but retain the row with a resolved/withdrawn status and decision reference. An in-scope P0 GAP blocks release, while P1 requires the normal recorded exception. Product docs must continue to describe shipped reality.
+- Case IDs are permanent and globally unique. Use `PREFIX-NNN`; a new prefix starts at `001`, otherwise use one greater than the highest number ever assigned in that domain, including retired IDs. Never renumber or reuse an ID. Keep an ID when behavior is renamed. When shipped behavior is removed, retire its ID in `docs/testing/retired-cases.md` with a substantive reason, replacement or `None`, and PR or release reference.
+- The `AUTO` tag means the case includes machine-driven repository or CI proof; its definition names the command, workflow, build, or automated portion and may still require manual/external assertions. Existing automated coverage does not replace a behavioral case. Add a durable `AUTO: path/to/test::name` annotation when a named test automates the behavior, and update it in the same PR if the test moves, is renamed, or is deleted.
+- When a case adds or changes a role, account, data state, upstream service/version, device, failure injection, evidence, or cleanup requirement, update `docs/testing/fixtures.md` and the run cleanup guidance in the same PR.
+- Keep committed catalog files run-neutral: active definitions stay `[ ]`, vector results and run metadata stay blank, and PASS/FAIL/BLOCKED/N/A annotations, dates, screenshots, and evidence links belong only in a release/issue artifact or a copy outside the worktree. Do not add run copies to `.gitignore`.
+- Update the catalog dashboard whenever cases are added or retired, then run `python3 docs/testing/check_catalog.py`. Every PR must list case IDs added, updated, retired, or confirmed accurate; `Affected case IDs: no change — <reason>` requires a specific reason. CI rejects missing or contradictory catalog declarations.
+- Catalog maintenance does not replace updates to the owning product documentation below.
 
 ## Architecture conventions
 
@@ -48,11 +64,12 @@ Docs are part of the change, not a follow-up. A feature is not merged-complete u
 | `README.md` | Product pitch, feature list, quick start, configuration & env-var tables |
 | `server/README.md` | API route reference, MCP tool table (incl. the tool count), DB tables, WebSocket events, env vars, server package tree |
 | `app/README.md` | App features/screens, navigation map, project structure, key dependencies |
+| `docs/testing/README.md` | Canonical regression catalog, stable case IDs, coverage scope, counts, and release qualification rules |
 | `docs/store-release.md` | Store release pipeline: how builds reach TestFlight/Play, signing secrets, one-time store-console setup |
 | `site/` | Marketing site (cantinarr.com): public pitch, store badges/links, live-demo link, self-host snippet |
 | `AGENTS.md` | Workflows, verification, conventions (this file) |
 
 - When a change touches a documented surface (new route, tool, env var, table, screen, workflow), update the owning doc **in the same PR**. The PR template's docs checklist is there to force the question.
 - Numbers drift fastest: tool counts, route lists, env-var tables, version floors (Go, Flutter/Dart). If you add one, update the count everywhere it appears (`grep -ri` for the old number).
-- Docs describe shipped reality — never "planned", "upcoming", or aspirational behavior.
+- Product docs describe shipped reality — never "planned", "upcoming", or aspirational behavior. Required but unimplemented behavior belongs only in an explicitly tagged catalog GAP until it ships.
 - `CLAUDE.md` must remain a thin import of this file so every agent reads one playbook. If you change workflows here, check `CLAUDE.md` still just imports and points.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Full API documentation is in [`server/README.md`](server/README.md#api-reference
 
 ## Contributing
 
-Contributions are welcome! Please open an issue to discuss your idea before submitting a PR. `AGENTS.md` is the operating manual for contributors and AI agents -- branch protocol, verification commands, and the documentation standard live there.
+Contributions are welcome! Please open an issue to discuss your idea before submitting a PR. [`AGENTS.md`](AGENTS.md) is the operating manual for contributors and AI agents, and the [master regression catalog](docs/testing/README.md) is the behavioral contract every change must reconcile.
 
 ## License
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,0 +1,58 @@
+# Cantinarr master regression catalog
+
+This is the canonical, committed behavioral test catalog for Cantinarr. It defines the observable contract that implementation changes must preserve and the release coverage needed to prove it. The committed files are always run-neutral; execute tests from a copy stored outside the worktree or attached to a release or issue.
+
+## Catalog map
+
+| Area | Case prefixes | Active cases |
+|---|---|---:|
+| [Build, operations, usability, and release](catalog/baseline-operations-release.md) | BASE, OPS, UX, PERF, REL, EXP | 72 |
+| [Authentication, navigation, users, and security](catalog/auth-users-security.md) | AUTH, NAV, USER, SEC | 88 |
+| [Instances, realtime behavior, and push](catalog/instances-realtime-push.md) | INST, RT, PUSH | 65 |
+| [Plex linking, libraries, and invitations](catalog/plex.md) | PLEX | 87 |
+| [Discovery and requests](catalog/discovery-requests.md) | DISC, REQ | 69 |
+| [Media services and download clients](catalog/media-services.md) | RAD, SON, BOOK, DOWN, TAUT | 91 |
+| [Issues, AI, and MCP](catalog/issues-ai-mcp.md) | ISS, AI, MCP | 115 |
+| **Total** | | **587** |
+
+The catalog contains **587 active cases**: **374 P0**, **205 P1**, and **8 P2**. Shared setup is in [Required regression fixtures](fixtures.md), execution metadata and evidence belong in the [run-copy template](run-template.md), explicitly unimplemented requirements are governed by the [known-gap ledger](known-gaps.md), and removed behavior is recorded in the permanent [retired-ID ledger](retired-cases.md).
+
+## How to execute it
+
+- Copy the entire `docs/testing/` tree outside the worktree, or preserve its layout in a release/issue artifact, then execute the applicable catalog files with `run-template.md`. Never record an execution in the canonical files and never add run copies to `.gitignore`.
+- Checkbox meanings in a run copy: `[ ]` not run and `[x]` passed. For another result, leave the box unchecked and append `— FAIL:`, `— BLOCKED:`, or `— N/A:` with a defect/evidence link and reason.
+- Never erase or overwrite a failure in an active run. Append retest evidence and the eventual resolution so the original failure remains auditable.
+- A UI toast alone does not prove an external mutation. For Plex, arrs, download clients, push, and AI providers, capture both Cantinarr's result and the external system's resulting state.
+- Do not check a parent case with a vector table until every applicable vector passes.
+- On every candidate, run BASE plus all P0/P1 cases in changed and dependency-affected areas. Run every P0 before a major release, storage/auth migration, or broad integration rewrite.
+
+Priorities describe impact:
+
+- **P0** blocks a release whose declared scope includes the area.
+- **P1** is a serious changed-area or dependency-affected regression.
+- **P2** is extended, compatibility, or exploratory coverage.
+
+Tags describe the proof surface: **AUTO** machine-driven repository or CI proof (possibly paired with manual/external assertions), **API** direct contract check, **UI** app behavior, **LIVE** real third-party service/device, **CHAOS** controlled failure/recovery, **SEC** authorization/privacy, **RT** realtime convergence, and **GAP** a required behavior that is explicitly known not to be implemented yet. A GAP needs a linked accepted decision in `known-gaps.md`; it remains a failure, not a waiver. Its ledger row is permanent and becomes resolved or withdrawn when the tag is removed. An in-scope P0 GAP blocks release, while P1 requires the normal recorded exception. Product documentation must still describe shipped reality.
+
+## Catalog maintenance contract
+
+- Before changing user-visible behavior, an API or route, screen, setting, schema, event, permission boundary, integration, deployment path, or workflow, search the catalog for affected case IDs. Reconcile those cases before declaring the change complete.
+- Update the catalog in the same PR as the behavior. Update an existing case when its setup, action, or expected result intentionally changes. Add a case for new behavior, for a defect that exposes missing regression coverage, or for a materially different boundary or failure mode.
+- For every new or changed behavior, cover every applicable dimension: happy path; empty, minimum, maximum, and invalid input; anonymous, requester, and admin authorization; persistence, restart, and upgrade; cancellation, timeout, retry, idempotency, duplicate submission, concurrency, and partial failure; cache freshness, realtime, and cross-device behavior; external source-of-truth verification; backward compatibility; and secret, privacy, and logging containment. Explain intentionally inapplicable high-risk dimensions in the PR.
+- A bug fix must identify an existing case that would have caught the bug, or add/strengthen one when none does. Never weaken an expected result merely to match broken implementation; record the defect or an accepted GAP instead.
+- Case IDs are permanent and globally unique. Use `PREFIX-NNN`; a new prefix starts at `001`, otherwise allocate one greater than the highest number ever assigned in that domain, including retired IDs. Never renumber or reuse an ID. When behavior is renamed, keep its ID. Retire a case only when its shipped behavior is removed, and add its ID, substantive reason, replacement or `None`, and PR or release reference to `retired-cases.md`.
+- The `AUTO` tag means the case includes machine-driven repository or CI proof; the case names the command, workflow, build, or automated portion and may still require manual/external assertions. Existing automated tests do not replace behavioral cases. When a named test automates a case, append a durable `AUTO: path/to/test::name` annotation; update that annotation in the same PR if the test moves, is renamed, or is removed.
+- When a case adds or changes a role, account, data state, upstream service/version, device, failure injection, evidence, or cleanup requirement, update `fixtures.md` and the run cleanup guidance in the same PR.
+- Keep active definitions unchecked, vector-result cells empty, run metadata blank, and the dashboard counts accurate. Run `python3 docs/testing/check_catalog.py` after every catalog edit.
+- Every PR must report the IDs added, updated, retired, or already verified as accurate. A PR with no catalog impact must give a specific reason; CI rejects blank, contradictory, or malformed catalog declarations.
+
+The repository-wide agent obligations are canonical in [`AGENTS.md`](../../AGENTS.md). Catalog maintenance supplements rather than replaces the owning product-documentation updates required there.
+
+## Release exit criteria
+
+- Every P0 case in the declared scope is executed, with external evidence for LIVE cases; a full or major-release run includes every P0.
+- Every P1 case in a changed or dependency-affected area is executed; remaining P1 cases have an explicit accepted scope decision in the run evidence.
+- No open defect can cause wrong-user or wrong-instance mutation, silent broadening of library/media scope, secret exposure, data loss, false “Available,” “resolved,” or “invited” state, or destructive action without confirmation.
+- CI/build checks are green for the exact commit and image tested, and required iOS, Android, Docker, store, and site workflows for the changed paths completed.
+- Documentation and public copy describe the tested shipped behavior, including known external-state limitations.
+- Test data and external side effects are cleaned up: temporary Plex shares/libraries, arr media/queue entries, download data, users/devices/tokens, AI OAuth links, webhooks, push tokens, and test issues/actions.

--- a/docs/testing/catalog/auth-users-security.md
+++ b/docs/testing/catalog/auth-users-security.md
@@ -1,0 +1,105 @@
+# Authentication, navigation, users, and security
+
+Identity, device sessions, authorization, navigation, user administration, privacy, and failure containment.
+
+These are canonical, run-neutral definitions. Keep every active case unchecked; record executions only in a copy assembled with the [run template](../run-template.md).
+
+## Authentication, accounts, devices, and authorization
+
+- [ ] `AUTH-001` · P0 · UI/API — On a fresh server, create the first admin once; verify a second setup attempt is rejected and cannot replace the admin.
+- [ ] `AUTH-002` · P0 · UI — Connect with a new-user link; verify the intended username is created, the link establishes a device session, and the user lands on the original internal destination or dashboard.
+- [ ] `AUTH-003` · P0 · API — Redeem the same one-time connect token again; verify it cannot create another account/session.
+- [ ] `AUTH-004` · P0 · UI — Issue another connect/device link for an existing username; verify it attaches a new device to the same user rather than creating a duplicate.
+- [ ] `AUTH-005` · P0 · UI — Let a connect link expire, then issue a fresh one; verify the expired link fails clearly and the new link succeeds.
+- [ ] `AUTH-006` · P0 · SEC — Try an external, scheme-relative, and malformed return target through login/connect; verify navigation only returns to an app-internal path.
+- [ ] `AUTH-007` · P0 · UI — Log in with an enabled password using correct and incorrect credentials; verify only the correct password creates a session and errors do not reveal whether another username exists.
+- [ ] `AUTH-008` · P0 · API — Exceed the public login/setup/connect/passkey rate limit from one IP; verify throttling after the documented allowance and recovery after the window.
+- [ ] `AUTH-009` · P0 · UI — Enable password for a user, let them set it, then disable password; verify subsequent password login fails and existing device sessions follow the documented device policy.
+- [ ] `AUTH-010` · P0 · SEC — Attempt to set a password for a user whose admin toggle is off; verify both UI and direct API reject it.
+- [ ] `AUTH-011` · P0 · LIVE/UI — Register and use a native passkey on an associated HTTPS iOS deployment; verify creation, login, listing, naming, and deletion.
+- [ ] `AUTH-012` · P0 · LIVE/UI — Repeat passkey registration/login on Android with matching `assetlinks.json`; verify the native credential provider accepts the RP.
+- [ ] `AUTH-013` · P1 · LIVE/UI — Register and use a browser passkey on supported desktop/web; verify origin/RP validation and browser fallback.
+- [ ] `AUTH-014` · P0 · SEC — Attempt passkey registration/login from an untrusted origin or mismatched RP; verify it fails without creating a credential.
+- [ ] `AUTH-015` · P0 · UI — Disable passkeys for a user with credentials; verify stored passkeys are revoked and can no longer authenticate.
+- [ ] `AUTH-016` · P1 · UI — Remove one of multiple passkeys; verify only that credential stops working and the remaining passkey still authenticates.
+- [ ] `AUTH-017` · P0 · UI/API — Refresh before/after access-token expiry and across restart; verify the same opaque `cnr1.` token is returned/reusable byte-for-byte. Redeem one legacy JWT refresh token and verify one-time migration to stable opaque form; transient 5xx preserves auth and genuine revocation returns 401.
+- [ ] `AUTH-018` · P0 · SEC — Revoke the current device from another admin session; verify its app refresh, WebSocket, push registration, and MCP tokens lose access promptly.
+- [ ] `AUTH-019` · P0 · UI — Delete a non-self user; verify their devices, tokens, grants, and access are removed without deleting another user's records.
+- [ ] `AUTH-020` · P0 · SEC — Attempt self-deletion, self-demotion when it would violate invariants, and deletion of protected/current admin states; verify guardrails match the UI and API.
+- [ ] `AUTH-021` · P0 · UI — Promote a user to admin and demote them again; verify routes/menu/permissions update without stale privileged access.
+- [ ] `AUTH-022` · P0 · SEC — As a requester, directly navigate/call every admin root (`/radarr`, `/sonarr`, `/chaptarr`, `/downloads`, `/tautulli`, `/approvals`, admin issues/actions/runs, setup, privileged settings); verify UI redirects and APIs return 403.
+- [ ] `AUTH-023` · P0 · SEC — As a requester, read allowed Radarr/Sonarr proxy resources but attempt writes, commands, interactive searches, config endpoints, and non-arr proxies; verify only the read-only allowlist succeeds.
+- [ ] `AUTH-024` · P0 · SEC — As an issue reporter, open their own issue and another user's issue; verify only their own thread is visible/repliable while admins can access both.
+- [ ] `AUTH-025` · P1 · UI — Show the Devices screen with current and other devices; verify model, last-seen, user, and “This device” are accurate and revoke confirmation targets the right ID.
+- [ ] `AUTH-026` · P1 · CHAOS — Revoke a device while that device is offline, then reconnect; verify it cannot refresh or silently recreate its session.
+- [ ] `AUTH-027` · P1 · API — Change the user role/grants while a long AI/tool turn is running; verify interactive dispatch reauthorizes and stops a now-unauthorized actor.
+- [ ] `AUTH-028` · P1 · UI — Verify there is no ordinary logout affordance and that the documented device-revocation recovery path is usable.
+- [ ] `AUTH-029` · P1 · SEC — Confirm AASA and Digital Asset Links responses contain only configured app/package identities, correct content types, and no secrets.
+- [ ] `AUTH-030` · P1 · UI — On plain HTTP, verify passkey limitations are explained and an enabled password can authorize MCP login.
+- [ ] `AUTH-031` · P1 · UI — During the first-login optional passkey offer, navigate/reload/skip/complete it; verify the saved internal destination is restored exactly once.
+- [ ] `AUTH-032` · P1 · CHAOS — Lose VPN/network during authentication restore and recover it; verify the saved connection remains and the app retries rather than deleting local auth state.
+- [ ] `AUTH-033` · P0 · UI — Load the embedded web app from root and a deep route; verify it auto-detects `Uri.base.origin`, checks that exact origin once, and never asks for/changes to an unrelated server URL.
+- [ ] `AUTH-034` · P0 · UI — On native, enter host with no scheme, HTTP/HTTPS, surrounding whitespace, one/many trailing slashes, malformed scheme/host, 404, refusal, TLS failure, and timeout; verify deterministic normalization plus editable, non-secret recovery copy.
+- [ ] `AUTH-035` · P0 · UI/API — Paste connect links with missing/wrong scheme, host, token, duplicate parameters, invalid encoding, whitespace, expired/reused token, and hostile extra parameters; verify safe rejection before unintended connection/session creation.
+- [ ] `AUTH-036` · P0 · UI — Redeem equivalent valid `cantinarr://connect` links by native deep link and paste; verify identical normalized server/account/device outcome, one token consumption, and an already-authenticated app does not switch accounts silently.
+
+## Navigation, shell, setup checklist, and cross-platform layout
+
+- [ ] `NAV-001` · P0 · UI — On compact and wide layouts, open every drawer/sidebar destination and every bottom-tab branch; verify selected state, back behavior, and preserved per-module tab stacks.
+- [ ] `NAV-002` · P0 · UI — Reload/deep-link every declared route; verify authenticated routes render inside the shell and malformed media/user IDs redirect or show the defensive invalid-link screen without crashing.
+- [ ] `NAV-003` · P0 · UI — As a requester, verify admin destinations are absent; as admin, verify destinations appear only when their service/attention conditions apply.
+- [ ] `NAV-004` · P0 · UI — Grant and revoke Chaptarr access while signed in; verify the Books dashboard tab and Chaptarr access appear/disappear and direct `/dashboard/books` access redirects when ungranted.
+- [ ] `NAV-005` · P1 · UI — Toggle Approvals, Issues, and Agent fixes between pinned and conditional; verify each menu entry follows its own setting and the switches remain recoverable from Settings.
+- [ ] `NAV-006` · P1 · UI — With zero, passive-tracking, and actionable issues, verify conditional Issues visibility follows active/tracking state while its numeric badge counts actionable only.
+- [ ] `NAV-007` · P1 · UI — Create/clear pending approvals, agent actions, and Plex invite waiters; verify menu entries, counts, and hamburger attention dot update live without duplicate entries.
+- [ ] `NAV-008` · P0 · UI — Run the setup checklist on a partially configured server; verify every item is derived from live configuration, opens the real settings route, and re-evaluates on return.
+- [ ] `NAV-009` · P1 · API/UI — Inject a newer-server/unknown setup item; verify it renders generically and contributes to counts without crashing the older client.
+- [ ] `NAV-010` · P1 · UI — Mute and unmute the setup drawer reminder; verify the wizard remains reachable and live counts continue updating.
+- [ ] `NAV-011` · P1 · UI — Hide the Watch on Plex guide from the guide and re-enable it from Settings; verify both menu and preference persist across restart per device.
+- [ ] `NAV-012` · P1 · UI — Open About and verify app/server version, links, and update guidance match the running build.
+- [ ] `NAV-013` · P0 · UI — On every primary surface, use global search; verify secondary work screens hide it and local filters do not conflict with global search state.
+- [ ] `NAV-014` · P1 · UI — Start a search, change module, return, clear, and rapidly type; verify debounce, cancellation, focus, and results belong to the latest query.
+- [ ] `NAV-015` · P1 · UI — Submit a question-like or no-result query to AI; verify the exact prompt is handed off and starts once, while a normal result query does not force AI.
+- [ ] `NAV-016` · P0 · UI — Resize/rotate at phone, tablet, desktop, and narrow-web breakpoints; verify no overflow, unreachable actions, duplicate navigation, or content hidden behind system insets.
+- [ ] `NAV-017` · P1 · UI — Use browser back/forward and native back gestures across detail sheets, secondary routes, and tab branches; verify no unexpected exit or route reset.
+- [ ] `NAV-018` · P1 · UI — Background/foreground the native app on each major screen; verify data refreshes where required and unsaved destructive dialogs never execute themselves.
+
+## Users, local account invitations, and devices
+
+- [ ] `USER-001` · P0 · UI — Render users covering admin/requester, self, 0/1/many devices, active/expired/no connect token, password/passkey on/off, included AI on/off, Plex email/stamp combinations; verify every independent tag is truthful.
+- [ ] `USER-002` · P0 · UI/API — Generate/copy/reissue connect links for a new name, pending account, expired invite, connected user, and user with all devices revoked; verify intended account/device semantics and one active link behavior.
+- [ ] `USER-003` · P0 · API — Redeem concurrent connect links for the same new username; verify one user identity and safe token consumption without duplicate accounts.
+- [ ] `USER-004` · P0 · UI/API — Promote/demote another user and attempt to demote/delete the last admin; verify permission changes are immediate and the admin invariant holds.
+- [ ] `USER-005` · P0 · UI/API — Delete a user after canceling once; verify their local sessions/devices/grants/preferences/credentials become inaccessible while other users and external Plex access are not falsely claimed removed.
+- [ ] `USER-006` · P0 · UI/API — Enable/disable password and passkey methods; verify confirmation, actual credential revocation, menu tags, and recovery through a fresh connect link.
+- [ ] `USER-007` · P0 · UI — Grant shared OAuth-backed included AI and cancel/accept the warning; verify cancellation changes nothing and acceptance changes only the target user.
+- [ ] `USER-008` · P0 · UI — Configure each per-user request/default-instance setting, navigate away/back/restart, and verify tri-state inheritance plus pins persist exactly.
+- [ ] `USER-009` · P0 · LIVE — Send per-user test push for delivered, no-token, gateway-disabled, dead-token, and upstream-error states; verify diagnostic counts/results target only that user's devices.
+- [ ] `USER-010` · P1 · UI — Test Users list initial failure, retry, refresh during an action, large user count, duplicate-like names, long Unicode name/email, and concurrent edits without acting on the wrong row.
+- [ ] `USER-011` · P0 · UI — Verify Cantinarr connect-link `Invited`/`Invite expired` tags remain distinct from Plex `Needs Plex invite`/`Plex invite sent` states in every cross-product.
+- [ ] `USER-012` · P1 · CHAOS — Authenticate to Server A and load Users/badges/providers; revoke that current device from another admin, complete forced auth loss, then connect the app's single stored session to Server B. Verify no cached A state can repopulate B.
+
+## Security, privacy, and failure containment
+
+- [ ] `SEC-001` · P0 · SEC — Inventory every DB/settings secret and verify AES-256-GCM ciphertext for arr/download/Tautulli/Plex/AI/API/OAuth/push/webhook credentials, with no plaintext duplicate columns/files.
+- [ ] `SEC-002` · P0 · SEC — Tamper with ciphertext/tag and use the wrong key; verify authenticated decryption fails closed and never overwrites the stored value with empty/default data.
+- [ ] `SEC-003` · P0 · SEC — Inspect every credential/instance/status/config/user API; verify only safe metadata/configured booleans, never secret values or encrypted blobs.
+- [ ] `SEC-004` · P0 · SEC — Verify incoming Cantinarr Authorization/Cookie/forwarding headers are stripped before upstream proxy calls and only the intended upstream auth is applied.
+- [ ] `SEC-005` · P0 · SEC — Scrub nested/case-varied secret keys, arrays, headers, URL userinfo, percent-encoded and repeated query secrets across proxy, MCP, chat, and remediation.
+- [ ] `SEC-006` · P0 · SEC — Feed misleading content types, malformed/encoded/deeply nested/oversized JSON and compressed bombs; verify bounded fail-closed handling without forwarding raw bodies.
+- [ ] `SEC-007` · P1 · SEC — Verify legitimate non-JSON/streaming/SSE responses remain usable only on intended routes and cannot bypass the structured scrubber.
+- [ ] `SEC-008` · P0 · SEC — Review request logs under success/error attacks; verify no query string, auth/cookie header, request body, dynamic secret path, user email, or upstream error body is logged.
+- [ ] `SEC-009` · P0 · SEC — Make each upstream redirect to another host; verify clients carrying credentials do not follow or leak headers.
+- [ ] `SEC-010` · P0 · SEC — Run the route inventory as anonymous/requester/admin with direct HTTP, not UI; verify every permission boundary and no method/path variant bypass.
+- [ ] `SEC-011` · P0 · SEC — Test CORS preflight/actual calls from same origin, hostile web origin, null origin, wildcard MCP clients, and credentialed mode; verify API and MCP policies remain distinct.
+- [ ] `SEC-012` · P0 · SEC — Test WebSocket origin/subprotocol/token handling and hostile forwarded headers behind proxy; verify trusted deployment works without cross-site socket access.
+- [ ] `SEC-013` · P0 · SEC — Render HTML/script/Markdown/control/bidi/huge Unicode in every user/model/upstream text surface; verify passive escaped text, no executable link/control injection, and safe layout.
+- [ ] `SEC-014` · P0 · SEC — Verify OAuth redirect, PKCE, state, audience/resource, authorization-code replay, refresh replay, and wrong-resource failures do not consume or expose valid tokens incorrectly.
+- [ ] `SEC-015` · P1 · SEC — Verify public auth/device-flow rate limits cannot be bypassed with route variants and authenticated device-flow churn does not starve household login.
+- [ ] `SEC-016` · P0 · SEC — Attempt SSRF through instance URLs, webhook public URL, AI verification URL, management portal, images, and MCP redirects; verify supported schemes/hosts/redirect rules and no cloud metadata access.
+- [ ] `SEC-017` · P1 · SEC — Attempt SQL/JSON/path/command injection in IDs, filters, instance names, emails, download item IDs, release refs, and filenames; verify parameterization/escaping and no unintended mutation.
+- [ ] `SEC-018` · P0 · SEC — Confirm regular-user `/api/config` reveals only effective services/grants; admin config may list instances but never credentials or webhook secrets.
+- [ ] `SEC-019` · P1 · SEC — Verify backups/support bundles/crash reports and app local storage contain only expected tokens/state and documented protection; no provider/Plex/upstream secrets on device.
+- [ ] `SEC-020` · P1 · SEC — Compare actual network destinations/storage with privacy policy; verify no undocumented telemetry or client-side third-party API keys.
+- [ ] `SEC-021` · P1 · CHAOS — Trigger panics/errors in background Plex, push, WebSocket, cache, and remediation work; verify recovery contains the fault, preserves server health, and logs redacted context.
+- [ ] `SEC-022` · P1 · API — Run fuzz/property checks for handler JSON decoders, ID/path parsing, proxy sanitizer, email validator, season scope, and notification payload conversion; verify no panic or unsafe default.

--- a/docs/testing/catalog/baseline-operations-release.md
+++ b/docs/testing/catalog/baseline-operations-release.md
@@ -1,0 +1,92 @@
+# Build, operations, usability, and release
+
+Build gates, install and upgrade behavior, product-wide usability, performance, release pipelines, and exploratory coverage.
+
+These are canonical, run-neutral definitions. Keep every active case unchecked; record executions only in a copy assembled with the [run template](../run-template.md).
+
+## Release gate and build baseline
+
+- [ ] `BASE-001` · P0 · AUTO — From `server/`, run `go vet ./...`; verify exit 0 with no diagnostics.
+- [ ] `BASE-002` · P0 · AUTO — From `server/`, run `go test ./...`; verify every package passes without retries or order dependence.
+- [ ] `BASE-003` · P0 · AUTO — From `server/`, run `CGO_ENABLED=0 go build ./cmd/server`; verify a working non-CGO server binary is produced.
+- [ ] `BASE-004` · P0 · AUTO — From `app/`, run `flutter analyze --no-fatal-infos`; verify no errors or warnings that CI treats as fatal.
+- [ ] `BASE-005` · P0 · AUTO — From `app/`, run `flutter test`; verify all unit and widget tests pass.
+- [ ] `BASE-006` · P0 · AUTO — From `app/`, run `flutter build web --release`; serve the output and verify the initial route renders without console/runtime errors.
+- [ ] `BASE-007` · P0 · AUTO — Build the root Dockerfile for the target architecture; start it with an empty config volume and verify `/api/health` and the embedded web app.
+- [ ] `BASE-008` · P0 · AUTO — Build `server/Dockerfile`; start it and verify the API-only image reaches healthy state.
+- [ ] `BASE-009` · P1 · AUTO — Verify both Docker images contain the pinned checksum-verified Codex app-server binary and bundled `LICENSE`/`NOTICE` files on amd64 and arm64.
+- [ ] `BASE-010` · P1 · AUTO — Run the CI-equivalent pinned Codex integration smoke test; verify protocol compatibility, startup, one turn, and clean shutdown.
+- [ ] `BASE-011` · P1 · AUTO — Parse iOS Swift sources with `swiftc -parse` when a local iOS toolchain is unavailable; otherwise build and launch the release candidate on a physical device.
+- [ ] `BASE-012` · P1 · AUTO — Build the signed Android AAB in CI and install an equivalent release build on a physical device; verify launch, networking, deep links, and passkey provider registration.
+- [ ] `BASE-013` · P0 · API — Call representative public, user, and admin endpoints; verify JSON content types, stable error envelopes, and no panic/HTML error bodies.
+- [ ] `BASE-014` · P1 · CHAOS — Run server and app tests three times with shuffled package/test order where supported; verify no shared-state, clock, port, or race flake.
+
+## Install, upgrade, persistence, and operations
+
+- [ ] `OPS-001` · P0 · UI/API — Start with an empty `/config`; complete first-run setup and verify one admin, a writable WAL database, and a generated encryption key are created.
+- [ ] `OPS-002` · P0 · SEC — Inspect a fresh and populated database/config volume; verify API keys, passwords, Plex token, push key, webhook credentials, and OAuth authorization are not plaintext.
+- [ ] `OPS-003` · P0 · API — Restart the server after configuring every service; verify users, device sessions, requests, settings, instances, Plex configuration, notification preferences, and encrypted credentials survive.
+- [ ] `OPS-004` · P0 · UI — Restart during an authenticated app session; verify the session refreshes and the current user is not sent to login.
+- [ ] `OPS-005` · P0 · CHAOS — Rotate `CANTINARR_JWT_SECRET`; verify permanent device sessions refresh successfully and nobody is signed out solely because of rotation.
+- [ ] `OPS-006` · P0 · SEC — Remove or replace the encryption key while retaining the DB; verify encrypted values fail closed with actionable server diagnostics and are never exposed as ciphertext/plaintext to clients.
+- [ ] `OPS-007` · P0 · API — Upgrade a copy of the oldest supported populated database to the candidate; verify all in-code migrations run once and existing accounts, grants, requests, Plex fields, and notification defaults remain correct.
+- [ ] `OPS-008` · P1 · API — Restart the upgraded database repeatedly; verify migrations are idempotent and no duplicate/backfill drift occurs.
+- [ ] `OPS-009` · P1 · API — Restore a DB plus its matching encryption key into a fresh container; verify all integrations and sessions recover.
+- [ ] `OPS-010` · P1 · API — Restore a DB without its WAL/SHM after a clean shutdown; verify the database opens and committed data is intact.
+- [ ] `OPS-011` · P1 · CHAOS — Fill the config filesystem or make it read-only during a settings write; verify the write fails visibly, prior state remains usable, and no partial secret/config is reported saved.
+- [ ] `OPS-012` · P1 · CHAOS — Stop each upstream service while Cantinarr runs; verify the affected screen shows a retryable error while unrelated modules remain usable.
+- [ ] `OPS-013` · P1 · UI — Change server public URL/proxy origin within supported configuration; verify connect links, webhook URLs, WebSocket, passkeys, and embedded SPA routing use the correct trusted origin.
+- [ ] `OPS-014` · P1 · API — Launch two processes against unsupported shared state/runtime arrangements; verify unsafe Codex runtime ownership or persistent filesystem use is rejected rather than silently shared.
+- [ ] `OPS-015` · P1 · API — With update checks disabled, a dev build, `latest`, and a semver build, verify only the eligible semver build checks GitHub and failures never block startup.
+- [ ] `OPS-016` · P1 · UI — Configure, change, clear, and reject an invalid update-portal URL; verify the update banner target and persisted setting match the accepted value.
+- [ ] `OPS-017` · P2 · UI — Dismiss an update banner, restart, then publish/simulate a newer version; verify dismissal is per release and the newer banner returns.
+
+## Product-wide usability, accessibility, compatibility, and performance
+
+- [ ] `UX-001` · P0 · UI — On every list/form/screen, verify initial loading, empty, loaded, initial error+retry, stale refresh failure, and pull-to-refresh states without infinite spinners.
+- [ ] `UX-002` · P0 · UI — Double-tap/press Enter rapidly on request, save, link, invite, grab, approve, delete, import, and remediation actions; verify controls disable and no duplicate external mutation.
+- [ ] `UX-003` · P0 · UI — Verify every destructive action names target, requires confirmation, defaults to preserving files/data, and cancel/background/back is inert.
+- [ ] `UX-004` · P1 · UI — Navigate away, resize/rotate, background/foreground, or lose network during non-destructive saves; verify clear final state and no wrong-context completion toast.
+- [ ] `UX-005` · P1 · UI — Operate all routes, cards, tabs, menus, sheets, dialogs, checkboxes, and icon actions by keyboard; verify logical focus, visible focus, Enter/Space/Escape/back behavior.
+- [ ] `UX-006` · P1 · UI — Use VoiceOver/TalkBack/browser accessibility tree; verify media identity/status, selected tabs, progress, form errors, counts, and icon actions have nonduplicative labels.
+- [ ] `UX-007` · P1 · UI — Test 200% text scale, device bold text, long English/Unicode values, RTL/bidi input, and small screens; verify no clipped critical copy/actions or spoofed labels.
+- [ ] `UX-008` · P1 · UI — Test missing/broken/slow poster/backdrop/avatar; verify consistent placeholder, semantics, cached-image identity, and no wrong-image reuse.
+- [ ] `UX-009` · P1 · UI/API — Test UTC±12/14, DST transitions, locale date formats, invalid/missing timestamps, and clock skew; verify release/history/expiry/last-seen grouping and no off-by-one day.
+- [ ] `UX-010` · P0 · UI — Audit requester surfaces; verify Available/Partially Available/Requested/Downloading language and no monitored/cutoff/unmet/arr workflow jargon outside admin context.
+- [ ] `UX-011` · P0 · API/UI — Test old-app/new-server unknown fields and new-app/old-server missing fields; display may degrade generically but mutation must fail closed when required identity/scope is absent.
+- [ ] `UX-012` · P0 · UI — Verify distinct same-title/year/library records remain distinct everywhere: discovery, global search, books, library, requests, releases, AI carousel, and MCP output.
+- [ ] `UX-013` · P1 · UI — Verify browser direct refresh and offline/cache recovery for every SPA route, then upgrade server assets and confirm the old cached app cannot become permanently unusable.
+- [ ] `UX-014` · P1 · UI — Verify native/web deep links with encoded paths, cold start, auth required, invalid record, and already-open destination.
+- [ ] `PERF-001` · P1 · API/UI — Load production-scale libraries, 10k history rows, 1k queue rows, 500 users/devices, and long issue transcripts; verify bounded pagination/memory and responsive interaction.
+- [ ] `PERF-002` · P1 · API — Connect many WebSocket clients and churn reconnects; verify bounded goroutines/subscriptions, authorized fan-out, and prompt cleanup.
+- [ ] `PERF-003` · P1 · API — Run concurrent requests, approvals, settings writes, queue polling, webhooks, and remediation against SQLite; verify no prolonged lock storm, partial invariant, or data loss.
+- [ ] `PERF-004` · P1 · API — Measure upstream timeout/cancellation for Plex, arrs, downloads, Tautulli, push, TMDB/Trakt, and AI; verify request cancellation propagates and server remains responsive.
+- [ ] `PERF-005` · P2 · UI — Scroll long image-heavy grids/lists on representative low-end iOS/Android and web hardware; verify stable frame rate, bounded cache, and no progressive memory leak.
+
+## Setup, updates, site, store, and release operations
+
+- [ ] `REL-001` · P0 · UI/API — On a fresh/fully/partially configured server, verify every current setup item (TMDB, Radarr, Sonarr, Chaptarr, downloads, Tautulli, Trakt, shared AI, push, Plex) derives from actual state with correct essential/optional counts.
+- [ ] `REL-002` · P1 · UI/API — Remove each configured integration and return from its destination; verify setup completion reverses immediately rather than storing stale progress.
+- [ ] `REL-003` · P0 · API/UI — Simulate newer/equal/older/malformed latest versions; verify only newer semver produces an admin banner and requesters never see update controls.
+- [ ] `REL-004` · P1 · CHAOS — Fail/slow GitHub update lookup; verify cached best-effort behavior never blocks server/app and honors the disable env var.
+- [ ] `REL-005` · P1 · UI — Save valid HTTP/HTTPS management portals, reject unsafe/invalid URLs, clear it, and verify banner target falls back to update guide.
+- [ ] `REL-006` · P0 · UI — Verify About shows exact app/server build versions and all update/privacy/support/repository links use the intended trusted destinations.
+- [ ] `REL-007` · P0 · LIVE — Pull the published GHCR image/tag on clean amd64 and arm64 hosts; verify `latest`, version tags, startup, health, embedded app, persistence, and bundled notices.
+- [ ] `REL-008` · P0 · LIVE — Exercise documented upgrade with a production-like `/config`, verify data and rollback prerequisites, and ensure the guide contains no destructive/incorrect command.
+- [ ] `REL-009` · P1 · LIVE — Run TestFlight workflow for an iOS-relevant change; verify signed build installs, entitlements/passkeys/push/deep links work, and excluded paths do not trigger unintended builds.
+- [ ] `REL-010` · P1 · LIVE — Run Play beta workflow for Android-relevant changes; verify signed AAB, package/version, passkeys/deep links, build-only PR behavior, and no upload without service-account secret.
+- [ ] `REL-011` · P1 · API — Verify store-listing-only changes use the listing workflow, copy/assets land in intended storefronts, and do not trigger irrelevant native builds.
+- [ ] `REL-012` · P1 · UI — Validate marketing site homepage/404/header policy at phone/desktop sizes; verify navigation, screenshots, self-host snippet, demo, store badges, privacy, and canonical links.
+- [ ] `REL-013` · P1 · LIVE — Deploy `site/` through Cloudflare workflow/manual Wrangler path; verify correct project, cache/security headers, assets/fonts, and live smoke without a build step.
+- [ ] `REL-014` · P1 · SEC/UI — Run link checker, HTML validation, accessibility audit, image-alt/contrast/keyboard checks, and verify no secret/env data is emitted into the static site.
+- [ ] `REL-015` · P0 · API — Compare shipped behavior with `README.md`, `server/README.md`, `app/README.md`, update/store docs, privacy policy, site copy, route/tool/env/table counts, and version floors; record any drift as a release defect.
+- [ ] `REL-016` · P0 · API — Verify `CLAUDE.md` remains only a thin import/pointer to `AGENTS.md` and contributor/test/release instructions do not conflict.
+- [ ] `REL-017` · P1 · UI/AUTO — Build `app/test/preview/screenshot_main.dart`, run `app/tool/screenshots/shoot.js`, and verify every required store image has deterministic populated data, documented dimensions/fastlane placement, no live credentials, and no clipped UI.
+
+## Exploratory and compatibility pass
+
+- [ ] `EXP-001` · P2 · UI — Run a 60-minute unscripted requester session across discover/search/request/status/guide/AI with network changes; record confusion, stale state, and crashes.
+- [ ] `EXP-002` · P2 · UI — Run a 90-minute admin session across every module with two instances, concurrent Admin B changes, and mixed external mutations; record wrong-target or stale-control risks.
+- [ ] `EXP-003` · P2 · LIVE — Repeat the highest-risk integration flows against the oldest and newest supported upstream Plex/arr/download/Tautulli versions.
+- [ ] `EXP-004` · P2 · UI — Run Chrome, Safari, and supported mobile web plus current iOS/Android release builds with slow 3G/high latency and intermittent VPN.
+- [ ] `EXP-005` · P2 · SEC — Perform a focused abuse pass as a curious household requester using browser devtools/direct API calls, guessed IDs, and prompt injection; record any information or mutation beyond role.

--- a/docs/testing/catalog/discovery-requests.md
+++ b/docs/testing/catalog/discovery-requests.md
@@ -1,0 +1,80 @@
+# Discovery and requests
+
+Discovery, search, detail views, availability, requester policy, approval, and request lifecycle behavior.
+
+These are canonical, run-neutral definitions. Keep every active case unchecked; record executions only in a copy assembled with the [run template](../run-template.md).
+
+## Discovery, search, media detail, and release timeline
+
+- [ ] `DISC-001` · P0 · UI/LIVE — Load actual dashboards: movie spotlight, Popular Movies, Top Rated, Coming Soon, Most Anticipated, Downloading Soon, Recently Downloaded; series spotlight, Popular TV Shows, Most Anticipated, Recently Downloaded, Airing Next. Verify identity/image/date/status/detail target.
+- [ ] `DISC-002` · P0 · CHAOS — Remove or invalidate TMDB credentials; verify discovery/search/detail fail with actionable empty/error states and no API token reaches the device.
+- [ ] `DISC-003` · P1 · API — Call movie/TV discover with page, genre, provider/region, year, and sort combinations; verify exact upstream forwarding, cache-key separation, page boundaries, and changed filters never reuse prior results.
+- [ ] `DISC-004` · P0 · UI — Search an exact movie, TV show, and person; verify each record keeps its media type/identity and opens the correct movie, TV, or person view.
+- [ ] `DISC-005` · P0 · UI — Search a title with two distinct matching records or duplicate library entries; verify no silent dedupe/merge and each result remains selectable.
+- [ ] `DISC-006` · P0 · UI/LIVE — Search as two users pinned to different default arr instances; verify availability chips are computed against each user's live default library, not shared cached state.
+- [ ] `DISC-007` · P0 · UI/LIVE — Move a title through unavailable, requested, downloading, partial, and available outside Cantinarr; verify search/detail chips converge over webhook/WebSocket/refetch with requester vocabulary only.
+- [ ] `DISC-008` · P1 · CHAOS — Return results out of order for rapidly changed searches; verify stale responses never replace the newest query.
+- [ ] `DISC-009` · P1 · UI — Search with empty, whitespace-only, punctuation, Unicode, apostrophe, long, and URL-like input; verify safe encoding, no injection/crash, and sensible empty states.
+- [ ] `DISC-010` · P0 · UI — Open movie detail; verify artwork/title, rating, tagline, genres, overview, request/status actions, admin arr link, trusted trailer, recommendations, and similar titles map to that movie with safe missing-field fallbacks.
+- [ ] `DISC-011` · P0 · UI — Open TV detail; verify artwork/title, rating, tagline, genres, overview, real-season availability/request controls, admin arr link, trailer, recommendations/similar; requester season selection deliberately excludes Specials.
+- [ ] `DISC-012` · P1 · UI — Open person detail and credits; verify movie/TV credits retain their media type, dates, character/job, and link to the correct detail.
+- [ ] `DISC-013` · P1 · CHAOS — Use missing poster/backdrop/profile URLs and image 404/timeouts; verify stable placeholders, readable layout, and no endless shimmer.
+- [ ] `DISC-014` · P1 · UI — Verify long titles, summaries, localized Unicode, unknown dates, and absent metadata do not overflow or display literal null values.
+- [ ] `DISC-015` · P0 · UI/LIVE — As admin, request/add a movie then TV show from discovery; verify “Open in Radarr/Sonarr” appears only after the exact ID exists and links to the matching item/instance.
+- [ ] `DISC-016` · P0 · SEC/UI — As requester, verify arr deep links never appear even when the title exists; as admin, verify no link appears for a nonmatching same-title record.
+- [ ] `DISC-017` · P1 · LIVE — With Trakt configured, load trending, popular, public lists/items, calendar, anticipated, and recommendations; verify IDs/media types bridge to usable details.
+- [ ] `DISC-018` · P1 · CHAOS — Disable/fail Trakt while TMDB works; verify TMDB-backed discovery remains functional and Trakt-only sections fail independently.
+- [ ] `DISC-019` · P0 · UI — In the Releases tab list view, combine movie releases and TV episodes; verify chronological ordering, media labels, availability, and links.
+- [ ] `DISC-020` · P0 · UI — In month-calendar view, cross month/year boundaries and today; verify correct local-day placement, navigation, and no UTC off-by-one.
+- [ ] `DISC-021` · P1 · UI — Verify repeated release events for distinct episodes/titles remain distinct while the same event is not duplicated by refresh.
+- [ ] `DISC-022` · P1 · CHAOS — Drop/reconnect WebSocket on dashboard rows and release timeline; verify one subscription, no duplicate rows/events, and eventual fresh data.
+- [ ] `DISC-023` · P1 · UI — Pull-to-refresh/retry each discovery/detail surface during loading, empty, error, and loaded states; verify one current request and preserved navigation.
+- [ ] `DISC-024` · P1 · SEC — Inspect all discovery and Trakt requests/responses/logs; verify TMDB/Trakt credentials remain server-side and secret-bearing upstream URLs are scrubbed.
+- [ ] `DISC-025` · P1 · API — Call `/api/discover/trending` across supported media/window parameters and `/api/discover/movies/now-playing`; verify bounded current identities even though these are not dashboard row names.
+- [ ] `DISC-026` · P0 · UI/LIVE — On Movies, verify spotlight plus Downloading Soon orders active downloads first then monitored/missing fallback, Recently Downloaded reflects imports, and direct import/resume refresh converges without duplicates.
+- [ ] `DISC-027` · P0 · UI/LIVE — On TV, verify spotlight, Recently Downloaded, and Airing Next uses unique series from the next seven-day calendar without duplicate shows or wrong episode links.
+- [ ] `DISC-028` · P1 · CHAOS/UI — With no default instance or one live-row source failing, verify TMDB discovery remains usable, only affected live rows degrade, and refresh recovers them.
+- [ ] `DISC-029` · P1 · UI/LIVE — Cover primary YouTube trailer, fallback YouTube video, no video, and invalid/missing key; Watch Trailer appears only when appropriate and launches the exact trusted target once.
+
+## Requests, availability, policies, and approvals
+
+- [ ] `REQ-001` · P0 · UI/LIVE — Request a new movie with no approval required; verify the correct user's Radarr instance receives the exact TMDB ID, configured root/profile, monitored flag, and search action once.
+- [ ] `REQ-002` · P0 · LIVE — Request a movie already in Radarr with a file; verify no duplicate add/search and Cantinarr reports Available.
+- [ ] `REQ-003` · P0 · LIVE — Request a movie already in Radarr without a file and monitored; verify no duplicate record and Requested/Downloading state reflects live progress.
+- [ ] `REQ-004` · P0 · LIVE — Request an existing unmonitored movie without a file; verify it is re-monitored and searched, preserving the existing record.
+- [ ] `REQ-005` · P0 · UI/LIVE — Request a new TV series with each coarse scope (`all`, `first`, `latest`, `pilot`); verify Sonarr monitoring/search behavior exactly matches the chosen scope and Specials are not accidentally included.
+- [ ] `REQ-006` · P0 · UI/LIVE — Select a noncontiguous set of real seasons; verify Specials are absent from requester UI and only selected real seasons are stored, monitored, and searched in sorted/deduplicated order.
+- [ ] `REQ-007` · P0 · LIVE — Request additional seasons for an existing series; verify monitoring is additive, chosen season episodes are monitored/searched, and previously monitored seasons are never unmonitored.
+- [ ] `REQ-008` · P0 · LIVE — Request pilot scope for an existing series; verify S01E01 is monitored/searched without incorrectly marking all of season 1.
+- [ ] `REQ-009` · P0 · LIVE — Request `all`/`first`/`latest` for an existing partially complete/dormant series; verify incomplete target seasons revive while complete files and unrelated monitoring remain intact.
+- [ ] `REQ-010` · P0 · API — Force the TMDB→TVDB bridge primary lookup to succeed; verify Sonarr receives the correct TVDB ID and cache is reused within its TTL.
+- [ ] `REQ-011` · P0 · API — Force the primary ID bridge to miss and Trakt fallback to succeed; verify the resolved TVDB ID is used once and stored with the request.
+- [ ] `REQ-012` · P0 · CHAOS — Make external-ID/Trakt resolution miss and Sonarr title fallback return no authoritative match or ambiguous/mismatched candidates; verify no wrong series is added and the user gets an actionable failure.
+- [ ] `REQ-013` · P0 · UI — With season choice enabled, verify season checkboxes/status chips, select/clear, Request N seasons, and Request More include only requestable seasons.
+- [ ] `REQ-014` · P0 · UI/SEC — With season choice disabled globally or for a user, verify the picker is status-only and a forged explicit list is ignored in favor of effective policy.
+- [ ] `REQ-015` · P0 · UI — Set global default scope to all/first/latest/pilot; verify users inheriting policy get that scope and the choice label is accurate.
+- [ ] `REQ-016` · P0 · UI — Set each per-user tri-state policy (inherit/on/off) for approval, season choice, and quality choice; verify effective options and request behavior for that user only.
+- [ ] `REQ-017` · P0 · UI/LIVE — Enable quality choice and pick valid Radarr/Sonarr profiles; verify the selected profile reaches the exact arr add and is stored on pending requests.
+- [ ] `REQ-018` · P0 · SEC — Disable quality choice and forge a profile ID; verify effective default profile is used and an invalid/cross-instance profile cannot be injected.
+- [ ] `REQ-019` · P1 · CHAOS — Delete/change a configured quality profile after a request becomes pending; verify approval shows the stored choice and fails safely or requires an explicit valid override—never a random profile.
+- [ ] `REQ-020` · P0 · UI — With approval required, submit movie, TV coarse-scope, explicit-season, ebook, audiobook, and both-format requests; verify no arr mutation yet and every queue row preserves exact user/media/options.
+- [ ] `REQ-021` · P0 · LIVE — Approve each pending media type without override; verify it executes the stored request once, records approver/time, leaves the queue, updates requester history/state, and sends configured decision push.
+- [ ] `REQ-022` · P0 · LIVE — Approve TV with scope/quality overrides and pending ebook/audiobook/both requests after overriding format each direction; verify only the final approved exact scope/profile/format set executes once and audit/status reflect it.
+- [ ] `REQ-023` · P0 · UI — Deny with empty and supplied reasons; verify terminal Denied state, optional reason visibility, queue removal, no arr mutation, and requester notification when enabled.
+- [ ] `REQ-024` · P0 · API/CHAOS — Have two admins approve/deny the same request concurrently and retry after a lost response; verify at-most-once arr execution and the loser reloads the durable winner.
+- [ ] `REQ-025` · P0 · CHAOS — Make arr add/search fail during direct request or approval; verify truthful failure/pending behavior, no false Available/approved claim, and a safe retry path without duplicate add.
+- [ ] `REQ-026` · P0 · API — Submit the same request rapidly/repeatedly from UI, API, and AI; verify duplicate pending/log/arr mutations are prevented while legitimate Request More/new-format requests remain possible.
+- [ ] `REQ-027` · P0 · UI — Verify request buttons and detail sheets for unavailable, pending, denied, requested, downloading, partial, and available states use the correct enabled action and requester vocabulary.
+- [ ] `REQ-028` · P0 · UI — For a partially available series, use Request More; verify it opens season status, prevents choosing complete/covered seasons, and requests only remaining selections.
+- [ ] `REQ-029` · P0 · LIVE — Change arr state directly (manual import, delete file, unmonitor, replace queue item); verify status is recomputed live rather than trusting request history.
+- [ ] `REQ-030` · P0 · UI — Inspect one user's request history as that user and another user; verify users see only their own rows while admins see only the intended pending admin queue.
+- [ ] `REQ-031` · P1 · UI — Verify status progress handles unknown total, 0%, partial, 100%, failed queue, and item removed before import without NaN/false Available.
+- [ ] `REQ-032` · P1 · CHAOS — Switch a user's default instance after a request; verify new availability/requests use the new instance while historical/audit context is not silently rewritten.
+- [ ] `REQ-033` · P1 · UI — Change global/per-user policies while a request is pending; verify the pending row retains its submitted exact choices and admin override is explicit.
+- [ ] `REQ-034` · P1 · SEC — Forge unsupported media type, bad/negative IDs, malformed season JSON, invalid scope/format/profile, and cross-service combinations; verify 4xx and zero upstream mutation.
+- [ ] `REQ-035` · P1 · UI — Create and resolve pending requests while the requester/admin is on another device; verify WebSocket badges, list rows, buttons, and history converge without manual restart.
+- [ ] `REQ-036` · P0 · LIVE — Verify request-pending push goes only to opted-in admins and decision push only to the original opted-in requester, with correct badge and deep link.
+- [ ] `REQ-037` · P0 · API/LIVE — As a caller allowed season choice, send explicit seasons `[0,1]`; verify S00 and S01 are preserved/sorted/deduplicated and no other season is monitored/searched despite Specials being hidden in requester UI.
+- [ ] `REQ-038` · P0 · LIVE — Make TMDB external IDs and Trakt miss, return one authoritative matching Sonarr title result, and verify that result's TVDB ID is persisted and the exact series is added.
+- [ ] `REQ-039` · P1 · API — Exercise the ID-bridge cache just under and over 30 days; verify under-TTL reuse, expired-row refetch/replacement, and no stale cross-media/ID mapping.
+- [ ] `REQ-040` · P0 · UI/API — With approval globally required and season/quality choice disabled, submit as admin; verify no pending row and valid admin explicit scope/profile choices execute exactly once without weakening requester policy.

--- a/docs/testing/catalog/instances-realtime-push.md
+++ b/docs/testing/catalog/instances-realtime-push.md
@@ -1,0 +1,79 @@
+# Instances, realtime behavior, and push
+
+External service configuration, defaults, webhooks, cache freshness, WebSocket behavior, and push delivery.
+
+These are canonical, run-neutral definitions. Keep every active case unchecked; record executions only in a copy assembled with the [run template](../run-template.md).
+
+## Credentials, instances, defaults, and webhooks
+
+- [ ] `INST-001` · P0 · UI/LIVE — Create and test one valid instance of each supported type: Radarr, Sonarr, Chaptarr, SABnzbd, qBittorrent, NZBGet, Transmission, and Tautulli; verify type-specific credentials and capabilities work.
+- [ ] `INST-002` · P0 · UI/CHAOS — Repeat creation with bad URL, bad credentials, wrong service type, TLS failure, timeout, and unreachable host; verify no unusable instance is silently reported healthy and secrets are absent from errors.
+- [ ] `INST-003` · P0 · UI — Edit name, URL, credential, and type-appropriate fields; verify a successful retest updates the correct instance and dependent screens use the new client.
+- [ ] `INST-004` · P0 · SEC — Fetch/list/edit instances and inspect app/server logs; verify API keys/passwords are write-only or redacted and never returned through models, proxy errors, URLs, or logs.
+- [ ] `INST-005` · P0 · UI — Delete each instance type with confirmation; verify it disappears from navigation/providers and unrelated instances/defaults remain intact.
+- [ ] `INST-006` · P1 · CHAOS — Delete an instance referenced by user defaults, an issue, or active UI state; verify foreign-reference behavior is safe, historical audit remains intelligible, and no other instance is substituted silently.
+- [ ] `INST-007` · P0 · UI — With two same-type instances, mark the second global default and accept takeover; verify exactly one default remains and all unpinned users switch.
+- [ ] `INST-008` · P1 · UI — Cancel global-default takeover; verify neither default flag changes.
+- [ ] `INST-009` · P0 · UI — Pin different Radarr/Sonarr defaults per user; verify discovery availability, requests, live rows, details, and AI request tools use that user's pinned instance.
+- [ ] `INST-010` · P0 · UI — Grant a user one Chaptarr instance; verify it grants Books access and all book search/library/request operations stay on that exact instance.
+- [ ] `INST-011` · P0 · UI — Reassign a Chaptarr user to a sibling instance, confirm the warning, and verify the old assignment is removed; cancel once and verify it remains unchanged.
+- [ ] `INST-012` · P1 · UI — Bulk-assign an exact set of users from an instance-centric screen; verify additions/removals are exact and do not modify other service types.
+- [ ] `INST-013` · P0 · LIVE — Configure instant updates on Radarr and Sonarr; verify Cantinarr rotates a server-only credential, upserts one managed Connect webhook, and the app never receives the secret.
+- [ ] `INST-014` · P0 · LIVE — Trigger Grab, Download/import, Add, library Delete, and file Delete for Radarr/Sonarr; verify exact instance/media invalidation and notification. Send Rename and verify 200 acknowledgement with no broadcast, push, or immediate mutation.
+- [ ] `INST-015` · P0 · SEC — Call a webhook with missing/wrong Basic auth, query-string credentials, wrong instance, and encoded/malformed paths; verify rejection and no event mutation.
+- [ ] `INST-016` · P1 · LIVE — Reconfigure the same webhook repeatedly; verify one managed webhook is updated, credentials rotate safely, and the previous credential stops working.
+- [ ] `INST-017` · P1 · CHAOS — Make arr accept webhook creation but lose the response; retry and verify no duplicate unmanaged hooks or secret disclosure.
+- [ ] `INST-018` · P0 · SEC — Proxy JSON containing nested API keys, authorization/cookie fields, URL userinfo, and secret query parameters; verify all are recursively scrubbed.
+- [ ] `INST-019` · P0 · SEC — Return malformed, encoded, and oversized JSON from an arr proxy; verify it fails closed rather than forwarding unsanitized content.
+- [ ] `INST-020` · P1 · LIVE — Verify TMDB, Trakt, and AI shared credentials save only after their connection/validation contract succeeds; failed replacement leaves the previously working value active.
+- [ ] `INST-021` · P1 · UI — Delete each shared credential; verify its feature becomes unavailable with actionable UI while unrelated providers remain configured.
+- [ ] `INST-022` · P1 · UI — Configure and clear the optional Trakt credential; verify enhanced rows/fallback disappear gracefully and TMDB discovery continues.
+- [ ] `INST-023` · P1 · API — Change a credential while clients are cached; verify the next request uses the new value and the old secret is not retained as active behavior.
+- [ ] `INST-024` · P2 · UI — Use names/URLs containing Unicode, spaces, long-but-valid values, and trailing slashes; verify canonical requests and labels without duplicate slashes or broken layout.
+
+## Managed arr webhooks, WebSocket, caching, and freshness
+
+- [ ] `RT-001` · P0 · LIVE — Verify managed webhook creation uses trusted `CANTINARR_PUBLIC_URL` behind a proxy and never derives a callback from hostile Forwarded/Host headers.
+- [ ] `RT-002` · P0 · LIVE — Reconfigure/upsert concurrently; verify one managed hook, current/pending credential rotation window, and eventual rejection of the old credential.
+- [ ] `RT-003` · P1 · LIVE — Upgrade a legacy callback-path webhook; verify migration to the current authenticated endpoint without duplicate notifications.
+- [ ] `RT-004` · P0 · CHAOS — Fail webhook rotation before/after remote upsert; verify the last working credential remains usable or recovery is explicit—never an unknowable silent break.
+- [ ] `RT-005` · P0 · API — Send webhook Test/unknown events; verify 200 acknowledgement with no user-visible mutation.
+- [ ] `RT-006` · P0 · LIVE — Send Radarr movie and Sonarr series add/delete/file-delete/grab events; verify only exact instance/media caches/statuses invalidate.
+- [ ] `RT-007` · P0 · LIVE — Import a movie and several episodes; verify availability/events and new-content notification once despite webhook + poll overlap.
+- [ ] `RT-008` · P0 · SEC — Send missing/wrong/query-string credentials, wrong instance type, path traversal/encoding, huge body, and malformed JSON; verify safe rejection and no access-log secret/query leakage.
+- [ ] `RT-009` · P0 · API — Connect WebSocket with valid/invalid/expired/revoked subprotocol auth; verify only the valid current user receives a connection.
+- [ ] `RT-010` · P0 · SEC — Produce events for two users pinned to different instances plus admin-only events; verify each socket receives only authorized/relevant data.
+- [ ] `RT-011` · P0 · CHAOS — Drop network, restart server, rotate tokens, sleep/wake device, and reconnect; verify one subscription and refetch/backfill repairs missed state.
+- [ ] `RT-012` · P0 · API — Replay a valid authenticated webhook and deliver duplicate/out-of-order events; verify safe acknowledgement/idempotence, newer state never regresses, and duplicate content notification/action is suppressed.
+- [ ] `RT-013` · P1 · API/UI — Verify REST `partial` and any realtime variant map to one Partially Available state, including older/newer payload compatibility.
+- [ ] `RT-014` · P1 · CHAOS — Send malformed/version-skew/unknown events; verify ignored/generic-safe handling and polling repairs state without a crash.
+- [ ] `RT-015` · P0 · LIVE — Make direct arr changes with no webhook; verify short polling/refetch paths eventually show truth and no permanent stored snapshot wins.
+- [ ] `RT-016` · P0 · API — Verify book library digest TTL/invalidation after add/import/delete and strict user+Chaptarr-instance cache keys.
+- [ ] `RT-017` · P1 · UI — Revoke the current device, demote the actor, or dispose the screen during an in-flight refresh/subscription; verify stale completion cannot repopulate private state after auth/scope loss.
+- [ ] `RT-018` · P1 · CHAOS — Fail a silent refresh while old data exists; verify it is retained with appropriate freshness/error feedback and never represented as newly verified.
+
+## Push gateway, preferences, delivery, and deep links
+
+- [ ] `PUSH-001` · P0 · API — Start with explicit gateway key; verify no enrollment call and successful authenticated send.
+- [ ] `PUSH-002` · P0 · API/SEC — Start with gateway URL and no key; verify one auto-enrollment, encrypted persisted key, restart reuse, and no key in logs/responses.
+- [ ] `PUSH-003` · P1 · CHAOS — Keep gateway down at boot then restore it; verify periodic self-healing enrollment and stored device-token reconciliation without restart.
+- [ ] `PUSH-004` · P0 · LIVE — Register, rotate, and delete APNs tokens for one/multiple devices; verify tokens bind to authenticated device/user and another user cannot alter them.
+- [ ] `PUSH-005` · P1 · LIVE — Return a dead-token result; verify that token is pruned while healthy tokens and unrelated devices remain.
+- [ ] `PUSH-006` · P0 · LIVE/UI — On iOS, cover not-determined, allowed, denied, settings redirect, and return-to-app; verify permission controls and token registration reflect actual OS state.
+- [ ] `PUSH-007` · P1 · UI — On web/Android, verify unsupported iOS permission controls are hidden/disabled without breaking account preference storage.
+- [ ] `PUSH-008` · P0 · UI/API — On a user with no preference row, verify defaults: request decisions off; request pending/new content/issues/actions/Plex categories on as documented and admin scoping still enforced.
+- [ ] `PUSH-009` · P0 · UI/API — Toggle every category independently, restart, and force save failure; verify persistence or optimistic rollback without changing other toggles.
+- [ ] `PUSH-010` · P0 · SEC — Forge admin-category preference as requester; verify SQL recipient selection still limits pending requests/issues/actions/Plex access requests to admins.
+- [ ] `PUSH-011` · P0 · LIVE — Submit a pending request; verify opted-in admins only, queue-depth badge, fixed body, and approval deep link.
+- [ ] `PUSH-012` · P0 · LIVE — Approve/deny a request; verify only its opted-in requester receives correct media identity and detail deep link.
+- [ ] `PUSH-013` · P0 · LIVE — Import movie and multiple episodes; verify opted-in audiences, correct movie/series copy, title collapse keys, and no duplicate from poll/webhook overlap.
+- [ ] `PUSH-014` · P0 · LIVE — Promote an issue to actionable and create an agent action; verify admin pushes/deep links, and verify passive observing/recovering produces neither.
+- [ ] `PUSH-015` · P1 · LIVE — Trigger remediation circuit breaker; verify opted-in admins receive the settings deep link once with no model/user-supplied text.
+- [ ] `PUSH-016` · P0 · LIVE — Execute all Plex notification cases in `PLEX-050`–`PLEX-052` across multiple devices and verify exact preference separation.
+- [ ] `PUSH-017` · P0 · LIVE/UI — Tap every notification type from foreground, background, and terminated app; verify exact detail/approval/issue/action/users/Plex/settings destination and no duplicate navigation.
+- [ ] `PUSH-018` · P1 · UI — Tap malformed payloads (missing/bad IDs, unknown type, wrong media type); verify safe no-op/fallback without opening an unrelated record.
+- [ ] `PUSH-019` · P0 · SEC — Put attacker-controlled text in usernames, titles, reports, agent output, and emails; verify lock-screen bodies remain server-authored templates and contain no secrets.
+- [ ] `PUSH-020` · P1 · LIVE — Fail one recipient among many; verify other sends complete and result/dead-token handling is per device.
+- [ ] `PUSH-021` · P1 · API — Verify 10-minute in-process dedupe suppresses duplicate source paths but a genuinely later event after the window sends again.
+- [ ] `PUSH-022` · P1 · CHAOS — Restart during fire-and-forget delivery or gateway timeout; verify app state remains correct, server does not block, and no false durable-delivery claim is shown.
+- [ ] `PUSH-023` · P1 · LIVE — Use self-test from preferences and admin per-user diagnostics; verify delivered/no-token/not-configured/partial/failure results and no test notification changes product badges.

--- a/docs/testing/catalog/issues-ai-mcp.md
+++ b/docs/testing/catalog/issues-ai-mcp.md
@@ -1,0 +1,136 @@
+# Issues, AI, and MCP
+
+Issue reporting and remediation, AI accounts and chat, tool settings, and all user/admin MCP contracts.
+
+These are canonical, run-neutral definitions. Keep every active case unchecked; record executions only in a copy assembled with the [run template](../run-template.md).
+
+## Issues, passive recovery, and AI remediation
+
+- [ ] `ISS-001` · P0 · UI/SEC — Toggle problem reporting off/on; verify the affordance and API are both disabled/enabled, not merely hidden.
+- [ ] `ISS-002` · P0 · UI/API — Report movie, whole-series, season, exact episode, and exact S00 special problems; verify immutable media type, instance ID, arr ID, season/episode scope, and reporter are exact.
+- [ ] `ISS-003` · P0 · SEC — Forge movie-on-Sonarr, TV-on-Radarr, another user's/inaccessible instance, nonexistent media, unsupported media type, or unavailable title; verify 4xx and no issue/agent side effect.
+- [ ] `ISS-004` · P1 · UI/API — Exercise every category; require bounded explanation for “Something else,” preserve safe Unicode text, and reject empty/oversized/malformed input.
+- [ ] `ISS-005` · P0 · API — Report the same media/scope/instance twice and the same title on two instances; verify true duplicate handling without merging distinct incidents.
+- [ ] `ISS-006` · P0 · UI — Verify a new issue starts in Watching/Recovery state with requester-safe copy, no reply/typing/completion controls, no admin attention badge, no push, and no agent run.
+- [ ] `ISS-007` · P0 · LIVE — During minimum watch/quiet windows, replace/progress the queue item; verify one incident tracks the new attempt, resets quiet timing, and remains passive.
+- [ ] `ISS-008` · P0 · LIVE — Complete an exact successful import during observation; verify the issue resolves silently only after matching file/import proof and configured settle time.
+- [ ] `ISS-009` · P0 · LIVE — Remove a queue item without import, expose a pre-existing file, or import a different movie/episode; verify none falsely proves recovery.
+- [ ] `ISS-010` · P0 · CHAOS — Return incomplete/capped/failed/out-of-order queue snapshots; verify uncertainty never masquerades as empty/recovered and durable timing remains monotonic.
+- [ ] `ISS-011` · P0 · CHAOS — Keep arr proof unavailable past the allowed window; verify Needs a closer look/Needs Admin rather than false resolution or unsafely starting mutations.
+- [ ] `ISS-012` · P0 · UI — Verify admin lists separate Needs attention, Tracking, and Closed; passive rows are muted/read, remain discoverable, and never inflate actionable badge.
+- [ ] `ISS-013` · P0 · UI — Open an actionable issue as admin and reporter; verify admin view marks it read, reporter view does not, and later non-admin status/reply reflags it.
+- [ ] `ISS-014` · P1 · UI — Toggle mark-resolved-as-read; verify clean automatic/agent resolution follows the setting while manual unread history remains truthful.
+- [ ] `ISS-015` · P0 · SEC — As reporter/unrelated user/admin, read and reply; verify reporter only owns their thread, unrelated access is denied, and admin access/audit is complete.
+- [ ] `ISS-016` · P0 · LIVE — Have the agent ask a reporter-only question; verify Awaiting your reply, requester-safe prompt, bounded reply, same-run resume, and no duplicate run.
+- [ ] `ISS-017` · P1 · CHAOS — Let reporter timeout expire across restart; verify terminal provenance/copy is correct and a late reply cannot silently resurrect a closed issue.
+- [ ] `ISS-018` · P0 · UI/API — Set investigate-only mode; run a persistent issue and verify investigation/audit can complete but no mutation proposal is stored or shown.
+- [ ] `ISS-019` · P0 · UI/API — Set supervised mode; verify each supported proposal card names action, service, instance name + immutable ID, exact media/queue scope, typed params, and passive rationale.
+- [ ] `ISS-020` · P0 · SEC — Verify a requester sees a read-only “waiting on an admin” proposal and cannot approve/deny via UI or direct API.
+- [ ] `ISS-021` · P0 · SEC/LIVE — For release grab, verify stored/API data contains only a one-way reference; approval re-searches exact scope and rejects missing, duplicate, stale, or metadata-mismatched releases.
+- [ ] `ISS-022` · P0 · SEC/LIVE — For episode or Specials issues, verify trigger/search/grab cannot broaden to season/series; movie and book scopes likewise fail closed on mismatches.
+- [ ] `ISS-023` · P0 · SEC/LIVE — For normal/force manual import, refetch candidates and verify only files matching exact issue identity can execute even if approved params are tampered.
+- [ ] `ISS-024` · P0 · LIVE — Approve every supported action type; confirmation must repeat exact target, one executor call occurs, durable result appears, and issue/run state advances truthfully.
+- [ ] `ISS-025` · P0 · LIVE — Deny with and without note; verify the old card freezes with decision, the same run resumes investigation, and no mutation executes.
+- [ ] `ISS-026` · P0 · CHAOS — Have two admins decide concurrently; verify one CAS winner, loser receives conflict/reloads winner, and executor runs at most once.
+- [ ] `ISS-027` · P0 · LIVE/CHAOS — Start arr recovery immediately before and immediately after action claim; verify proposal becomes superseded, run aborts to passive recovery, and executor is not called.
+- [ ] `ISS-028` · P0 · CHAOS — Kill the server after dispatch but before result persistence; on restart verify Outcome unknown/Needs Admin, no replay, and no second proposal until human verification.
+- [ ] `ISS-029` · P0 · CHAOS — Produce partial/ambiguous executor result; verify it stops at Needs Admin and never claims resolution.
+- [ ] `ISS-030` · P0 · UI/API — Mark resolved and Close without fix with required bounded notes; verify actor, disposition, note, proposal supersession, run abort, and aggregate closure commit atomically.
+- [ ] `ISS-031` · P0 · UI/API — Dismiss an issue and compare with reviewed completion; verify distinct provenance/copy/audit and no implication that a fix was verified.
+- [ ] `ISS-032` · P0 · CHAOS — Race admin completion against another decision/recovery; verify 409 and winner reload without overwriting audit.
+- [ ] `ISS-033` · P1 · UI — Reopen closed threads; verify full messages, action decisions/results, run summaries, closure provenance, ordered step ledger, token counts, and stop reason remain reachable.
+- [ ] `ISS-034` · P1 · CHAOS — Fail refresh while cached issue/action/run data is visible; verify persistent stale warning/retry, retained useful data, and unsafe action controls disabled.
+- [ ] `ISS-035` · P0 · API — Hit per-run tool-step, turn, token, active wall-clock, concurrency, daily-run, and reporter-reply budgets at boundaries; verify the documented safe terminal/paused state.
+- [ ] `ISS-036` · P0 · CHAOS — Trigger repeated agent give-ups; verify circuit breaker disables auto-dispatch at threshold, sends one admin warning, preserves manual/supervised control, and requires deliberate re-enable.
+- [ ] `ISS-037` · P0 · SEC — Configure personal AI for the reporter and remove their included grant; verify remediation still uses only the admin's current shared provider/credential.
+- [ ] `ISS-038` · P0 · LIVE — Save a valid remediation model override, change shared provider, and run; verify stale provider-bound override is ignored until a new real validation succeeds.
+- [ ] `ISS-039` · P0 · SEC — Put credentials/URLs/tokens in report text, model output, tool results/errors, resume results, and audit text; verify model-facing/persisted derived data is scrubbed while authorized UI retains the original reporter message.
+- [ ] `ISS-040` · P1 · API — Exercise AI health system issue creation/dedup/recovery; verify it is admin-only, never enters remediation queue, and closes with `ai_health_restored`.
+- [ ] `ISS-041` · P1 · SEC — For a book issue, allow only durable exact queue/manual-import actions; unsupported title-level book mutations must fail closed.
+- [ ] `ISS-042` · P1 · UI — Verify all issue statuses/provenance values, including unknown future values, render safe non-crashing labels and never expose internal arr/agent jargon to requesters.
+
+## AI credentials, access, OAuth, and assistant chat
+
+- [ ] `AI-001` · P0 · UI — With no personal source and no included grant, verify assistant/settings explain unavailable access and expose only legitimate setup choices.
+- [ ] `AI-002` · P0 · UI/API — Grant/revoke included AI for regular and admin users; require the shared-account quota/cost warning for OAuth-backed grants and apply revocation immediately.
+- [ ] `AI-003` · P0 · UI/API — Configure personal Anthropic, OpenAI, and Gemini providers while included access is absent/present/different; verify the personal selection is explicit and caller-scoped.
+- [ ] `AI-004` · P0 · SEC/LIVE — Break a selected personal key/model/OAuth link; verify requests fail as personal and never silently spend the included account.
+- [ ] `AI-005` · P0 · UI — Delete personal selection; verify fallback to included only when granted, otherwise unavailable, without deleting unrelated stored provider credentials unexpectedly.
+- [ ] `AI-006` · P0 · SEC — Save/replace/delete personal/shared API keys and reopen settings/network/logs/DB; verify write-only flags in APIs and AES-encrypted secret storage.
+- [ ] `AI-007` · P0 · LIVE — For each personal/shared provider, save a valid provider+model+key candidate; verify one real tool-free low-reasoning turn completes before atomic activation.
+- [ ] `AI-008` · P0 · LIVE/CHAOS — Test invalid credential, unsupported model/access, quota/rate limit, temporary outage, timeout, malformed/empty response, and partial-stream failure; verify safe distinct category and prior working profile unchanged.
+- [ ] `AI-009` · P0 · API/CHAOS — Have two admins save provider/model/key concurrently or fail one field in a multi-field save; verify no mismatched/partial shared profile becomes active.
+- [ ] `AI-010` · P1 · LIVE — Verify shared health check runs at most once per 24 hours across restarts; disabling it stops background turns but never mandatory save validation.
+- [ ] `AI-011` · P1 · CHAOS — Fail then recover the health check; verify one deduplicated admin system issue and clean automatic resolution on next success.
+- [ ] `AI-012` · P0 · LIVE/UI — Start a personal OpenAI OAuth device flow; verify only the exact trusted HTTPS OpenAI origin opens, code/expiry/poll interval render, and tokens never pass through app state.
+- [ ] `AI-013` · P0 · LIVE/UI — Complete personal OAuth; verify account identity/usage windows, model validation, selected source, restart persistence, and chat.
+- [ ] `AI-014` · P0 · LIVE/UI — Repeat the device flow for admin-shared OAuth; verify only admins see shared identity/plan/usage and granted users learn only that access is included.
+- [ ] `AI-015` · P1 · UI/CHAOS — Reopen, cancel, navigate away from, locally/server-expire, or fail a pending OAuth flow; verify server cleanup and no orphan authorization.
+- [ ] `AI-016` · P1 · UI — Disconnect personal/shared OAuth when connected, provider changed, runtime unavailable, or model validation failed; verify removal remains possible and scope is correct.
+- [ ] `AI-017` · P1 · API — On non-Linux source deployment verify OAuth runtime unavailable; on official Linux image verify private tmpfs runtime ownership/mode and successful operation.
+- [ ] `AI-018` · P0 · UI/LIVE — Start chat and verify ordered SSE frames: conversation ID, text, tool start/end, media results, error if any, then `[DONE]`; app never leaves a permanent typing state.
+- [ ] `AI-019` · P0 · UI — Ask for recommendations/search; verify visible tool activity and carousel cards have correct media identity, images, navigation, and remain visible during streaming.
+- [ ] `AI-020` · P0 · LIVE — Ask the assistant to check status, list requests, and request movie/TV; verify effective user instance/policy/approval/season permissions match the normal UI.
+- [ ] `AI-021` · P0 · SEC — As requester, prompt-inject/guess admin tools and instance IDs; verify no queue/library/history/health/release/import/mutation access.
+- [ ] `AI-022` · P0 · LIVE — As admin, exercise queue/calendar/library/history/health/doctor/release/manual-import/remediation tools; verify exact instance/media scope and the same safety gates as direct UI.
+- [ ] `AI-023` · P0 · CHAOS — Revoke role, device, or included grant and disable a tool while a turn is paused/running; verify dispatch reauthorization terminates safely rather than returning privileged data.
+- [ ] `AI-024` · P0 · CHAOS — Lose provider/network response before/after a tool mutation; verify no automatic replay duplicates a request/grab/import/remediation action.
+- [ ] `AI-025` · P0 · UI — Close/reopen assistant and send follow-ups; verify one conversation persists across navigation and keeps grounded context until its idle expiry.
+- [ ] `AI-026` · P0 · API — Change user, personal/included source, provider account/key fingerprint, model, OAuth generation, restart, or fail a turn; verify prior conversation cannot be resumed under the new binding.
+- [ ] `AI-027` · P1 · API — Reach byte bounds/eviction/4-hour backend inactivity and app's focused-session idle behavior; verify whole signed continuation pairs are discarded rather than truncated/corrupted.
+- [ ] `AI-028` · P0 · API — Attempt a second turn for one user, exceed 16 server turns, and exceed four included turns; verify nonblocking rejection before provider call/spend and recovery when slots free.
+- [ ] `AI-029` · P1 · UI — Cancel, background, disconnect, and navigate during streaming; verify resources stop/settle, composer state recovers, and partial output is labeled truthfully.
+- [ ] `AI-030` · P0 · SEC — Put secrets in prompts/tool inputs/upstream errors and inspect stream, transcript, logs, debug records, and carousel; verify credential scrubber catches nested JSON, headers, URL userinfo, and query parameters.
+- [ ] `AI-031` · P1 · UI — Verify provider/model catalogs, including recommended and named Codex models, tolerate unknown/deprecated models and never silently select another paid model.
+- [ ] `AI-032` · P1 · CHAOS — Restart or rotate the shared OAuth credential while concurrent users chat; verify serialized account refresh and actual requesting-user tool permissions remain separate.
+
+## AI tool settings and MCP OAuth/server
+
+- [ ] `MCP-001` · P0 · UI/API — List all 26 tools; verify name, description, admin marker, enabled state, and documented count agree in Settings, chat, `/mcp`, README, and guide.
+- [ ] `MCP-002` · P0 · UI/API — Toggle every tool off/on; verify it disappears/is rejected immediately in both chat and MCP without affecting unrelated tools.
+- [ ] `MCP-003` · P0 · SEC — Enable debug for one hour; verify only tool name/timing/status/payload sizes are logged, expiry/extension works, and inputs/outputs/errors are never recorded.
+- [ ] `MCP-004` · P0 · API — Fetch all well-known OAuth/protected-resource metadata; verify issuer, resource, scopes, endpoints, and content types match the deployed public origin.
+- [ ] `MCP-005` · P0 · SEC/API — Dynamically register valid loopback/native/HTTPS clients and reject unsafe redirect URI changes, duplicate/mismatched redirects, and malformed metadata.
+- [ ] `MCP-006` · P0 · SEC/LIVE — Complete authorization-code flow with S256 PKCE, state, exact redirect/resource/scope, and password; verify code is one-time/short-lived and wrong verifier/redirect/resource fails.
+- [ ] `MCP-007` · P0 · LIVE — Complete secure-browser passkey authorization and create a first passkey from MCP login for a connect-link-only user; verify correct Cantinarr identity/device.
+- [ ] `MCP-008` · P0 · API — Use an access token at `/mcp`, ordinary API, and wrong audience; verify short-lived audience binding and no cross-resource acceptance.
+- [ ] `MCP-009` · P0 · SEC/API — Rotate a refresh token, replay the old token, restart server, and advance sliding lifetime boundaries; verify persistence, replay rejection, and one-year policy.
+- [ ] `MCP-010` · P0 · SEC — Revoke the device/user/change role; verify active MCP calls and access/refresh tokens promptly lose authorization.
+- [ ] `MCP-011` · P0 · API — Exercise Streamable HTTP initialize, GET/POST/DELETE, `Mcp-Session-Id`, reconnect, concurrent sessions, cleanup, malformed JSON-RPC, and expired/unknown session behavior.
+- [ ] `MCP-012` · P1 · API — Discover prompt templates and `guide://cantinarr/agent-guide.md`; verify contents are readable, role-safe, current, and survive restart.
+- [ ] `MCP-013` · P0 · SEC — Verify requester tool enumeration excludes/denies admin tools server-side even if the client supplies a known admin tool name.
+- [ ] `MCP-014` · P0 · SEC — For every tool below, repeat enabled happy path, disabled, unauthorized role, invalid input, upstream failure, and secret-redaction checks—not only the happy row.
+
+- [ ] `MCP-015` · P1 · UI — Verify inbound MCP login copy/URLs cannot be confused with outbound OpenAI/ChatGPT device authorization.
+
+### MCP user tools (run in chat and an external MCP client)
+
+- [ ] `MCP-016` · P0 · LIVE — `search_movies`: search exact/ambiguous/empty/Unicode input; verify distinct TMDB movie identities and bounded results.
+- [ ] `MCP-017` · P1 · LIVE — `search_movie_collections`: find a franchise and verify collection/part identities without merging unrelated remakes.
+- [ ] `MCP-018` · P0 · LIVE — `search_tv_shows`: verify exact TMDB TV identities and no movie-type substitution.
+- [ ] `MCP-019` · P1 · LIVE — `get_trending`: exercise movie/TV/all and day/week inputs; verify current bounded media results.
+- [ ] `MCP-020` · P0 · LIVE — `get_movie_details`: verify metadata and live request status for an exact movie ID.
+- [ ] `MCP-021` · P0 · LIVE — `get_tv_details`: verify metadata/seasons and live status for an exact TV ID.
+- [ ] `MCP-022` · P1 · LIVE — `get_recommendations`: verify requested media type/source and distinct navigable results.
+- [ ] `MCP-023` · P0 · LIVE — `check_request_status`: cover unavailable/requested/downloading/partial/available on the caller's effective instance.
+- [ ] `MCP-024` · P0 · LIVE — `request_media`: request movie/TV with allowed scope; verify normal approval/policy/idempotency and no privilege bypass.
+- [ ] `MCP-025` · P0 · LIVE — `list_my_requests`: verify caller-only history, accurate media/scope/status, and no other user records.
+- [ ] `MCP-026` · P1 · UI/API — `display_media`: curate valid results, reject invented/mismatched IDs, and render a stable carousel without mutating media.
+
+### MCP admin tools (run in chat and an external MCP client)
+
+- [ ] `MCP-027` · P0 · LIVE — `get_queue`: filter combined exact instances/services and verify queue identity/status without cross-instance mixing.
+- [ ] `MCP-028` · P1 · LIVE — `get_calendar`: exercise movie/series/date range and verify exact release scope/local dates.
+- [ ] `MCP-029` · P0 · LIVE — `get_library`: filter media/instance/query and keep distinct library records.
+- [ ] `MCP-030` · P0 · LIVE — `get_history`: verify grab/import/failure records and exact instance/media filters.
+- [ ] `MCP-031` · P0 · LIVE — `trigger_search`: execute movie/series/season/episode scope and verify no broader search command.
+- [ ] `MCP-032` · P0 · SEC/LIVE — `search_releases`: return exact-scope metadata plus one-way references only, never raw capabilities.
+- [ ] `MCP-033` · P0 · SEC/LIVE — `grab_release`: re-search authoritative scope and grab the unique matching reference/indexer; reject stale/ambiguous/mismatched input.
+- [ ] `MCP-034` · P0 · LIVE — `remove_queue_item`: exercise safe remove and explicit blocklist/re-search flags on the exact download.
+- [ ] `MCP-035` · P1 · LIVE — `get_disk_space`: return each instance/disk once with correct units/free space and safe missing fields.
+- [ ] `MCP-036` · P1 · LIVE — `get_arr_health`: cover healthy and indexer/client/root/disk/remote-path warnings by exact instance.
+- [ ] `MCP-037` · P0 · LIVE — `diagnose_queue`: cover every Import Doctor class and verify its exact suggested next tool call/arguments.
+- [ ] `MCP-038` · P0 · SEC/LIVE — `get_manual_import_candidates`: list only the exact stuck download's files/mappings/rejections with scrubbed paths/secrets as required.
+- [ ] `MCP-039` · P0 · SEC/LIVE — `execute_manual_import`: normal/force import only confirmed candidates matching exact media/episode identity.
+- [ ] `MCP-040` · P0 · LIVE — `remediate_queue_item`: execute remove, blocklist+search, and category hand-off with exact scope and explicit destructive choices.
+- [ ] `MCP-041` · P0 · LIVE — `rescan_media`: rescan exact movie/series and verify import pass without cross-title action.

--- a/docs/testing/catalog/media-services.md
+++ b/docs/testing/catalog/media-services.md
@@ -1,0 +1,113 @@
+# Media services and download clients
+
+Radarr, Sonarr, Chaptarr, download-client, queue, and Tautulli behavior.
+
+These are canonical, run-neutral definitions. Keep every active case unchecked; record executions only in a copy assembled with the [run template](../run-template.md).
+
+## Radarr administration
+
+- [ ] `RAD-001` · P0 · UI/LIVE — Load a large Radarr library; verify paging/filter/search, movie status bars, file size/quality, monitored state, and instance selector are accurate.
+- [ ] `RAD-002` · P1 · UI — Switch between two Radarr instances while loading/filtering; verify rows/actions never mix instances and the selected instance remains visible.
+- [ ] `RAD-003` · P0 · UI — Open movie detail from library/discovery; verify poster/title/year/runtime/rating/overview, status, file quality/size/release group/relative path, matching queue/messages, history, report action, and Automatic/Interactive actions belong to the exact movie.
+- [ ] `RAD-004` · P0 · LIVE — Run Automatic search and verify one exact MovieSearch command; use app refresh/pull-to-refresh and verify detail/queue/history reload without issuing an arr Refresh command. Rescan is tested only through Import Doctor.
+- [ ] `RAD-005` · P0 · LIVE — Open interactive movie release search; verify sorting, quality, size, protocol, indexer, seeders/leechers, rejection reasons, and grab the selected release only.
+- [ ] `RAD-006` · P0 · SEC — Verify raw release capability/GUID secrets are not exposed beyond supported UI/proxy contracts and rejected releases cannot be grabbed accidentally.
+- [ ] `RAD-007` · P0 · LIVE — Remove a movie, cancel once, then confirm with delete-files unchecked; verify Radarr record is removed and disk files remain.
+- [ ] `RAD-008` · P0 · LIVE — Remove a disposable movie with delete-files checked; verify explicit confirmation and both Radarr record and intended files are removed—nothing else.
+- [ ] `RAD-009` · P0 · UI — Verify no swipe or unlabeled gesture can perform deletion and delete-files is never preselected.
+- [ ] `RAD-010` · P0 · LIVE — Load queue/history/wanted/calendar; verify supported paging, timestamps/event types, Wanted Missing/Cutoff segmentation, calendar dates, and links target the right movie without expecting nonexistent local search controls.
+- [ ] `RAD-011` · P1 · UI — Handle queue entries with unknown movie, missing size/ETA, warnings/errors, stalled state, and completed-but-importing state without crash or misleading completion.
+- [ ] `RAD-012` · P0 · LIVE — For each Radarr Import Doctor class, verify explanation/raw messages and ordered supported fixes match server classification.
+- [ ] `RAD-013` · P0 · LIVE — Preview manual import candidates, select valid files, execute normal/force import, and verify quality/language blobs round-trip and only the intended movie files import.
+- [ ] `RAD-014` · P0 · LIVE — Exercise remove, blocklist + re-search, category hand-off, and rescan fixes; verify confirmation/parameters and resulting queue/library state.
+- [ ] `RAD-015` · P1 · CHAOS — Lose the response to a destructive/command action; reload external state before retry and verify the UI does not claim a result it cannot prove.
+- [ ] `RAD-016` · P0 · SEC — As requester, browse permitted Radarr reads and verify all movie commands, release searches, mutations, configuration, and deletion remain admin-only.
+- [ ] `RAD-017` · P1 · LIVE — Make a manual Radarr add/delete/import while the library screen is open; verify webhook/WebSocket refreshes without duplicate rows or stale availability.
+- [ ] `RAD-018` · P1 · UI — Verify library-only local filter/search clear/count behavior; on queue/history/calendar verify load/empty/error/retry/paging/scroll, and on Wanted verify Missing/Cutoff segmentation plus refresh.
+- [ ] `RAD-019` · P0 · LIVE — On a disposable Radarr queue item, test cancel, neither flag, remove-from-client only, blocklist only, and both; verify safe defaults, exact instance/item, external-client effect, search behavior, and refreshed queue.
+
+## Sonarr administration
+
+- [ ] `SON-001` · P0 · UI/LIVE — Load a large Sonarr library; verify series status distinguishes continuing caught-up, ended complete, monitored missing, unmonitored missing, and upcoming.
+- [ ] `SON-002` · P1 · UI — Switch Sonarr instances during loading/filtering; verify series, queue, commands, and detail never cross instance boundaries.
+- [ ] `SON-003` · P0 · UI — Drill series → All Seasons/season → episode; verify episode totals include unmonitored missing episodes correctly and Specials remain distinct.
+- [ ] `SON-004` · P0 · UI — Verify per-episode download progress, air date, monitored/file state, quality/size, history, and messages correspond to the exact episode.
+- [ ] `SON-005` · P0 · LIVE — Toggle series, season, and episode monitoring; verify intended flags/episodes change without altering unrelated seasons.
+- [ ] `SON-006` · P0 · LIVE — Trigger series, monitored-series, season, and exact episode searches; verify command type and IDs at Sonarr and only intended scope searches.
+- [ ] `SON-007` · P0 · LIVE — Long-press a season/episode and use each offered action; verify visible menu scope, confirmation, exact target, and refreshed result.
+- [ ] `SON-008` · P0 · UI/LIVE — Enter episode multi-select; test All, Undownloaded, manual mix, clear, and selection persistence; batch search only the selected exact episodes.
+- [ ] `SON-009` · P0 · LIVE — Batch-delete files for selected episodes, cancel once, then confirm; verify only selected episode files are removed and series/other files remain.
+- [ ] `SON-010` · P0 · LIVE — Delete one disposable episode file with confirmation; verify the episode remains in Sonarr as missing and no adjacent file is touched.
+- [ ] `SON-011` · P0 · UI/LIVE — Edit series profile, series type, path, tags, season folders, and monitored settings; verify saved Sonarr state and reload match exactly.
+- [ ] `SON-012` · P1 · CHAOS — Submit invalid path/profile/type/tag or lose edit response; verify old state remains/reloads and no partial success toast.
+- [ ] `SON-013` · P0 · LIVE — Open interactive release search for a series season and exact episode; verify scope, sorting/metadata/rejections, and selected grab at Sonarr.
+- [ ] `SON-014` · P0 · UI — Open IMDb, TheTVDB, TMDB, and Trakt links; verify only present trusted URLs render and each points at the exact series.
+- [ ] `SON-015` · P0 · LIVE — Remove a series with files preserved, then a disposable series with files deleted; verify cancellation/default safety and exact external results.
+- [ ] `SON-016` · P0 · LIVE — Load queue/history/wanted/calendar; verify missing/cutoff, episode/series context, pagination, local time, and navigation.
+- [ ] `SON-017` · P0 · LIVE — Run every Import Doctor classification on Sonarr queue entries; verify shared explanations/raw messages and valid fix ordering.
+- [ ] `SON-018` · P0 · LIVE — Preview and execute manual/force import for single-episode, multi-episode, and Specials candidates; verify exact identity filtering prevents cross-episode import.
+- [ ] `SON-019` · P0 · LIVE — Exercise remove, blocklist + scope-correct re-search, category hand-off, and series rescan; verify queue/history/library outcome.
+- [ ] `SON-020` · P1 · CHAOS — Return inconsistent/missing series, season, episode, queue, or file IDs; verify destructive/search/import actions fail closed rather than falling back by title.
+- [ ] `SON-021` · P0 · SEC — As requester, verify permitted reads remain scrubbed and all commands, release searches, edits, file deletion, and series removal are denied.
+- [ ] `SON-022` · P1 · LIVE — Make direct Sonarr monitoring/import/delete/add changes while open; verify live refresh and requester availability without duplicate records.
+- [ ] `SON-023` · P1 · UI — Verify library-only local filtering/counts; Wanted Missing/Cutoff segmentation; and queue/history/calendar load/empty/error/retry/paging/scroll without expecting nonexistent local search.
+- [ ] `SON-024` · P0 · LIVE — On a disposable Sonarr queue item, test cancel, neither flag, remove-from-client only, blocklist only, and both; verify safe defaults, exact instance/item, external-client effect, scope-correct re-search, and refreshed queue.
+
+## Chaptarr books
+
+- [ ] `BOOK-001` · P0 · UI/LIVE — As a granted user, search a new author/book and request ebook; verify the matching ebook root/media type/monitor flags and search are used.
+- [ ] `BOOK-002` · P0 · UI/LIVE — Request audiobook; verify the audiobook root/media type/monitor flags are used and ebook state is untouched.
+- [ ] `BOOK-003` · P0 · UI/LIVE — Request both formats; verify exactly one ebook record and one audiobook record share the foreignBookId/group as one logical title, with no duplicate same-format record.
+- [ ] `BOOK-004` · P0 · LIVE — From ebook-only, request audiobook; verify exactly one separate audiobook record is added/monitored/searched and the ebook record remains untouched.
+- [ ] `BOOK-005` · P0 · LIVE — Repeat audiobook-only → ebook; verify exactly one separate ebook record and no mutation/duplication of the audiobook record.
+- [ ] `BOOK-006` · P0 · UI — Verify downloaded formats are disabled as Downloaded/In Library, monitored-without-file formats remain requestable, and denied requests become requestable again.
+- [ ] `BOOK-007` · P0 · UI — Search duplicate titles/editions and owned records; verify owned results float with chips but distinct records are never merged.
+- [ ] `BOOK-008` · P0 · UI/LIVE — On author detail, toggle format bookmarks independently; empty adds/searches only that missing format, while filled unmonitors only that exact format and leaves the sibling unchanged.
+- [ ] `BOOK-009` · P0 · UI — As an ungranted user, verify Books tab/routes/API are absent/denied; grant access and verify the correct assigned Chaptarr data appears.
+- [ ] `BOOK-010` · P0 · LIVE — Load Chaptarr library/author drill-down with complete, continuing, monitored-missing, unmonitored-missing, ebook-only, and audiobook-only fixtures; verify statuses and totals.
+- [ ] `BOOK-011` · P0 · LIVE — Search releases for an exact book/format, review sorting/metadata/rejections, and grab one; verify exact book/format at Chaptarr.
+- [ ] `BOOK-012` · P0 · LIVE — Remove an author, cancel once, preserve files by default, then test delete-files on a disposable fixture; verify exact outcomes.
+- [ ] `BOOK-013` · P0 · LIVE — Load queue/history/wanted missing/cutoff pages; verify pagination, format labels, author/book navigation, and distinct records.
+- [ ] `BOOK-014` · P0 · LIVE — Run supported Import Doctor classifications/fixes for Chaptarr, including exact queue/manual-import scope; verify no title-level mutation occurs without a durable book ID.
+- [ ] `BOOK-015` · P0 · LIVE — Preview/force manual import for ebook and audiobook candidates; verify format/media type, quality/language data, and exact file mapping.
+- [ ] `BOOK-016` · P1 · CHAOS — Simulate Chaptarr async author refresh or partial add failure; verify best-effort follow-up monitoring/search converges and retry does not duplicate records.
+- [ ] `BOOK-017` · P1 · CHAOS — Return stock Servarr bare release arrays, fork envelopes, and unexpected objects; verify accepted shapes render and unexpected shapes fail empty/safely.
+- [ ] `BOOK-018` · P1 · LIVE — Reassign the user to another Chaptarr instance while viewing/requesting; verify caches are user+instance safe and no ownership/request leaks across libraries.
+- [ ] `BOOK-019` · P1 · LIVE — Change book state directly in Chaptarr; verify the short-TTL digest/refetch updates ownership and request buttons without a permanent snapshot.
+- [ ] `BOOK-020` · P1 · UI — Verify long titles/authors, missing covers/editions, local filters, pagination, empty/error/retry states, and no duplicate search results.
+- [ ] `BOOK-021` · P0 · LIVE — On a disposable Chaptarr queue item, test cancel, neither flag, remove-from-client only, blocklist only, and both; verify safe defaults, exact instance/book-format item, external-client effect, and refreshed queue.
+- [ ] `BOOK-022` · P0 · UI/LIVE — For a logical title with both format records, start Automatic and Interactive search; choose ebook/audiobook and verify exact format/book ID, cancel is inert, and a single-format title skips the prompt.
+- [ ] `BOOK-023` · P1 · LIVE — Run author-level Automatic search; verify the exact author ID and active Chaptarr instance receive one command and sibling instances/authors remain untouched.
+
+## Download clients and unified downloads
+
+Run client-specific cases once for **each** of SABnzbd, qBittorrent, NZBGet, and Transmission; do not accept one client as proof for the other adapters.
+
+- [ ] `DOWN-001` · P0 · LIVE — Load each client's queue; verify item ID/name/category/status, size/progress, speed, ETA, client/instance identity, and aggregate rates map correctly.
+- [ ] `DOWN-002` · P0 · LIVE — Load each client's history; verify completed/failed status, timestamps, size/category, supported history limit/ordering, and client identity without assuming pagination.
+- [ ] `DOWN-003` · P0 · LIVE — Pause and resume one active item per client; verify exact external item state and UI convergence.
+- [ ] `DOWN-004` · P0 · LIVE — Pause all and resume all per client; verify only the selected instance/client changes and commands are not repeated.
+- [ ] `DOWN-005` · P0 · LIVE — Remove a disposable item with data/files preserved; verify queue removal and data retention using that client's semantics.
+- [ ] `DOWN-006` · P0 · LIVE — Remove a disposable item with data/files deletion explicitly selected; verify confirmation and exact external deletion.
+- [ ] `DOWN-007` · P0 · UI — Cancel every remove dialog and verify no external mutation; delete-data must always default off.
+- [ ] `DOWN-008` · P0 · UI — Switch among multiple download clients while requests are in flight; verify queue/history/actions never target the previously selected instance.
+- [ ] `DOWN-009` · P1 · LIVE — Cover paused, queued, downloading, stalled, checking, seeding/post-processing, completed, warning, and failed statuses per applicable client; verify readable normalized labels.
+- [ ] `DOWN-010` · P1 · UI — Cover zero/unknown size, infinite/unknown ETA, zero speed, Unicode names, duplicate names with distinct IDs, and very large values; verify stable formatting and identity.
+- [ ] `DOWN-011` · P0 · SEC — As requester, direct-call download read/mutation routes; verify all are denied and no client metadata leaks.
+- [ ] `DOWN-012` · P1 · CHAOS — Stop each client during load and during pause/resume/delete; verify scoped retryable errors, no optimistic false state, and safe external-state refresh before retry.
+- [ ] `DOWN-013` · P1 · CHAOS — Lose a mutation response after the client applied it; refresh and reconcile before allowing repeat, especially destructive delete.
+- [ ] `DOWN-014` · P1 · LIVE — Verify WebSocket queue snapshots update rate/progress/state without duplicates, survive reconnect, and stop after leaving the module or forced auth loss from current-device revocation.
+- [ ] `DOWN-015` · P1 · SEC — Inspect URLs/logs/errors for client usernames, passwords, cookies, API keys, and torrent hashes where sensitive; verify appropriate scrubbing.
+- [ ] `DOWN-016` · P1 · UI — Verify queue/history tab state, pull-to-refresh, empty/error/retry, scroll restoration, and compact/wide layouts for every adapter without expecting nonexistent local filter/search.
+
+## Tautulli
+
+- [ ] `TAUT-001` · P0 · LIVE — Load active direct-play, direct-stream, video-transcode, and audio-transcode sessions; verify user/title/player/progress/quality/decision badges and session count.
+- [ ] `TAUT-002` · P1 · LIVE — Cover paused/buffering/remote/local/multiple-user streams and missing media/image/session fields; verify truthful labels and stable layout.
+- [ ] `TAUT-003` · P0 · LIVE — Load watch history; verify user/media/title/timestamps/duration/platform plus supported history limit/ordering without assuming pagination.
+- [ ] `TAUT-004` · P0 · LIVE — Load top movies, shows, and users for supported periods; verify stat type, label, play count, ordering, and empty categories without inventing unsupported duration.
+- [ ] `TAUT-005` · P0 · SEC — As requester, verify Tautulli menu/routes/API are denied and usernames/watch history are not exposed.
+- [ ] `TAUT-006` · P1 · CHAOS — Fail Tautulli authentication, connection, or one command; verify only the affected tab errors and retry recovers after credentials/service return.
+- [ ] `TAUT-007` · P1 · UI — Switch Tautulli instances/tabs while loading; verify no mixed stream/history/stats results and local refresh works.
+- [ ] `TAUT-008` · P1 · SEC — Verify Tautulli API key and upstream URLs are absent from client responses/logging.
+- [ ] `TAUT-009` · P1 · LIVE/UI — Start/change/end a stream while Activity stays visible; verify 10-second refresh converges without overlapping requests, instance changes discard stale results, and timer stops on screen disposal.

--- a/docs/testing/catalog/plex.md
+++ b/docs/testing/catalog/plex.md
@@ -1,0 +1,144 @@
+# Plex linking, libraries, and invitations
+
+Plex ownership, server selection, explicit and all-library scopes, current and future libraries, invites, lifecycle truth, errors, and races.
+
+These are canonical, run-neutral definitions. Keep every active case unchecked; record executions only in a copy assembled with the [run template](../run-template.md).
+
+## Plex onboarding, linking, library sharing, and invitations
+
+These are real Plex end-to-end tests. “Invite sent” is not proven by Cantinarr's timestamp or toast. For every share-scope case, capture the exact outgoing/stored global section IDs, Plex Manage Library Access, and a recipient view of each uniquely named marker item. Accept the initial invite before future-library checks, remove shares before reusing recipients, and distinguish pending-invite 422 behavior from accepted-share 422 behavior.
+
+- [ ] `PLEX-001` · P0 · SEC/UI — As a requester, direct-call/open all admin Plex endpoints/settings; verify 403/redirect and no account/server/library metadata leaks.
+- [ ] `PLEX-002` · P0 · UI/LIVE — From unlinked state, start the PIN flow; verify the external URL is exactly Plex's trusted app origin, carries the stable client ID/code, and no Plex token enters the app URL or logs.
+- [ ] `PLEX-003` · P1 · UI/LIVE — Leave a PIN unapproved; verify automatic polling remains in waiting state, “check now” gives appropriate guidance, and no linked state/settings are created.
+- [ ] `PLEX-004` · P1 · UI/LIVE — Reopen the approval page from the waiting state and approve it; verify the same flow links once and polling stops.
+- [ ] `PLEX-005` · P1 · UI/LIVE — Cancel an in-progress PIN flow; verify local polling/buttons reset, a later link starts cleanly, and cancellation alone does not unlink an already linked account.
+- [ ] `PLEX-006` · P1 · CHAOS — Let the Plex PIN expire or return an invalid PIN; verify a retryable error and no token/account persistence.
+- [ ] `PLEX-007` · P0 · LIVE — Approve a valid PIN; verify the linked Plex username appears, the server verifies the token, and refresh/restart preserves linked state.
+- [ ] `PLEX-008` · P0 · SEC — Inspect `/api/admin/plex/status`, other API responses, DB, client/server logs, network inspector, and crash output; verify the Plex token is only encrypted at rest and never returned/logged.
+- [ ] `PLEX-009` · P1 · CHAOS — Make Plex token verification fail after PIN approval; verify Cantinarr does not store the token or claim the account linked.
+- [ ] `PLEX-010` · P0 · LIVE — List resources for an account with owned servers, a shared server, and player/client resources; verify only owned Plex Media Servers appear.
+- [ ] `PLEX-011` · P1 · UI — Link an account with no owned server; verify “No owned servers found,” no configuration can be saved, and the manual explanation is accurate.
+- [ ] `PLEX-012` · P0 · UI/LIVE — Select each of two owned servers; verify the matching machine identifier/name are saved and only that server receives later shares.
+- [ ] `PLEX-013` · P0 · UI — Switch servers before saving; verify the old server's selected library IDs are cleared and the new server's libraries load before selection.
+- [ ] `PLEX-014` · P1 · CHAOS — Fail the server-list request; verify linked state remains, a retry message appears, and no phantom server or destructive reset is saved.
+- [ ] `PLEX-015` · P0 · LIVE — Load movie, show, music, and photo libraries; verify title/type and Plex-global section IDs map to the correct server sections, not local section keys.
+- [ ] `PLEX-016` · P1 · CHAOS — Fail or return malformed XML for a library-list request; verify a retryable error, no fake checked libraries, and Save cannot silently broaden an existing subset.
+- [ ] `PLEX-017` · P0 · UI/LIVE — Check one library, save, reload/restart, and invite a new Plex account; verify exactly that library is shared and every unchecked current library is absent.
+- [ ] `PLEX-018` · P0 · UI/LIVE — Check several non-adjacent libraries, save, reload, and invite; verify exactly those global section IDs are shared regardless of list order.
+- [ ] `PLEX-019` · P0 · UI/LIVE — Check then uncheck every library and save; verify the API persists `library_section_ids: []` and the UI reloads with all boxes unchecked—not with a stale subset.
+- [ ] `PLEX-020` · P0 · UI/LIVE — With all libraries unchecked, invite and accept from a brand-new account; verify that account can open every current library on the selected server.
+- [ ] `PLEX-021` · P0 · LIVE — Keep “all libraries” (`[]`) saved, add a new Plex library, then invite and accept from another new account without resaving Cantinarr; verify the new library is included automatically.
+- [ ] `PLEX-022` · P0 · LIVE — Invite and accept while “all libraries” (`[]`) is saved, then add a new Plex library after acceptance; verify the already-shared account gains that future library without a new invite.
+- [ ] `PLEX-023` · P0 · LIVE — Save an explicit subset, invite and accept, add a new Plex library, then test the existing share and another new invite; verify the new library is not silently included and the explicit subset remains exact.
+- [ ] `PLEX-024` · P1 · LIVE — Rename a selected Plex library; verify its stable section ID remains selected/shared and the updated title appears after reload.
+- [ ] `PLEX-025` · P1 · LIVE/CHAOS — Delete a selected Plex library; verify Cantinarr never converts the stale explicit selection into “all,” and any invite/save error is visible and repairable.
+- [ ] `PLEX-026` · P1 · UI — Toggle auto-invite without pressing Save, leave/reload, and verify persisted behavior did not change; then Save and verify the exact toggle survives restart.
+- [ ] `PLEX-027` · P0 · UI — Attempt Save with no server; verify “Pick a server first,” no configured status, and no auto-invite activation.
+- [ ] `PLEX-028` · P1 · CHAOS — Fail settings persistence; verify Save reports failure, re-enables controls, and the previous server/library/auto-invite configuration remains authoritative.
+- [ ] `PLEX-029` · P0 · UI/API — With Plex unlinked or linked-but-no-server, share a valid email as a user; verify no automatic invite occurs, admins are notified of a manual waiter, and the Users tag/drawer count appear.
+- [ ] `PLEX-030` · P0 · UI/LIVE — With auto-invite off and valid configuration, share a new Plex email; verify no Plex share occurs until an admin explicitly chooses Send Plex invite.
+- [ ] `PLEX-031` · P0 · UI/LIVE — Send a one-tap invite; verify selected server/libraries and exact trimmed email at Plex, `plex_invited_at` is stamped, Users reload clears the initiating admin's waiter, and a fresh `/me`/reopened guide shows sent.
+- [ ] `PLEX-032` · P0 · UI/LIVE — With auto-invite on, share a new Plex email; verify one invite without admin action, settled `/me` has a stamp, a refreshed/reopened guide shows sent, and no backend waiter remains.
+- [ ] `PLEX-033` · P0 · LIVE — Repeat auto-invite with all libraries unchecked; verify the external Plex share receives all current libraries and retains the future-library behavior in `PLEX-021`/`PLEX-022`.
+- [ ] `PLEX-034` · P0 · LIVE — Repeat auto-invite with an explicit subset; verify only the chosen section IDs are shared.
+- [ ] `PLEX-035` · P0 · UI/API — Submit an email with leading/trailing whitespace; verify it is trimmed once in storage, display, admin state, and the Plex invite payload.
+- [ ] `PLEX-036` · P1 · UI/API — Submit empty, whitespace, no-`@`, missing local/domain, internal whitespace/tab/newline, and over-254-byte values; verify client/server reject each and no email/stamp/notification/invite changes.
+- [ ] `PLEX-037` · P1 · UI/API — Require UI/server to accept `first.last+tag@sub.example`, `a@b`, and a valid exactly-254-ASCII-byte address; reject multiple `@`, internal `\r`/Unicode whitespace, and any UTF-8 address over 254 bytes with zero state/side effects.
+- [ ] `PLEX-038` · P0 · API/LIVE — Resubmit the identical stored email after an invite; verify no new admin notification, no auto-invite, and the existing `plex_invited_at` remains set locally and after profile refresh.
+- [ ] `PLEX-039` · P0 · UI/LIVE — Change an invited user's email; verify the old invite stamp clears immediately, waiting state returns, admins are notified, and manual/auto invite targets only the new address.
+- [ ] `PLEX-040` · P1 · CHAOS — Change the email rapidly twice while auto-invite is running; verify final user state corresponds to the last address, no invite is sent to an unintended stale address, and admin badge/state settles correctly.
+- [ ] `PLEX-041` · P0 · LIVE — Invite an email/account that already has server access; verify Plex 422 maps to `already_shared`, the user is stamped, no misleading “check your inbox” push is sent, and the UI says it already has access.
+- [ ] `PLEX-042` · P1 · UI/LIVE — Resend while the original invite is still pending; verify Plex's exact response and that Cantinarr never labels the recipient “already has access,” emits no false fresh-email push, and preserves the pending external scope.
+- [ ] `PLEX-043` · P0 · CHAOS — Separately inject failures known to occur before Plex commits (connection refusal/TLS, 401/403/429/5xx, and malformed non-2xx error response); verify no stamp/requester success, auto-invite emits failed admin copy, and manual invite shows only its local failure/retry UI.
+- [ ] `PLEX-044` · P1 · CHAOS — Expire/revoke the linked Plex token after configuration; verify listing/inviting fails visibly, token/status is not exposed, and no user is stamped until relink + successful retry.
+- [ ] `PLEX-045` · P0 · UI — Without configured one-tap invites, choose “Invite in Plex…” for a waiting user; verify the exact email reaches the clipboard and the trusted Plex Manage Library Access page opens.
+- [ ] `PLEX-046` · P1 · CHAOS — Deny clipboard or external-browser launch where the platform permits; verify the app remains stable and gives enough information to complete/retry manually.
+- [ ] `PLEX-047` · P0 · UI — Verify users with no Plex email have no send/manual invite action or Plex state tag; waiting users show email + “Needs Plex invite”; stamped users show “Plex invite sent” + Resend.
+- [ ] `PLEX-048` · P0 · UI — With waiters 0, 1, and several, verify exact drawer visibility/count and Users destination; email/auto-invite events refresh all admins, while Admin A's manual invite explicitly reloads and clears Admin A without negative/duplicate counts.
+- [ ] `PLEX-049` · P1 · CHAOS — Drop the WebSocket during email/invite changes; reconnect or manually refresh and verify the waiter count and Users state converge to backend truth without negative/duplicate counts.
+- [ ] `PLEX-050` · P0 · LIVE — With admin Plex-access-request push enabled, test manual-waiting, auto-sent, and auto-failed states; verify fixed privacy-safe body text, correct deep link to Users, per-user collapse ID, and no username/email on the lock screen.
+- [ ] `PLEX-051` · P0 · LIVE — With requester push enabled, use two clean recipient accounts for one fresh manual and one fresh auto invite; verify exactly one push per account, Watch on Plex deep link, sent state after refresh, and no push for duplicate/already-shared.
+- [ ] `PLEX-052` · P1 · LIVE — Disable each Plex notification preference independently; verify the disabled push is suppressed while WebSocket/UI state and the other category still work.
+- [ ] `PLEX-053` · P0 · UI — In the Watch on Plex guide, test no-email, waiting, and sent states across two devices; verify exact email/change action/copy and that entry or explicit profile refresh reads backend truth. Live update while already open is tested separately.
+- [ ] `PLEX-054` · P1 · UI — Hide/re-enable the guide before and after sharing an email; verify preference changes navigation only and never clears email/invite state.
+- [ ] `PLEX-055` · P0 · UI/LIVE — Unlink and cancel once, then confirm; verify token/account/server/library/auto-invite settings are forgotten, existing Plex shares remain intact, and Users falls back to manual invite actions.
+- [ ] `PLEX-056` · P0 · LIVE/API — Relink after unlink; verify the stable `X-Plex-Client-Identifier` is reused while the old token/config are not, and a server must be selected again.
+- [ ] `PLEX-057` · P1 · LIVE — Share account A, change settings, then invite fresh account B; verify B gets the new scope while A retains the old external scope. Resend A must not claim `already_shared` updated its permissions; existing shares require manual Plex changes until update-share exists.
+- [ ] `PLEX-058` · P1 · CHAOS — Trigger two admins to invite the same waiter concurrently; verify Plex duplicate handling leaves one coherent stamped state, clears the waiter once, and emits at most one truthful fresh-invite user notification.
+- [ ] `PLEX-059` · P1 · API — With valid Plex configuration and an upstream call counter: nonnumeric ID → 400, non-positive ID → 400, absent/deleted user → 404, and existing user with no email → 409; verify zero Plex calls/stamps/notifications.
+- [ ] `PLEX-060` · P1 · SEC — Verify the stored invite timestamp is described/used only as “Cantinarr sent/recognized the invite,” never as proof the recipient accepted it or still has live Plex access.
+- [ ] `PLEX-061` · P0 · LIVE — Explicitly check every current library (nonempty ID list), invite/accept, then add a future library; verify the recipient does **not** gain that new library, proving explicit-current differs from unchecked/all-future mode.
+- [ ] `PLEX-062` · P0 · CHAOS/SEC — Corrupt, delete, or store `null`/malformed `plex_library_ids`; verify Cantinarr fails closed and never interprets damaged configuration as empty/all-library access.
+- [ ] `PLEX-063` · P0 · CHAOS — Fail a library fetch after selecting a new server, then press Save; verify the app blocks the save or preserves a known explicit scope instead of persisting empty/all by accident.
+- [ ] `PLEX-064` · P0 · CHAOS — Fail one of the server/name/library/auto-invite setting writes; verify the update is atomic and no partially mixed configuration becomes active.
+- [ ] `PLEX-065` · P0 · LIVE/API — Return duplicate-share 422 and unrelated invalid-email/payload/permission 422 responses; verify only a positively identified duplicate maps to `already_shared`.
+- [ ] `PLEX-066` · P0 · CHAOS — Make DB invite-timestamp persistence fail after Plex succeeds; verify the endpoint does not report durable success/send a success push while the user still counts as waiting, and recovery can reconcile safely.
+- [ ] `PLEX-067` · P1 · LIVE — Enable auto-invite when users are already waiting; verify there is no retroactive sweep, zero Plex calls/stamps occur for them, and every existing waiter remains visible for manual invite until a new email change event.
+- [ ] `PLEX-068` · P1 · LIVE — Configure Plex after users already shared emails; verify configuration alone makes zero invite calls/stamps and all preexisting waiters remain visible/actionable for manual invite.
+- [ ] `PLEX-069` · P1 · UI/LIVE — Complete the manual “Invite in Plex…” fallback; verify Cantinarr does not falsely stamp it, and record that without external sync/reconciliation the user and badge truthfully remain waiting rather than pretending success.
+- [ ] `PLEX-070` · P1 · LIVE — Observe a fresh invite before acceptance, after acceptance, after decline/expiry/cancel, and after owner revoke; verify external Plex truth manually and confirm Cantinarr never labels its send timestamp as any of those live states.
+- [ ] `PLEX-071` · P1 · LIVE — Change accepted user's library permissions directly in Plex and have the recipient leave the share; verify Cantinarr does not claim live access and the test record documents the unsynchronized external state.
+- [ ] `PLEX-072` · P1 · LIVE — Delete the Cantinarr user after they accept Plex access; verify local records/badges disappear but external Plex access is not claimed revoked and is cleaned up deliberately in Plex.
+- [ ] `PLEX-073` · P1 · CHAOS/UI — Poll an expired PIN and a Plex response slower than the 3-second timer; verify polling terminates/does not overlap, link success renders once, and no duplicate load/snackbar occurs.
+- [ ] `PLEX-074` · P1 · CHAOS/UI — Rapidly switch owned servers while library requests complete out of order; verify only the currently selected server's libraries render and can be saved.
+- [ ] `PLEX-075` · P1 · API/SEC — Submit duplicate/zero/negative/stale/foreign-server section IDs and a machine/name mismatch directly; verify unowned/invalid access scopes are rejected rather than trusted from the client.
+- [ ] `PLEX-076` · P1 · GAP/UI/API — After a successful manual fallback, use the required explicit truthful reconciliation/marking flow; verify it clears waiting state without claiming acceptance or changing Plex permissions. Retain as a product-gap failure until such a flow exists.
+- [ ] `PLEX-077` · P0 · CHAOS/API — Configure owner A/server/subset/auto-invite, corrupt/delete only the token, then relink owner B without Unlink; verify old machine/library/auto settings are cleared or revalidated and no stale-owner invite can be sent.
+- [ ] `PLEX-078` · P0 · CHAOS/LIVE — Let Plex commit a share but drop the response until Cantinarr times out; prove external access exists while local stamp/push do not, then retry and verify duplicate handling reconciles state without claiming a fresh email.
+- [ ] `PLEX-079` · P0 · CHAOS/LIVE — Pause a manual invite after Cantinarr reads email A, change the user to email B, then release A's response; verify A's invite cannot stamp B as invited.
+- [ ] `PLEX-080` · P0 · GAP/UI/RT — Admin A sends a one-tap invite while Admin B stays elsewhere; verify Admin B's waiter count converges without reopening Users/manual refresh. Retain as a realtime-gap failure until an admin event exists.
+- [ ] `PLEX-081` · P1 · GAP/UI/RT — Keep the recipient guide open while an admin sends the invite; verify it changes to check-inbox without route reopen/arbitrary delay. Retain as a realtime-gap failure until the profile consumes the event.
+- [ ] `PLEX-082` · P1 · LIVE — Invite an unregistered email, record Plex's exact response/pending state, then create/accept that account; verify Cantinarr stamps only when Plex accepted the share request and never infers acceptance.
+- [ ] `PLEX-083` · P0 · API/SEC — Omit `library_section_ids` and send it as explicit `null`; verify neither silently authorizes empty/all-library access unless the request explicitly selected that documented mode.
+- [ ] `PLEX-084` · P1 · GAP/UI/API — As a waiting (unstamped) user, withdraw the shared email; verify email/stamp clear, waiting/admin counts converge, no invite runs, and later auto-invite has no stale target. Retain as a product-gap failure until withdrawal is supported.
+- [ ] `PLEX-085` · P0 · CHAOS/UI/API — Revoke the Plex token externally, then inspect status, setup checklist, Users actions, server list, and invite; verify no misleading operational/configured state, no stamp, and a clear relink path.
+- [ ] `PLEX-086` · P1 · CHAOS — Delay auto-invite before Plex commits, let the email POST return, then restart; verify no stamp/sent copy, user remains a waiter after restart, and one manual retry sends/stamps exactly once.
+- [ ] `PLEX-087` · P1 · UI/LIVE — Resend after the recipient accepted access; verify `already_shared` copy is now truthful, no new-email push is sent, and existing libraries are neither removed nor silently broadened.
+
+### Plex vector subresults
+
+Do not check the parent case until every applicable vector below passes. Record evidence/defect per row so a partial pass is visible.
+
+| Parent | Vector | Expected | Result / evidence |
+|---|---|---|---|
+| PLEX-036 | Empty / ASCII-whitespace-only | Reject; zero state/side effects | |
+| PLEX-036 | No `@` | Reject; zero state/side effects | |
+| PLEX-036 | `@nothing-before` | Reject; zero state/side effects | |
+| PLEX-036 | `nothing-after@` | Reject; zero state/side effects | |
+| PLEX-036 | Internal space | Reject; zero state/side effects | |
+| PLEX-036 | Internal tab | Reject; zero state/side effects | |
+| PLEX-036 | Internal newline | Reject; zero state/side effects | |
+| PLEX-036 | Valid address over 254 bytes | Reject; zero state/side effects | |
+| PLEX-037 | `first.last+tag@sub.example` | Accept identically in UI/server | |
+| PLEX-037 | `a@b` | Accept identically in UI/server | |
+| PLEX-037 | Valid exactly 254 ASCII bytes | Accept identically in UI/server | |
+| PLEX-037 | Multiple `@` | Reject identically in UI/server | |
+| PLEX-037 | Internal carriage return | Reject identically in UI/server | |
+| PLEX-037 | Internal Unicode whitespace | Reject identically in UI/server | |
+| PLEX-037 | ≤254 characters but >254 UTF-8 bytes | Reject identically in UI/server | |
+| PLEX-043 | Connection refused/DNS | Fail before commit; no stamp/success | |
+| PLEX-043 | TLS verification failure | Fail before commit; no stamp/success | |
+| PLEX-043 | Plex 401 | Fail before commit; no stamp/success | |
+| PLEX-043 | Plex 403 | Fail before commit; no stamp/success | |
+| PLEX-043 | Plex 429 | Fail before commit; no stamp/success | |
+| PLEX-043 | Plex 5xx | Fail before commit; no stamp/success | |
+| PLEX-043 | Malformed non-2xx error body | Fail safely; no stamp/success | |
+| PLEX-059 | Nonnumeric user ID | 400; zero Plex calls | |
+| PLEX-059 | User ID `0` | 400; zero Plex calls | |
+| PLEX-059 | Negative user ID | 400; zero Plex calls | |
+| PLEX-059 | Never-existing user | 404; zero Plex calls | |
+| PLEX-059 | Deleted user | 404; zero Plex calls | |
+| PLEX-059 | Existing user, no email | 409; zero Plex calls | |
+| PLEX-070 | Invite pending | External pending recorded; local label only says sent | |
+| PLEX-070 | Recipient accepted | External access works; no false local acceptance claim | |
+| PLEX-070 | Recipient declined | External decline recorded; no false local live-state claim | |
+| PLEX-070 | Invite expired | External expiry recorded; no false local live-state claim | |
+| PLEX-070 | Owner canceled pending invite | External cancel recorded; no false local live-state claim | |
+| PLEX-070 | Owner revoked accepted share | Access gone externally; no false local live-state claim | |
+| PLEX-075 | Duplicate section IDs | Reject; no setting change | |
+| PLEX-075 | Section ID `0` | Reject; no setting change | |
+| PLEX-075 | Negative section ID | Reject; no setting change | |
+| PLEX-075 | Deleted/stale section ID | Reject; no setting change | |
+| PLEX-075 | Section ID from another server | Reject; no setting change | |
+| PLEX-075 | Machine ID / display-name mismatch | Reject; no setting change | |

--- a/docs/testing/check_catalog.py
+++ b/docs/testing/check_catalog.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Validate the canonical regression catalog's structural invariants."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[1]
+INDEX = HERE / "README.md"
+CATALOG_DIR = HERE / "catalog"
+RETIRED = HERE / "retired-cases.md"
+KNOWN_GAPS = HERE / "known-gaps.md"
+
+CASE_RE = re.compile(
+    r"^- \[(?P<state>[ xX])\] `(?P<id>[A-Z]+-\d{3})` · "
+    r"(?P<priority>P[0-2]) · (?P<tags>[A-Z]+(?:/[A-Z]+)*) — (?P<description>\S.*)$"
+)
+GROUP_RE = re.compile(
+    r"^\| \[(?P<label>[^]]+)\]\((?P<path>catalog/[^)]+\.md)\) \| "
+    r"(?P<prefixes>[A-Z]+(?:, [A-Z]+)*) \| (?P<count>\d+) \|$"
+)
+RETIRED_RE = re.compile(r"^\| `(?P<id>[A-Z]+-\d{3})` \|(?P<fields>.+)\|$")
+GAP_RE = re.compile(r"^\| `(?P<id>[A-Z]+-\d{3})` \|(?P<fields>.+)\|$")
+SUMMARY_RE = re.compile(
+    r"contains \*\*(?P<total>\d+) active cases\*\*: \*\*(?P<p0>\d+) P0\*\*, "
+    r"\*\*(?P<p1>\d+) P1\*\*, and \*\*(?P<p2>\d+) P2\*\*\."
+)
+TOTAL_RE = re.compile(r"^\| \*\*Total\*\* \| \| \*\*(?P<count>\d+)\*\* \|$")
+KNOWN_TAGS = {"AUTO", "API", "UI", "LIVE", "CHAOS", "SEC", "RT", "GAP"}
+ALLOWED_PREFIXES = {
+    "AI", "AUTH", "BASE", "BOOK", "DISC", "DOWN", "EXP", "INST", "ISS", "MCP", "NAV", "OPS",
+    "PERF", "PLEX", "PUSH", "RAD", "REL", "REQ", "RT", "SEC", "SON", "TAUT", "USER", "UX",
+}
+NON_CASE_TOKENS = {"AES-256"}
+RESULT_ANNOTATION_RE = re.compile(r"— (?:PASS|FAIL|BLOCKED|N/A):")
+AUTO_REFERENCE_RE = re.compile(r"AUTO:\s+`?(?P<path>[^`\s:]+)::(?P<symbol>[^`\s]+)`?")
+MARKDOWN_LINK_RE = re.compile(r"\[[^]]+\]\((?P<target>[^)]+)\)")
+ID_REFERENCE_RE = re.compile(r"\b[A-Z]+-\d{3}\b")
+EXPLICIT_ID_REFERENCE_RE = re.compile(r"`(?P<id>[A-Z]+-\d{3})`")
+VECTOR_PARENT_RE = re.compile(r"^\| (?P<id>[A-Z]+-\d{3}) \|")
+
+
+def add_error(errors: list[str], message: str) -> None:
+    errors.append(message)
+
+
+def read_retired(text: str, errors: list[str]) -> set[str]:
+    retired: set[str] = set()
+    for line_number, line in enumerate(text.splitlines(), 1):
+        if not line.startswith("| `"):
+            continue
+        match = RETIRED_RE.fullmatch(line)
+        if match is None:
+            add_error(errors, f"retired-cases.md:{line_number}: malformed retired-ID row")
+            continue
+        fields = [field.strip() for field in match.group("fields").split("|")]
+        if len(fields) != 3 or any(not field for field in fields):
+            add_error(
+                errors,
+                f"retired-cases.md:{line_number}: reason, replacement (or None), and PR/release are required",
+            )
+            continue
+        case_id = match.group("id")
+        if case_id in retired:
+            add_error(errors, f"retired-cases.md:{line_number}: duplicate retired ID {case_id}")
+        retired.add(case_id)
+    return retired
+
+
+def read_known_gaps(text: str, errors: list[str]) -> dict[str, str]:
+    gaps: dict[str, str] = {}
+    for line_number, line in enumerate(text.splitlines(), 1):
+        if not line.startswith("| `"):
+            continue
+        match = GAP_RE.fullmatch(line)
+        if match is None:
+            add_error(errors, f"known-gaps.md:{line_number}: malformed GAP row")
+            continue
+        fields = [field.strip() for field in match.group("fields").split("|")]
+        if len(fields) != 4 or any(not field for field in fields):
+            add_error(errors, f"known-gaps.md:{line_number}: status, owner, limitation, and accepted reference are required")
+            continue
+        status = fields[0]
+        if status not in {"Open", "Resolved", "Withdrawn"}:
+            add_error(errors, f"known-gaps.md:{line_number}: unknown GAP status {status!r}")
+        if not MARKDOWN_LINK_RE.search(fields[3]) and not re.search(r"https?://|#[0-9]+|\bv\d", fields[3]):
+            add_error(errors, f"known-gaps.md:{line_number}: GAP needs a linked decision, issue, PR, or release")
+        case_id = match.group("id")
+        if case_id in gaps:
+            add_error(errors, f"known-gaps.md:{line_number}: duplicate GAP ID {case_id}")
+        gaps[case_id] = status
+    return gaps
+
+
+def git_text(ref: str, path: str) -> str | None:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def previous_ids(ref: str, errors: list[str]) -> tuple[set[str], set[str], set[str]]:
+    verify = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if verify.returncode != 0:
+        add_error(errors, f"cannot resolve catalog history base ref {ref!r}")
+        return set(), set(), set()
+    result = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", ref, "--", "docs/testing/catalog"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        add_error(errors, f"cannot read catalog history from base ref {ref!r}")
+        return set(), set(), set()
+
+    active: set[str] = set()
+    paths = result.stdout.splitlines()
+    for path in paths:
+        content = git_text(ref, path)
+        if content is None:
+            add_error(errors, f"cannot read historical catalog file {path!r} from {ref!r}")
+            continue
+        active.update(match.group("id") for match in map(CASE_RE.fullmatch, content.splitlines()) if match)
+
+    retired_content = git_text(ref, "docs/testing/retired-cases.md")
+    old_retired: set[str] = set()
+    if paths and retired_content is None:
+        add_error(errors, f"cannot read historical retired-ID ledger from {ref!r}")
+    elif retired_content:
+        old_retired = {
+            match.group("id")
+            for match in map(RETIRED_RE.fullmatch, retired_content.splitlines())
+            if match
+        }
+    known_gaps_content = git_text(ref, "docs/testing/known-gaps.md")
+    old_gaps: set[str] = set()
+    if paths and known_gaps_content is None:
+        add_error(errors, f"cannot read historical GAP ledger from {ref!r}")
+    elif known_gaps_content:
+        old_gaps = {
+            match.group("id")
+            for match in map(GAP_RE.fullmatch, known_gaps_content.splitlines())
+            if match
+        }
+    return active, old_retired, old_gaps
+
+
+def default_base_ref(errors: list[str]) -> str:
+    result = subprocess.run(
+        ["git", "merge-base", "HEAD", "origin/main"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        add_error(errors, "cannot determine merge base of HEAD and origin/main; fetch origin or pass --base-ref")
+        return ""
+    return result.stdout.strip()
+
+
+def heading_anchor(heading: str) -> str:
+    anchor = re.sub(r"[^\w\- ]", "", heading.strip().lower())
+    return re.sub(r" +", "-", anchor)
+
+
+def validate_links(path: Path, text: str, errors: list[str]) -> None:
+    for match in MARKDOWN_LINK_RE.finditer(text):
+        target = match.group("target")
+        if target.startswith(("http://", "https://", "/")):
+            continue
+        target_path, _, anchor = target.partition("#")
+        resolved = (path.parent / target_path).resolve() if target_path else path.resolve()
+        if target_path and not resolved.exists():
+            add_error(errors, f"{path.relative_to(ROOT)}: broken link target {target}")
+            continue
+        if anchor and resolved.is_file():
+            headings = {
+                heading_anchor(line.lstrip("# "))
+                for line in resolved.read_text(encoding="utf-8").splitlines()
+                if line.startswith("#")
+            }
+            if anchor not in headings:
+                add_error(errors, f"{path.relative_to(ROOT)}: broken Markdown anchor {target}")
+
+
+def validate_run_template(path: Path, text: str, errors: list[str]) -> None:
+    section = ""
+    section_counts: Counter[str] = Counter()
+    for line_number, line in enumerate(text.splitlines(), 1):
+        if line.startswith("## "):
+            section = line[3:]
+            section_counts[section] += 1
+            continue
+        if not line.startswith("|") or line.startswith("|---"):
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if section == "Run record" and cells != ["Field", "Value"]:
+            if len(cells) != 2:
+                add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: malformed run-record row")
+                continue
+            field, value = cells
+            expected = "NOT RUN" if field == "Result" else ""
+            if value != expected:
+                add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: committed run metadata is not blank")
+        elif section == "Execution evidence log" and cells != [
+            "Case ID",
+            "Result",
+            "Version / environment",
+            "Evidence",
+            "Defect / note",
+            "Tester / date",
+        ]:
+            if any(cells):
+                add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: committed execution evidence is not blank")
+        elif section not in {"Run record", "Execution evidence log"}:
+            add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: unexpected table outside a run-neutral section")
+    for required_section in ("Run record", "Execution evidence log"):
+        if section_counts[required_section] != 1:
+            add_error(
+                errors,
+                f"{path.relative_to(ROOT)}: expected exactly one {required_section!r} heading; "
+                f"found {section_counts[required_section]}",
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base-ref",
+        help="Git ref used to verify ID history (default: merge-base of HEAD and origin/main)",
+    )
+    args = parser.parse_args()
+    errors: list[str] = []
+
+    required = [INDEX, CATALOG_DIR, RETIRED, KNOWN_GAPS, HERE / "fixtures.md", HERE / "run-template.md"]
+    for path in required:
+        if not path.exists():
+            add_error(errors, f"missing required catalog path: {path.relative_to(ROOT)}")
+    if errors:
+        print("\n".join(f"ERROR: {error}" for error in errors), file=sys.stderr)
+        return 1
+
+    index_text = INDEX.read_text(encoding="utf-8")
+    retired_text = RETIRED.read_text(encoding="utf-8")
+    retired = read_retired(retired_text, errors)
+    known_gaps_text = KNOWN_GAPS.read_text(encoding="utf-8")
+    gap_ledger = read_known_gaps(known_gaps_text, errors)
+
+    cases: dict[str, tuple[Path, int, str, str, str]] = {}
+    priorities: Counter[str] = Counter()
+    prefixes: Counter[str] = Counter()
+    file_prefixes: dict[str, Counter[str]] = {}
+    catalog_texts: dict[Path, str] = {}
+
+    catalog_files = sorted(CATALOG_DIR.glob("*.md"))
+    if not catalog_files:
+        add_error(errors, "catalog directory contains no Markdown files")
+
+    for path in catalog_files:
+        text = path.read_text(encoding="utf-8")
+        catalog_texts[path] = text
+        validate_links(path, text, errors)
+        current_prefixes: Counter[str] = Counter()
+
+        for line_number, line in enumerate(text.splitlines(), 1):
+            vector_parent = VECTOR_PARENT_RE.match(line)
+            if vector_parent and line.split("|")[-2].strip():
+                add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: canonical vector result is not blank")
+
+            if not line.startswith("- ["):
+                continue
+            match = CASE_RE.fullmatch(line)
+            if match is None:
+                add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: malformed active-case line")
+                continue
+            case_id = match.group("id")
+            if match.group("state") != " ":
+                add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: canonical case {case_id} is checked")
+            if RESULT_ANNOTATION_RE.search(match.group("description")):
+                add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: canonical case {case_id} contains a run result")
+            if case_id in cases:
+                prior_path, prior_line, *_ = cases[case_id]
+                add_error(
+                    errors,
+                    f"{path.relative_to(ROOT)}:{line_number}: duplicate {case_id}; first defined at "
+                    f"{prior_path.relative_to(ROOT)}:{prior_line}",
+                )
+            tags = match.group("tags").split("/")
+            unknown_tags = sorted(set(tags) - KNOWN_TAGS)
+            if unknown_tags:
+                add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: {case_id} has unknown tags {unknown_tags}")
+            if "GAP" in tags and not re.search(r"\bgap\b", match.group("description"), re.IGNORECASE):
+                add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: {case_id} has GAP tag without an explicit gap explanation")
+            auto_references = list(AUTO_REFERENCE_RE.finditer(match.group("description")))
+            if "AUTO:" in match.group("description") and not auto_references:
+                add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: {case_id} has malformed AUTO reference")
+            for auto_ref in auto_references:
+                reference_path = Path(auto_ref.group("path"))
+                resolved = (ROOT / reference_path).resolve()
+                if reference_path.is_absolute() or ROOT not in resolved.parents or not resolved.is_file():
+                    add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: {case_id} has invalid AUTO path {reference_path}")
+                    continue
+                try:
+                    automated_source = resolved.read_text(encoding="utf-8")
+                except UnicodeDecodeError:
+                    add_error(errors, f"{path.relative_to(ROOT)}:{line_number}: {case_id} AUTO path is not a text file")
+                    continue
+                if auto_ref.group("symbol") not in automated_source:
+                    add_error(
+                        errors,
+                        f"{path.relative_to(ROOT)}:{line_number}: {case_id} AUTO symbol "
+                        f"{auto_ref.group('symbol')} is absent from {reference_path}",
+                    )
+
+            prefix = case_id.split("-", 1)[0]
+            cases[case_id] = (path, line_number, match.group("priority"), match.group("tags"), match.group("description"))
+            priorities[match.group("priority")] += 1
+            prefixes[prefix] += 1
+            current_prefixes[prefix] += 1
+        file_prefixes[path.relative_to(HERE).as_posix()] = current_prefixes
+
+    active_ids = set(cases)
+    gap_ids = {case_id for case_id, (_, _, _, tags, _) in cases.items() if "GAP" in tags.split("/")}
+    open_gap_ids = {case_id for case_id, status in gap_ledger.items() if status == "Open"}
+    if gap_ids != open_gap_ids:
+        add_error(
+            errors,
+            f"open known-gaps.md IDs {sorted(open_gap_ids)} do not match active GAP cases {sorted(gap_ids)}",
+        )
+    overlap = active_ids & retired
+    if overlap:
+        add_error(errors, f"active IDs also appear in the retired ledger: {', '.join(sorted(overlap))}")
+
+    summary = SUMMARY_RE.search(index_text)
+    actual_summary = {"total": len(cases), "p0": priorities["P0"], "p1": priorities["P1"], "p2": priorities["P2"]}
+    if summary is None:
+        add_error(errors, "README.md: missing catalog priority summary")
+    else:
+        declared = {key: int(value) for key, value in summary.groupdict().items()}
+        if declared != actual_summary:
+            add_error(errors, f"README.md: stale priority summary {declared}; actual is {actual_summary}")
+
+    assigned_prefixes: set[str] = set()
+    group_count = 0
+    referenced_files: set[str] = set()
+    for line_number, line in enumerate(index_text.splitlines(), 1):
+        match = GROUP_RE.fullmatch(line)
+        if match is None:
+            continue
+        relative_path = match.group("path")
+        referenced_files.add(relative_path)
+        declared_prefixes = match.group("prefixes").split(", ")
+        duplicates = assigned_prefixes & set(declared_prefixes)
+        if duplicates:
+            add_error(errors, f"README.md:{line_number}: prefixes appear in multiple groups: {sorted(duplicates)}")
+        assigned_prefixes.update(declared_prefixes)
+        expected_count = sum(prefixes[prefix] for prefix in declared_prefixes)
+        group_count += expected_count
+        if int(match.group("count")) != expected_count:
+            add_error(errors, f"README.md:{line_number}: group count is {match.group('count')}; actual is {expected_count}")
+        actual_file_prefixes = set(file_prefixes.get(relative_path, Counter()))
+        if actual_file_prefixes != set(declared_prefixes):
+            add_error(
+                errors,
+                f"README.md:{line_number}: {relative_path} contains prefixes {sorted(actual_file_prefixes)}; "
+                f"dashboard declares {sorted(declared_prefixes)}",
+            )
+
+    expected_files = {path.relative_to(HERE).as_posix() for path in catalog_files}
+    if referenced_files != expected_files:
+        add_error(errors, f"README.md: catalog links {sorted(referenced_files)} do not match files {sorted(expected_files)}")
+    if assigned_prefixes != set(prefixes):
+        add_error(errors, f"README.md: dashboard prefixes {sorted(assigned_prefixes)} do not match active prefixes {sorted(prefixes)}")
+    if set(prefixes) != ALLOWED_PREFIXES:
+        add_error(errors, f"active prefixes {sorted(prefixes)} do not match the explicit registry {sorted(ALLOWED_PREFIXES)}")
+
+    total_match = next((TOTAL_RE.fullmatch(line) for line in index_text.splitlines() if TOTAL_RE.fullmatch(line)), None)
+    if total_match is None or int(total_match.group("count")) != len(cases) or group_count != len(cases):
+        add_error(errors, f"README.md: total dashboard count does not equal {len(cases)} active cases")
+
+    all_known_ids = active_ids | retired
+    known_prefixes = set(prefixes) | {case_id.split("-", 1)[0] for case_id in retired}
+    for path, text in catalog_texts.items():
+        references = set(EXPLICIT_ID_REFERENCE_RE.findall(text))
+        references.update(VECTOR_PARENT_RE.findall(text))
+        references.update({
+            reference
+            for reference in ID_REFERENCE_RE.findall(text)
+            if reference.split("-", 1)[0] in known_prefixes
+        })
+        unknown_case_tokens = {
+            reference
+            for reference in ID_REFERENCE_RE.findall(text)
+            if reference not in NON_CASE_TOKENS and reference.split("-", 1)[0] not in ALLOWED_PREFIXES
+        }
+        if unknown_case_tokens:
+            add_error(errors, f"{path.relative_to(ROOT)}: case-shaped tokens use unknown prefixes {sorted(unknown_case_tokens)}")
+        unknown_refs = sorted(references - all_known_ids)
+        if unknown_refs:
+            add_error(errors, f"{path.relative_to(ROOT)}: references unknown case IDs {unknown_refs}")
+
+    run_template = HERE / "run-template.md"
+    validate_run_template(run_template, run_template.read_text(encoding="utf-8"), errors)
+    for path in [INDEX, RETIRED, KNOWN_GAPS, HERE / "fixtures.md", run_template]:
+        validate_links(path, path.read_text(encoding="utf-8"), errors)
+
+    base_ref = args.base_ref or default_base_ref(errors)
+    old_active, old_retired, old_gaps = previous_ids(base_ref, errors) if base_ref else (set(), set(), set())
+    missing_without_retirement = old_active - active_ids - retired
+    if missing_without_retirement:
+        add_error(errors, f"active IDs removed without retirement: {', '.join(sorted(missing_without_retirement))}")
+    removed_retired = old_retired - retired
+    if removed_retired:
+        add_error(errors, f"retired IDs removed from the permanent ledger: {', '.join(sorted(removed_retired))}")
+    reused_retired = old_retired & active_ids
+    if reused_retired:
+        add_error(errors, f"retired IDs reused as active cases: {', '.join(sorted(reused_retired))}")
+    removed_gap_history = old_gaps - set(gap_ledger)
+    if removed_gap_history:
+        add_error(errors, f"historical GAP rows removed from the permanent ledger: {', '.join(sorted(removed_gap_history))}")
+    unknown_gap_cases = set(gap_ledger) - active_ids - retired
+    if unknown_gap_cases:
+        add_error(errors, f"GAP ledger references neither active nor retired cases: {', '.join(sorted(unknown_gap_cases))}")
+
+    if old_active or old_retired:
+        old_known = old_active | old_retired
+        new_ids = active_ids - old_known
+        old_numbers: dict[str, list[int]] = {}
+        for case_id in old_known:
+            prefix, number = case_id.split("-", 1)
+            old_numbers.setdefault(prefix, []).append(int(number))
+        new_numbers: dict[str, list[int]] = {}
+        for case_id in new_ids:
+            prefix, number = case_id.split("-", 1)
+            new_numbers.setdefault(prefix, []).append(int(number))
+        for prefix, numbers in new_numbers.items():
+            prior = old_numbers.get(prefix, [])
+            if not prior:
+                expected = list(range(1, 1 + len(numbers)))
+                previous = 0
+            else:
+                previous = max(prior)
+                expected = list(range(previous + 1, previous + 1 + len(numbers)))
+            if sorted(numbers) != expected:
+                add_error(
+                    errors,
+                    f"new {prefix} IDs must append consecutively after {previous:03d}; "
+                    f"expected {expected}, found {sorted(numbers)}",
+                )
+
+    if errors:
+        print("\n".join(f"ERROR: {error}" for error in errors), file=sys.stderr)
+        return 1
+
+    priority_output = ", ".join(f"{priority}={priorities[priority]}" for priority in ("P0", "P1", "P2"))
+    print(f"Validated {len(cases)} active cases across {len(prefixes)} prefixes ({priority_output}); {len(retired)} retired IDs reserved.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/testing/check_pr_catalog.py
+++ b/docs/testing/check_pr_catalog.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Require every pull request to make one unambiguous catalog declaration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+from check_catalog import (
+    CASE_RE,
+    CATALOG_DIR,
+    GAP_RE,
+    KNOWN_GAPS,
+    RETIRED,
+    RETIRED_RE,
+    ROOT,
+    VECTOR_PARENT_RE,
+    default_base_ref,
+    git_text,
+)
+
+
+DECLARATION_RE = re.compile(r"^Affected case IDs:\s*(?P<value>.+?)\s*$", re.MULTILINE)
+CASE_ID_RE = re.compile(r"^[A-Z]+-\d{3}$")
+RANGE_RE = re.compile(r"^(?P<start>[A-Z]+-\d{3})\.\.(?P<end>[A-Z]+-\d{3})$")
+NO_CHANGE_RE = re.compile(r"^no change\s+[—-]\s+(?P<reason>.+)$", re.IGNORECASE)
+OPTIONS = (
+    "Updated, added, or retired affected cases, counts, and automation references",
+    "Existing catalog cases already describe the affected behavior and remain accurate",
+    "No catalog impact — explained in **What**",
+)
+
+
+def catalog_ids() -> tuple[set[str], set[str]]:
+    active: set[str] = set()
+    for path in CATALOG_DIR.glob("*.md"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = CASE_RE.fullmatch(line)
+            if match:
+                active.add(match.group("id"))
+    retired = {
+        match.group("id")
+        for match in map(RETIRED_RE.fullmatch, RETIRED.read_text(encoding="utf-8").splitlines())
+        if match
+    }
+    return active, retired
+
+
+def case_records(contents: list[str]) -> dict[str, str]:
+    definitions: dict[str, str] = {}
+    vectors: dict[str, list[str]] = {}
+    for content in contents:
+        for line in content.splitlines():
+            match = CASE_RE.fullmatch(line)
+            if match:
+                definitions[match.group("id")] = line
+            vector = VECTOR_PARENT_RE.match(line)
+            if vector:
+                vectors.setdefault(vector.group("id"), []).append(line)
+    return {
+        f"case:{case_id}": definition + "\n" + "\n".join(vectors.get(case_id, []))
+        for case_id, definition in definitions.items()
+    }
+
+
+def current_catalog_records() -> dict[str, str]:
+    records = case_records([path.read_text(encoding="utf-8") for path in CATALOG_DIR.glob("*.md")])
+    for path, pattern, kind in ((RETIRED, RETIRED_RE, "retired"), (KNOWN_GAPS, GAP_RE, "gap")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = pattern.fullmatch(line)
+            if match:
+                records[f"{kind}:{match.group('id')}"] = line
+    return records
+
+
+def base_catalog_records(ref: str, errors: list[str]) -> dict[str, str]:
+    verify = subprocess.run(
+        ["git", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if verify.returncode != 0:
+        errors.append(f"cannot resolve PR catalog base ref {ref!r}")
+        return {}
+    listing = subprocess.run(
+        ["git", "ls-tree", "-r", "--name-only", ref, "--", "docs/testing/catalog"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if listing.returncode != 0:
+        errors.append(f"cannot read PR catalog base ref {ref!r}")
+        return {}
+
+    catalog_contents: list[str] = []
+    paths = listing.stdout.splitlines()
+    for path in paths:
+        content = git_text(ref, path)
+        if content is None:
+            errors.append(f"cannot read historical catalog file {path!r} from {ref!r}")
+            continue
+        catalog_contents.append(content)
+    records = case_records(catalog_contents)
+    for path, pattern, kind in (
+        ("docs/testing/retired-cases.md", RETIRED_RE, "retired"),
+        ("docs/testing/known-gaps.md", GAP_RE, "gap"),
+    ):
+        content = git_text(ref, path)
+        if content is None:
+            if paths:
+                errors.append(f"cannot read historical {kind} ledger from {ref!r}")
+            continue
+        for line in content.splitlines():
+            match = pattern.fullmatch(line)
+            if match:
+                records[f"{kind}:{match.group('id')}"] = line
+    return records
+
+
+def changed_catalog_ids(base_ref: str, errors: list[str]) -> set[str]:
+    base = base_catalog_records(base_ref, errors)
+    current = current_catalog_records()
+    changed_records = {
+        key
+        for key in set(base) | set(current)
+        if base.get(key) != current.get(key)
+    }
+    return {key.split(":", 1)[1] for key in changed_records}
+
+
+def expand_ids(value: str, errors: list[str]) -> set[str]:
+    case_ids: set[str] = set()
+    for token in (part.strip() for part in value.split(",")):
+        if not token:
+            errors.append("affected case list contains an empty entry")
+            continue
+        if CASE_ID_RE.fullmatch(token):
+            case_ids.add(token)
+            continue
+        range_match = RANGE_RE.fullmatch(token)
+        if range_match is None:
+            errors.append(f"invalid case ID or range {token!r}; use PREFIX-001 or PREFIX-001..PREFIX-009")
+            continue
+        start_prefix, start_number = range_match.group("start").split("-", 1)
+        end_prefix, end_number = range_match.group("end").split("-", 1)
+        if start_prefix != end_prefix or int(start_number) > int(end_number):
+            errors.append(f"invalid case range {token!r}")
+            continue
+        case_ids.update(
+            f"{start_prefix}-{number:03d}"
+            for number in range(int(start_number), int(end_number) + 1)
+        )
+    return case_ids
+
+
+def validate(body: str, changed_ids: set[str] | None = None) -> list[str]:
+    errors: list[str] = []
+    declarations = list(DECLARATION_RE.finditer(body))
+    if len(declarations) != 1:
+        return ["PR body must contain exactly one nonblank 'Affected case IDs:' declaration"]
+    declaration = declarations[0].group("value").strip()
+
+    option_states: list[bool] = []
+    for option in OPTIONS:
+        matches = list(re.finditer(rf"^- \[(?P<state>[ xX])\] {re.escape(option)}$", body, re.MULTILINE))
+        if len(matches) != 1:
+            errors.append(f"PR body must contain exactly one catalog option line: {option}")
+            option_states.append(False)
+        else:
+            option_states.append(matches[0].group("state").lower() == "x")
+    if sum(option_states) != 1:
+        errors.append("select exactly one regression-catalog option")
+
+    no_change = NO_CHANGE_RE.fullmatch(declaration)
+    if no_change:
+        reason = no_change.group("reason").strip()
+        if len(reason) < 10 or "specific reason" in reason.lower() or reason.startswith("<"):
+            errors.append("'no change' requires a substantive, specific reason")
+        if len(option_states) == 3 and not option_states[2]:
+            errors.append("a 'no change' declaration must select the no-catalog-impact option")
+        if changed_ids:
+            errors.append(
+                "catalog definitions changed, so the PR must select the updated option and list every changed ID"
+            )
+        return errors
+
+    if len(option_states) == 3 and option_states[2]:
+        errors.append("the no-catalog-impact option requires 'no change — <specific reason>'")
+
+    affected = expand_ids(declaration, errors)
+    if not affected:
+        errors.append("list at least one affected case ID")
+        return errors
+
+    active, retired = catalog_ids()
+    allowed = active | retired if option_states and option_states[0] else active
+    unknown = affected - allowed
+    if unknown:
+        errors.append(f"affected declaration references unknown or inapplicable IDs: {', '.join(sorted(unknown))}")
+    if changed_ids is not None:
+        if changed_ids and not option_states[0]:
+            errors.append("catalog definitions changed, so select the updated/added/retired option")
+        if not changed_ids and option_states[0]:
+            errors.append("the updated/added/retired option is selected, but no catalog definitions changed")
+        if option_states[0] and not changed_ids.issubset(affected):
+            missing = sorted(changed_ids - affected)
+            if missing:
+                errors.append(f"affected declaration omits changed IDs: {', '.join(missing)}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--body-file", type=Path, help="Read a PR body from this file instead of GITHUB_EVENT_PATH")
+    parser.add_argument("--base-ref", help="Git ref used to compare catalog definitions")
+    args = parser.parse_args()
+
+    base_ref = args.base_ref
+    if args.body_file:
+        body = args.body_file.read_text(encoding="utf-8")
+    else:
+        event_path = os.environ.get("GITHUB_EVENT_PATH")
+        if not event_path:
+            print("ERROR: GITHUB_EVENT_PATH is unset; pass --body-file for a local check", file=sys.stderr)
+            return 1
+        event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        body = event.get("pull_request", {}).get("body") or ""
+        base_ref = base_ref or event.get("pull_request", {}).get("base", {}).get("sha")
+
+    history_errors: list[str] = []
+    base_ref = base_ref or default_base_ref(history_errors)
+    changed_ids = changed_catalog_ids(base_ref, history_errors) if base_ref else set()
+    if history_errors:
+        print("\n".join(f"ERROR: {error}" for error in history_errors), file=sys.stderr)
+        return 1
+
+    errors = validate(body, changed_ids)
+    if errors:
+        print("\n".join(f"ERROR: {error}" for error in errors), file=sys.stderr)
+        return 1
+    print("Validated pull-request regression catalog declaration.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/testing/check_pr_catalog.py
+++ b/docs/testing/check_pr_catalog.py
@@ -162,6 +162,7 @@ def expand_ids(value: str, errors: list[str]) -> set[str]:
 
 
 def validate(body: str, changed_ids: set[str] | None = None) -> list[str]:
+    body = body.replace("\r\n", "\n").replace("\r", "\n")
     errors: list[str] = []
     declarations = list(DECLARATION_RE.finditer(body))
     if len(declarations) != 1:

--- a/docs/testing/fixtures.md
+++ b/docs/testing/fixtures.md
@@ -1,0 +1,12 @@
+# Required regression fixtures
+
+Use these shared accounts, services, media states, and failure fixtures when executing applicable catalog cases. Keep credentials and other secrets out of evidence.
+
+- Two admins (`Admin A`, `Admin B`) and at least three requesters: a default user, a restricted-policy user, and a user with no Chaptarr/included-AI grant.
+- Two Radarr instances and two Sonarr instances with different libraries/defaults; two Chaptarr instances; one of each download client (SABnzbd, qBittorrent, NZBGet, Transmission); Tautulli; and at least one deliberately unreachable instance.
+- A Plex owner account with two owned servers and movie/show/music/photo libraries; at least four disposable registered recipient accounts, one already-shared account, one pending-but-unaccepted account, and one unregistered email. Put a uniquely named marker item in every test library, and ensure the owner can remove shares plus create/delete temporary libraries between cases.
+- Movie fixtures in unavailable, pending, requested, downloading, partial, and available states; TV fixtures with Specials, missing seasons, a missing episode, an unmonitored season, and an ended complete show.
+- Book fixtures with ebook-only, audiobook-only, both formats, monitored-without-file, duplicate-title records, missing, and cutoff-unmet states.
+- Queue fixtures for normal progress and every Import Doctor class: sample, archive/unpack, TheXEM mapping, not-an-upgrade, unparseable/invalid, remote path, client unavailable, stalled torrent, permission failure, and a valid manual-import candidate.
+- Two physical push-capable devices for one account, another device for an admin, and one stale/dead push token.
+- Personal and shared test credentials for every enabled AI provider, plus invalid-key, no-model-access, quota-exhausted (or mocked equivalent), and temporarily unavailable fixtures.

--- a/docs/testing/known-gaps.md
+++ b/docs/testing/known-gaps.md
@@ -1,0 +1,12 @@
+# Known regression-contract gaps
+
+Every `GAP` case requires a durable, accepted tracking decision here. A GAP documents required behavior that is not shipped; it never grants a release exception. In-scope P0 gaps block release, while P1 gaps require the same explicit recorded exception as any other failing P1 case. Rows are permanent: change `Open` to `Resolved` when the behavior ships or `Withdrawn` after an accepted decision removes the requirement, and add the resolving reference instead of deleting history.
+
+The four initial entries were accepted as part of adopting this master catalog and are governed by the [catalog maintenance contract](README.md#catalog-maintenance-contract). Replace or supplement that decision link with an implementation issue when work is scheduled.
+
+| Case ID | Status | Owning surface | Current limitation | Accepted decision / resolution |
+|---|---|---|---|---|
+| `PLEX-076` | Open | Plex manual-invite lifecycle | No truthful reconciliation/marking flow after the manual Plex fallback. | [Initial catalog adoption](README.md#catalog-maintenance-contract) |
+| `PLEX-080` | Open | Plex admin realtime | Other admins' waiter counts do not receive a dedicated invite event. | [Initial catalog adoption](README.md#catalog-maintenance-contract) |
+| `PLEX-081` | Open | Plex requester realtime | An open requester guide does not consume an invite-state event. | [Initial catalog adoption](README.md#catalog-maintenance-contract) |
+| `PLEX-084` | Open | Plex shared-email lifecycle | A waiting requester cannot withdraw their shared Plex email. | [Initial catalog adoption](README.md#catalog-maintenance-contract) |

--- a/docs/testing/retired-cases.md
+++ b/docs/testing/retired-cases.md
@@ -1,0 +1,6 @@
+# Retired regression case IDs
+
+Retired IDs remain permanently reserved and are excluded from active catalog counts. Add a row only when shipped behavior is removed; never delete a row or reuse its ID.
+
+| Case ID | Reason | Replacement | PR / release |
+|---|---|---|---|

--- a/docs/testing/run-template.md
+++ b/docs/testing/run-template.md
@@ -1,0 +1,32 @@
+# Regression run-copy template
+
+Copy the entire `docs/testing/` tree outside the worktree, or preserve its directory layout in a release/issue artifact. Fill metadata, case checkboxes, vector results, and evidence only in that execution copy. Never overwrite a failure during a retest; append the retest and resolution so the original result remains auditable. The committed catalog must remain blank and run-neutral.
+
+## Run record
+
+| Field | Value |
+|---|---|
+| Version / commit | |
+| Candidate image digest | |
+| Catalog files / case IDs in scope | |
+| Started / finished | |
+| Tester(s) | |
+| Fresh-install environment | |
+| Upgrade-from version | |
+| Web browsers | |
+| iOS device / OS / build | |
+| Android device / OS / build | |
+| Server architecture | |
+| Linked external services | |
+| Result | NOT RUN |
+| Accepted exceptions / issues | |
+
+## Execution evidence log
+
+Append one row for every failure, block, accepted N/A, and any P0/P1 result that needs external proof. Keep evidence free of secrets.
+
+| Case ID | Result | Version / environment | Evidence | Defect / note | Tester / date |
+|---|---|---|---|---|---|
+| | | | | | |
+
+Apply the release exit criteria from the canonical master-catalog index before declaring the run complete.


### PR DESCRIPTION
## What

- Add a canonical 587-case behavioral regression catalog, split into seven domain files with shared fixtures, a run-copy template, permanent retired-ID history, and governed known gaps.
- Require agents and contributors to reconcile affected case IDs in the same PR as behavior changes, including permissions, persistence, failure, concurrency, realtime, external-state, security, fixture, and cleanup dimensions.
- Enforce catalog shape/history and PR declarations in CI so cases cannot be silently checked, renumbered, deleted, left out of the dashboard, or bypassed with a blank catalog statement.

## Verification

- `python3 docs/testing/check_catalog.py`
- Confirmed an invalid history base fails closed.
- Confirmed valid, invalid, duplicate-option, existing-case, no-impact, diff-aware, and vector-parent PR declaration paths.
- `git diff --check`
- Parsed `.github/workflows/ci.yml` with Ruby/Psych.
- Go and Flutter suites were not run locally because this changes documentation and CI validation only; the required PR jobs run vet, tests, builds, analyze, and web build.

## Regression catalog

Affected case IDs: AI-001..AI-032, AUTH-001..AUTH-036, BASE-001..BASE-014, BOOK-001..BOOK-023, DISC-001..DISC-029, DOWN-001..DOWN-016, EXP-001..EXP-005, INST-001..INST-024, ISS-001..ISS-042, MCP-001..MCP-041, NAV-001..NAV-018, OPS-001..OPS-017, PERF-001..PERF-005, PLEX-001..PLEX-087, PUSH-001..PUSH-023, RAD-001..RAD-019, REL-001..REL-017, REQ-001..REQ-040, RT-001..RT-018, SEC-001..SEC-022, SON-001..SON-024, TAUT-001..TAUT-009, USER-001..USER-012, UX-001..UX-014

- [x] Updated, added, or retired affected cases, counts, and automation references
- [ ] Existing catalog cases already describe the affected behavior and remain accurate
- [ ] No catalog impact — explained in **What**

## Docs

- [x] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [x] `docs/testing/` — behavioral contracts, stable case IDs, fixtures, counts, release scope
- [x] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above