### PR TITLE
fix: remove download client count from marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **[cantinarr.com](https://cantinarr.com)** · **[Live demo](https://demo.cantinarr.com)**
 
-Discover and request movies, TV shows, and books. Get push notifications. Manage Radarr, Sonarr, Chaptarr, and four download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step. You set the agent's operating boundaries. Your household gets the simple experience; you keep control of access, approvals, and quality.
+Discover and request movies, TV shows, and books. Get push notifications. Manage Radarr, Sonarr, Chaptarr, and your download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step. You set the agent's operating boundaries. Your household gets the simple experience; you keep control of access, approvals, and quality.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐

--- a/app/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/app/android/fastlane/metadata/android/en-US/full_description.txt
@@ -1,4 +1,4 @@
-Cantinarr is the intelligent control app for your self-hosted media server — discovery and requests for your household, control of Radarr, Sonarr, and Chaptarr for you, unified management of four download clients, plus diagnosis and admin-approved fixes when downloads get stuck.
+Cantinarr is the intelligent control app for your self-hosted media server — discovery and requests for your household, control of Radarr, Sonarr, and Chaptarr for you, unified management of your download clients, plus diagnosis and admin-approved fixes when downloads get stuck.
 
 You need a Cantinarr server to use this app. The server is open source and runs as a single Docker container; setup instructions are on GitHub.
 

--- a/app/ios/fastlane/metadata/en-US/description.txt
+++ b/app/ios/fastlane/metadata/en-US/description.txt
@@ -1,4 +1,4 @@
-Cantinarr is the intelligent control app for your self-hosted media server — discovery and requests for your household, control of Radarr, Sonarr, and Chaptarr for you, unified management of four download clients, plus diagnosis and admin-approved fixes when downloads get stuck.
+Cantinarr is the intelligent control app for your self-hosted media server — discovery and requests for your household, control of Radarr, Sonarr, and Chaptarr for you, unified management of your download clients, plus diagnosis and admin-approved fixes when downloads get stuck.
 
 You need a Cantinarr server to use this app. The server is open source and runs as a single Docker container; setup instructions are on GitHub.
 

--- a/site/index.html
+++ b/site/index.html
@@ -56,7 +56,7 @@
     <div class="hero-copy">
       <p class="kicker rise">Self-hosted · Open source · AGPL-3.0</p>
       <h1 class="rise d1">Your media server just learned to <em>run itself.</em></h1>
-      <p class="lede rise d2">Discover and request movies, shows, and books. Get push notifications. Manage Radarr, Sonarr, Chaptarr, and four download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step. You set the agent’s operating boundaries.</p>
+      <p class="lede rise d2">Discover and request movies, shows, and books. Get push notifications. Manage Radarr, Sonarr, Chaptarr, and your download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step. You set the agent’s operating boundaries.</p>
       <ul class="hero-loop rise d3" aria-label="Cantinarr capabilities">
         <li>Discover</li>
         <li>Request</li>


### PR DESCRIPTION
## Summary

- replace “four download clients” with “your download clients” in the site hero and README pitch
- align the App Store and Play Store descriptions with the durable wording

## Verification

- flutter analyze --no-fatal-infos
- flutter test (340 tests)
- git diff --check
- verified no numbered download-client claim remains in customer-facing marketing copy

## Docs

- updated README, marketing site, and both store listings