### PR TITLE
test: add private Maestro Markdown evidence reports

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -31,7 +31,10 @@ from catalog IDs to current proof.
 Run `make check-test-automation` after adding or changing catalog cases,
 Maestro flows, suites, or automation mappings. Run the current private-lab UI
 smoke suite with `make maestro-lab-smoke`; it never targets a public server or
-a household setup.
+a household setup. Each live suite prints a private, self-contained Markdown
+report path with catalog traceability, normalized results, and fixture-checkpoint
+screenshots. Reports are labeled unreviewed and exclude console logs; inspect
+every image before sharing the bundle.
 
 Use `PASS` when the expected behavior is observed, `FAIL` when it is not, `BLOCKED` when the test cannot be completed, and `N/A` when the case does not apply to the tested configuration.
 

--- a/docs/testing/automation.md
+++ b/docs/testing/automation.md
@@ -83,9 +83,45 @@ E2E_ARGS="--deploy --reset" make maestro-lab-smoke
 Docker volume. It does not destroy or broaden the Droplet. `make destroy` in
 the private lab repo remains the billable-resource teardown.
 
-Maestro writes JUnit, logs, and failure screenshots under the ignored
-`e2e/maestro/.artifacts/` tree. The runner uses a restrictive umask and
-redacts the selected password before reporting the artifact path.
+Every suite run with structurally valid evidence prints the path to a portable
+Markdown evidence bundle. Malformed or unsafe input aborts atomically without
+publishing a partial report:
+
+```text
+e2e/maestro/.artifacts/suites/smoke/<run-id>/report/
+├── REPORT.md
+├── manifest.json
+├── screenshots/
+└── junit/
+```
+
+`REPORT.md` contains the overall result, harness revision and dirty state,
+exact harness content hash, candidate deployment/reset provenance,
+Maestro/platform metadata, timings, role labels, complete-versus-partial
+catalog mappings and scopes, relative links to normalized JUnit, and one
+embedded success screenshot per passing flow.
+`manifest.json` carries the same results plus PNG dimensions and SHA-256 hashes
+for machine consumers.
+
+The portable report directory is a private evidence candidate rather than a
+recursive copy of Maestro output. It is labeled `SCREENSHOTS UNREVIEWED` until
+a person inspects every image. Each flow must end with exactly one literal `evidence-*`
+`takeScreenshot` command after its assertions. The validator rejects arbitrary
+paths, interpolation, duplicate captures, nested captures, and evidence that is
+not the final top-level command. Only that named PNG is copied; it is decoded
+and canonically re-encoded as RGBA so source chunks and ancillary metadata are
+discarded, then its checksum and dimensions are recorded. Console logs,
+automatic failure screenshots, command JSON, stack traces, tunnel ports, and
+absolute workstation paths remain in the sibling private raw tree. They are
+not embedded because arbitrary output may contain sensitive values or pixels.
+
+All raw and report artifacts remain below the ignored
+`e2e/maestro/.artifacts/` tree with private permissions. The runner streams the
+console through password redaction, sanitizes the complete raw tree, and writes
+a completion marker before report generation will trust it. An interrupted or
+unsanitized artifact directory fails closed. Human screenshot review is still
+required before moving a report outside the private repository; byte redaction
+cannot remove a value rendered into image pixels.
 
 ## Traceability and conversion workflow
 
@@ -101,8 +137,9 @@ When converting a case:
 1. Split its assertions by proof surface; do not force API or chaos assertions through UI taps.
 2. Add the lower-level proof first where applicable, then one Maestro journey only if visible integration behavior remains.
 3. Put every catalog ID in the test/flow name or comment and add a scoped mapping in `automation.json`.
-4. Use `partial` until every clause and required vector has proof; add `AUTO` only when the parent is complete.
-5. Run `make check-test-automation`, the relevant normal tests, and the live lab suite when its environment is required.
+4. End each Maestro flow with one reviewed `evidence-*` screenshot on a deterministic fixture screen that cannot show credentials or external content.
+5. Use `partial` until every clause and required vector has proof; add `AUTO` only when the parent is complete.
+6. Run `make check-test-automation`, the relevant normal tests, and the live lab suite when its environment is required; visually inspect the generated Markdown evidence.
 
 PR CI validates the catalog, manifest, and flow wiring but does not receive
 DigitalOcean, SSH, or lab credentials. Live lab execution belongs on the

--- a/e2e/maestro/flows/auth/password-login.yaml
+++ b/e2e/maestro/flows/auth/password-login.yaml
@@ -62,3 +62,4 @@ tags:
     visible: "View Cantinarr Fixture Moon details"
     timeout: 20000
 - assertNotVisible: "Invalid username or password"
+- takeScreenshot: evidence-auth-007-signed-in

--- a/e2e/maestro/flows/authorization/requester-navigation.yaml
+++ b/e2e/maestro/flows/authorization/requester-navigation.yaml
@@ -43,3 +43,4 @@ tags:
 - assertNotVisible: "Navigate to AI Assistant"
 - assertNotVisible: "Navigate to Approvals"
 - assertNotVisible: "Navigate to Agent fixes"
+- takeScreenshot: evidence-auth-022-requester-boundary

--- a/e2e/maestro/flows/navigation/admin-modules.yaml
+++ b/e2e/maestro/flows/navigation/admin-modules.yaml
@@ -42,3 +42,4 @@ tags:
 - assertVisible: "Navigate to Tautulli"
 - assertVisible: "Navigate to Settings"
 - assertNotVisible: "Navigate to AI Assistant"
+- takeScreenshot: evidence-nav-001-admin-modules

