### PR TITLE
fix: clarify push and agent control copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **[cantinarr.com](https://cantinarr.com)** · **[Live demo](https://demo.cantinarr.com)**
 
-Discover and request movies, TV shows, and books. Manage Radarr, Sonarr, Chaptarr, and four download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step. Every consequential agent fix remains behind your approval. Your household gets the simple experience; you keep control of access, approvals, and quality.
+Discover and request movies, TV shows, and books. Get push notifications. Manage Radarr, Sonarr, Chaptarr, and four download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step. You set the agent's operating boundaries. Your household gets the simple experience; you keep control of access, approvals, and quality.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -169,7 +169,7 @@ By default, users are passwordless and passkeyless: a connect link starts a perm
 2. Open the link on your device -- it creates your account and connects automatically
 3. Browse movies, TV shows, and books powered by TMDB, Trakt, and Chaptarr
 4. Tap "Request" on anything you want -- pick seasons or book formats if you like
-5. Watch download progress live; get a push when your request is approved and when it's ready
+5. Watch download progress live and get push notifications
 6. Something wrong with a file? Tap "Report a problem"; Cantinarr quietly watches for an in-flight Radarr/Sonarr recovery, then investigates only if the problem persists
 7. Ask the AI assistant for recommendations or to make requests for you. Use the included server provider when granted, or choose your own provider under **Settings > AI Access**
 

--- a/app/ios/fastlane/metadata/en-US/description.txt
+++ b/app/ios/fastlane/metadata/en-US/description.txt
@@ -9,7 +9,7 @@ Everyone you share the server with gets a clean way to find and request things:
 • Browse trending and popular movies and shows, powered by TMDB and Trakt
 • Search everything from one bar, with plain availability labels: Available, Requested, Downloading
 • Request in one tap, or pick exactly which seasons (or book formats) you want
-• Watch download progress live, and get a push notification when your request is approved and when it's ready
+• Watch download progress live and get push notifications
 • Something wrong with a file? Report a problem right on the title and the server's AI agent can investigate
 • Ask the built-in AI assistant what to watch tonight; bring your own AI key or ChatGPT link, or use an admin-provided AI provider when granted
 

--- a/app/ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/app/ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-Discover and request movies, shows, and books. Manage Radarr, Sonarr, Chaptarr, and four download clients. Diagnose stuck downloads; agent fixes need your approval.
+Discover and request movies, shows, and books. Get push notifications. Manage your media stack and diagnose stuck downloads. Set the agent's operating boundaries.

--- a/site/index.html
+++ b/site/index.html
@@ -4,11 +4,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Cantinarr — Your media server just learned to run itself.</title>
-<meta name="description" content="Discover and request movies, shows, and books. Manage supported arrs and four download clients. Diagnose stuck downloads and approve agent fixes from the same app.">
+<meta name="description" content="Discover and request movies, shows, and books. Get push notifications. Manage your media stack and diagnose stuck downloads. Set the agent’s operating boundaries.">
 <link rel="canonical" href="https://cantinarr.com/">
 <meta property="og:site_name" content="Cantinarr">
 <meta property="og:title" content="Cantinarr — Your media server just learned to run itself.">
-<meta property="og:description" content="Discover and request movies, shows, and books. Manage supported arrs and four download clients. Diagnose stuck downloads and approve agent fixes from the same app.">
+<meta property="og:description" content="Discover and request movies, shows, and books. Get push notifications. Manage your media stack and diagnose stuck downloads. Set the agent’s operating boundaries.">
 <meta property="og:url" content="https://cantinarr.com/">
 <meta property="og:type" content="website">
 <meta property="og:image" content="https://cantinarr.com/static/og-afe0b181.png">
@@ -17,7 +17,7 @@
 <meta property="og:image:alt" content="Cantinarr — Discover, request, manage, and repair.">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Cantinarr — Your media server just learned to run itself.">
-<meta name="twitter:description" content="Discover and request movies, shows, and books. Manage supported arrs and four download clients. Diagnose stuck downloads and approve agent fixes from the same app.">
+<meta name="twitter:description" content="Discover and request movies, shows, and books. Get push notifications. Manage your media stack and diagnose stuck downloads. Set the agent’s operating boundaries.">
 <meta name="twitter:image" content="https://cantinarr.com/static/og-afe0b181.png">
 <meta name="twitter:image:alt" content="Cantinarr — Discover, request, manage, and repair.">
 <meta name="theme-color" content="#0C0805">
@@ -27,7 +27,7 @@
 <link rel="preload" href="/static/fonts/schibsted-var.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="/site.css">
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Cantinarr","operatingSystem":"iOS, Android, Web, Self-hosted (Docker)","applicationCategory":"EntertainmentApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://cantinarr.com/","image":"https://cantinarr.com/static/og-afe0b181.png","description":"Discover and request movies, shows, and books. Manage supported arrs and four download clients. Diagnose stuck downloads and approve agent fixes from the same app.","license":"https://www.gnu.org/licenses/agpl-3.0.html","sameAs":["https://github.com/windoze95/cantinarr"]}
+{"@context":"https://schema.org","@type":"SoftwareApplication","name":"Cantinarr","operatingSystem":"iOS, Android, Web, Self-hosted (Docker)","applicationCategory":"EntertainmentApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://cantinarr.com/","image":"https://cantinarr.com/static/og-afe0b181.png","description":"Discover and request movies, shows, and books. Get push notifications. Manage your media stack and diagnose stuck downloads. Set the agent’s operating boundaries.","license":"https://www.gnu.org/licenses/agpl-3.0.html","sameAs":["https://github.com/windoze95/cantinarr"]}
 </script>
 </head>
 <body>
@@ -56,7 +56,7 @@
     <div class="hero-copy">
       <p class="kicker rise">Self-hosted · Open source · AGPL-3.0</p>
       <h1 class="rise d1">Your media server just learned to <em>run itself.</em></h1>
-      <p class="lede rise d2">Discover and request movies, shows, and books. Manage Radarr, Sonarr, Chaptarr, and four download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step — every agent fix needs your approval.</p>
+      <p class="lede rise d2">Discover and request movies, shows, and books. Get push notifications. Manage Radarr, Sonarr, Chaptarr, and four download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step. You set the agent’s operating boundaries.</p>
       <ul class="hero-loop rise d3" aria-label="Cantinarr capabilities">
         <li>Discover</li>
         <li>Request</li>
@@ -111,7 +111,7 @@
       <article class="tcard reveal">
         <span class="tnum">03</span>
         <h3>It just lands</h3>
-        <p>Cantinarr adds it to the right arr with the right IDs, quality profile, and folder — then pushes a notification the moment it's ready to watch.</p>
+        <p>Cantinarr adds it to the right arr with the right IDs, quality profile, and folder — and keeps you posted with push notifications.</p>
       </article>
     </div>
   </div>


### PR DESCRIPTION
## What changed

- Add the exact sentence `Get push notifications.` immediately after the discovery/request pitch.
- Replace approval-centric hero language with `You set the agent's operating boundaries.`
- Align site metadata, the canonical README pitch, the site flow copy, and App Store promotional/full-description copy.
- Remove the older approval/ready lifecycle wording so lower-page and store copy do not contradict the new generic push claim.

## Why

The autonomy message should emphasize administrator control over agent scope, mode, budgets, and timing instead of making human approval the headline. Push should remain a clean capability statement rather than an over-specific request lifecycle promise.

## Verification

- `flutter analyze --no-fatal-infos`
- `flutter test` (340 tests)
- Local site and static-asset requests
- JSON-LD and manifest validation
- App Store promotional text 162/170 characters; full description 2877/4000
- Repo-wide stale-copy search
- `git diff --check`

## Docs

- Updated the root README pitch and user flow.
- No behavior or test-catalog change is required.