--- a/scripts/check_test_automation.py
+++ b/scripts/check_test_automation.py
@@ -59,6 +59,7 @@ ALLOWED_FLOW_COMMANDS = {
     "runFlow",
     "scrollUntilVisible",
     "swipe",
+    "takeScreenshot",
     "tapOn",
 }
 FLOW_COMMAND_RE = re.compile(
@@ -75,6 +76,7 @@ ALLOWED_BODY_VARIABLES = {
 }
 FLOW_URL_HEADER = "url: ${MAESTRO_SERVER_URL}"
 FLOW_TAG_RE = re.compile(r"  - [a-z0-9-]+")
+EVIDENCE_SCREENSHOT_RE = re.compile(r"evidence-[a-z0-9]+(?:-[a-z0-9]+)*")
 
 
 class ValidationError(Exception):
@@ -197,6 +199,8 @@ def validate_maestro_commands(
     validated_helpers: set[Path] | None = None,
     visiting_helpers: set[Path] | None = None,
     first_line_number: int = 1,
+    allow_evidence: bool = False,
+    evidence_names: list[str] | None = None,
 ) -> None:
     relative = path.relative_to(ROOT).as_posix()
     if re.search(r"https?://", body):
@@ -247,6 +251,22 @@ def validate_maestro_commands(
                 raise ValidationError(
                     f"{relative}:{line_number} must launch only the configured lab URL"
                 )
+            if command == "takeScreenshot":
+                value = suffix[1:].strip() if suffix.startswith(":") else suffix
+                if (
+                    not allow_evidence
+                    or not value
+                    or value != unquoted_scalar(value)
+                    or not EVIDENCE_SCREENSHOT_RE.fullmatch(value)
+                ):
+                    raise ValidationError(
+                        f"{relative}:{line_number} may capture only a literal evidence-* screenshot"
+                    )
+                if evidence_names is None:
+                    raise ValidationError(
+                        f"{relative}:{line_number} cannot capture report evidence here"
+                    )
+                evidence_names.append(value)
             if command == "runFlow":
                 reference = suffix[1:].strip() if suffix.startswith(":") else suffix
                 if reference:
@@ -295,7 +315,7 @@ def validate_maestro_commands(
                 )
 
 
-def validate_flow(path: Path, validated_helpers: set[Path] | None = None) -> None:
+def validate_flow(path: Path, validated_helpers: set[Path] | None = None) -> tuple[str, str]:
     relative = path.relative_to(ROOT).as_posix()
     if path.is_symlink():
         raise ValidationError(f"{relative} must not be a symlink")
@@ -331,12 +351,24 @@ def validate_flow(path: Path, validated_helpers: set[Path] | None = None) -> Non
     ]
     if header_interpolations != ["MAESTRO_SERVER_URL"]:
         raise ValidationError(f"{relative} has an unsafe Maestro header interpolation")
+    evidence_names: list[str] = []
     validate_maestro_commands(
         path,
         body,
         validated_helpers=validated_helpers,
         first_line_number=len(header.splitlines()) + 2,
+        allow_evidence=True,
+        evidence_names=evidence_names,
     )
+    if len(evidence_names) != 1:
+        raise ValidationError(
+            f"{relative} must contain exactly one reviewed evidence screenshot"
+        )
+    if body.rstrip().splitlines()[-1] != f"- takeScreenshot: {evidence_names[0]}":
+        raise ValidationError(
+            f"{relative} must capture its reviewed evidence as the final top-level command"
+        )
+    return header_lines[1].removeprefix("name: ").strip(), evidence_names[0]
 
 
 def validate_manifest(cases: dict[str, dict[str, object]]) -> tuple[int, int, set[Path]]:
@@ -376,7 +408,9 @@ def validate_manifest(cases: dict[str, dict[str, object]]) -> tuple[int, int, se
         for value in specs:
             path = normalized_repo_path(value, f"proof {case_id} spec")
             normalized_specs.append(path.relative_to(ROOT).as_posix())
-            if path.suffix in {".yaml", ".yml"} and FLOWS_DIR in path.parents:
+            if FLOWS_DIR in path.parents and path.suffix != ".yaml":
+                raise ValidationError(f"Maestro flow specs must use the .yaml extension: {value}")
+            if path.suffix == ".yaml" and FLOWS_DIR in path.parents:
                 validate_flow(path)
                 if case_id not in path.read_text():
                     raise ValidationError(f"{path.relative_to(ROOT)} does not name mapped case {case_id}")
@@ -404,6 +438,9 @@ def validate_suites(mapped_flows: set[Path]) -> None:
     for suite_name, entries in suites.items():
         if not re.fullmatch(r"[a-z0-9-]+", suite_name) or not isinstance(entries, list) or not entries:
             raise ValidationError(f"invalid or empty Maestro suite {suite_name}")
+        suite_slugs: set[str] = set()
+        suite_evidence: set[str] = set()
+        suite_flow_names: set[str] = set()
         for entry in entries:
             if not isinstance(entry, dict) or set(entry) != {"flow", "user"}:
                 raise ValidationError(f"suite {suite_name} entries need exactly flow and user")
@@ -412,12 +449,33 @@ def validate_suites(mapped_flows: set[Path]) -> None:
             flow = normalized_repo_path(entry["flow"], f"suite {suite_name} flow")
             if FLOWS_DIR not in flow.parents:
                 raise ValidationError(f"suite {suite_name} flow is outside e2e/maestro/flows")
-            validate_flow(flow, validated_helpers)
+            if flow.suffix != ".yaml":
+                raise ValidationError(f"suite {suite_name} flows must use the .yaml extension")
+            flow_name, evidence_name = validate_flow(flow, validated_helpers)
+            relative_flow = flow.relative_to(FLOWS_DIR).with_suffix("")
+            slug = "-".join(relative_flow.parts)
+            if slug in suite_slugs:
+                raise ValidationError(f"suite {suite_name} has a colliding flow slug: {slug}")
+            if evidence_name in suite_evidence:
+                raise ValidationError(
+                    f"suite {suite_name} has a duplicate evidence name: {evidence_name}"
+                )
+            if flow_name in suite_flow_names:
+                raise ValidationError(
+                    f"suite {suite_name} has a duplicate flow name: {flow_name}"
+                )
+            suite_slugs.add(slug)
+            suite_evidence.add(evidence_name)
+            suite_flow_names.add(flow_name)
             if flow in suite_flows:
                 raise ValidationError(f"flow appears more than once across suites: {flow.relative_to(ROOT)}")
             suite_flows.add(flow)
 
-    repository_flows = set(FLOWS_DIR.rglob("*.yaml")) | set(FLOWS_DIR.rglob("*.yml"))
+    legacy_flows = set(FLOWS_DIR.rglob("*.yml"))
+    if legacy_flows:
+        paths = sorted(path.relative_to(ROOT).as_posix() for path in legacy_flows)
+        raise ValidationError(f"Maestro flows must use the .yaml extension: {paths}")
+    repository_flows = set(FLOWS_DIR.rglob("*.yaml"))
     if repository_flows != suite_flows:
         missing = sorted(path.relative_to(ROOT).as_posix() for path in repository_flows - suite_flows)
         extra = sorted(path.relative_to(ROOT).as_posix() for path in suite_flows - repository_flows)

--- a/scripts/redact_maestro.py
+++ b/scripts/redact_maestro.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import os
 from pathlib import Path
+import stat
 import sys
 
 
@@ -31,18 +32,27 @@ def stream(secrets: list[str]) -> int:
 
 
 def sanitize_tree(root: Path, secrets: list[str]) -> int:
+    if root.is_symlink():
+        raise RuntimeError("artifact root must be a real directory")
     if not root.exists():
         return 0
+    if not root.is_dir():
+        raise RuntimeError("artifact root must be a real directory")
 
     replacements = [(secret.encode(), REDACTION.encode()) for secret in secrets]
     for path in sorted(root.rglob("*")):
         if path.is_symlink():
-            raise RuntimeError(f"artifact tree contains a symlink: {path}")
-        if not path.is_file():
-            continue
+            raise RuntimeError("artifact tree contains a symlink")
         relative = path.relative_to(root).as_posix()
         if any(secret in relative for secret in secrets):
-            raise RuntimeError(f"artifact filename contains a secret: {path}")
+            raise RuntimeError("artifact filename contains a secret")
+        metadata = path.lstat()
+        if stat.S_ISDIR(metadata.st_mode):
+            continue
+        if not stat.S_ISREG(metadata.st_mode):
+            raise RuntimeError("artifact tree contains an unsupported filesystem node")
+        if metadata.st_nlink != 1:
+            raise RuntimeError("artifact tree contains a hardlinked file")
         data = path.read_bytes()
         sanitized = data
         for secret, replacement in replacements:
@@ -51,7 +61,7 @@ def sanitize_tree(root: Path, secrets: list[str]) -> int:
             path.write_bytes(sanitized)
         for secret, _ in replacements:
             if secret in path.read_bytes():
-                raise RuntimeError(f"secret redaction failed for {path}")
+                raise RuntimeError("secret redaction failed")
     return 0
 
 
@@ -75,6 +85,10 @@ def main() -> int:
 if __name__ == "__main__":
     try:
         raise SystemExit(main())
-    except (OSError, RuntimeError) as exc:
-        print(f"maestro redaction failed: {exc}", file=sys.stderr)
+    except OSError:
+        print("maestro redaction failed: artifact I/O error", file=sys.stderr)
+        raise SystemExit(1)
+    except RuntimeError as exc:
+        message = redact_text(str(exc), secrets_from_environment())
+        print(f"maestro redaction failed: {message}", file=sys.stderr)
         raise SystemExit(1)

--- a/scripts/render_maestro_report.py
+++ b/scripts/render_maestro_report.py
@@ -1,0 +1,939 @@
+#!/usr/bin/env python3
+"""Render a private Markdown evidence candidate for one Maestro lab suite run."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+import re
+import struct
+import sys
+import xml.etree.ElementTree as ET
+import zlib
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+EVIDENCE_RE = re.compile(r"^- takeScreenshot: (evidence-[a-z0-9]+(?:-[a-z0-9]+)*)$")
+MAX_XML_BYTES = 1_000_000
+MAX_PNG_BYTES = 20_000_000
+MAX_PIXELS = 16_777_216
+HARNESS_SCRIPT_NAMES = (
+    "check_test_automation.py",
+    "maestro_safety.py",
+    "redact_maestro.py",
+    "render_maestro_report.py",
+    "run-maestro-flow.sh",
+    "run-maestro-lab.sh",
+)
+
+
+class ReportError(Exception):
+    """Raised when report inputs cross a containment or trust boundary."""
+
+
+@dataclass
+class FlowResult:
+    flow: str
+    name: str
+    role: str
+    status: str
+    duration: float | None
+    tags: list[str]
+    evidence_name: str
+    evidence_path: str | None
+    evidence_sha256: str | None
+    evidence_width: int | None
+    evidence_height: int | None
+    junit_path: str | None
+    proofs: list[dict[str, str]]
+    report_error: str | None = None
+
+
+def load_json(path: Path) -> object:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ReportError(f"cannot read valid JSON from {path}: {exc}") from exc
+
+
+def assert_under(path: Path, root: Path, *, must_exist: bool = True) -> Path:
+    try:
+        resolved_root = root.resolve(strict=True)
+        resolved = path.resolve(strict=must_exist)
+    except OSError as exc:
+        raise ReportError(f"cannot resolve report path {path}: {exc}") from exc
+    if resolved == resolved_root or resolved_root not in resolved.parents:
+        raise ReportError(f"report path escapes its allowed root: {path}")
+    current = path
+    while True:
+        if current.is_symlink():
+            raise ReportError(f"report path contains a symlink: {current}")
+        if current == root:
+            break
+        if current == current.parent:
+            raise ReportError(f"report path does not reach its allowed root: {path}")
+        current = current.parent
+    return resolved
+
+
+def assert_real_path_chain(path: Path, anchor: Path) -> None:
+    try:
+        relative = path.relative_to(anchor)
+    except ValueError as exc:
+        raise ReportError(f"path is outside its trusted anchor: {path}") from exc
+    current = anchor
+    if current.is_symlink():
+        raise ReportError(f"trusted path contains a symlink: {current}")
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            raise ReportError(f"trusted path contains a symlink: {current}")
+
+
+def harness_content_sha256(root: Path) -> str:
+    candidates = {
+        root / "Makefile",
+        root / "docs" / "testing" / "automation.json",
+        root / "e2e" / "maestro" / "config.yaml",
+        root / "e2e" / "maestro" / "suites.json",
+        *(root / "scripts" / name for name in HARNESS_SCRIPT_NAMES),
+    }
+    maestro_root = root / "e2e" / "maestro"
+    for directory in (maestro_root / "flows", maestro_root / "helpers"):
+        if directory.is_dir() and not directory.is_symlink():
+            candidates.update(directory.rglob("*.yaml"))
+            candidates.update(directory.rglob("*.yml"))
+    digest = hashlib.sha256()
+    included = 0
+    for path in sorted(candidates):
+        if not path.exists():
+            continue
+        if path.is_symlink() or not path.is_file():
+            raise ReportError("harness inputs must be regular files")
+        try:
+            relative = path.relative_to(root).as_posix().encode()
+        except ValueError as exc:
+            raise ReportError("harness input escaped the source root") from exc
+        data = path.read_bytes()
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(len(data).to_bytes(8, "big"))
+        digest.update(data)
+        included += 1
+    if included == 0:
+        raise ReportError("no harness inputs were found")
+    return digest.hexdigest()
+
+
+def flow_slug(flow: str) -> str:
+    prefix = "e2e/maestro/flows/"
+    if not flow.startswith(prefix) or not flow.endswith(".yaml"):
+        raise ReportError(f"invalid Maestro flow path: {flow}")
+    relative = flow.removeprefix(prefix).removesuffix(".yaml")
+    if not relative or any(part in {"", ".", ".."} for part in relative.split("/")):
+        raise ReportError(f"invalid Maestro flow path: {flow}")
+    slug = relative.replace("/", "-")
+    if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", slug):
+        raise ReportError(f"invalid Maestro flow slug: {flow}")
+    return slug
+
+
+def flow_metadata(root: Path, flow: str) -> tuple[str, list[str], str]:
+    path = assert_under(root / flow, root / "e2e" / "maestro" / "flows")
+    if not path.is_file():
+        raise ReportError(f"flow is not a regular file: {flow}")
+    lines = path.read_text().splitlines()
+    try:
+        separator = lines.index("---")
+    except ValueError as exc:
+        raise ReportError(f"flow lacks a header separator: {flow}") from exc
+    name_lines = [line.removeprefix("name: ") for line in lines[:separator] if line.startswith("name: ")]
+    tags = [line.removeprefix("  - ") for line in lines[:separator] if line.startswith("  - ")]
+    evidence = [
+        match.group(1)
+        for line in lines[separator + 1 :]
+        if (match := EVIDENCE_RE.fullmatch(line))
+    ]
+    if len(name_lines) != 1 or not name_lines[0].strip():
+        raise ReportError(f"flow has an invalid name: {flow}")
+    if len(evidence) != 1:
+        raise ReportError(f"flow must have exactly one reviewed evidence screenshot: {flow}")
+    return name_lines[0], tags, evidence[0]
+
+
+def role_label(username: str) -> str:
+    labels = {
+        "lab-admin": "Primary administrator",
+        "lab-admin-b": "Administrator",
+        "lab-requester": "Requester",
+        "lab-restricted": "Restricted requester",
+        "lab-no-grants": "No-grants requester",
+    }
+    try:
+        return labels[username]
+    except KeyError as exc:
+        raise ReportError(f"suite uses an unknown lab role: {username}") from exc
+
+
+def proofs_by_flow(automation_path: Path) -> dict[str, list[dict[str, str]]]:
+    data = load_json(automation_path)
+    if not isinstance(data, dict) or data.get("schema_version") != 1:
+        raise ReportError("automation manifest has an unsupported schema")
+    mapped: dict[str, list[dict[str, str]]] = {}
+    for proof in data.get("proofs", []):
+        if not isinstance(proof, dict) or set(proof) != {
+            "case_id",
+            "status",
+            "runner",
+            "specs",
+            "scope",
+        }:
+            raise ReportError("automation manifest contains an invalid proof")
+        values = {
+            "case_id": str(proof.get("case_id", "")),
+            "status": str(proof.get("status", "")),
+            "scope": str(proof.get("scope", "")),
+        }
+        specs = proof.get("specs")
+        if (
+            not re.fullmatch(r"[A-Z]+-[0-9]{3}", values["case_id"])
+            or values["status"] not in {"automated", "partial"}
+            or not (20 <= len(values["scope"].strip()) <= 1_000)
+            or not isinstance(specs, list)
+            or not specs
+            or any(not isinstance(spec, str) for spec in specs)
+        ):
+            raise ReportError("automation manifest contains unsafe proof metadata")
+        for spec in specs:
+            mapped.setdefault(str(spec), []).append(values)
+    for proofs in mapped.values():
+        proofs.sort(key=lambda item: item["case_id"])
+    return mapped
+
+
+def parse_junit(path: Path) -> tuple[str, float | None]:
+    if path.is_symlink() or not path.is_file():
+        raise ReportError(f"JUnit input is not a regular file: {path}")
+    data = path.read_bytes()
+    if len(data) > MAX_XML_BYTES:
+        raise ReportError(f"JUnit input is too large: {path}")
+    try:
+        text = data.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise ReportError(f"JUnit input is not UTF-8: {path}") from exc
+    if "<!DOCTYPE" in text.upper() or "<!ENTITY" in text.upper():
+        raise ReportError(f"JUnit input contains a forbidden declaration: {path}")
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as exc:
+        raise ReportError(f"JUnit input is malformed: {path}") from exc
+    suites = root.findall("./testsuite") if root.tag == "testsuites" else []
+    if len(suites) != 1:
+        raise ReportError(f"JUnit input must contain exactly one testsuite: {path}")
+    suite = suites[0]
+    cases = suite.findall("./testcase")
+    if len(cases) != 1:
+        raise ReportError(f"JUnit input must contain exactly one testcase: {path}")
+    if "tests" in suite.attrib and suite.attrib["tests"] != "1":
+        raise ReportError(f"JUnit input has a contradictory test count: {path}")
+    suite_failures = 0
+    for attribute in ("failures", "errors", "skipped"):
+        raw_count = suite.attrib.get(attribute, "0")
+        if not re.fullmatch(r"[0-9]+", raw_count):
+            raise ReportError(f"JUnit input has an invalid {attribute} count: {path}")
+        suite_failures += int(raw_count)
+    case = cases[0]
+    raw_status = case.attrib.get("status", "").upper()
+    failed = (
+        suite_failures > 0
+        or case.find(".//failure") is not None
+        or case.find(".//error") is not None
+        or case.find(".//skipped") is not None
+    )
+    status = "PASS" if raw_status == "SUCCESS" and not failed else "FAIL"
+    try:
+        duration = float(case.attrib["time"]) if "time" in case.attrib else None
+    except ValueError as exc:
+        raise ReportError(f"JUnit input has an invalid duration: {path}") from exc
+    if duration is not None and (not math.isfinite(duration) or duration < 0 or duration > 86_400):
+        raise ReportError(f"JUnit input duration is out of range: {path}")
+    return status, duration
+
+
+def normalized_junit(name: str, flow: str, status: str, duration: float | None, tags: list[str]) -> bytes:
+    testsuites = ET.Element("testsuites")
+    failed = status != "PASS"
+    suite = ET.SubElement(
+        testsuites,
+        "testsuite",
+        {
+            "name": "Cantinarr Maestro lab",
+            "tests": "1",
+            "failures": "1" if failed else "0",
+            "time": f"{duration:.1f}" if duration is not None else "0.0",
+        },
+    )
+    case = ET.SubElement(
+        suite,
+        "testcase",
+        {
+            "id": name,
+            "name": name,
+            "classname": name,
+            "file": flow,
+            "time": f"{duration:.1f}" if duration is not None else "0.0",
+            "status": "SUCCESS" if not failed else "ERROR",
+        },
+    )
+    properties = ET.SubElement(case, "properties")
+    ET.SubElement(properties, "property", {"name": "tags", "value": ", ".join(tags)})
+    if failed:
+        failure = ET.SubElement(case, "failure", {"message": "Maestro flow failed"})
+        failure.text = "See the private sibling raw artifacts for diagnostics."
+    ET.indent(testsuites, space="  ")
+    return ET.tostring(testsuites, encoding="utf-8", xml_declaration=True) + b"\n"
+
+
+def png_chunk(kind: bytes, data: bytes) -> bytes:
+    return (
+        struct.pack(">I", len(data))
+        + kind
+        + data
+        + struct.pack(">I", zlib.crc32(kind + data) & 0xFFFFFFFF)
+    )
+
+
+def paeth(left: int, above: int, upper_left: int) -> int:
+    estimate = left + above - upper_left
+    left_distance = abs(estimate - left)
+    above_distance = abs(estimate - above)
+    upper_left_distance = abs(estimate - upper_left)
+    if left_distance <= above_distance and left_distance <= upper_left_distance:
+        return left
+    if above_distance <= upper_left_distance:
+        return above
+    return upper_left
+
+
+def decode_scanlines(
+    compressed: bytes,
+    *,
+    width: int,
+    height: int,
+    channels: int,
+) -> list[bytes]:
+    row_bytes = width * channels
+    expected = height * (row_bytes + 1)
+    decoder = zlib.decompressobj()
+    decoded = bytearray()
+    remaining = compressed
+    try:
+        while remaining:
+            produced = decoder.decompress(remaining, expected + 1 - len(decoded))
+            decoded.extend(produced)
+            if len(decoded) > expected:
+                raise ReportError("evidence PNG expands beyond its declared dimensions")
+            remaining = decoder.unconsumed_tail
+            if not remaining:
+                break
+    except zlib.error as exc:
+        raise ReportError("evidence PNG contains invalid compressed pixels") from exc
+    if not decoder.eof or decoder.unused_data or remaining or len(decoded) != expected:
+        raise ReportError("evidence PNG pixel data does not match its declared dimensions")
+
+    rows: list[bytes] = []
+    previous = bytes(row_bytes)
+    offset = 0
+    for _ in range(height):
+        filter_type = decoded[offset]
+        filtered = decoded[offset + 1 : offset + 1 + row_bytes]
+        offset += row_bytes + 1
+        if filter_type not in {0, 1, 2, 3, 4}:
+            raise ReportError("evidence PNG uses an unsupported row filter")
+        reconstructed = bytearray(row_bytes)
+        for index, value in enumerate(filtered):
+            left = reconstructed[index - channels] if index >= channels else 0
+            above = previous[index]
+            upper_left = previous[index - channels] if index >= channels else 0
+            if filter_type == 0:
+                predictor = 0
+            elif filter_type == 1:
+                predictor = left
+            elif filter_type == 2:
+                predictor = above
+            elif filter_type == 3:
+                predictor = (left + above) // 2
+            else:
+                predictor = paeth(left, above, upper_left)
+            reconstructed[index] = (value + predictor) & 0xFF
+        row = bytes(reconstructed)
+        rows.append(row)
+        previous = row
+    return rows
+
+
+def canonical_rgba_png(raw: bytes) -> tuple[bytes, int, int]:
+    if len(raw) > MAX_PNG_BYTES or not raw.startswith(PNG_SIGNATURE):
+        raise ReportError("evidence image is not an allowed PNG")
+    offset = len(PNG_SIGNATURE)
+    width = height = color_type = None
+    channels = None
+    palette: list[tuple[int, int, int]] | None = None
+    transparency: bytes | None = None
+    idat_parts: list[bytes] = []
+    saw_ihdr = saw_idat = saw_iend = False
+    ended_idat = False
+    chunk_index = 0
+    while offset < len(raw):
+        if offset + 12 > len(raw):
+            raise ReportError("evidence PNG has a truncated chunk")
+        length = struct.unpack(">I", raw[offset : offset + 4])[0]
+        end = offset + 12 + length
+        if end > len(raw):
+            raise ReportError("evidence PNG has an invalid chunk length")
+        kind = raw[offset + 4 : offset + 8]
+        data = raw[offset + 8 : offset + 8 + length]
+        expected_crc = struct.unpack(">I", raw[offset + 8 + length : end])[0]
+        if not re.fullmatch(rb"[A-Za-z]{4}", kind) or kind[2:3].islower():
+            raise ReportError("evidence PNG has an invalid chunk type")
+        if zlib.crc32(kind + data) & 0xFFFFFFFF != expected_crc:
+            raise ReportError("evidence PNG has an invalid checksum")
+        if chunk_index == 0 and kind != b"IHDR":
+            raise ReportError("evidence PNG header is not first")
+        if kind == b"IHDR":
+            if saw_ihdr or chunk_index != 0 or length != 13:
+                raise ReportError("evidence PNG has an invalid header")
+            width, height, bit_depth, color_type, compression, filtering, interlace = struct.unpack(
+                ">IIBBBBB", data
+            )
+            if (
+                not (1 <= width <= 4096 and 1 <= height <= 4096)
+                or width * height > MAX_PIXELS
+                or bit_depth != 8
+                or color_type not in {0, 2, 3, 4, 6}
+                or compression != 0
+                or filtering != 0
+                or interlace != 0
+            ):
+                raise ReportError("evidence PNG header uses an unsupported format")
+            channels = {0: 1, 2: 3, 3: 1, 4: 2, 6: 4}[color_type]
+            saw_ihdr = True
+        elif kind == b"PLTE":
+            if not saw_ihdr or saw_idat or palette is not None or color_type in {0, 4}:
+                raise ReportError("evidence PNG has an invalid palette")
+            if length == 0 or length > 768 or length % 3:
+                raise ReportError("evidence PNG has an invalid palette")
+            palette = [tuple(data[index : index + 3]) for index in range(0, length, 3)]
+        elif kind == b"tRNS":
+            if not saw_ihdr or saw_idat or transparency is not None:
+                raise ReportError("evidence PNG has invalid transparency data")
+            valid_length = (
+                (color_type == 0 and length == 2)
+                or (color_type == 2 and length == 6)
+                or (
+                    color_type == 3
+                    and palette is not None
+                    and 1 <= length <= len(palette)
+                )
+            )
+            if not valid_length:
+                raise ReportError("evidence PNG has invalid transparency data")
+            transparency = data
+        elif kind == b"IDAT":
+            if not saw_ihdr or ended_idat or (color_type == 3 and palette is None):
+                raise ReportError("evidence PNG has invalid pixel chunk ordering")
+            saw_idat = True
+            idat_parts.append(data)
+        elif kind == b"IEND":
+            if not saw_idat or length != 0:
+                raise ReportError("evidence PNG has an invalid end marker")
+            saw_iend = True
+            offset = end
+            if offset != len(raw):
+                raise ReportError("evidence PNG contains trailing data")
+            break
+        elif kind[:1].isupper():
+            raise ReportError("evidence PNG contains an unsupported critical chunk")
+        elif saw_idat:
+            ended_idat = True
+        offset = end
+        chunk_index += 1
+    if not saw_ihdr or not saw_idat or not saw_iend:
+        raise ReportError("evidence PNG is incomplete")
+    assert width is not None and height is not None and color_type is not None and channels is not None
+    rows = decode_scanlines(
+        b"".join(idat_parts), width=width, height=height, channels=channels
+    )
+    rgba_rows: list[bytes] = []
+    transparent_gray = struct.unpack(">H", transparency)[0] if color_type == 0 and transparency else None
+    transparent_rgb = (
+        struct.unpack(">HHH", transparency) if color_type == 2 and transparency else None
+    )
+    palette_alpha = list(transparency or b"") if color_type == 3 else []
+    for row in rows:
+        rgba = bytearray()
+        for index in range(0, len(row), channels):
+            pixel = row[index : index + channels]
+            if color_type == 0:
+                gray = pixel[0]
+                if gray == transparent_gray:
+                    rgba.extend((0, 0, 0, 0))
+                else:
+                    rgba.extend((gray, gray, gray, 255))
+            elif color_type == 2:
+                red, green, blue = pixel
+                if (red, green, blue) == transparent_rgb:
+                    rgba.extend((0, 0, 0, 0))
+                else:
+                    rgba.extend((red, green, blue, 255))
+            elif color_type == 3:
+                palette_index = pixel[0]
+                if palette is None or palette_index >= len(palette):
+                    raise ReportError("evidence PNG references an invalid palette entry")
+                alpha = (
+                    palette_alpha[palette_index]
+                    if palette_index < len(palette_alpha)
+                    else 255
+                )
+                rgba.extend((*palette[palette_index], alpha) if alpha else (0, 0, 0, 0))
+            elif color_type == 4:
+                gray, alpha = pixel
+                rgba.extend((gray, gray, gray, alpha) if alpha else (0, 0, 0, 0))
+            else:
+                red, green, blue, alpha = pixel
+                rgba.extend((red, green, blue, alpha) if alpha else (0, 0, 0, 0))
+        rgba_rows.append(bytes(rgba))
+    scanlines = b"".join(b"\x00" + row for row in rgba_rows)
+    header = struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)
+    canonical = (
+        PNG_SIGNATURE
+        + png_chunk(b"IHDR", header)
+        + png_chunk(b"IDAT", zlib.compress(scanlines, level=9))
+        + png_chunk(b"IEND", b"")
+    )
+    return canonical, width, height
+
+
+def sanitize_png(source: Path, destination: Path) -> tuple[str, int, int]:
+    if source.is_symlink() or not source.is_file():
+        raise ReportError(f"evidence image is not a regular file: {source}")
+    raw = source.read_bytes()
+    output, width, height = canonical_rgba_png(raw)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(output)
+    destination.chmod(0o600)
+    return hashlib.sha256(output).hexdigest(), width, height
+
+
+def markdown_escape(value: str) -> str:
+    collapsed = " ".join(value.split())
+    return re.sub(r"([\\`*_\[\]<>|])", r"\\\1", collapsed)
+
+
+def report_time(value: str | None) -> str:
+    if value is None:
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    if not re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z", value):
+        raise ReportError("generated-at must be a UTC timestamp ending in Z")
+    return value
+
+
+def _render_report(
+    *,
+    root: Path,
+    suite_name: str,
+    run_dir: Path,
+    harness_revision: str,
+    harness_dirty: bool,
+    harness_sha256: str,
+    deployed_this_run: bool,
+    reset_requested: bool,
+    maestro_version: str,
+    platform: str,
+    staging_created: list[bool],
+    generated_at: str | None = None,
+) -> tuple[Path, bool]:
+    if not re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", suite_name):
+        raise ReportError("suite name contains unsupported characters")
+    allowed_runs = root / "e2e" / "maestro" / ".artifacts" / "suites"
+    suite_runs = allowed_runs / suite_name
+    assert_real_path_chain(suite_runs, root)
+    resolved_run = assert_under(run_dir, suite_runs)
+    if not resolved_run.is_dir():
+        raise ReportError("suite run path is not a directory")
+    if resolved_run.parent != suite_runs.resolve(strict=True):
+        raise ReportError("suite run must be an immediate child of its selected suite directory")
+    final_report_dir = resolved_run / "report"
+    if final_report_dir.exists() or final_report_dir.is_symlink():
+        raise ReportError("suite report directory already exists")
+    report_dir = resolved_run / f".report-staging-{os.getpid()}"
+    if report_dir.exists() or report_dir.is_symlink():
+        raise ReportError("suite report staging directory already exists")
+    report_dir.mkdir(mode=0o700)
+    staging_created[0] = True
+    (report_dir / "screenshots").mkdir(mode=0o700)
+    (report_dir / "junit").mkdir(mode=0o700)
+
+    current_harness_sha256 = harness_content_sha256(root)
+    if not re.fullmatch(r"[a-f0-9]{64}", harness_sha256):
+        raise ReportError("harness content hash is invalid")
+    if current_harness_sha256 != harness_sha256:
+        raise ReportError("harness inputs changed while the suite was running")
+
+    suites_data = load_json(root / "e2e" / "maestro" / "suites.json")
+    if not isinstance(suites_data, dict) or suites_data.get("schema_version") != 1:
+        raise ReportError("suite map has an unsupported schema")
+    suite = suites_data.get("suites", {}).get(suite_name)
+    if not isinstance(suite, list) or not suite:
+        raise ReportError(f"unknown or empty Maestro suite: {suite_name}")
+    mapped_proofs = proofs_by_flow(root / "docs" / "testing" / "automation.json")
+
+    results: list[FlowResult] = []
+    report_valid = True
+    seen_slugs: set[str] = set()
+    seen_evidence: set[str] = set()
+    seen_names: set[str] = set()
+    for item in suite:
+        if not isinstance(item, dict) or set(item) != {"flow", "user"}:
+            raise ReportError("suite entry has an invalid schema")
+        flow = str(item["flow"])
+        slug = flow_slug(flow)
+        name, tags, evidence_name = flow_metadata(root, flow)
+        if slug in seen_slugs:
+            raise ReportError(f"suite contains a colliding flow slug: {slug}")
+        if evidence_name in seen_evidence:
+            raise ReportError(f"suite contains a duplicate evidence name: {evidence_name}")
+        if name in seen_names:
+            raise ReportError(f"suite contains a duplicate flow name: {name}")
+        seen_slugs.add(slug)
+        seen_evidence.add(evidence_name)
+        seen_names.add(name)
+        status_file = resolved_run / "statuses" / f"{slug}.exit"
+        raw_dir = resolved_run / "raw" / slug
+        status = "NOT RUN"
+        duration = None
+        report_error = None
+        evidence_path = evidence_sha256 = junit_path = None
+        evidence_width = evidence_height = None
+        junit_parsed = False
+
+        if status_file.exists() or status_file.is_symlink():
+            assert_under(status_file, resolved_run)
+            if status_file.is_symlink() or not status_file.is_file():
+                raise ReportError(f"flow status is not a regular file: {status_file}")
+            if status_file.stat().st_nlink != 1:
+                raise ReportError(f"flow status is hardlinked: {status_file}")
+            raw_exit = status_file.read_text().strip()
+            if not re.fullmatch(r"[0-9]{1,3}", raw_exit):
+                raise ReportError(f"flow status is invalid: {status_file}")
+            exit_code = int(raw_exit)
+            trusted = raw_dir.is_dir() and not raw_dir.is_symlink()
+            if trusted:
+                assert_under(raw_dir, resolved_run)
+                marker = raw_dir / ".sanitized"
+                trusted = (
+                    marker.is_file()
+                    and not marker.is_symlink()
+                    and marker.read_bytes() == b"sanitized\n"
+                )
+            if trusted:
+                for artifact in raw_dir.rglob("*"):
+                    if artifact.is_symlink():
+                        raise ReportError(f"trusted artifact tree contains a symlink: {artifact}")
+                    if artifact.is_file() and artifact.stat().st_nlink != 1:
+                        raise ReportError(f"trusted artifact tree contains a hardlink: {artifact}")
+            if not trusted:
+                status = "ERROR"
+                report_error = "The flow did not produce a completed, sanitized artifact set."
+                report_valid = False
+            else:
+                junit_source = raw_dir / "report.xml"
+                if junit_source.is_file() and not junit_source.is_symlink():
+                    junit_status, duration = parse_junit(junit_source)
+                    status = "PASS" if exit_code == 0 and junit_status == "PASS" else "FAIL"
+                    junit_parsed = True
+                else:
+                    status = "ERROR"
+                    report_error = "The flow did not produce a valid JUnit result."
+                    report_valid = False
+
+                if status == "PASS":
+                    candidates = [
+                        path
+                        for path in raw_dir.rglob(f"{evidence_name}.png")
+                        if path.is_file() and not path.is_symlink()
+                    ]
+                    if len(candidates) != 1:
+                        status = "ERROR"
+                        report_error = "The passing flow did not produce exactly one reviewed evidence screenshot."
+                        report_valid = False
+                    else:
+                        evidence_target = report_dir / "screenshots" / f"{evidence_name}.png"
+                        evidence_sha256, evidence_width, evidence_height = sanitize_png(
+                            candidates[0], evidence_target
+                        )
+                        evidence_path = f"screenshots/{evidence_name}.png"
+
+                if junit_parsed:
+                    junit_target = report_dir / "junit" / f"{slug}.xml"
+                    junit_target.write_bytes(
+                        normalized_junit(name, flow, status, duration, tags)
+                    )
+                    junit_target.chmod(0o600)
+                    junit_path = f"junit/{slug}.xml"
+
+        results.append(
+            FlowResult(
+                flow=flow,
+                name=name,
+                role=role_label(str(item["user"])),
+                status=status,
+                duration=duration,
+                tags=tags,
+                evidence_name=evidence_name,
+                evidence_path=evidence_path,
+                evidence_sha256=evidence_sha256,
+                evidence_width=evidence_width,
+                evidence_height=evidence_height,
+                junit_path=junit_path,
+                proofs=mapped_proofs.get(flow, []),
+                report_error=report_error,
+            )
+        )
+
+    if any(result.status in {"FAIL", "ERROR"} for result in results):
+        overall = "FAIL"
+    elif any(result.status == "NOT RUN" for result in results):
+        overall = "INCOMPLETE"
+    else:
+        overall = "PASS"
+    passed = sum(result.status == "PASS" for result in results)
+    failed = sum(result.status in {"FAIL", "ERROR"} for result in results)
+    not_run = sum(result.status == "NOT RUN" for result in results)
+    total_duration = sum(result.duration or 0 for result in results)
+    created = report_time(generated_at)
+
+    manifest = {
+        "schema_version": 1,
+        "suite": suite_name,
+        "result": overall,
+        "generated_at": created,
+        "harness_revision": harness_revision,
+        "harness_dirty": harness_dirty,
+        "harness_sha256": harness_sha256,
+        "deployed_this_run": deployed_this_run,
+        "reset_requested": reset_requested,
+        "screenshot_review_status": "UNREVIEWED",
+        "platform": platform,
+        "maestro_version": maestro_version,
+        "summary": {
+            "planned": len(results),
+            "passed": passed,
+            "failed": failed,
+            "not_run": not_run,
+            "duration_seconds": total_duration,
+        },
+        "results": [result.__dict__ for result in results],
+    }
+    manifest_path = report_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    manifest_path.chmod(0o600)
+
+    icon = {"PASS": "✅", "FAIL": "❌", "ERROR": "⚠️", "NOT RUN": "⏭️"}
+    lines = [
+        f"# Cantinarr Maestro `{suite_name}` report",
+        "",
+        f"> **{overall}** · **PRIVATE / SCREENSHOTS UNREVIEWED** · Generated locally from the disposable fixture lab. Review every image before sharing this bundle.",
+        "",
+        "## Run summary",
+        "",
+        "| Result | Planned | Passed | Failed | Not run | Duration |",
+        "|---|---:|---:|---:|---:|---:|",
+        f"| **{overall}** | {len(results)} | {passed} | {failed} | {not_run} | {total_duration:.1f}s |",
+        "",
+        "## Environment",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Harness revision | `{markdown_escape(harness_revision)}` ({'dirty' if harness_dirty else 'clean'}) |",
+        f"| Harness content SHA-256 | `{harness_sha256}` |",
+        "| Candidate provenance | "
+        + (
+            "Built and deployed from this checkout immediately before the suite |"
+            if deployed_this_run
+            else "Pre-existing lab deployment; its source revision was not attested by this run |"
+        ),
+        "| Lab state | "
+        + (
+            "A reset was requested; completion is not separately attested |"
+            if reset_requested
+            else "No reset requested; prior lab state is not attested |"
+        ),
+        f"| Platform | `{markdown_escape(platform)}` |",
+        f"| Maestro | `{markdown_escape(maestro_version)}` |",
+        "| Headless browser window | `500×1400` |",
+        f"| Generated | `{created}` |",
+        "| Target | Private workstation-loopback SSH tunnel |",
+        "| Content | Deterministic checksum-locked CC0 fixtures only |",
+        "| AI/cloud execution | Disabled and forbidden by the repository validator |",
+        "",
+        "## Results",
+        "",
+        "| Status | Flow | Catalog coverage | Role | Duration | Evidence |",
+        "|---|---|---|---|---:|---|",
+    ]
+    for result in results:
+        coverage = ", ".join(
+            f"`{proof['case_id']}` ({proof['status']})" for proof in result.proofs
+        ) or "—"
+        evidence = f"[PNG]({result.evidence_path})" if result.evidence_path else "—"
+        duration = f"{result.duration:.1f}s" if result.duration is not None else "—"
+        lines.append(
+            f"| {icon[result.status]} {result.status} | `{result.flow}` | {coverage} | {result.role} | {duration} | {evidence} |"
+        )
+
+    lines.extend(["", "## Evidence", ""])
+    for result in results:
+        lines.extend([f"### {icon[result.status]} {markdown_escape(result.name)}", ""])
+        if result.proofs:
+            lines.append("Catalog proof:")
+            lines.append("")
+            for proof in result.proofs:
+                lines.append(
+                    f"- `{proof['case_id']}` — **{proof['status']}**: {markdown_escape(proof['scope'])}"
+                )
+            lines.append("")
+        lines.append(f"Role: **{result.role}**  ")
+        lines.append(f"Result: **{result.status}**")
+        lines.append("")
+        if result.evidence_path:
+            lines.append(f"![{markdown_escape(result.name)}]({result.evidence_path})")
+            lines.append("")
+            lines.append(
+                f"PNG: `{result.evidence_width}×{result.evidence_height}` · SHA-256 `{result.evidence_sha256}`"
+            )
+            lines.append("")
+        elif result.status in {"FAIL", "ERROR"}:
+            lines.append(
+                "No screenshot is embedded: automatic failure captures are private and may show an unreviewed sensitive screen."
+            )
+            lines.append("")
+        elif result.status == "NOT RUN":
+            lines.append("This flow was not executed after an earlier suite failure.")
+            lines.append("")
+        if result.report_error:
+            lines.extend([f"Report note: {markdown_escape(result.report_error)}", ""])
+        links = []
+        if result.junit_path:
+            links.append(f"[normalized JUnit]({result.junit_path})")
+        if links:
+            lines.extend(["Artifacts: " + " · ".join(links), ""])
+
+    lines.extend(
+        [
+            "## Security attestation",
+            "",
+            "- The suite targeted only a loopback SSH forward into the disposable lab.",
+            "- The lab password was removed from streaming console output and the sibling raw artifact tree before this report was rendered.",
+            "- Only explicit, final `evidence-*` checkpoint screenshots were considered; their pixels have not been human-approved.",
+            "- Every included PNG was decoded and canonically re-encoded as RGBA, then SHA-256 checksumed.",
+            "- Console logs, automatic failure screenshots, command JSON, stack traces, local paths, tunnel ports, and raw environment values are excluded from this bundle.",
+            "- Keep this report private until a person reviews every screenshot and confirms the fixture-only content policy.",
+            "",
+            "Machine-readable metadata: [manifest.json](manifest.json).",
+            "",
+        ]
+    )
+    report_path = report_dir / "REPORT.md"
+    report_path.write_text("\n".join(lines))
+    report_path.chmod(0o600)
+    if harness_content_sha256(root) != harness_sha256:
+        raise ReportError("harness inputs changed while the report was being rendered")
+    report_dir.rename(final_report_dir)
+    return final_report_dir / "REPORT.md", report_valid and overall == "PASS"
+
+
+def render_report(
+    *,
+    root: Path,
+    suite_name: str,
+    run_dir: Path,
+    harness_revision: str,
+    harness_dirty: bool,
+    harness_sha256: str,
+    deployed_this_run: bool,
+    reset_requested: bool,
+    maestro_version: str,
+    platform: str,
+    generated_at: str | None = None,
+) -> tuple[Path, bool]:
+    staging = run_dir / f".report-staging-{os.getpid()}"
+    staging_created = [False]
+    try:
+        return _render_report(
+            root=root,
+            suite_name=suite_name,
+            run_dir=run_dir,
+            harness_revision=harness_revision,
+            harness_dirty=harness_dirty,
+            harness_sha256=harness_sha256,
+            deployed_this_run=deployed_this_run,
+            reset_requested=reset_requested,
+            maestro_version=maestro_version,
+            platform=platform,
+            staging_created=staging_created,
+            generated_at=generated_at,
+        )
+    except BaseException:
+        if staging_created[0] and staging.is_dir() and not staging.is_symlink():
+            shutil.rmtree(staging, ignore_errors=True)
+        raise
+
+
+def main() -> int:
+    if sys.argv[1:] == ["--print-harness-sha256"]:
+        print(harness_content_sha256(ROOT))
+        return 0
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--suite", required=True)
+    parser.add_argument("--run-dir", required=True, type=Path)
+    parser.add_argument("--harness-revision", required=True)
+    parser.add_argument("--harness-dirty", choices=("true", "false"), required=True)
+    parser.add_argument("--harness-sha256", required=True)
+    parser.add_argument("--deployed-this-run", choices=("true", "false"), required=True)
+    parser.add_argument("--reset-requested", choices=("true", "false"), required=True)
+    parser.add_argument("--maestro-version", required=True)
+    parser.add_argument("--platform", default="web")
+    parser.add_argument("--generated-at")
+    args = parser.parse_args()
+    report, valid = render_report(
+        root=ROOT,
+        suite_name=args.suite,
+        run_dir=args.run_dir,
+        harness_revision=args.harness_revision,
+        harness_dirty=args.harness_dirty == "true",
+        harness_sha256=args.harness_sha256,
+        deployed_this_run=args.deployed_this_run == "true",
+        reset_requested=args.reset_requested == "true",
+        maestro_version=args.maestro_version,
+        platform=args.platform,
+        generated_at=args.generated_at,
+    )
+    print(report)
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ReportError) as exc:
+        print(f"Maestro report generation failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/run-maestro-flow.sh
+++ b/scripts/run-maestro-flow.sh
@@ -14,7 +14,25 @@ die() {
   exit 1
 }
 
-[[ $# -eq 1 ]] || die "usage: scripts/run-maestro-flow.sh FLOW.yaml"
+assert_no_symlink_components() {
+  local path="$1"
+  local current="${path}"
+  while [[ "${current}" != "${ROOT_DIR}" ]]; do
+    [[ "${current}" == "${ROOT_DIR}/"* ]] ||
+      die "artifact path is outside the source checkout"
+    [[ ! -L "${current}" ]] ||
+      die "artifact path contains a symlink"
+    current="$(dirname "${current}")"
+  done
+}
+
+artifacts_root=""
+if [[ "${1:-}" == "--artifacts-root" ]]; then
+  [[ $# -ge 3 ]] || die "--artifacts-root requires a directory and flow"
+  artifacts_root="$2"
+  shift 2
+fi
+[[ $# -eq 1 ]] || die "usage: scripts/run-maestro-flow.sh [--artifacts-root DIR] FLOW.yaml"
 flow_dir="$(cd "$(dirname "$1")" 2>/dev/null && pwd -P)" || die "flow directory does not exist"
 flow="${flow_dir}/$(basename "$1")"
 [[ -f "${flow}" ]] || die "flow does not exist: ${flow}"
@@ -30,6 +48,74 @@ python3 "${SCRIPT_DIR}/maestro_safety.py" \
   --config "${ROOT_DIR}/e2e/maestro/config.yaml" \
   -- "${MAESTRO_SERVER_URL}" ||
   die "Maestro URL/config safety validation failed"
+
+relative="${flow#"${ROOT_DIR}/e2e/maestro/flows/"}"
+slug="${relative%.yaml}"
+slug="${slug//\//-}"
+run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+if [[ -n "${artifacts_root}" ]]; then
+  [[ -d "${artifacts_root}" && ! -L "${artifacts_root}" ]] ||
+    die "suite artifact root must be an existing real directory"
+  assert_no_symlink_components "${artifacts_root}"
+  artifacts_root="$(cd "${artifacts_root}" && pwd -P)"
+  case "${artifacts_root}" in
+    "${ROOT_DIR}/e2e/maestro/.artifacts/suites/"*"/raw") ;;
+    *) die "suite artifact root is outside the private Maestro suite tree" ;;
+  esac
+  artifacts="${artifacts_root}/${slug}"
+  [[ ! -e "${artifacts}" && ! -L "${artifacts}" ]] ||
+    die "suite artifact directory already exists: ${slug}"
+else
+  artifacts="${ROOT_DIR}/e2e/maestro/.artifacts/${slug}/${run_id}"
+fi
+assert_no_symlink_components "${artifacts}"
+mkdir -p "${artifacts}/debug"
+assert_no_symlink_components "${artifacts}/debug"
+chmod 0700 "${ROOT_DIR}/e2e/maestro/.artifacts" "${artifacts}" "${artifacts}/debug"
+artifacts_physical="$(cd "${artifacts}" && pwd -P)" ||
+  die "artifact directory could not be resolved"
+[[ "${artifacts_physical}" == "${artifacts}" ]] ||
+  die "artifact directory crossed a symlink boundary"
+readonly artifacts_physical
+
+artifacts_sanitized=0
+
+sanitize_or_remove_artifacts() {
+  local current_physical
+  [[ -d "${artifacts}" && ! -L "${artifacts}" ]] || return 1
+  current_physical="$(cd "${artifacts}" && pwd -P)" || return 1
+  [[ "${current_physical}" == "${artifacts_physical}" ]] || return 1
+  if python3 "${SCRIPT_DIR}/redact_maestro.py" tree "${artifacts}"; then
+    if printf 'sanitized\n' >"${artifacts}/.sanitized"; then
+      chmod 0600 "${artifacts}/.sanitized"
+      artifacts_sanitized=1
+      return 0
+    fi
+  fi
+  if [[ -d "${artifacts}" && ! -L "${artifacts}" ]]; then
+    current_physical="$(cd "${artifacts}" && pwd -P)" || return 1
+    if [[ "${current_physical}" == "${artifacts_physical}" ]]; then
+      rm -rf -- "${artifacts}"
+    fi
+  fi
+  return 1
+}
+
+cleanup_artifacts() {
+  local status=$?
+  trap - EXIT INT TERM
+  set +e
+  if [[ "${artifacts_sanitized}" -eq 0 && -e "${artifacts}" ]]; then
+    if ! sanitize_or_remove_artifacts; then
+      printf 'maestro flow warning: interrupted artifacts could not be redacted and were removed\n' >&2
+    fi
+  fi
+  exit "${status}"
+}
+
+trap cleanup_artifacts EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 java_major_version() {
   command -v java >/dev/null 2>&1 || return 1
@@ -78,41 +164,6 @@ maestro_version="$(maestro --version 2>/dev/null | sed -nE 's/.*([0-9]+\.[0-9]+\
 [[ "${maestro_version}" == "${TESTED_MAESTRO_VERSION}" ]] ||
   die "Maestro ${TESTED_MAESTRO_VERSION} is required (found ${maestro_version})"
 
-relative="${flow#"${ROOT_DIR}/e2e/maestro/flows/"}"
-slug="${relative%.yaml}"
-slug="${slug//\//-}"
-run_id="$(date -u +%Y%m%dT%H%M%SZ)-$$"
-artifacts="${ROOT_DIR}/e2e/maestro/.artifacts/${slug}/${run_id}"
-mkdir -p "${artifacts}/debug"
-chmod 0700 "${ROOT_DIR}/e2e/maestro/.artifacts" "${artifacts}" "${artifacts}/debug"
-
-artifacts_sanitized=0
-
-sanitize_or_remove_artifacts() {
-  if python3 "${SCRIPT_DIR}/redact_maestro.py" tree "${artifacts}"; then
-    artifacts_sanitized=1
-    return 0
-  fi
-  rm -rf -- "${artifacts}"
-  return 1
-}
-
-cleanup_artifacts() {
-  local status=$?
-  trap - EXIT INT TERM
-  set +e
-  if [[ "${artifacts_sanitized}" -eq 0 && -e "${artifacts}" ]]; then
-    if ! sanitize_or_remove_artifacts; then
-      printf 'maestro flow warning: interrupted artifacts could not be redacted and were removed\n' >&2
-    fi
-  fi
-  exit "${status}"
-}
-
-trap cleanup_artifacts EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
 printf 'Running %s against the private loopback lab as %s\n' "${relative}" "${MAESTRO_USERNAME}"
 set +e
 maestro --platform=web --no-ansi test \
@@ -122,8 +173,12 @@ maestro --platform=web --no-ansi test \
   --format=JUNIT \
   --output="${artifacts}/report.xml" \
   --test-output-dir="${artifacts}/debug" \
+  --debug-output="${artifacts}/debug" \
+  --flatten-debug-output \
   "${flow}" \
-  2>&1 | python3 "${SCRIPT_DIR}/redact_maestro.py" stream
+  2>&1 \
+  | python3 "${SCRIPT_DIR}/redact_maestro.py" stream \
+  | tee "${artifacts}/console.log"
 statuses=("${PIPESTATUS[@]}")
 set -e
 
@@ -132,5 +187,6 @@ sanitize_or_remove_artifacts || {
 }
 
 [[ "${statuses[1]}" -eq 0 ]] || die "console redaction failed"
+[[ "${statuses[2]}" -eq 0 ]] || die "redacted console log could not be written"
 [[ "${statuses[0]}" -eq 0 ]] || die "${relative} failed; redacted artifacts: ${artifacts}"
 printf 'Passed %s; redacted JUnit/artifacts: %s\n' "${relative}" "${artifacts}"

--- a/scripts/run-maestro-lab.sh
+++ b/scripts/run-maestro-lab.sh
@@ -8,6 +8,7 @@ readonly SCRIPT_DIR
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
 readonly ROOT_DIR
 DEFAULT_LAB_DIR="$(cd "${ROOT_DIR}/../.." && pwd)/cantinarr-lab"
+readonly TESTED_MAESTRO_VERSION="2.6.1"
 
 suite="smoke"
 reset=0
@@ -22,12 +23,26 @@ Runs the selected Maestro web suite against the private disposable lab. The
 lab repo defaults to ../../cantinarr-lab and can be overridden with
 CANTINARR_LAB_DIR. --deploy first builds/deploys this checkout as the lab
 candidate. --reset performs the lab's full volume reset once before the suite.
+Every execution writes a private Markdown evidence bundle beneath
+e2e/maestro/.artifacts/suites/.
 EOF
 }
 
 die() {
   printf 'maestro lab suite failed: %s\n' "$*" >&2
   exit 1
+}
+
+assert_no_symlink_components() {
+  local path="$1"
+  local current="${path}"
+  while [[ "${current}" != "${ROOT_DIR}" ]]; do
+    [[ "${current}" == "${ROOT_DIR}/"* ]] ||
+      die "artifact path is outside the source checkout"
+    [[ ! -L "${current}" ]] ||
+      die "artifact path contains a symlink"
+    current="$(dirname "${current}")"
+  done
 }
 
 while [[ $# -gt 0 ]]; do
@@ -56,6 +71,9 @@ while [[ $# -gt 0 ]]; do
     *) die "unknown option: $1" ;;
   esac
 done
+
+[[ "${suite}" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]] ||
+  die "suite name contains unsupported characters"
 
 lab_dir="${CANTINARR_LAB_DIR:-${DEFAULT_LAB_DIR}}"
 suite_file="${ROOT_DIR}/e2e/maestro/suites.json"
@@ -91,6 +109,33 @@ fi
 python3 "${SCRIPT_DIR}/check_test_automation.py" >/dev/null ||
   die "Maestro suite failed the local safety validator"
 
+artifact_root="${ROOT_DIR}/e2e/maestro/.artifacts"
+suite_root="${artifact_root}/suites/${suite}"
+assert_no_symlink_components "${suite_root}"
+mkdir -p "${suite_root}"
+assert_no_symlink_components "${suite_root}"
+chmod 0700 "${ROOT_DIR}/e2e/maestro/.artifacts" \
+  "${ROOT_DIR}/e2e/maestro/.artifacts/suites" "${suite_root}"
+suite_run="$(mktemp -d "${suite_root}/$(date -u +%Y%m%dT%H%M%SZ).XXXXXX")" ||
+  die "could not create the private suite artifact directory"
+mkdir -p "${suite_run}/raw" "${suite_run}/statuses"
+chmod 0700 "${suite_run}" "${suite_run}/raw" "${suite_run}/statuses"
+
+harness_revision="$(git -C "${ROOT_DIR}" rev-parse --verify HEAD 2>/dev/null)" ||
+  die "could not determine the harness revision"
+harness_status="$(git -C "${ROOT_DIR}" status --porcelain)" ||
+  die "could not determine the harness dirty state"
+harness_dirty=false
+if [[ -n "${harness_status}" ]]; then
+  harness_dirty=true
+fi
+harness_sha256="$(python3 "${SCRIPT_DIR}/render_maestro_report.py" --print-harness-sha256)" ||
+  die "could not determine the harness content hash"
+deployed_this_run=false
+[[ "${deploy}" -eq 1 ]] && deployed_this_run=true
+reset_requested=false
+[[ "${reset}" -eq 1 ]] && reset_requested=true
+
 # A fresh loopback origin keeps Chromium from reusing a Flutter service worker
 # or cached bundle from an earlier candidate deployed on the same Droplet.
 e2e_port="$(python3 - <<'PY'
@@ -120,18 +165,58 @@ if [[ "${deploy}" -eq 1 ]]; then
 fi
 
 first=1
+suite_status=0
 while IFS=$'\t' read -r user flow; do
   [[ -f "${ROOT_DIR}/${flow}" ]] || die "suite flow is missing: ${flow}"
+  slug="${flow#e2e/maestro/flows/}"
+  slug="${slug%.yaml}"
+  slug="${slug//\//-}"
   args=(e2e-run --user "${user}" --platform web --port "${e2e_port}")
   if [[ "${reset}" -eq 1 && "${first}" -eq 1 ]]; then
     args+=(--reset)
   fi
-  args+=(-- "${SCRIPT_DIR}/run-maestro-flow.sh" "${ROOT_DIR}/${flow}")
+  args+=(-- "${SCRIPT_DIR}/run-maestro-flow.sh" \
+    --artifacts-root "${suite_run}/raw" "${ROOT_DIR}/${flow}")
+  set +e
   (
     cd "${lab_dir}"
     scripts/lab "${args[@]}"
   )
+  flow_status=$?
+  set -e
+  printf '%s\n' "${flow_status}" >"${suite_run}/statuses/${slug}.exit"
+  chmod 0600 "${suite_run}/statuses/${slug}.exit"
   first=0
+  if [[ "${flow_status}" -ne 0 ]]; then
+    suite_status="${flow_status}"
+    break
+  fi
 done <"${mapfile_cmd}"
 
+set +e
+report_path="$(
+  python3 "${SCRIPT_DIR}/render_maestro_report.py" \
+    --suite "${suite}" \
+    --run-dir "${suite_run}" \
+    --harness-revision "${harness_revision}" \
+    --harness-dirty "${harness_dirty}" \
+    --harness-sha256 "${harness_sha256}" \
+    --deployed-this-run "${deployed_this_run}" \
+    --reset-requested "${reset_requested}" \
+    --maestro-version "${TESTED_MAESTRO_VERSION}" \
+    --platform web
+)"
+report_status=$?
+set -e
+if [[ -n "${report_path}" ]]; then
+  printf 'Private Markdown report: %s\n' "${report_path}"
+fi
+if [[ "${report_status}" -ne 0 ]]; then
+  printf 'Maestro %s suite report generation failed.\n' "${suite}" >&2
+  [[ "${suite_status}" -ne 0 ]] || suite_status="${report_status}"
+fi
+if [[ "${suite_status}" -ne 0 ]]; then
+  printf 'Maestro %s suite failed against the private disposable lab.\n' "${suite}" >&2
+  exit "${suite_status}"
+fi
 printf 'Maestro %s suite passed against the private disposable lab.\n' "${suite}"

--- a/scripts/tests/maestro-runner-test.sh
+++ b/scripts/tests/maestro-runner-test.sh
@@ -16,7 +16,18 @@ fail() {
 }
 
 sandbox="$(mktemp -d "${TMPDIR:-/tmp}/cantinarr-maestro-runner-test.XXXXXX")"
-trap 'rm -rf -- "${sandbox}"' EXIT
+suite_run=''
+mismatch_suite_run=''
+cleanup() {
+  rm -rf -- "${sandbox}"
+  case "${suite_run}" in
+    "${ROOT_DIR}/e2e/maestro/.artifacts/suites/smoke/"*) rm -rf -- "${suite_run}" ;;
+  esac
+  case "${mismatch_suite_run}" in
+    "${ROOT_DIR}/e2e/maestro/.artifacts/suites/smoke/"*) rm -rf -- "${mismatch_suite_run}" ;;
+  esac
+}
+trap cleanup EXIT
 
 expect_url_rejected() {
   local value="$1"
@@ -127,6 +138,7 @@ if [[ "${1:-}" == "--version" ]]; then
 fi
 output=''
 debug=''
+flow="${!#}"
 for argument in "$@"; do
   case "${argument}" in
     --output=*) output="${argument#--output=}" ;;
@@ -135,10 +147,24 @@ for argument in "$@"; do
 done
 [[ -n "${output}" && -n "${debug}" ]]
 mkdir -p "$(dirname "${output}")" "${debug}"
-printf '<password>%s</password>\n' "${MAESTRO_PASSWORD}" >"${output}"
+if [[ "${FAKE_JUNIT_ERROR:-0}" -eq 1 ]]; then
+  printf '<testsuites><testsuite tests="1" failures="1" time="1.0"><testcase name="Fake" status="ERROR" time="1.0"><failure>failed</failure></testcase></testsuite></testsuites>\n' >"${output}"
+else
+  printf '<testsuites><testsuite tests="1" failures="0" time="1.0"><testcase name="Fake" status="SUCCESS" time="1.0"><system-out>%s</system-out></testcase></testsuite></testsuites>\n' \
+    "${MAESTRO_PASSWORD}" >"${output}"
+fi
 printf '{"password":"%s"}\n' "${MAESTRO_PASSWORD}" >"${debug}/commands.json"
+printf 'fake Maestro output contains %s\n' "${MAESTRO_PASSWORD}"
+if [[ -n "${FAKE_SCREENSHOT:-}" ]]; then
+  evidence="$(sed -nE 's/^- takeScreenshot: (evidence-[a-z0-9-]+)$/\1/p' "${flow}")"
+  [[ -n "${evidence}" ]]
+  cp "${FAKE_SCREENSHOT}" "${debug}/${evidence}.png"
+fi
 if [[ "${FAKE_MAESTRO_SECRET_FILENAME:-0}" -eq 1 ]]; then
   printf 'unsafe filename\n' >"${debug}/${MAESTRO_PASSWORD}.txt"
+fi
+if [[ "${FAKE_MAESTRO_SECRET_DIRECTORY:-0}" -eq 1 ]]; then
+  mkdir "${debug}/${MAESTRO_PASSWORD}"
 fi
 if [[ "${FAKE_MAESTRO_INTERRUPT:-0}" -eq 1 ]]; then
   kill -TERM "${PPID}"
@@ -146,6 +172,78 @@ if [[ "${FAKE_MAESTRO_INTERRUPT:-0}" -eq 1 ]]; then
 fi
 EOF
 chmod 0700 "${fake_bin}/java" "${fake_bin}/maestro"
+
+fake_lab="${sandbox}/fake-lab"
+mkdir -p "${fake_lab}/scripts"
+cat >"${fake_lab}/scripts/lab" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+[[ "${1:-}" == "e2e-run" ]]
+shift
+user=''
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --user) user="$2"; shift 2 ;;
+    --platform | --port) shift 2 ;;
+    --reset) shift ;;
+    --) shift; break ;;
+    *) exit 2 ;;
+  esac
+done
+[[ -n "${user}" && $# -gt 0 ]]
+MAESTRO_SERVER_URL=http://127.0.0.1:18585 \
+MAESTRO_USERNAME="${user}" \
+MAESTRO_PASSWORD=fake-suite-secret \
+exec "$@"
+EOF
+chmod 0700 "${fake_lab}/scripts/lab"
+fake_screenshot="${sandbox}/evidence.png"
+python3 - "${fake_screenshot}" <<'PY'
+import base64
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_bytes(base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+))
+PY
+
+suite_output="$(
+  PATH="${fake_bin}:${PATH}" \
+    FAKE_SCREENSHOT="${fake_screenshot}" \
+    CANTINARR_LAB_DIR="${fake_lab}" \
+    /bin/bash "${ROOT_DIR}/scripts/run-maestro-lab.sh"
+)"
+report_path="$(sed -n 's/^Private Markdown report: //p' <<<"${suite_output}")"
+suite_run="${report_path%/report/REPORT.md}"
+[[ -f "${report_path}" ]] || fail "suite did not produce a Markdown report"
+[[ "$(find "$(dirname "${report_path}")/screenshots" -type f -name '*.png' | wc -l | tr -d ' ')" == 3 ]] ||
+  fail "suite report did not contain three reviewed screenshots"
+grep -F -q -- '> **PASS**' "${report_path}" || fail "suite report did not pass"
+if grep -R -F -q -- 'fake-suite-secret' "$(dirname "${report_path}")"; then
+  fail "suite report retained the raw password"
+fi
+[[ ! -d "$(dirname "${report_path}")/logs" ]] ||
+  fail "suite report copied unrestricted console logs"
+
+set +e
+mismatch_output="$(
+  PATH="${fake_bin}:${PATH}" \
+    FAKE_JUNIT_ERROR=1 \
+    FAKE_SCREENSHOT="${fake_screenshot}" \
+    CANTINARR_LAB_DIR="${fake_lab}" \
+    /bin/bash "${ROOT_DIR}/scripts/run-maestro-lab.sh" 2>&1
+)"
+mismatch_status=$?
+set -e
+[[ "${mismatch_status}" -ne 0 ]] || fail "JUnit/exit disagreement returned success"
+[[ "${mismatch_output}" != *"suite passed against"* ]] ||
+  fail "JUnit/exit disagreement announced a passing suite"
+mismatch_report="$(sed -n 's/^Private Markdown report: //p' <<<"${mismatch_output}")"
+mismatch_suite_run="${mismatch_report%/report/REPORT.md}"
+[[ -f "${mismatch_report}" ]] || fail "JUnit/exit disagreement did not write its failure report"
+grep -F -q -- '> **FAIL**' "${mismatch_report}" ||
+  fail "JUnit/exit disagreement report did not fail"
 
 unsupported_bin="${sandbox}/unsupported-bin"
 fallback_jdk="${sandbox}/openjdk@21"
@@ -199,17 +297,36 @@ if grep -R -F -q -- "${secret}" "${fixture}/e2e/maestro/.artifacts"; then
 fi
 
 set +e
-PATH="${fake_bin}:${PATH}" \
-  FAKE_MAESTRO_SECRET_FILENAME=1 \
-  MAESTRO_SERVER_URL=http://127.0.0.1:18585 \
-  MAESTRO_USERNAME=lab-admin-b \
-  MAESTRO_PASSWORD="${secret}" \
-  /bin/bash "${fixture}/scripts/run-maestro-flow.sh" "${fixture_flow}" >/dev/null 2>&1
+filename_output="$(
+  PATH="${fake_bin}:${PATH}" \
+    FAKE_MAESTRO_SECRET_FILENAME=1 \
+    MAESTRO_SERVER_URL=http://127.0.0.1:18585 \
+    MAESTRO_USERNAME=lab-admin-b \
+    MAESTRO_PASSWORD="${secret}" \
+    /bin/bash "${fixture}/scripts/run-maestro-flow.sh" "${fixture_flow}" 2>&1
+)"
 filename_status=$?
 set -e
 [[ "${filename_status}" -ne 0 ]] || fail "secret-bearing artifact filename was retained"
+[[ "${filename_output}" != *"${secret}"* ]] ||
+  fail "secret-bearing artifact filename leaked through stderr"
 if [[ "$(find "${fixture}/e2e/maestro/.artifacts" -print)" == *"${secret}"* ]]; then
   fail "failed redaction left a secret-bearing artifact path"
 fi
+
+set +e
+directory_output="$(
+  PATH="${fake_bin}:${PATH}" \
+    FAKE_MAESTRO_SECRET_DIRECTORY=1 \
+    MAESTRO_SERVER_URL=http://127.0.0.1:18585 \
+    MAESTRO_USERNAME=lab-admin-b \
+    MAESTRO_PASSWORD="${secret}" \
+    /bin/bash "${fixture}/scripts/run-maestro-flow.sh" "${fixture_flow}" 2>&1
+)"
+directory_status=$?
+set -e
+[[ "${directory_status}" -ne 0 ]] || fail "secret-bearing artifact directory was retained"
+[[ "${directory_output}" != *"${secret}"* ]] ||
+  fail "secret-bearing artifact directory leaked through stderr"
 
 printf 'maestro runner tests passed\n'

--- a/scripts/tests/test_e2e_automation.py
+++ b/scripts/tests/test_e2e_automation.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import base64
 import io
+import json
 import os
 import sys
 import tempfile
@@ -15,6 +17,7 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 import check_test_automation as automation  # noqa: E402
 import maestro_safety  # noqa: E402
 import redact_maestro  # noqa: E402
+import render_maestro_report as reports  # noqa: E402
 
 
 class LoopbackURLTests(unittest.TestCase):
@@ -79,7 +82,8 @@ class FlowSafetyTests(unittest.TestCase):
         self.root_patch.stop()
         self.temporary.cleanup()
 
-    def write_flow(self, body: str) -> None:
+    def write_flow(self, body: str, evidence: str | None = "evidence-test") -> None:
+        evidence_command = f"- takeScreenshot: {evidence}\n" if evidence is not None else ""
         self.flow.write_text(
             "url: ${MAESTRO_SERVER_URL}\n"
             "name: Safety fixture\n"
@@ -89,6 +93,7 @@ class FlowSafetyTests(unittest.TestCase):
             "- inputText: ${MAESTRO_USERNAME}\n"
             "- inputText: ${MAESTRO_PASSWORD}\n"
             f"{body}"
+            f"{evidence_command}"
         )
 
     def assert_rejected(self, body: str) -> None:
@@ -214,6 +219,40 @@ class FlowSafetyTests(unittest.TestCase):
         with self.assertRaises(automation.ValidationError):
             automation.validate_flow(self.flow)
 
+    def test_accepts_one_literal_final_evidence_screenshot(self) -> None:
+        self.write_flow("- launchApp\n", evidence="evidence-auth-signed-in")
+        automation.validate_flow(self.flow)
+
+    def test_rejects_unsafe_or_ambiguous_evidence_screenshots(self) -> None:
+        values = (
+            "screenshot",
+            "evidence-../outside",
+            "/tmp/evidence-outside",
+            "evidence-folder/file",
+            "${MAESTRO_PASSWORD}",
+            '"evidence-quoted"',
+        )
+        for value in values:
+            with self.subTest(value=value):
+                self.write_flow("- launchApp\n", evidence=value)
+                with self.assertRaises(automation.ValidationError):
+                    automation.validate_flow(self.flow)
+
+        self.write_flow(
+            "- launchApp\n- takeScreenshot: evidence-first\n",
+            evidence="evidence-second",
+        )
+        with self.assertRaises(automation.ValidationError):
+            automation.validate_flow(self.flow)
+
+    def test_requires_evidence_to_be_the_final_top_level_command(self) -> None:
+        self.write_flow(
+            "- launchApp\n- takeScreenshot: evidence-too-early\n- tapOn: Safe\n",
+            evidence=None,
+        )
+        with self.assertRaises(automation.ValidationError):
+            automation.validate_flow(self.flow)
+
 
 class RedactionTests(unittest.TestCase):
     def test_sanitizes_text_and_binary_artifacts(self) -> None:
@@ -269,6 +308,492 @@ class RedactionTests(unittest.TestCase):
             (root / f"failure-{secret}.txt").write_text("safe contents")
             with self.assertRaises(RuntimeError):
                 redact_maestro.sanitize_tree(root, [secret])
+
+    def test_rejects_secret_bearing_directory_name(self) -> None:
+        secret = "generated-lab-password"
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            (root / f"failure-{secret}").mkdir()
+            with self.assertRaises(RuntimeError):
+                redact_maestro.sanitize_tree(root, [secret])
+
+    def test_rejects_symlinked_artifact_root_without_touching_target(self) -> None:
+        secret = "generated-lab-password"
+        with tempfile.TemporaryDirectory() as raw:
+            outside = Path(raw) / "outside"
+            outside.mkdir()
+            target = outside / "victim.txt"
+            target.write_text(secret)
+            root = Path(raw) / "artifacts"
+            root.symlink_to(outside, target_is_directory=True)
+
+            with self.assertRaises(RuntimeError):
+                redact_maestro.sanitize_tree(root, [secret])
+            self.assertEqual(target.read_text(), secret)
+
+    def test_rejects_hardlinked_artifact_without_touching_target(self) -> None:
+        secret = "generated-lab-password"
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw) / "artifacts"
+            root.mkdir()
+            target = Path(raw) / "outside.txt"
+            target.write_text(secret)
+            os.link(target, root / "linked.txt")
+
+            with self.assertRaises(RuntimeError):
+                redact_maestro.sanitize_tree(root, [secret])
+            self.assertEqual(target.read_text(), secret)
+
+
+class ReportTests(unittest.TestCase):
+    PNG = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+    )
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name).resolve()
+        self.flows = self.root / "e2e" / "maestro" / "flows"
+        self.run_dir = (
+            self.root
+            / "e2e"
+            / "maestro"
+            / ".artifacts"
+            / "suites"
+            / "smoke"
+            / "20260717T010203Z.abcdef"
+        )
+        (self.root / "docs" / "testing").mkdir(parents=True)
+        (self.run_dir / "raw").mkdir(parents=True)
+        (self.run_dir / "statuses").mkdir()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def configure(self, entries: list[tuple[str, str, str]]) -> None:
+        suite = []
+        proofs = []
+        for index, (flow, user, evidence) in enumerate(entries, 1):
+            path = self.root / flow
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                "url: ${MAESTRO_SERVER_URL}\n"
+                f"name: Report flow {index}\n"
+                "tags:\n"
+                "  - smoke\n"
+                "  - lab\n"
+                "---\n"
+                "- launchApp\n"
+                f"- takeScreenshot: {evidence}\n"
+            )
+            suite.append({"flow": flow, "user": user})
+            proofs.append(
+                {
+                    "case_id": f"AUTH-{index:03d}",
+                    "status": "automated" if index == 1 else "partial",
+                    "runner": "maestro-web",
+                    "specs": [flow],
+                    "scope": f"Safe report scope {index}.",
+                }
+            )
+        (self.root / "e2e" / "maestro" / "suites.json").write_text(
+            json.dumps({"schema_version": 1, "suites": {"smoke": suite}})
+        )
+        (self.root / "docs" / "testing" / "automation.json").write_text(
+            json.dumps({"schema_version": 1, "proofs": proofs})
+        )
+
+    def png_with_text_metadata(self) -> bytes:
+        iend = self.PNG.rfind(b"\x00\x00\x00\x00IEND")
+        self.assertGreater(iend, 0)
+        data = b"Comment\x00private metadata"
+        chunk = reports.png_chunk(b"tEXt", data)
+        return self.PNG[:iend] + chunk + self.PNG[iend:]
+
+    def png_with_chunk(self, kind: bytes, data: bytes) -> bytes:
+        iend = self.PNG.rfind(b"\x00\x00\x00\x00IEND")
+        self.assertGreater(iend, 0)
+        return self.PNG[:iend] + reports.png_chunk(kind, data) + self.PNG[iend:]
+
+    def add_result(
+        self,
+        flow: str,
+        evidence: str,
+        *,
+        exit_code: int,
+        junit_status: str,
+        include_marker: bool = True,
+        include_evidence: bool = True,
+    ) -> Path:
+        slug = reports.flow_slug(flow)
+        raw = self.run_dir / "raw" / slug
+        debug = raw / "debug"
+        debug.mkdir(parents=True)
+        if include_marker:
+            (raw / ".sanitized").write_text("sanitized\n")
+        failure = "<failure>failed</failure>" if junit_status != "SUCCESS" else ""
+        (raw / "report.xml").write_text(
+            "<testsuites><testsuite tests=\"1\" failures=\"0\" time=\"2.5\">"
+            f"<testcase name=\"Report\" status=\"{junit_status}\" time=\"2.5\">"
+            f"{failure}</testcase></testsuite></testsuites>"
+        )
+        (raw / "console.log").write_text(
+            f"root={self.root} target=http://127.0.0.1:43210 result={junit_status}\n"
+        )
+        if include_evidence:
+            (debug / f"{evidence}.png").write_bytes(self.png_with_text_metadata())
+        status = self.run_dir / "statuses" / f"{slug}.exit"
+        status.write_text(f"{exit_code}\n")
+        return raw
+
+    def render(self) -> tuple[Path, bool]:
+        return reports.render_report(
+            root=self.root,
+            suite_name="smoke",
+            run_dir=self.run_dir,
+            harness_revision="abc123def456",
+            harness_dirty=False,
+            harness_sha256=reports.harness_content_sha256(self.root),
+            deployed_this_run=False,
+            reset_requested=False,
+            maestro_version="2.6.1",
+            platform="web",
+            generated_at="2026-07-17T01:02:03Z",
+        )
+
+    def test_renders_portable_passing_report_and_strips_png_metadata(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        self.add_result(flow, evidence, exit_code=0, junit_status="SUCCESS")
+
+        report, valid = self.render()
+
+        self.assertTrue(valid)
+        body = report.read_text()
+        self.assertIn("**PASS**", body)
+        self.assertIn("`AUTH-001` (automated)", body)
+        self.assertIn(f"screenshots/{evidence}.png", body)
+        self.assertNotIn(str(self.root), body)
+        self.assertNotIn("43210", body)
+        copied = report.parent / "screenshots" / f"{evidence}.png"
+        self.assertTrue(copied.is_file())
+        self.assertNotIn(b"tEXt", copied.read_bytes())
+        self.assertNotIn(b"private metadata", copied.read_bytes())
+        self.assertEqual(copied.stat().st_mode & 0o777, 0o600)
+        manifest = json.loads((report.parent / "manifest.json").read_text())
+        self.assertEqual(manifest["summary"]["passed"], 1)
+        self.assertEqual(manifest["harness_revision"], "abc123def456")
+        self.assertFalse(manifest["deployed_this_run"])
+        self.assertEqual(manifest["screenshot_review_status"], "UNREVIEWED")
+        self.assertIn("source revision was not attested", body)
+        self.assertFalse((report.parent / "logs").exists())
+        self.assertNotIn("fake Maestro output", body)
+
+    def test_failure_omits_unreviewed_png_and_marks_later_flow_not_run(self) -> None:
+        first = "e2e/maestro/flows/auth/password-login.yaml"
+        second = "e2e/maestro/flows/navigation/admin-modules.yaml"
+        self.configure(
+            [
+                (first, "lab-admin-b", "evidence-auth-signed-in"),
+                (second, "lab-admin-b", "evidence-admin-modules"),
+            ]
+        )
+        raw = self.add_result(
+            first,
+            "evidence-auth-signed-in",
+            exit_code=1,
+            junit_status="ERROR",
+            include_evidence=False,
+        )
+        (raw / "debug" / "screenshot-failure.png").write_bytes(self.PNG)
+
+        report, valid = self.render()
+
+        self.assertFalse(valid)
+        body = report.read_text()
+        self.assertIn("> **FAIL**", body)
+        self.assertIn("❌ FAIL", body)
+        self.assertIn("⏭️ NOT RUN", body)
+        self.assertIn("automatic failure captures are private", body)
+        self.assertEqual(list((report.parent / "screenshots").iterdir()), [])
+
+    def test_invalid_sanitized_marker_fails_closed(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        raw = self.add_result(flow, evidence, exit_code=0, junit_status="SUCCESS")
+        (raw / ".sanitized").write_text("not-sanitized\n")
+
+        report, valid = self.render()
+
+        self.assertFalse(valid)
+        self.assertIn("⚠️ ERROR", report.read_text())
+        self.assertEqual(list((report.parent / "screenshots").iterdir()), [])
+
+    def test_missing_sanitized_marker_fails_closed_but_writes_report(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        self.add_result(
+            flow,
+            evidence,
+            exit_code=0,
+            junit_status="SUCCESS",
+            include_marker=False,
+        )
+
+        report, valid = self.render()
+
+        self.assertFalse(valid)
+        self.assertIn("⚠️ ERROR", report.read_text())
+        self.assertEqual(list((report.parent / "screenshots").iterdir()), [])
+
+    def test_missing_passing_evidence_writes_failing_normalized_junit(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        self.add_result(
+            flow,
+            evidence,
+            exit_code=0,
+            junit_status="SUCCESS",
+            include_evidence=False,
+        )
+
+        report, passed = self.render()
+
+        self.assertFalse(passed)
+        junit = report.parent / "junit" / "auth-password-login.xml"
+        body = junit.read_text()
+        self.assertIn('failures="1"', body)
+        self.assertIn('status="ERROR"', body)
+
+    def test_rejects_symlink_in_trusted_artifact_tree(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        raw = self.add_result(flow, evidence, exit_code=0, junit_status="SUCCESS")
+        outside = self.root / "outside.txt"
+        outside.write_text("outside")
+        (raw / "linked.txt").symlink_to(outside)
+
+        with self.assertRaises(reports.ReportError):
+            self.render()
+
+        self.assertEqual(list(self.run_dir.glob(".report-staging-*")), [])
+
+    def test_rejects_nonfinite_junit_duration_and_cleans_staging(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        raw = self.add_result(flow, evidence, exit_code=0, junit_status="SUCCESS")
+        (raw / "report.xml").write_text(
+            '<testsuites><testsuite><testcase status="SUCCESS" time="NaN"/>'
+            "</testsuite></testsuites>"
+        )
+
+        with self.assertRaises(reports.ReportError):
+            self.render()
+
+        self.assertEqual(list(self.run_dir.glob(".report-staging-*")), [])
+        self.assertFalse((self.run_dir / "report").exists())
+
+    def test_rejects_non_utf8_junit_declarations(self) -> None:
+        path = self.run_dir / "utf16.xml"
+        xml = (
+            '<?xml version="1.0" encoding="UTF-16"?>'
+            '<!DOCTYPE testsuites [<!ENTITY ok "SUCCESS">]>'
+            '<testsuites><testsuite><testcase status="&ok;" time="1.0"/>'
+            "</testsuite></testsuites>"
+        )
+        path.write_bytes(xml.encode("utf-16"))
+
+        with self.assertRaises(reports.ReportError):
+            reports.parse_junit(path)
+
+    def test_treats_skipped_or_contradictory_junit_as_failure(self) -> None:
+        skipped = self.run_dir / "skipped.xml"
+        skipped.write_text(
+            '<testsuites><testsuite tests="1" failures="0">'
+            '<testcase status="SUCCESS" time="0.1"><skipped/></testcase>'
+            "</testsuite></testsuites>"
+        )
+        contradictory = self.run_dir / "contradictory.xml"
+        contradictory.write_text(
+            '<testsuites><testsuite tests="1" failures="1">'
+            '<testcase status="SUCCESS" time="0.1"/>'
+            "</testsuite></testsuites>"
+        )
+
+        self.assertEqual(reports.parse_junit(skipped), ("FAIL", 0.1))
+        self.assertEqual(reports.parse_junit(contradictory), ("FAIL", 0.1))
+
+    def test_rejects_unknown_critical_png_chunk_and_cleans_staging(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        raw = self.add_result(flow, evidence, exit_code=0, junit_status="SUCCESS")
+        secret = b"SHOULD-NOT-SURVIVE-REPORT"
+        (raw / "debug" / f"{evidence}.png").write_bytes(
+            self.png_with_chunk(b"SECR", secret)
+        )
+
+        with self.assertRaises(reports.ReportError):
+            self.render()
+
+        self.assertEqual(list(self.run_dir.glob(".report-staging-*")), [])
+        self.assertFalse((self.run_dir / "report").exists())
+
+    def test_rejects_duplicate_evidence_names(self) -> None:
+        shared = "evidence-shared"
+        self.configure(
+            [
+                ("e2e/maestro/flows/auth/one.yaml", "lab-admin-b", shared),
+                ("e2e/maestro/flows/navigation/two.yaml", "lab-admin-b", shared),
+            ]
+        )
+
+        with self.assertRaises(reports.ReportError):
+            self.render()
+
+        self.assertEqual(list(self.run_dir.glob(".report-staging-*")), [])
+
+    def test_rejects_duplicate_flow_names(self) -> None:
+        entries = [
+            (
+                "e2e/maestro/flows/auth/one.yaml",
+                "lab-admin-b",
+                "evidence-first",
+            ),
+            (
+                "e2e/maestro/flows/navigation/two.yaml",
+                "lab-admin-b",
+                "evidence-second",
+            ),
+        ]
+        self.configure(entries)
+        second = self.root / entries[1][0]
+        second.write_text(second.read_text().replace("Report flow 2", "Report flow 1"))
+
+        with self.assertRaises(reports.ReportError):
+            self.render()
+
+    def test_rejects_colliding_flattened_flow_slugs(self) -> None:
+        self.configure(
+            [
+                (
+                    "e2e/maestro/flows/foo/bar-baz.yaml",
+                    "lab-admin-b",
+                    "evidence-first",
+                ),
+                (
+                    "e2e/maestro/flows/foo-bar/baz.yaml",
+                    "lab-admin-b",
+                    "evidence-second",
+                ),
+            ]
+        )
+
+        with self.assertRaises(reports.ReportError):
+            self.render()
+
+    def test_escapes_markdown_from_flow_metadata(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        path = self.root / flow
+        path.write_text(
+            path.read_text().replace(
+                "name: Report flow 1",
+                "name: Screenshot ![tracking](https://attacker.invalid/pixel)",
+            )
+        )
+        self.add_result(flow, evidence, exit_code=0, junit_status="SUCCESS")
+
+        report, passed = self.render()
+
+        self.assertTrue(passed)
+        body = report.read_text()
+        self.assertNotIn("![tracking](https://attacker.invalid/pixel)", body)
+        self.assertIn(r"!\[tracking\]", body)
+
+    def test_rejects_harness_changes_during_suite(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        self.add_result(flow, evidence, exit_code=0, junit_status="SUCCESS")
+        original_hash = reports.harness_content_sha256(self.root)
+        (self.root / flow).write_text((self.root / flow).read_text() + "# changed\n")
+
+        with self.assertRaises(reports.ReportError):
+            reports.render_report(
+                root=self.root,
+                suite_name="smoke",
+                run_dir=self.run_dir,
+                harness_revision="abc123def456",
+                harness_dirty=True,
+                harness_sha256=original_hash,
+                deployed_this_run=False,
+                reset_requested=False,
+                maestro_version="2.6.1",
+                platform="web",
+            )
+
+        self.assertEqual(list(self.run_dir.glob(".report-staging-*")), [])
+
+    def test_rechecks_harness_immediately_before_publish(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        self.add_result(flow, evidence, exit_code=0, junit_status="SUCCESS")
+        digest = reports.harness_content_sha256(self.root)
+
+        with mock.patch.object(
+            reports,
+            "harness_content_sha256",
+            side_effect=[digest, "0" * 64],
+        ), self.assertRaises(reports.ReportError):
+            reports.render_report(
+                root=self.root,
+                suite_name="smoke",
+                run_dir=self.run_dir,
+                harness_revision="abc123def456",
+                harness_dirty=False,
+                harness_sha256=digest,
+                deployed_this_run=False,
+                reset_requested=False,
+                maestro_version="2.6.1",
+                platform="web",
+            )
+
+        self.assertEqual(list(self.run_dir.glob(".report-staging-*")), [])
+        self.assertFalse((self.run_dir / "report").exists())
+
+    def test_rejects_unsafe_proof_metadata(self) -> None:
+        flow = "e2e/maestro/flows/auth/password-login.yaml"
+        evidence = "evidence-auth-signed-in"
+        self.configure([(flow, "lab-admin-b", evidence)])
+        automation_path = self.root / "docs" / "testing" / "automation.json"
+        data = json.loads(automation_path.read_text())
+        data["proofs"][0]["case_id"] = "AUTH-001` ![remote](https://attacker.invalid/pixel) `"
+        automation_path.write_text(json.dumps(data))
+
+        with self.assertRaises(reports.ReportError):
+            self.render()
+
+        self.assertEqual(list(self.run_dir.glob(".report-staging-*")), [])
+
+    def test_rejects_symlink_in_artifact_anchor(self) -> None:
+        anchor = self.root / "trusted"
+        outside = self.root / "outside"
+        anchor.mkdir()
+        outside.mkdir()
+        linked = anchor / "linked"
+        linked.symlink_to(outside, target_is_directory=True)
+
+        with self.assertRaises(reports.ReportError):
+            reports.assert_real_path_chain(linked / "child", self.root)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- add atomic private Markdown evidence bundles for Maestro suite runs
- embed one explicit passing-flow screenshot, normalized JUnit, a machine-readable manifest, timings, role labels, and catalog traceability
- content-address the harness and report whether the candidate was deployed/reset by the run
- decode and canonically re-encode evidence PNGs while excluding console logs and automatic failure captures
- fail closed on unsafe paths, symlinks, hardlinks, malformed PNG/JUnit, duplicate report identities, harness mutation, and runner/JUnit disagreements
- document the report layout, privacy boundary, and required human screenshot review

## Why

The private disposable lab needs a useful result artifact that one operator can inspect without copying raw Maestro output or accidentally packaging credentials, workstation details, or unreviewed failure screens. This creates that evidence layer while keeping the report explicitly private until its screenshots are reviewed.

## User/developer impact

`make maestro-lab-smoke` now prints a path under `e2e/maestro/.artifacts/suites/` containing `REPORT.md`, `manifest.json`, canonical screenshots, and normalized JUnit. Each current smoke flow ends at a deterministic fixture-only evidence checkpoint. A valid failing result now propagates a nonzero suite exit instead of being announced as a pass.

## Verification

- `make check-test-automation` (40 Python tests, shell runner tests, 584-case catalog validator)
- `python3 -m py_compile scripts/render_maestro_report.py scripts/check_test_automation.py scripts/redact_maestro.py scripts/maestro_safety.py`
- `bash -n scripts/run-maestro-lab.sh scripts/run-maestro-flow.sh scripts/tests/maestro-runner-test.sh`
- `shellcheck scripts/run-maestro-lab.sh scripts/run-maestro-flow.sh scripts/tests/maestro-runner-test.sh`
- `git diff --check`
- live private-lab smoke run: 3/3 passed in 93 seconds; all three screenshots manually inspected and the final bundle scanned for paths/endpoints/secrets
- independent correctness, security, and adversarial review; final exploit corpus clean
