### PR TITLE
fix(proxy): bind requesters to their effective instance and harden the arr proxy boundary

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -35,7 +35,7 @@ A single Go binary that bridges your arr stack, serves the web UI, and keeps API
 - **Import Doctor** -- Plain-English diagnosis of stuck downloads with one-click fixes (manual/force import, remove+blocklist+re-search, category hand-off, rescan), shared by the app, the AI assistant, and MCP.
 - **Push notifications** -- APNs delivery through a self-hosted push gateway with zero-config auto-enrollment, per-user preference categories, and admin-scoped alerts.
 - **Real-time updates** -- WebSocket hub polls arr queues (30s) and download clients (15s) and pushes progress, queue snapshots, and change pings; arr webhooks make external changes (manual imports, deletes) land instantly.
-- **Arr proxy** -- Read-only Radarr/Sonarr browsing for users, full passthrough for admins, without exposing API keys.
+- **Arr proxy** -- Read-only Radarr/Sonarr browsing for users, ordinary-method passthrough for admins (tunnel/reflection methods blocked for everyone), without exposing API keys.
 - **Secrets encrypted at rest** -- Instance API keys/passwords, personal and shared AI credentials, OpenAI OAuth authorization, webhook tokens, and the JWT secret are AES-256-GCM encrypted in SQLite.
 - **Flutter web embed** -- The web build ships inside the binary via `go:embed`. One container, one port, API + UI.
 - **Single Alpine image** -- A static, no-CGO Go server plus the pinned Codex app-server helper, with one exposed port.
@@ -277,7 +277,9 @@ GET|PUT /api/instances/{instanceID}/users    # admin: which users are pinned/ass
 POST   /api/instances/{instanceID}/webhook   # admin: rotate credentials and upsert a managed arr webhook
 ANY    /api/instances/{instanceID}/*         # proxy to the instance's own API; JSON secrets are redacted
 ```
-The proxy allows read-only Radarr/Sonarr browsing (library, queue, history, wanted, calendar) for regular users; writes, commands, interactive search, config, and all non-arr services require admin. JSON responses are bounded and recursively scrubbed for credential fields and secret-bearing URL query parameters before they reach any client. An encoded, malformed, or oversized JSON response fails closed rather than bypassing that scrubber.
+The proxy allows read-only Radarr/Sonarr browsing (library, queue, history, wanted, calendar) for regular users; writes, commands, interactive search, config, and all non-arr services require admin. Requesters are bound to their own effective instance -- their pin, or the deterministic global default/fallback -- exactly as `/api/config` reports it; a sibling instance the admin has hidden cannot be reached by guessing its ID, and instance authorization is classified from stored metadata so an undecryptable secret can never widen access. JSON responses are bounded and recursively scrubbed for credential fields and secret-bearing URL query parameters before they reach any client. An encoded, malformed, streaming, or oversized JSON response fails closed rather than bypassing that scrubber.
+
+The proxy is also a transport trust boundary. `CONNECT`, `TRACE`, and `TRACK` are rejected before instance resolution or any upstream contact, and an upstream protocol upgrade (`101`) is refused, so the HTTP proxy can never become an opaque tunnel or reflect the injected `X-Api-Key`. Inbound Cantinarr session cookies and every forwarded credential, client-identity assertion (reverse-proxy `X-Auth-*`/`Remote-*`/mTLS headers), routing/method-override, and request-trailer header terminate here; only the instance's own `X-Api-Key` is added outbound. Upstream responses are marked private and non-cacheable, and nginx/lighttpd internal-redirect controls (`X-Accel-*`, `X-Sendfile`, `X-Reproxy-URL`) plus response trailers are stripped so a fronting web server cannot be steered by an upstream header.
 
 ### Downloads & monitoring (admin)
 ```

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -452,7 +452,12 @@ func androidAssetLinksHandler(cfg *config.Config) http.HandlerFunc {
 	}
 }
 
-func configHandler(cfg *config.Config, store *instance.Store, creds *credentials.Registry, aiHandler *ai.Handler, remediationService *remediation.Service) http.HandlerFunc {
+type configInstanceStore interface {
+	ListAll() ([]instance.Instance, error)
+	ListUserDefaults(userID int64) (map[string]string, error)
+}
+
+func configHandler(cfg *config.Config, store configInstanceStore, creds *credentials.Registry, aiHandler *ai.Handler, remediationService *remediation.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Cache-Control", "no-store")
 		// Build instances list
@@ -476,8 +481,11 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 		}
 		overrides := map[string]string{}
 		if userID != 0 {
-			if ov, err := store.ListUserDefaults(userID); err == nil {
-				overrides = ov
+			var err error
+			overrides, err = store.ListUserDefaults(userID)
+			if err != nil {
+				http.Error(w, `{"error":"temporarily unavailable, retry shortly"}`, http.StatusServiceUnavailable)
+				return
 			}
 		}
 
@@ -492,10 +500,14 @@ func configHandler(cfg *config.Config, store *instance.Store, creds *credentials
 				if !isAdmin && visibleDefaults[inst.ServiceType] != inst.ID {
 					continue
 				}
-				// Effective default: a per-user override wins over the global
-				// is_default flag for its service type.
+				// A requester's filtered entry is always its effective default,
+				// including the deterministic first-instance fallback when no row
+				// carries the global is_default flag. Admins retain the configured
+				// global flag unless their own per-user override selects a sibling.
 				isDefault := inst.IsDefault
-				if pinned, ok := overrides[inst.ServiceType]; ok {
+				if !isAdmin {
+					isDefault = visibleDefaults[inst.ServiceType] == inst.ID
+				} else if pinned, ok := overrides[inst.ServiceType]; ok {
 					isDefault = pinned == inst.ID
 				}
 				instances = append(instances, instanceInfo{

--- a/server/internal/api/router_test.go
+++ b/server/internal/api/router_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -158,6 +159,272 @@ func TestConfigHandlerShowsAllInstancesForAdmin(t *testing.T) {
 	}
 }
 
+// SEC-018: An unflagged Radarr/Sonarr fallback is still the requester's effective default.
+func TestConfigHandlerMarksDeterministicFallbackAsEffectiveDefault(t *testing.T) {
+	store, creds, remediationSvc, userID := newConfigHandlerTestState(t)
+	// Deliberately insert the lexically later siblings first and leave every
+	// global default flag unset. ListAll's stable order and proxy authorization's
+	// metadata-only fallback both select Alpha.
+	createConfigInstance(t, store, "radarr", "Zulu Radarr", false)
+	alphaRadarr := createConfigInstance(t, store, "radarr", "Alpha Radarr", false)
+	createConfigInstance(t, store, "sonarr", "Zulu Sonarr", false)
+	alphaSonarr := createConfigInstance(t, store, "sonarr", "Alpha Sonarr", false)
+
+	resp := requestConfig(t, store, creds, remediationSvc, &auth.Claims{
+		UserID: userID,
+		Role:   auth.RoleUser,
+	})
+	want := map[string]string{
+		alphaRadarr.ID: "radarr",
+		alphaSonarr.ID: "sonarr",
+	}
+	if len(resp.Instances) != len(want) {
+		t.Fatalf("instances = %#v, want exactly the two deterministic fallbacks", resp.Instances)
+	}
+	for _, inst := range resp.Instances {
+		if want[inst.ID] != inst.ServiceType {
+			t.Fatalf("unexpected fallback instance: %#v", inst)
+		}
+		if !inst.IsDefault {
+			t.Fatalf("effective fallback must be marked default: %#v", inst)
+		}
+	}
+}
+
+// SEC-018: A defaults/grants lookup failure cannot expose global or hidden sibling metadata.
+func TestConfigHandlerFailsClosedWhenUserDefaultsUnavailable(t *testing.T) {
+	_, creds, remediationSvc, userID := newConfigHandlerTestState(t)
+	store := &failingConfigInstanceStore{
+		defaultsErr: errors.New("database detail must stay private"),
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{
+		UserID: userID,
+		Role:   auth.RoleUser,
+	}))
+	rec := httptest.NewRecorder()
+
+	configHandler(&config.Config{}, store, creds, nil, remediationSvc)(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
+	}
+	if store.listAllCalls != 0 {
+		t.Fatalf("ListAll calls = %d, want 0 after defaults lookup failure", store.listAllCalls)
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte(store.defaultsErr.Error())) {
+		t.Fatalf("config error leaked storage detail: %s", rec.Body.String())
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+}
+
+// SEC-018: requester and admin config responses expose only effective, non-secret configuration.
+func TestConfigHandlerResponsesUseLeastPrivilegeSecretFreeShapes(t *testing.T) {
+	store, creds, remediationSvc, userID := newConfigHandlerTestState(t)
+	instances := []instance.Instance{
+		{
+			ServiceType: "radarr", Name: "Main Radarr", IsDefault: true,
+			URL: "https://main-radarr-url-secret.invalid", APIKey: "main-radarr-api-secret",
+			Username: "main-radarr-user-secret", Password: "main-radarr-password-secret",
+		},
+		{
+			ServiceType: "radarr", Name: "Pinned Radarr",
+			URL: "https://pinned-radarr-url-secret.invalid", APIKey: "pinned-radarr-api-secret",
+			Username: "pinned-radarr-user-secret", Password: "pinned-radarr-password-secret",
+		},
+		{
+			ServiceType: "sonarr", Name: "Main Sonarr", IsDefault: true,
+			URL: "https://main-sonarr-url-secret.invalid", APIKey: "main-sonarr-api-secret",
+			Username: "main-sonarr-user-secret", Password: "main-sonarr-password-secret",
+		},
+		{
+			ServiceType: "chaptarr", Name: "Granted Books",
+			URL: "https://books-url-secret.invalid", APIKey: "books-api-secret",
+			Username: "books-user-secret", Password: "books-password-secret",
+		},
+		{
+			ServiceType: "chaptarr", Name: "Private Books",
+			URL: "https://private-books-url-secret.invalid", APIKey: "private-books-api-secret",
+			Username: "private-books-user-secret", Password: "private-books-password-secret",
+		},
+		{
+			ServiceType: "qbittorrent", Name: "Admin Download Client",
+			URL: "https://download-url-secret.invalid", APIKey: "download-api-secret",
+			Username: "download-user-secret", Password: "download-password-secret",
+		},
+	}
+	secretSentinels := make([]string, 0, len(instances)*4+len(credentials.AllKeys)+8)
+	for i := range instances {
+		if err := store.Create(&instances[i]); err != nil {
+			t.Fatalf("create %s instance: %v", instances[i].ServiceType, err)
+		}
+		secretSentinels = append(secretSentinels,
+			instances[i].URL,
+			instances[i].APIKey,
+			instances[i].Username,
+			instances[i].Password,
+		)
+	}
+	if err := store.SetUserDefault(userID, "radarr", instances[1].ID); err != nil {
+		t.Fatalf("pin requester Radarr: %v", err)
+	}
+	if err := store.SetUserDefault(userID, "chaptarr", instances[3].ID); err != nil {
+		t.Fatalf("grant requester Chaptarr: %v", err)
+	}
+	webhookToken, err := store.WebhookToken(instances[1].ID)
+	if err != nil {
+		t.Fatalf("create webhook token: %v", err)
+	}
+	pendingWebhookToken, err := store.PrepareWebhookToken(instances[1].ID)
+	if err != nil {
+		t.Fatalf("prepare webhook token: %v", err)
+	}
+	secretSentinels = append(secretSentinels, webhookToken, pendingWebhookToken)
+
+	for _, key := range credentials.AllKeys {
+		value := "credential-secret-" + key
+		if err := creds.SetCredential(key, value); err != nil {
+			t.Fatalf("seed credential %s: %v", key, err)
+		}
+		secretSentinels = append(secretSentinels, value)
+	}
+
+	cfg := &config.Config{
+		JWTSecret:         "config-jwt-secret",
+		ServerName:        "Coverage Lab",
+		PublicURL:         "https://config-public-url-secret.invalid",
+		EncryptionKeyFile: "/config/encryption-key-path-secret",
+		PushGatewayURL:    "https://config-push-gateway-secret.invalid",
+		PushAPIKey:        "config-push-api-key-secret",
+		PushEnrollToken:   "config-push-enroll-token-secret",
+		CodexBin:          "/config/codex-bin-secret",
+		CodexRuntimeDir:   "/config/codex-runtime-secret",
+	}
+	secretSentinels = append(secretSentinels,
+		cfg.JWTSecret,
+		cfg.PublicURL,
+		cfg.EncryptionKeyFile,
+		cfg.PushGatewayURL,
+		cfg.PushAPIKey,
+		cfg.PushEnrollToken,
+		cfg.CodexBin,
+		cfg.CodexRuntimeDir,
+	)
+
+	tests := []struct {
+		name      string
+		role      string
+		instances map[string]string
+	}{
+		{
+			name: "requester sees only effective defaults and grants",
+			role: auth.RoleUser,
+			instances: map[string]string{
+				instances[1].ID: "radarr",
+				instances[2].ID: "sonarr",
+				instances[3].ID: "chaptarr",
+			},
+		},
+		{
+			name: "admin sees all instance metadata",
+			role: auth.RoleAdmin,
+			instances: map[string]string{
+				instances[0].ID: "radarr",
+				instances[1].ID: "radarr",
+				instances[2].ID: "sonarr",
+				instances[3].ID: "chaptarr",
+				instances[4].ID: "chaptarr",
+				instances[5].ID: "qbittorrent",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+			req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{
+				UserID: userID,
+				Role:   tt.role,
+			}))
+			rec := httptest.NewRecorder()
+			configHandler(cfg, store, creds, nil, remediationSvc)(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+			}
+
+			raw := rec.Body.Bytes()
+			for _, secret := range secretSentinels {
+				if secret != "" && bytes.Contains(raw, []byte(secret)) {
+					t.Fatalf("config response exposed sentinel %q: %s", secret, raw)
+				}
+			}
+			if bytes.Contains(raw, []byte("enc:v1:")) {
+				t.Fatalf("config response exposed an encrypted credential blob: %s", raw)
+			}
+
+			var payload map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &payload); err != nil {
+				t.Fatalf("decode config response: %v", err)
+			}
+			assertExactMapKeys(t, payload,
+				"server_name", "version", "services", "instances", "issues_enabled", "allow_reporting",
+			)
+
+			var services map[string]bool
+			if err := json.Unmarshal(payload["services"], &services); err != nil {
+				t.Fatalf("decode services: %v", err)
+			}
+			assertExactMapKeys(t, services, "radarr", "sonarr", "chaptarr", "ai", "tmdb", "trakt")
+			for _, serviceType := range []string{"radarr", "sonarr", "chaptarr", "ai", "tmdb", "trakt"} {
+				if !services[serviceType] {
+					t.Errorf("services[%q] = false, want true", serviceType)
+				}
+			}
+
+			var gotInstances []map[string]json.RawMessage
+			if err := json.Unmarshal(payload["instances"], &gotInstances); err != nil {
+				t.Fatalf("decode instances: %v", err)
+			}
+			if len(gotInstances) != len(tt.instances) {
+				t.Fatalf("instances = %s, want %d entries", payload["instances"], len(tt.instances))
+			}
+			seen := make(map[string]bool, len(gotInstances))
+			for _, got := range gotInstances {
+				assertExactMapKeys(t, got, "id", "service_type", "name", "is_default")
+				var id, serviceType string
+				if err := json.Unmarshal(got["id"], &id); err != nil {
+					t.Fatalf("decode instance id: %v", err)
+				}
+				if err := json.Unmarshal(got["service_type"], &serviceType); err != nil {
+					t.Fatalf("decode instance service type: %v", err)
+				}
+				wantServiceType, ok := tt.instances[id]
+				if !ok || wantServiceType != serviceType {
+					t.Errorf("unexpected config instance id=%q service_type=%q", id, serviceType)
+				}
+				if seen[id] {
+					t.Errorf("config instance id=%q appeared more than once", id)
+				}
+				seen[id] = true
+			}
+		})
+	}
+}
+
+func assertExactMapKeys[V any](t *testing.T, got map[string]V, want ...string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("JSON keys = %#v, want exactly %v", got, want)
+	}
+	for _, key := range want {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("JSON keys = %#v, missing %q", got, key)
+		}
+	}
+}
+
 type configHandlerResponse struct {
 	Services  map[string]bool `json:"services"`
 	Instances []struct {
@@ -166,6 +433,25 @@ type configHandlerResponse struct {
 		Name        string `json:"name"`
 		IsDefault   bool   `json:"is_default"`
 	} `json:"instances"`
+}
+
+type failingConfigInstanceStore struct {
+	defaultsErr  error
+	listAllCalls int
+}
+
+func (s *failingConfigInstanceStore) ListUserDefaults(int64) (map[string]string, error) {
+	return nil, s.defaultsErr
+}
+
+func (s *failingConfigInstanceStore) ListAll() ([]instance.Instance, error) {
+	s.listAllCalls++
+	return []instance.Instance{{
+		ID:          "hidden-radarr",
+		ServiceType: "radarr",
+		Name:        "Hidden sibling",
+		IsDefault:   true,
+	}}, nil
 }
 
 func newConfigHandlerTestState(t *testing.T) (*instance.Store, *credentials.Registry, *remediation.Service, int64) {

--- a/server/internal/auth/arr_proxy.go
+++ b/server/internal/auth/arr_proxy.go
@@ -2,77 +2,135 @@ package auth
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
 )
 
-// arrReadResources is the allowlist of Servarr resources a non-admin user may
-// read (GET) through the instance proxy, keyed by the first path segment after
-// the API-version marker ("/api/v3/" for Radarr/Sonarr, "/api/v1/" for
-// Chaptarr). It is deliberately limited to browsing data and excludes every
-// credential-bearing or privileged endpoint: indexers, download clients,
-// notifications, import lists, and config/host (which carries the instance's own
-// API key) are all absent, as are interactive indexer search ("release") and
-// command endpoints. Those remain admin-only.
-var arrReadResources = map[string]bool{
-	"movie":           true, // Radarr: library list, detail, lookup
-	"series":          true, // Sonarr: library list, detail, lookup
-	"episode":         true, // Sonarr: episodes for a series
-	"author":          true, // Chaptarr: library list, detail, lookup
-	"book":            true, // Chaptarr: books for an author, detail, lookup
-	"bookfile":        true, // Chaptarr: imported book files
-	"calendar":        true, // upcoming / aired releases
-	"queue":           true, // active download queue (progress only)
-	"history":         true, // grab / import history
-	"wanted":          true, // wanted/missing, wanted/cutoff
-	"qualityprofile":  true, // profile names shown on items
-	"metadataprofile": true, // Chaptarr: metadata profile names
-	"rootfolder":      true, // root folder list
+// arrReadResources is the service-specific allowlist of Servarr resources a
+// non-admin user may read (GET) through the instance proxy. It deliberately
+// excludes every credential-bearing or privileged endpoint: indexers,
+// download clients, notifications, import lists, and config/host (which carries
+// the instance's own API key) are all absent, as are interactive indexer search
+// ("release") and command endpoints. Those remain admin-only.
+var arrReadResources = map[string]map[string]bool{
+	"radarr": {
+		"movie":    true,
+		"calendar": true,
+		"queue":    true,
+		"history":  true,
+		"wanted":   true,
+	},
+	"sonarr": {
+		"series":   true,
+		"episode":  true,
+		"calendar": true,
+		"queue":    true,
+		"history":  true,
+		"wanted":   true,
+	},
+	"chaptarr": {
+		"author":     true,
+		"book":       true,
+		"bookfile":   true,
+		"calendar":   true,
+		"queue":      true,
+		"history":    true,
+		"wanted":     true,
+		"MediaCover": true,
+	},
 }
 
-// arrAPIMarkers are the API-version path segments whose read resources are
-// browsable by non-admins: v3 (Radarr/Sonarr) and v1 (Chaptarr/Readarr).
-var arrAPIMarkers = []string{"/api/v3/", "/api/v1/"}
+// arrAPIPrefixes binds each supported arr service to the API version Cantinarr
+// implements. A path for another version is denied rather than guessed.
+var arrAPIPrefixes = map[string]string{
+	"radarr":   "api/v3/",
+	"sonarr":   "api/v3/",
+	"chaptarr": "api/v1/",
+}
 
 // isArrReadResource reports whether forwardPath — the portion of an instance
-// proxy request after the API-version marker, e.g. "movie/123", "author/7", or
-// "wanted/missing" — targets an allowlisted read resource.
-func isArrReadResource(forwardPath string) bool {
-	// Reject path traversal so an allowlisted prefix can't be used to reach a
-	// non-allowlisted endpoint (e.g. "movie/../config/host") once the reverse
-	// proxy forwards the path to the upstream service.
-	if forwardPath == "" || strings.Contains(forwardPath, "..") {
+// proxy request after the API-version marker — matches a complete allowlisted
+// read route. Matching only the first segment would accidentally expose sibling
+// operations such as movie/lookup or movie/editor.
+func isArrReadResource(serviceType, forwardPath string) bool {
+	// Reject residual escapes, backslashes, empty segments, and traversal before
+	// applying route shapes. These are parsed inconsistently by Go, proxies, and
+	// the .NET arr services and must never broaden an allowlisted route.
+	if forwardPath == "" || strings.Contains(forwardPath, "%") || strings.Contains(forwardPath, "\\") || strings.Contains(forwardPath, "..") {
 		return false
 	}
-	resource := forwardPath
-	if i := strings.IndexByte(forwardPath, '/'); i >= 0 {
-		resource = forwardPath[:i]
-	}
-	return arrReadResources[resource]
-}
-
-// isArrReadPath reports whether urlPath is a Servarr read path. urlPath is the
-// full incoming request path, e.g. "/api/instances/<id>/api/v3/movie" or
-// ".../api/v1/author". Anything that is not a recognized arr API path (other
-// services proxied through the same route, such as download clients) returns
-// false and therefore requires admin access.
-func isArrReadPath(urlPath string) bool {
-	for _, marker := range arrAPIMarkers {
-		if i := strings.Index(urlPath, marker); i >= 0 {
-			return isArrReadResource(urlPath[i+len(marker):])
+	segments := strings.Split(forwardPath, "/")
+	for _, segment := range segments {
+		if segment == "" || segment == "." {
+			return false
 		}
 	}
-	return false
+	resource := segments[0]
+	if !arrReadResources[serviceType][resource] {
+		return false
+	}
+
+	if serviceType == "chaptarr" && resource == "MediaCover" {
+		// The sole requester consumer is an owned-book cover returned as
+		// /MediaCover/Books/{numeric-id}/... . Lookup covers and every other
+		// MediaCover subtree remain admin-only.
+		return len(segments) >= 4 && segments[1] == "Books" && isPositiveDecimalID(segments[2])
+	}
+
+	suffix := segments[1:]
+	switch resource {
+	case "movie", "series", "episode", "author", "book", "bookfile":
+		if len(suffix) == 0 {
+			return true
+		}
+		if serviceType == "chaptarr" && resource == "book" && len(suffix) == 1 && suffix[0] == "lookup" {
+			// Dashboard book discovery has no Cantinarr metadata-provider
+			// equivalent and intentionally uses this exact read-only lookup.
+			return true
+		}
+		return len(suffix) == 1 && isPositiveDecimalID(suffix[0])
+	case "calendar", "queue", "history":
+		return len(suffix) == 0
+	case "wanted":
+		return len(suffix) == 1 && (suffix[0] == "missing" || suffix[0] == "cutoff")
+	default:
+		return false
+	}
 }
 
-// InstanceAccessChecker resolves an instance's service type and whether a user
-// has been granted access to it. Implemented by *instance.Store; declared as an
+func isPositiveDecimalID(value string) bool {
+	if value == "" || value == "0" {
+		return false
+	}
+	for i := 0; i < len(value); i++ {
+		if value[i] < '0' || value[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// isArrReadPath reports whether the proxy-relative wildcard path is an
+// allowlisted read for the concrete service type. Requiring the version prefix
+// at the beginning prevents an arr-looking marker embedded later in a path from
+// being treated as authorization.
+func isArrReadPath(serviceType, forwardPath string) bool {
+	prefix, ok := arrAPIPrefixes[serviceType]
+	if !ok || !strings.HasPrefix(forwardPath, prefix) {
+		return false
+	}
+	return isArrReadResource(serviceType, strings.TrimPrefix(forwardPath, prefix))
+}
+
+// InstanceAccessChecker resolves an instance's service type and whether it is
+// the effective instance exposed to a user. Implemented by *instance.Store; declared as an
 // interface here so the auth package does not import instance (which would form
 // an import cycle).
 type InstanceAccessChecker interface {
 	LookupServiceType(instanceID string) (string, bool, error)
-	UserHasInstanceAccess(userID int64, instanceID string) (bool, error)
+	UserCanAccessInstance(userID int64, instanceID, serviceType string) (bool, error)
 }
 
 // RequireArrProxyAccess authorizes instance-proxy requests. A GET to an
@@ -82,10 +140,10 @@ type InstanceAccessChecker interface {
 // interactive search, config endpoint, or non-arr service — requires the
 // admin-level instances:manage.
 //
-// Service types with no global default (chaptarr) are additionally per-user
-// access-gated: a non-admin may touch a chaptarr instance only if an admin has
-// explicitly granted it to them (a user_default_instances row). The middleware
-// must run after AuthMiddleware and on a route carrying the {instanceID} param.
+// Every requester read is bound to the same effective instance exposed in
+// /api/config: a per-user Radarr/Sonarr pin or global fallback, or an explicit
+// Chaptarr grant. The middleware must run after AuthMiddleware and on a route
+// carrying the {instanceID} param.
 func RequireArrProxyAccess(access InstanceAccessChecker) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -95,30 +153,56 @@ func RequireArrProxyAccess(access InstanceAccessChecker) func(http.Handler) http
 				return
 			}
 
-			isAdmin := HasPermission(claims.Role, PermissionInstancesManage)
-
-			// Per-user access gate for service types without a global default: a
-			// chaptarr instance is reachable by a non-admin only if an admin has
-			// explicitly granted that instance to them. Admins bypass the gate.
-			if !isAdmin {
-				instanceID := chi.URLParam(r, "instanceID")
-				if instanceID != "" {
-					if serviceType, ok, err := access.LookupServiceType(instanceID); err == nil && ok && serviceType == "chaptarr" {
-						granted, err := access.UserHasInstanceAccess(claims.UserID, instanceID)
-						if err != nil || !granted {
-							http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
-							return
-						}
-					}
-				}
+			// Admins may proxy every configured service and operation. In
+			// particular, do not make their access depend on a redundant metadata
+			// lookup; the proxy handler performs the authoritative instance load.
+			if HasPermission(claims.Role, PermissionInstancesManage) {
+				next.ServeHTTP(w, r)
+				return
 			}
 
-			required := PermissionInstancesManage
-			if r.Method == http.MethodGet && isArrReadPath(r.URL.Path) {
-				required = PermissionArrBrowse
+			// A requester can only perform read-only arr browsing. Reject an
+			// unrecognized role or write before consulting instance metadata.
+			if !HasPermission(claims.Role, PermissionArrBrowse) || r.Method != http.MethodGet {
+				http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
+				return
 			}
 
-			if !HasPermission(claims.Role, required) {
+			instanceID := chi.URLParam(r, "instanceID")
+			if instanceID == "" {
+				http.Error(w, `{"error":"instance ID required"}`, http.StatusBadRequest)
+				return
+			}
+
+			serviceType, exists, err := access.LookupServiceType(instanceID)
+			if err != nil {
+				http.Error(w, `{"error":"temporarily unavailable, retry shortly"}`, http.StatusServiceUnavailable)
+				return
+			}
+			if !exists {
+				http.Error(w, `{"error":"instance not found"}`, http.StatusNotFound)
+				return
+			}
+
+			// Chi matches against RawPath when one exists, so unescape the
+			// wildcard before validating it. Otherwise an encoded ".." segment
+			// could pass the textual allowlist and be decoded by the upstream.
+			forwardPath, err := url.PathUnescape(chi.URLParam(r, "*"))
+			if err != nil || !isArrReadPath(serviceType, forwardPath) {
+				http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
+				return
+			}
+
+			// The visible config exposes exactly one effective Radarr/Sonarr
+			// instance (the user's pin or the global default) and one explicitly
+			// granted Chaptarr instance. Enforce that same boundary even when a
+			// caller guesses or retains a hidden sibling instance UUID.
+			allowed, err := access.UserCanAccessInstance(claims.UserID, instanceID, serviceType)
+			if err != nil {
+				http.Error(w, `{"error":"temporarily unavailable, retry shortly"}`, http.StatusServiceUnavailable)
+				return
+			}
+			if !allowed {
 				http.Error(w, `{"error":"permission denied"}`, http.StatusForbidden)
 				return
 			}

--- a/server/internal/auth/arr_proxy_test.go
+++ b/server/internal/auth/arr_proxy_test.go
@@ -2,8 +2,10 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -14,75 +16,117 @@ type mockAccess struct {
 	serviceType string
 	exists      bool
 	granted     bool
+	lookupErr   error
+	grantErr    error
+	lookupCalls int
+	grantCalls  int
 }
 
-func (m mockAccess) LookupServiceType(instanceID string) (string, bool, error) {
-	return m.serviceType, m.exists, nil
+func (m *mockAccess) LookupServiceType(instanceID string) (string, bool, error) {
+	m.lookupCalls++
+	return m.serviceType, m.exists, m.lookupErr
 }
 
-func (m mockAccess) UserHasInstanceAccess(userID int64, instanceID string) (bool, error) {
-	return m.granted, nil
+func (m *mockAccess) UserCanAccessInstance(userID int64, instanceID, serviceType string) (bool, error) {
+	m.grantCalls++
+	return m.granted, m.grantErr
 }
 
-// AUTH-023: Requester arr proxy access is limited to the read allowlist.
+// AUTH-023: Requester arr proxy access is service-, version-, and resource-bound.
 func TestIsArrReadPath(t *testing.T) {
 	tests := []struct {
-		path string
-		want bool
+		name        string
+		serviceType string
+		path        string
+		want        bool
 	}{
-		// Allowlisted Radarr/Sonarr v3 read resources.
-		{"/api/instances/abc/api/v3/movie", true},
-		{"/api/instances/abc/api/v3/movie/123", true},
-		{"/api/instances/abc/api/v3/movie/lookup", true},
-		{"/api/instances/abc/api/v3/series", true},
-		{"/api/instances/abc/api/v3/episode", true},
-		{"/api/instances/abc/api/v3/calendar", true},
-		{"/api/instances/abc/api/v3/queue", true},
-		{"/api/instances/abc/api/v3/history", true},
-		{"/api/instances/abc/api/v3/wanted/missing", true},
-		{"/api/instances/abc/api/v3/qualityprofile", true},
-		{"/api/instances/abc/api/v3/rootfolder", true},
+		// Allowlisted Radarr v3 read resources.
+		{"radarr movie list", "radarr", "api/v3/movie", true},
+		{"radarr movie detail", "radarr", "api/v3/movie/123", true},
+		{"radarr calendar", "radarr", "api/v3/calendar", true},
+		{"radarr queue", "radarr", "api/v3/queue", true},
+		{"radarr history", "radarr", "api/v3/history", true},
+		{"radarr wanted", "radarr", "api/v3/wanted/missing", true},
+
+		// Allowlisted Sonarr v3 read resources.
+		{"sonarr series", "sonarr", "api/v3/series", true},
+		{"sonarr episode", "sonarr", "api/v3/episode", true},
+		{"sonarr calendar", "sonarr", "api/v3/calendar", true},
+		{"sonarr queue", "sonarr", "api/v3/queue", true},
+		{"sonarr history", "sonarr", "api/v3/history", true},
+		{"sonarr wanted", "sonarr", "api/v3/wanted/cutoff", true},
 
 		// Allowlisted Chaptarr v1 read resources.
-		{"/api/instances/abc/api/v1/author", true},
-		{"/api/instances/abc/api/v1/author/7", true},
-		{"/api/instances/abc/api/v1/book/123", true},
-		{"/api/instances/abc/api/v1/book/lookup", true},
-		{"/api/instances/abc/api/v1/bookfile", true},
-		{"/api/instances/abc/api/v1/queue", true},
-		{"/api/instances/abc/api/v1/history", true},
-		{"/api/instances/abc/api/v1/wanted/missing", true},
-		{"/api/instances/abc/api/v1/qualityprofile", true},
-		{"/api/instances/abc/api/v1/metadataprofile", true},
-		{"/api/instances/abc/api/v1/rootfolder", true},
+		{"chaptarr owned cover", "chaptarr", "api/v1/MediaCover/Books/9/cover.jpg", true},
+		{"chaptarr author", "chaptarr", "api/v1/author", true},
+		{"chaptarr author detail", "chaptarr", "api/v1/author/7", true},
+		{"chaptarr book", "chaptarr", "api/v1/book/123", true},
+		{"chaptarr book lookup", "chaptarr", "api/v1/book/lookup", true},
+		{"chaptarr book file", "chaptarr", "api/v1/bookfile", true},
+		{"chaptarr calendar", "chaptarr", "api/v1/calendar", true},
+		{"chaptarr queue", "chaptarr", "api/v1/queue", true},
+		{"chaptarr history", "chaptarr", "api/v1/history", true},
+		{"chaptarr wanted", "chaptarr", "api/v1/wanted/missing", true},
 
-		// Privileged / credential-bearing — must NOT be user-readable (v3 or v1).
-		{"/api/instances/abc/api/v3/config/host", false},
-		{"/api/instances/abc/api/v3/notification", false},
-		{"/api/instances/abc/api/v3/downloadclient", false},
-		{"/api/instances/abc/api/v3/indexer", false},
-		{"/api/instances/abc/api/v3/importlist", false},
-		{"/api/instances/abc/api/v3/system/status", false},
-		{"/api/instances/abc/api/v3/command", false},
-		{"/api/instances/abc/api/v3/release", false},
-		{"/api/instances/abc/api/v1/config/host", false},
-		{"/api/instances/abc/api/v1/command", false},
-		{"/api/instances/abc/api/v1/release", false},
+		// Service identity and version are part of the allowlist.
+		{"radarr cannot read sonarr resource", "radarr", "api/v3/series", false},
+		{"sonarr cannot read radarr resource", "sonarr", "api/v3/movie", false},
+		{"chaptarr cannot read radarr resource", "chaptarr", "api/v1/movie", false},
+		{"radarr v1 rejected", "radarr", "api/v1/movie", false},
+		{"sonarr v1 rejected", "sonarr", "api/v1/series", false},
+		{"chaptarr v3 rejected", "chaptarr", "api/v3/author", false},
+		{"download client rejected", "sabnzbd", "api/v3/movie", false},
+		{"unknown service rejected", "future-arr", "api/v3/movie", false},
 
-		// Path traversal must not escape the allowlist.
-		{"/api/instances/abc/api/v3/movie/../config/host", false},
-		{"/api/instances/abc/api/v1/author/../config/host", false},
+		// Privileged / credential-bearing resources are never requester-readable.
+		{"config", "radarr", "api/v3/config/host", false},
+		{"notification", "radarr", "api/v3/notification", false},
+		{"download client config", "sonarr", "api/v3/downloadclient", false},
+		{"indexer", "sonarr", "api/v3/indexer", false},
+		{"import list", "radarr", "api/v3/importlist", false},
+		{"system status", "sonarr", "api/v3/system/status", false},
+		{"command", "radarr", "api/v3/command", false},
+		{"release search", "sonarr", "api/v3/release", false},
+		{"radarr external metadata lookup", "radarr", "api/v3/movie/lookup", false},
+		{"sonarr external metadata lookup", "sonarr", "api/v3/series/lookup", false},
+		{"chaptarr author metadata lookup", "chaptarr", "api/v1/author/lookup", false},
+		{"radarr editor subroute", "radarr", "api/v3/movie/editor", false},
+		{"history arbitrary subroute", "sonarr", "api/v3/history/series", false},
+		{"chaptarr config", "chaptarr", "api/v1/config/host", false},
+		{"chaptarr command", "chaptarr", "api/v1/command", false},
+		{"chaptarr release search", "chaptarr", "api/v1/release", false},
+		{"radarr quality profiles", "radarr", "api/v3/qualityprofile", false},
+		{"radarr root folders", "radarr", "api/v3/rootfolder", false},
+		{"sonarr quality profiles", "sonarr", "api/v3/qualityprofile", false},
+		{"sonarr root folders", "sonarr", "api/v3/rootfolder", false},
+		{"chaptarr quality profiles", "chaptarr", "api/v1/qualityprofile", false},
+		{"chaptarr metadata profiles", "chaptarr", "api/v1/metadataprofile", false},
+		{"chaptarr root folders", "chaptarr", "api/v1/rootfolder", false},
+		{"chaptarr lookup cover proxy", "chaptarr", "api/v1/MediaCoverProxy/cover.jpg", false},
+		{"chaptarr bare media cover", "chaptarr", "api/v1/MediaCover", false},
+		{"chaptarr authors media cover", "chaptarr", "api/v1/MediaCover/Authors/9/fanart.jpg", false},
+		{"chaptarr config media cover", "chaptarr", "api/v1/MediaCover/Config/9/secret.txt", false},
+		{"chaptarr media cover without id", "chaptarr", "api/v1/MediaCover/Books/cover.jpg", false},
+		{"chaptarr media cover zero id", "chaptarr", "api/v1/MediaCover/Books/0/cover.jpg", false},
+		{"chaptarr lowercase media cover", "chaptarr", "api/v1/mediacover/Books/9/cover.jpg", false},
+		{"radarr media cover remains admin only", "radarr", "api/v3/MediaCover/1/poster.jpg", false},
 
-		// Non-arr proxy paths (e.g. download clients) are not reads.
-		{"/api/instances/abc/api/v2/torrents/info", false},
-		{"/api/instances/abc/", false},
-		{"/api/instances/abc/api/v3/", false},
-		{"/api/instances/abc/api/v1/", false},
+		// Traversal, embedded markers, and empty resources fail closed.
+		{"radarr traversal", "radarr", "api/v3/movie/../config/host", false},
+		{"chaptarr traversal", "chaptarr", "api/v1/author/../config/host", false},
+		{"chaptarr cover traversal", "chaptarr", "api/v1/MediaCover/Books/9/../config.xml", false},
+		{"marker embedded later", "radarr", "prefix/api/v3/movie", false},
+		{"wrong API family", "radarr", "api/v2/torrents/info", false},
+		{"empty path", "radarr", "", false},
+		{"empty v3 resource", "radarr", "api/v3/", false},
+		{"empty v1 resource", "chaptarr", "api/v1/", false},
 	}
 	for _, tt := range tests {
-		if got := isArrReadPath(tt.path); got != tt.want {
-			t.Errorf("isArrReadPath(%q) = %v, want %v", tt.path, got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isArrReadPath(tt.serviceType, tt.path); got != tt.want {
+				t.Errorf("isArrReadPath(%q, %q) = %v, want %v", tt.serviceType, tt.path, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -91,35 +135,40 @@ func TestIsArrReadPath(t *testing.T) {
 func withRouteContext(req *http.Request, instanceID string) *http.Request {
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("instanceID", instanceID)
+	prefix := "/api/instances/" + instanceID + "/"
+	rctx.URLParams.Add("*", strings.TrimPrefix(req.URL.EscapedPath(), prefix))
 	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 }
 
 // AUTH-023: Requester writes and privileged arr reads are denied.
 func TestRequireArrProxyAccess(t *testing.T) {
 	tests := []struct {
-		name   string
-		role   string
-		method string
-		path   string
-		want   int
+		name        string
+		role        string
+		serviceType string
+		method      string
+		path        string
+		want        int
 	}{
-		{"user reads movie library", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/movie", http.StatusOK},
-		{"user reads calendar", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/calendar", http.StatusOK},
-		{"user reads series", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/series", http.StatusOK},
-		{"user reads queue", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/queue", http.StatusOK},
-		{"user cannot read config", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/config/host", http.StatusForbidden},
-		{"user cannot add movie", RoleUser, http.MethodPost, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
-		{"user cannot delete movie", RoleUser, http.MethodDelete, "/api/instances/abc/api/v3/movie/1", http.StatusForbidden},
-		{"user cannot interactive search", RoleUser, http.MethodGet, "/api/instances/abc/api/v3/release", http.StatusForbidden},
-		{"admin reads config", RoleAdmin, http.MethodGet, "/api/instances/abc/api/v3/config/host", http.StatusOK},
-		{"admin adds movie", RoleAdmin, http.MethodPost, "/api/instances/abc/api/v3/movie", http.StatusOK},
+		{"user reads movie library", RoleUser, "radarr", http.MethodGet, "/api/instances/abc/api/v3/movie", http.StatusOK},
+		{"user reads calendar", RoleUser, "radarr", http.MethodGet, "/api/instances/abc/api/v3/calendar", http.StatusOK},
+		{"user reads series", RoleUser, "sonarr", http.MethodGet, "/api/instances/abc/api/v3/series", http.StatusOK},
+		{"user reads queue", RoleUser, "sonarr", http.MethodGet, "/api/instances/abc/api/v3/queue", http.StatusOK},
+		{"user cannot read config", RoleUser, "radarr", http.MethodGet, "/api/instances/abc/api/v3/config/host", http.StatusForbidden},
+		{"user cannot add movie", RoleUser, "radarr", http.MethodPost, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
+		{"user cannot replace movie", RoleUser, "radarr", http.MethodPut, "/api/instances/abc/api/v3/movie/1", http.StatusForbidden},
+		{"user cannot patch movie", RoleUser, "radarr", http.MethodPatch, "/api/instances/abc/api/v3/movie/1", http.StatusForbidden},
+		{"user cannot delete movie", RoleUser, "radarr", http.MethodDelete, "/api/instances/abc/api/v3/movie/1", http.StatusForbidden},
+		{"user cannot run command", RoleUser, "sonarr", http.MethodPost, "/api/instances/abc/api/v3/command", http.StatusForbidden},
+		{"user cannot interactive search", RoleUser, "sonarr", http.MethodGet, "/api/instances/abc/api/v3/release", http.StatusForbidden},
+		{"unknown role cannot browse", "future-role", "radarr", http.MethodGet, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
+		{"admin reads config", RoleAdmin, "radarr", http.MethodGet, "/api/instances/abc/api/v3/config/host", http.StatusOK},
+		{"admin adds movie", RoleAdmin, "radarr", http.MethodPost, "/api/instances/abc/api/v3/movie", http.StatusOK},
 	}
 
-	// For radarr/sonarr the access checker reports a non-gated service type, so
-	// only the resource/permission rules apply.
-	access := mockAccess{serviceType: "sonarr", exists: true}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			access := &mockAccess{serviceType: tt.serviceType, exists: true, granted: true}
 			nextCalled := false
 			h := RequireArrProxyAccess(access)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				nextCalled = true
@@ -137,6 +186,12 @@ func TestRequireArrProxyAccess(t *testing.T) {
 			if wantNext := tt.want == http.StatusOK; nextCalled != wantNext {
 				t.Fatalf("nextCalled = %v, want %v", nextCalled, wantNext)
 			}
+			if tt.role == RoleAdmin && access.lookupCalls != 0 {
+				t.Fatalf("admin lookup calls = %d, want 0", access.lookupCalls)
+			}
+			if tt.role == RoleUser && tt.method != http.MethodGet && access.lookupCalls != 0 {
+				t.Fatalf("write lookup calls = %d, want 0", access.lookupCalls)
+			}
 		})
 	}
 }
@@ -148,22 +203,25 @@ func TestRequireArrProxyAccess(t *testing.T) {
 // AUTH-023: Per-instance grants never broaden requester proxy access to writes.
 func TestRequireArrProxyAccess_ChaptarrGate(t *testing.T) {
 	tests := []struct {
-		name    string
-		role    string
-		method  string
-		path    string
-		granted bool
-		want    int
+		name     string
+		role     string
+		method   string
+		path     string
+		granted  bool
+		grantErr error
+		want     int
 	}{
-		{"granted user reads chaptarr", RoleUser, http.MethodGet, "/api/instances/chaptarr-1/api/v1/author", true, http.StatusOK},
-		{"non-granted user blocked", RoleUser, http.MethodGet, "/api/instances/chaptarr-1/api/v1/author", false, http.StatusForbidden},
-		{"granted user cannot write", RoleUser, http.MethodPost, "/api/instances/chaptarr-1/api/v1/release", true, http.StatusForbidden},
-		{"admin reads without grant", RoleAdmin, http.MethodGet, "/api/instances/chaptarr-1/api/v1/author", false, http.StatusOK},
-		{"admin writes without grant", RoleAdmin, http.MethodPost, "/api/instances/chaptarr-1/api/v1/release", false, http.StatusOK},
+		{"granted user reads chaptarr", RoleUser, http.MethodGet, "/api/instances/chaptarr-1/api/v1/author", true, nil, http.StatusOK},
+		{"granted user reads owned cover", RoleUser, http.MethodGet, "/api/instances/chaptarr-1/api/v1/MediaCover/Books/9/cover.jpg", true, nil, http.StatusOK},
+		{"non-granted user blocked", RoleUser, http.MethodGet, "/api/instances/chaptarr-1/api/v1/author", false, nil, http.StatusForbidden},
+		{"grant lookup fault is retryable", RoleUser, http.MethodGet, "/api/instances/chaptarr-1/api/v1/author", false, errors.New("database unavailable"), http.StatusServiceUnavailable},
+		{"granted user cannot write", RoleUser, http.MethodPost, "/api/instances/chaptarr-1/api/v1/release", true, nil, http.StatusForbidden},
+		{"admin reads without grant", RoleAdmin, http.MethodGet, "/api/instances/chaptarr-1/api/v1/author", false, nil, http.StatusOK},
+		{"admin writes without grant", RoleAdmin, http.MethodPost, "/api/instances/chaptarr-1/api/v1/release", false, nil, http.StatusOK},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			access := mockAccess{serviceType: "chaptarr", exists: true, granted: tt.granted}
+			access := &mockAccess{serviceType: "chaptarr", exists: true, granted: tt.granted, grantErr: tt.grantErr}
 			nextCalled := false
 			h := RequireArrProxyAccess(access)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				nextCalled = true
@@ -181,13 +239,215 @@ func TestRequireArrProxyAccess_ChaptarrGate(t *testing.T) {
 			if wantNext := tt.want == http.StatusOK; nextCalled != wantNext {
 				t.Fatalf("nextCalled = %v, want %v", nextCalled, wantNext)
 			}
+			if tt.role == RoleAdmin && (access.lookupCalls != 0 || access.grantCalls != 0) {
+				t.Fatalf("admin access calls = lookup:%d grant:%d, want zero", access.lookupCalls, access.grantCalls)
+			}
+			if tt.method != http.MethodGet && tt.role != RoleAdmin && (access.lookupCalls != 0 || access.grantCalls != 0) {
+				t.Fatalf("write access calls = lookup:%d grant:%d, want zero", access.lookupCalls, access.grantCalls)
+			}
+		})
+	}
+}
+
+// AUTH-023: Non-arr, missing, unknown, and unavailable instance lookups fail closed.
+func TestRequireArrProxyAccess_ServiceBoundary(t *testing.T) {
+	tests := []struct {
+		name        string
+		serviceType string
+		exists      bool
+		lookupErr   error
+		path        string
+		want        int
+	}{
+		{"radarr read admitted", "radarr", true, nil, "/api/instances/abc/api/v3/movie", http.StatusOK},
+		{"sonarr read admitted", "sonarr", true, nil, "/api/instances/abc/api/v3/series", http.StatusOK},
+		{"radarr rejects sonarr resource", "radarr", true, nil, "/api/instances/abc/api/v3/series", http.StatusForbidden},
+		{"radarr rejects v1", "radarr", true, nil, "/api/instances/abc/api/v1/movie", http.StatusForbidden},
+		{"sonarr rejects v1", "sonarr", true, nil, "/api/instances/abc/api/v1/series", http.StatusForbidden},
+		{"sabnzbd rejects arr-shaped path", "sabnzbd", true, nil, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
+		{"qbittorrent rejects arr-shaped path", "qbittorrent", true, nil, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
+		{"nzbget rejects arr-shaped path", "nzbget", true, nil, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
+		{"transmission rejects arr-shaped path", "transmission", true, nil, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
+		{"tautulli rejects arr-shaped path", "tautulli", true, nil, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
+		{"unknown service rejects arr-shaped path", "future-service", true, nil, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
+		{"empty service rejects arr-shaped path", "", true, nil, "/api/instances/abc/api/v3/movie", http.StatusForbidden},
+		{"missing instance is not found", "", false, nil, "/api/instances/abc/api/v3/movie", http.StatusNotFound},
+		{"lookup fault is retryable", "", false, errors.New("database unavailable"), "/api/instances/abc/api/v3/movie", http.StatusServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			access := &mockAccess{
+				serviceType: tt.serviceType,
+				exists:      tt.exists,
+				lookupErr:   tt.lookupErr,
+				granted:     tt.want == http.StatusOK,
+			}
+			nextCalled := false
+			h := RequireArrProxyAccess(access)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := withRouteContext(httptest.NewRequest(http.MethodGet, tt.path, nil), "abc")
+			req = req.WithContext(context.WithValue(req.Context(), ClaimsKey, &Claims{Role: RoleUser, UserID: 7}))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tt.want, rec.Body.String())
+			}
+			if wantNext := tt.want == http.StatusOK; nextCalled != wantNext {
+				t.Fatalf("nextCalled = %v, want %v", nextCalled, wantNext)
+			}
+			if access.lookupCalls != 1 {
+				t.Fatalf("lookup calls = %d, want 1", access.lookupCalls)
+			}
+			wantGrantCalls := 0
+			if tt.want == http.StatusOK {
+				wantGrantCalls = 1
+			}
+			if access.grantCalls != wantGrantCalls {
+				t.Fatalf("effective-instance calls = %d, want %d", access.grantCalls, wantGrantCalls)
+			}
+			if tt.lookupErr != nil && strings.Contains(rec.Body.String(), tt.lookupErr.Error()) {
+				t.Fatalf("lookup error leaked in response: %s", rec.Body.String())
+			}
+		})
+	}
+
+	t.Run("missing route parameter", func(t *testing.T) {
+		access := &mockAccess{serviceType: "radarr", exists: true}
+		h := RequireArrProxyAccess(access)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			t.Fatal("handler should not run without an instance ID")
+		}))
+		req := withRouteContext(httptest.NewRequest(http.MethodGet, "/api/instances/abc/api/v3/movie", nil), "")
+		req = req.WithContext(context.WithValue(req.Context(), ClaimsKey, &Claims{Role: RoleUser, UserID: 7}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
+		}
+		if access.lookupCalls != 0 {
+			t.Fatalf("lookup calls = %d, want 0", access.lookupCalls)
+		}
+	})
+
+	t.Run("admin bypasses failing lookup", func(t *testing.T) {
+		access := &mockAccess{serviceType: "sabnzbd", exists: true, lookupErr: errors.New("database unavailable")}
+		nextCalled := false
+		h := RequireArrProxyAccess(access)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			nextCalled = true
+			w.WriteHeader(http.StatusOK)
+		}))
+		req := withRouteContext(httptest.NewRequest(http.MethodPost, "/api/instances/abc/api", nil), "abc")
+		req = req.WithContext(context.WithValue(req.Context(), ClaimsKey, &Claims{Role: RoleAdmin, UserID: 1}))
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK || !nextCalled {
+			t.Fatalf("status = %d nextCalled = %v, want 200/true", rec.Code, nextCalled)
+		}
+		if access.lookupCalls != 0 || access.grantCalls != 0 {
+			t.Fatalf("admin access calls = lookup:%d grant:%d, want zero", access.lookupCalls, access.grantCalls)
+		}
+	})
+}
+
+// AUTH-023: A valid read path is still bound to the requester's one effective instance.
+func TestRequireArrProxyAccess_EffectiveInstanceBoundary(t *testing.T) {
+	tests := []struct {
+		name      string
+		allowed   bool
+		accessErr error
+		want      int
+	}{
+		{name: "effective instance admitted", allowed: true, want: http.StatusOK},
+		{name: "hidden sibling denied", want: http.StatusForbidden},
+		{name: "effective instance lookup fault is retryable", accessErr: errors.New("database unavailable"), want: http.StatusServiceUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			access := &mockAccess{
+				serviceType: "radarr",
+				exists:      true,
+				granted:     tt.allowed,
+				grantErr:    tt.accessErr,
+			}
+			nextCalled := false
+			h := RequireArrProxyAccess(access)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			}))
+			req := withRouteContext(
+				httptest.NewRequest(http.MethodGet, "/api/instances/radarr-sibling/api/v3/movie", nil),
+				"radarr-sibling",
+			)
+			req = req.WithContext(context.WithValue(req.Context(), ClaimsKey, &Claims{Role: RoleUser, UserID: 7}))
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != tt.want {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tt.want, rec.Body.String())
+			}
+			if nextCalled != (tt.want == http.StatusOK) {
+				t.Fatalf("nextCalled = %v, want %v", nextCalled, tt.want == http.StatusOK)
+			}
+			if access.lookupCalls != 1 || access.grantCalls != 1 {
+				t.Fatalf("access calls = lookup:%d effective:%d, want 1/1", access.lookupCalls, access.grantCalls)
+			}
+			if tt.accessErr != nil && strings.Contains(rec.Body.String(), tt.accessErr.Error()) {
+				t.Fatalf("effective-instance error leaked in response: %s", rec.Body.String())
+			}
+		})
+	}
+}
+
+// AUTH-023: Encoded path traversal cannot escape an allowlisted arr resource.
+func TestRequireArrProxyAccess_RejectsEncodedTraversal(t *testing.T) {
+	for _, path := range []string{
+		"/api/instances/abc/api/v3/movie/%2e%2e/config/host",
+		"/api/instances/abc/api/v3/movie/%2E%2E/config/host",
+		"/api/instances/abc/api/v3/movie%2f..%2fconfig/host",
+		"/api/instances/abc/api/v3/movie/%252e%252e/config/host",
+		"/api/instances/abc/api/v3/movie%252f..%252fconfig/host",
+	} {
+		t.Run(path, func(t *testing.T) {
+			access := &mockAccess{serviceType: "radarr", exists: true, granted: true}
+			nextCalled := false
+			router := chi.NewRouter()
+			router.With(RequireArrProxyAccess(access)).Handle("/api/instances/{instanceID}/*", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			req = req.WithContext(context.WithValue(req.Context(), ClaimsKey, &Claims{Role: RoleUser, UserID: 7}))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+			}
+			if nextCalled {
+				t.Fatal("handler ran for encoded traversal")
+			}
+			if access.lookupCalls != 1 || access.grantCalls != 0 {
+				t.Fatalf(
+					"access calls = lookup:%d effective:%d, want 1/0 (path classification must reject before the effective-instance lookup)",
+					access.lookupCalls,
+					access.grantCalls,
+				)
+			}
 		})
 	}
 }
 
 // AUTH-023: Anonymous proxy access fails closed.
 func TestRequireArrProxyAccess_RequiresClaims(t *testing.T) {
-	h := RequireArrProxyAccess(mockAccess{})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	h := RequireArrProxyAccess(&mockAccess{})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Fatal("handler should not run without claims")
 	}))
 	req := withRouteContext(httptest.NewRequest(http.MethodGet, "/api/instances/abc/api/v3/movie", nil), "abc")

--- a/server/internal/credentials/registry_test.go
+++ b/server/internal/credentials/registry_test.go
@@ -2,7 +2,10 @@ package credentials
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"log"
+	"strings"
 	"testing"
 	"time"
 
@@ -160,6 +163,125 @@ func TestIsAIConfiguredExcludesUserOAuth(t *testing.T) {
 	}
 	if !registry.IsAIConfigured() {
 		t.Fatal("shared AI did not report configured for selected API-key provider")
+	}
+}
+
+// SEC-002: persisted credential reads fail closed without rewriting tampered or wrong-key ciphertext.
+func TestGetCredentialDecryptionFailurePreservesStoredCiphertext(t *testing.T) {
+	const (
+		credentialValue = "synthetic-persisted-credential-secret"
+		envelopePrefix  = "enc:v1:"
+		gcmNonceSize    = 12
+	)
+
+	mutateEnvelope := func(t *testing.T, stored []byte, index func([]byte) int) []byte {
+		t.Helper()
+		if !bytes.HasPrefix(stored, []byte(envelopePrefix)) {
+			t.Fatalf("stored credential is not an encrypted envelope: %q", stored)
+		}
+		raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(string(stored), envelopePrefix))
+		if err != nil {
+			t.Fatalf("decode stored credential: %v", err)
+		}
+		position := index(raw)
+		if position < 0 || position >= len(raw) {
+			t.Fatalf("mutation index %d outside envelope of %d bytes", position, len(raw))
+		}
+		raw[position] ^= 0x01
+		return []byte(envelopePrefix + base64.StdEncoding.EncodeToString(raw))
+	}
+
+	tests := []struct {
+		name      string
+		mutate    func(t *testing.T, stored []byte) []byte
+		readerKey byte
+	}{
+		{
+			name: "tampered ciphertext",
+			mutate: func(t *testing.T, stored []byte) []byte {
+				return mutateEnvelope(t, stored, func(raw []byte) int {
+					if len(raw) <= gcmNonceSize {
+						t.Fatalf("encrypted envelope has no ciphertext: %d bytes", len(raw))
+					}
+					return gcmNonceSize
+				})
+			},
+			readerKey: 0x42,
+		},
+		{
+			name: "tampered authentication tag",
+			mutate: func(t *testing.T, stored []byte) []byte {
+				return mutateEnvelope(t, stored, func(raw []byte) int { return len(raw) - 1 })
+			},
+			readerKey: 0x42,
+		},
+		{
+			name:      "wrong key",
+			mutate:    func(_ *testing.T, stored []byte) []byte { return stored },
+			readerKey: 0x07,
+		},
+	}
+
+	previousLogWriter := log.Writer()
+	var capturedLog bytes.Buffer
+	log.SetOutput(&capturedLog)
+	t.Cleanup(func() { log.SetOutput(previousLogWriter) })
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, err := db.Open(":memory:")
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = database.Close() })
+
+			writerCipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x42}, 32))
+			if err != nil {
+				t.Fatalf("create writer cipher: %v", err)
+			}
+			writer := NewRegistry(database, writerCipher)
+			if err := writer.SetCredential(KeyOpenAIKey, credentialValue); err != nil {
+				t.Fatalf("seed encrypted credential: %v", err)
+			}
+
+			var encrypted []byte
+			if err := database.QueryRow(
+				"SELECT CAST(value AS BLOB) FROM settings WHERE key = ?", KeyOpenAIKey,
+			).Scan(&encrypted); err != nil {
+				t.Fatalf("read encrypted credential: %v", err)
+			}
+			before := tt.mutate(t, append([]byte(nil), encrypted...))
+			if _, err := database.Exec(
+				"UPDATE settings SET value = ? WHERE key = ?", string(before), KeyOpenAIKey,
+			); err != nil {
+				t.Fatalf("replace stored credential: %v", err)
+			}
+
+			readerCipher, err := secrets.NewCipher(bytes.Repeat([]byte{tt.readerKey}, 32))
+			if err != nil {
+				t.Fatalf("create reader cipher: %v", err)
+			}
+			capturedLog.Reset()
+			if got := NewRegistry(database, readerCipher).GetCredential(KeyOpenAIKey); got != "" {
+				t.Fatalf("GetCredential returned %q, want fail-closed empty value", got)
+			}
+			if output := capturedLog.String(); strings.Contains(output, credentialValue) || strings.Contains(output, string(before)) {
+				t.Fatalf("decryption log exposed stored credential material: %s", output)
+			}
+
+			var after []byte
+			if err := database.QueryRow(
+				"SELECT CAST(value AS BLOB) FROM settings WHERE key = ?", KeyOpenAIKey,
+			).Scan(&after); err != nil {
+				t.Fatalf("read rejected credential: %v", err)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatalf("rejected credential was rewritten: before=%q after=%q", before, after)
+			}
+			if len(after) == 0 {
+				t.Fatal("rejected credential was overwritten with an empty/default value")
+			}
+		})
 	}
 }
 

--- a/server/internal/instance/registry.go
+++ b/server/internal/instance/registry.go
@@ -390,17 +390,17 @@ func (r *Registry) InvalidateClient(instanceID string) {
 }
 
 // LookupServiceType returns an instance's service type and whether the
-// instance exists. It lets leaf service packages (e.g. tautulli, whose client
-// type this package caches) resolve instances without importing this package.
+// instance exists. It uses the metadata-only lookup so authorization never
+// needs to read or decrypt the instance's stored credentials.
 func (s *Store) LookupServiceType(instanceID string) (string, bool, error) {
-	inst, err := s.Get(instanceID)
+	serviceType, err := s.ServiceTypeOf(instanceID)
 	if err != nil {
 		return "", false, err
 	}
-	if inst == nil {
+	if serviceType == "" {
 		return "", false, nil
 	}
-	return inst.ServiceType, true, nil
+	return serviceType, true, nil
 }
 
 // getInstanceOfType loads an instance and verifies its service type.

--- a/server/internal/instance/store.go
+++ b/server/internal/instance/store.go
@@ -72,7 +72,7 @@ func (s *Store) encryptSecrets(inst *Instance) (apiKey, password string, err err
 // List returns all instances of the given service type, ordered by sort_order.
 func (s *Store) List(serviceType string) ([]Instance, error) {
 	rows, err := s.db.Query(
-		"SELECT "+instanceColumns+" FROM service_instances WHERE service_type = ? ORDER BY sort_order, name",
+		"SELECT "+instanceColumns+" FROM service_instances WHERE service_type = ? ORDER BY sort_order, name, id",
 		serviceType,
 	)
 	if err != nil {
@@ -85,7 +85,7 @@ func (s *Store) List(serviceType string) ([]Instance, error) {
 // ListAll returns all instances across all service types.
 func (s *Store) ListAll() ([]Instance, error) {
 	rows, err := s.db.Query(
-		"SELECT " + instanceColumns + " FROM service_instances ORDER BY service_type, sort_order, name",
+		"SELECT " + instanceColumns + " FROM service_instances ORDER BY service_type, sort_order, name, id",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list all instances: %w", err)
@@ -400,13 +400,13 @@ func (s *Store) Delete(id string) error {
 func (s *Store) GetDefault(serviceType string) (*Instance, error) {
 	var inst Instance
 	err := s.db.QueryRow(
-		"SELECT "+instanceColumns+" FROM service_instances WHERE service_type = ? AND is_default = 1 ORDER BY sort_order LIMIT 1",
+		"SELECT "+instanceColumns+" FROM service_instances WHERE service_type = ? AND is_default = 1 ORDER BY sort_order, name, id LIMIT 1",
 		serviceType,
 	).Scan(&inst.ID, &inst.ServiceType, &inst.Name, &inst.URL, &inst.APIKey, &inst.Username, &inst.Password, &inst.IsDefault, &inst.SortOrder, &inst.CreatedAt)
 	if err == sql.ErrNoRows {
 		// Fall back to first instance
 		err = s.db.QueryRow(
-			"SELECT "+instanceColumns+" FROM service_instances WHERE service_type = ? ORDER BY sort_order LIMIT 1",
+			"SELECT "+instanceColumns+" FROM service_instances WHERE service_type = ? ORDER BY sort_order, name, id LIMIT 1",
 			serviceType,
 		).Scan(&inst.ID, &inst.ServiceType, &inst.Name, &inst.URL, &inst.APIKey, &inst.Username, &inst.Password, &inst.IsDefault, &inst.SortOrder, &inst.CreatedAt)
 	}
@@ -596,6 +596,56 @@ func (s *Store) UserHasInstanceAccess(userID int64, instanceID string) (bool, er
 		return false, fmt.Errorf("check user instance access: %w", err)
 	}
 	return true, nil
+}
+
+// UserCanAccessInstance reports whether instanceID is the service instance
+// exposed to a requester: their per-user pin when present, otherwise the global
+// Radarr/Sonarr default. Chaptarr deliberately has no global fallback, so its
+// per-user row is an explicit grant. All lookups are metadata-only and never
+// decrypt the instance's credentials.
+func (s *Store) UserCanAccessInstance(userID int64, instanceID, serviceType string) (bool, error) {
+	pinnedID, pinned, err := s.GetUserDefault(userID, serviceType)
+	if err != nil {
+		return false, err
+	}
+	if pinned {
+		return pinnedID == instanceID, nil
+	}
+	if serviceType == "chaptarr" {
+		return false, nil
+	}
+	if serviceType != "radarr" && serviceType != "sonarr" {
+		return false, nil
+	}
+
+	defaultID, err := s.defaultInstanceID(serviceType)
+	if err != nil {
+		return false, err
+	}
+	return defaultID != "" && defaultID == instanceID, nil
+}
+
+// defaultInstanceID mirrors GetDefault's explicit-default-then-first fallback
+// without selecting or decrypting any credential columns.
+func (s *Store) defaultInstanceID(serviceType string) (string, error) {
+	var instanceID string
+	err := s.db.QueryRow(
+		"SELECT id FROM service_instances WHERE service_type = ? AND is_default = 1 ORDER BY sort_order, name, id LIMIT 1",
+		serviceType,
+	).Scan(&instanceID)
+	if err == sql.ErrNoRows {
+		err = s.db.QueryRow(
+			"SELECT id FROM service_instances WHERE service_type = ? ORDER BY sort_order, name, id LIMIT 1",
+			serviceType,
+		).Scan(&instanceID)
+	}
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("get default instance id: %w", err)
+	}
+	return instanceID, nil
 }
 
 // Count returns the number of instances for a service type.

--- a/server/internal/instance/store_test.go
+++ b/server/internal/instance/store_test.go
@@ -47,6 +47,134 @@ func mkInstance(t *testing.T, s *Store, serviceType, name string) string {
 	return inst.ID
 }
 
+// AUTH-023: Proxy authorization classifies instances without decrypting secrets.
+func TestLookupServiceTypeUsesServiceMetadata(t *testing.T) {
+	s := newTestStore(t)
+	serviceTypes := []string{
+		"radarr",
+		"sonarr",
+		"chaptarr",
+		"sabnzbd",
+		"qbittorrent",
+		"nzbget",
+		"transmission",
+		"tautulli",
+	}
+
+	for _, serviceType := range serviceTypes {
+		instanceID := mkInstance(t, s, serviceType, "Lookup "+serviceType)
+		got, exists, err := s.LookupServiceType(instanceID)
+		if err != nil {
+			t.Fatalf("LookupServiceType(%s): %v", serviceType, err)
+		}
+		if !exists || got != serviceType {
+			t.Fatalf("LookupServiceType(%s) = (%q, %v), want (%q, true)", serviceType, got, exists, serviceType)
+		}
+	}
+
+	if got, exists, err := s.LookupServiceType("missing-instance"); err != nil || exists || got != "" {
+		t.Fatalf("LookupServiceType(missing) = (%q, %v, %v), want (\"\", false, nil)", got, exists, err)
+	}
+
+	corruptID := mkInstance(t, s, "sonarr", "Undecryptable secrets")
+	if _, err := s.db.Exec(
+		"UPDATE service_instances SET api_key = 'enc:v1:not-valid-base64!' WHERE id = ?",
+		corruptID,
+	); err != nil {
+		t.Fatalf("corrupt encrypted API key: %v", err)
+	}
+	if _, err := s.Get(corruptID); err == nil {
+		t.Fatal("Get with corrupt encrypted API key unexpectedly succeeded")
+	}
+	if got, exists, err := s.LookupServiceType(corruptID); err != nil || !exists || got != "sonarr" {
+		t.Fatalf("metadata lookup with corrupt secret = (%q, %v, %v), want (sonarr, true, nil)", got, exists, err)
+	}
+
+	if err := s.db.Close(); err != nil {
+		t.Fatalf("close database: %v", err)
+	}
+	if _, _, err := s.LookupServiceType(corruptID); err == nil {
+		t.Fatal("LookupServiceType on closed database unexpectedly succeeded")
+	}
+}
+
+// AUTH-023: requester proxy access follows the same deterministic effective instance shown in config.
+func TestUserCanAccessInstanceUsesEffectiveDefaults(t *testing.T) {
+	s := newTestStore(t)
+	alice := createUser(t, s, "effective-alice")
+	bob := createUser(t, s, "effective-bob")
+
+	// Insert the lexically later name first with tied sort order. The fallback
+	// must still select Alpha, matching ListAll/effectiveUserInstanceIDs rather
+	// than SQLite insertion order.
+	zulu := &Instance{
+		ServiceType: "radarr", Name: "Zulu", URL: "http://zulu.invalid",
+		APIKey: "zulu-key", SortOrder: 0,
+	}
+	alpha := &Instance{
+		ServiceType: "radarr", Name: "Alpha", URL: "http://alpha.invalid",
+		APIKey: "alpha-key", SortOrder: 0,
+	}
+	for _, inst := range []*Instance{zulu, alpha} {
+		if err := s.Create(inst); err != nil {
+			t.Fatalf("create %s: %v", inst.Name, err)
+		}
+	}
+
+	assertAccess := func(userID int64, instanceID, serviceType string, want bool) {
+		t.Helper()
+		got, err := s.UserCanAccessInstance(userID, instanceID, serviceType)
+		if err != nil {
+			t.Fatalf("UserCanAccessInstance(%d, %s, %s): %v", userID, instanceID, serviceType, err)
+		}
+		if got != want {
+			t.Fatalf("UserCanAccessInstance(%d, %s, %s) = %v, want %v", userID, instanceID, serviceType, got, want)
+		}
+	}
+
+	assertAccess(alice, alpha.ID, "radarr", true)
+	assertAccess(alice, zulu.ID, "radarr", false)
+	assertAccess(bob, alpha.ID, "radarr", true)
+	assertAccess(bob, zulu.ID, "radarr", false)
+
+	if err := s.SetUserDefault(alice, "radarr", zulu.ID); err != nil {
+		t.Fatalf("pin Alice to Zulu: %v", err)
+	}
+	assertAccess(alice, alpha.ID, "radarr", false)
+	assertAccess(alice, zulu.ID, "radarr", true)
+	assertAccess(bob, alpha.ID, "radarr", true)
+
+	// A global-default change affects unpinned users immediately but never
+	// broadens them to both siblings.
+	zulu.IsDefault = true
+	if err := s.Update(zulu); err != nil {
+		t.Fatalf("make Zulu global default: %v", err)
+	}
+	assertAccess(bob, alpha.ID, "radarr", false)
+	assertAccess(bob, zulu.ID, "radarr", true)
+	if err := s.ClearUserDefault(alice, "radarr"); err != nil {
+		t.Fatalf("clear Alice override: %v", err)
+	}
+	assertAccess(alice, zulu.ID, "radarr", true)
+	assertAccess(alice, alpha.ID, "radarr", false)
+
+	booksA := mkInstance(t, s, "chaptarr", "Books A")
+	booksB := mkInstance(t, s, "chaptarr", "Books B")
+	assertAccess(alice, booksA, "chaptarr", false)
+	assertAccess(alice, booksB, "chaptarr", false)
+	if err := s.SetUserDefault(alice, "chaptarr", booksB); err != nil {
+		t.Fatalf("grant Alice Books B: %v", err)
+	}
+	assertAccess(alice, booksA, "chaptarr", false)
+	assertAccess(alice, booksB, "chaptarr", true)
+
+	assertAccess(alice, zulu.ID, "sabnzbd", false)
+	if _, err := s.db.Exec("UPDATE service_instances SET api_key = 'enc:v1:corrupt' WHERE id = ?", zulu.ID); err != nil {
+		t.Fatalf("corrupt default secret: %v", err)
+	}
+	assertAccess(alice, zulu.ID, "radarr", true)
+}
+
 func TestUserDefaultInstances(t *testing.T) {
 	s := newTestStore(t)
 	user := createUser(t, s, "alice")

--- a/server/internal/proxy/handler.go
+++ b/server/internal/proxy/handler.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -21,6 +22,18 @@ func NewHandler(store *instance.Store) *Handler {
 // InstanceProxy proxies requests to a specific service instance by ID.
 func (h *Handler) InstanceProxy() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// CONNECT is a tunnel protocol, while TRACE/TRACK can reflect the stored
+		// upstream API key injected by this proxy. None is an ordinary arr API
+		// method. Reject them before even resolving the instance so the all-callers
+		// credential and body-inspection boundary cannot be bypassed.
+		if isUnsafeProxyMethod(r.Method) {
+			w.Header().Set("Content-Type", "application/json")
+			enforcePrivateProxyCachePolicy(w.Header())
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			_, _ = io.WriteString(w, `{"error":"proxy method is not supported"}`)
+			return
+		}
+
 		instanceID := chi.URLParam(r, "instanceID")
 		if instanceID == "" {
 			http.Error(w, `{"error":"instance ID required"}`, http.StatusBadRequest)
@@ -52,18 +65,40 @@ func (h *Handler) InstanceProxy() http.HandlerFunc {
 	}
 }
 
+func isUnsafeProxyMethod(method string) bool {
+	return strings.EqualFold(method, http.MethodConnect) ||
+		strings.EqualFold(method, http.MethodTrace) ||
+		strings.EqualFold(method, "TRACK")
+}
+
 func (h *Handler) proxyRequest(w http.ResponseWriter, r *http.Request, target *url.URL, apiKey, stripPrefix string) {
 	proxy := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
+		Rewrite: func(proxyRequest *httputil.ProxyRequest) {
+			req := proxyRequest.Out
 			// The inbound Cantinarr session and every credential-like client header
 			// terminate at this trust boundary. Only the instance's own API key is
 			// added after stripping; a user's bearer JWT/cookies must never reach an
-			// administrator-configured upstream host.
+			// administrator-configured upstream host. Rewrite runs after Go removes
+			// hop-by-hop and Connection-nominated headers, so a client cannot arrange
+			// for those removals to discard the upstream credentials added below.
 			for name := range req.Header {
-				if isSensitiveQueryName(name) {
+				if isSensitiveQueryName(name) || isClientCookieHeader(name) || isClientForwardingHeader(name) || isClientRoutingMetadataHeader(name) || isClientIdentityCredentialHeader(name) {
 					req.Header.Del(name)
 				}
 			}
+			// ReverseProxy intentionally re-adds requested upgrade headers before
+			// Rewrite runs. Cantinarr cannot inspect bytes after a 101 switch, so no
+			// client (including an admin) may turn this HTTP proxy into an arbitrary
+			// bidirectional tunnel.
+			req.Header.Del("Connection")
+			req.Header.Del("Upgrade")
+			req.Header.Del("HTTP2-Settings")
+			// Client trailers arrive only after the outbound body has been read, so
+			// deleting their declaration is not enough. Remove the trailer map as
+			// well, and do not advertise trailer support to the upstream.
+			req.Header.Del("Trailer")
+			req.Header.Del("Te")
+			req.Trailer = nil
 			req.URL.Scheme = target.Scheme
 			req.URL.Host = target.Host
 			req.URL.Path = joinURLPath(target.Path, strings.TrimPrefix(req.URL.Path, stripPrefix))
@@ -75,12 +110,14 @@ func (h *Handler) proxyRequest(w http.ResponseWriter, r *http.Request, target *u
 			// bypass the response sanitizer.
 			req.Header.Set("Accept-Encoding", "identity")
 		},
-		ModifyResponse: sanitizeProxyResponse,
+		ModifyResponse: sanitizeProxyTransportResponse,
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
 			// ModifyResponse errors are intentionally opaque: an upstream parse
 			// error must never reflect the response body (and any embedded secret)
 			// back to the client or into the default ReverseProxy error log.
+			sanitizeResponseHeaders(w.Header())
 			w.Header().Set("Content-Type", "application/json")
+			enforcePrivateProxyCachePolicy(w.Header())
 			w.WriteHeader(http.StatusBadGateway)
 			_, _ = w.Write([]byte(`{"error":"unsafe upstream response"}`))
 		},
@@ -94,6 +131,141 @@ func (h *Handler) proxyRequest(w http.ResponseWriter, r *http.Request, target *u
 	proxy.ServeHTTP(w, r)
 }
 
+// sanitizeProxyTransportResponse applies the content scrubber and then removes
+// response trailers. Transport populates Response.Trailer only after Body reaches
+// EOF, so the body wrapper clears it after every read as well as at Close.
+func sanitizeProxyTransportResponse(resp *http.Response) error {
+	if resp.StatusCode == http.StatusSwitchingProtocols {
+		sanitizeResponseHeaders(resp.Header)
+		return errUnsanitizableUpgrade
+	}
+	if err := sanitizeProxyResponse(resp); err != nil {
+		return err
+	}
+
+	resp.Header.Del("Trailer")
+	resp.Trailer = nil
+	if resp.Body != nil && resp.Body != http.NoBody {
+		resp.Body = &trailerDroppingResponseBody{ReadCloser: resp.Body, response: resp}
+	}
+	return nil
+}
+
+type trailerDroppingResponseBody struct {
+	io.ReadCloser
+	response *http.Response
+}
+
+func (b *trailerDroppingResponseBody) Read(p []byte) (int, error) {
+	n, err := b.ReadCloser.Read(p)
+	b.response.Trailer = nil
+	return n, err
+}
+
+func (b *trailerDroppingResponseBody) Close() error {
+	err := b.ReadCloser.Close()
+	b.response.Trailer = nil
+	return err
+}
+
 func joinURLPath(base, path string) string {
 	return strings.TrimRight(base, "/") + "/" + strings.TrimLeft(path, "/")
+}
+
+// isClientCookieHeader matches every cookie-family request header. The shared
+// sensitive-name rule catches "Cookie" but not spellings like "Cookie2", which
+// still carry a client session that must not reach an upstream arr.
+func isClientCookieHeader(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	return strings.HasPrefix(name, "cookie") || name == "set-cookie"
+}
+
+func isClientForwardingHeader(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "forwarded" || name == "x-forwarded" || strings.HasPrefix(name, "x-forwarded-") {
+		return true
+	}
+	switch name {
+	case "cf-connecting-ip",
+		"client-ip",
+		"fastly-client-ip",
+		"fly-client-ip",
+		"true-client-ip",
+		"via",
+		"x-cluster-client-ip",
+		"x-envoy-external-address",
+		"x-original-forwarded-for",
+		"x-real-ip":
+		return true
+	default:
+		return false
+	}
+}
+
+func isClientRoutingMetadataHeader(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if strings.HasPrefix(name, "x-original-") || strings.HasPrefix(name, "x-rewrite-") || strings.HasPrefix(name, "sec-websocket-") {
+		return true
+	}
+	switch name {
+	case "origin",
+		"referer",
+		"x-envoy-original-path",
+		"x-http-method",
+		"x-http-method-override",
+		"x-method-override",
+		"x-override-method":
+		return true
+	default:
+		return false
+	}
+}
+
+// Identity-aware reverse proxies inject signed assertions and identity
+// metadata after the public client connection is authenticated. Those values
+// belong to Cantinarr's trust boundary and must not be forwarded to an arr,
+// even when their header names do not use a generic token/credential suffix.
+func isClientIdentityCredentialHeader(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if strings.HasPrefix(name, "cf-access-") ||
+		strings.HasPrefix(name, "remote-") ||
+		strings.HasPrefix(name, "ssl-client-") ||
+		strings.HasPrefix(name, "ssl_client_") ||
+		strings.HasPrefix(name, "x-amzn-oidc-") ||
+		strings.HasPrefix(name, "x-auth-") ||
+		strings.HasPrefix(name, "x-auth-request-") ||
+		strings.HasPrefix(name, "x-authenticated-") ||
+		strings.HasPrefix(name, "x-authentik-") ||
+		strings.HasPrefix(name, "x-client-cert-") ||
+		strings.HasPrefix(name, "x-envoy-peer-metadata") ||
+		strings.HasPrefix(name, "x-goog-authenticated-user-") ||
+		strings.HasPrefix(name, "x-goog-iap-") ||
+		strings.HasPrefix(name, "x-identity-") ||
+		strings.HasPrefix(name, "x-keycloak-") ||
+		strings.HasPrefix(name, "x-ms-client-principal") ||
+		strings.HasPrefix(name, "x-ms-token-aad-") ||
+		strings.HasPrefix(name, "x-pomerium-") ||
+		strings.HasPrefix(name, "x-remote-") ||
+		strings.HasPrefix(name, "x-spiffe-") ||
+		strings.HasPrefix(name, "x-ssl-client-") ||
+		strings.HasPrefix(name, "x-tls-client-") ||
+		strings.HasPrefix(name, "x-user-") ||
+		strings.HasPrefix(name, "x_ssl_client_") {
+		return true
+	}
+	switch name {
+	case "dpop",
+		"x-client-cert",
+		"x-client-dn",
+		"x-email",
+		"x-groups",
+		"x-principal",
+		"x-roles",
+		"x-subject",
+		"x-user",
+		"x-username":
+		return true
+	default:
+		return false
+	}
 }

--- a/server/internal/proxy/handler_test.go
+++ b/server/internal/proxy/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
@@ -120,26 +121,100 @@ func startTestProxyWithBasePath(t *testing.T, upstream http.Handler, basePath st
 
 // SEC-004: Cantinarr credentials are stripped before upstream auth is applied.
 func TestInstanceProxyStripsCantinarrCredentialsBeforeUpstream(t *testing.T) {
+	var clientFacingHost string
 	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for _, name := range []string{"Authorization", "Cookie", "X-Session-Token", "Proxy-Authorization"} {
-			if got := r.Header.Get(name); got != "" {
+		for _, name := range []string{
+			"Authorization",
+			"Cf-Connecting-Ip",
+			"Client-Ip",
+			"Connection",
+			"Cookie",
+			"Cookie2",
+			"Fastly-Client-Ip",
+			"Fly-Client-Ip",
+			"Forwarded",
+			"Proxy-Authorization",
+			"True-Client-Ip",
+			"Via",
+			"X-Cluster-Client-Ip",
+			"X-Connection-Only-Secret",
+			"X-Envoy-External-Address",
+			"X-Forwarded",
+			"X-Forwarded-For",
+			"X-Forwarded-Host",
+			"X-Forwarded-Port",
+			"X-Forwarded-Proto",
+			"X-Original-Forwarded-For",
+			"X-Real-Ip",
+			"X-Session-Token",
+		} {
+			if got := r.Header.Values(name); len(got) != 0 {
 				t.Errorf("upstream received %s: %q", name, got)
 			}
 		}
 		if got := r.Header.Get("X-Api-Key"); got != "test-instance-api-key" {
-			t.Errorf("upstream X-Api-Key = %q", got)
+			t.Errorf("upstream X-Api-Key = %q, want stored instance key", got)
+		}
+		if got := r.Header.Get("Accept-Encoding"); got != "identity" {
+			t.Errorf("upstream Accept-Encoding = %q, want identity", got)
+		}
+		if got := r.Header.Get("X-Request-Id"); got != "safe-correlation-id" {
+			t.Errorf("upstream X-Request-Id = %q, want preserved safe header", got)
+		}
+		if got := r.URL.Path; got != "/api/v3/system/status" {
+			t.Errorf("upstream path = %q", got)
+		}
+		if got := r.URL.Query().Get("term"); got != "dune" {
+			t.Errorf("upstream safe query = %q, want dune", got)
+		}
+		if got := r.URL.Query().Get("page"); got != "2" {
+			t.Errorf("upstream page query = %q, want 2", got)
+		}
+		if r.Host == "" || r.Host == clientFacingHost {
+			t.Errorf("upstream Host = %q, want configured upstream host", r.Host)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"ok":true}`))
 	}))
-	req, err := http.NewRequest(http.MethodGet, proxyURL+"/api/instances/"+instanceID+"/api/v3/system/status", nil)
+	parsedProxyURL, err := url.Parse(proxyURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientFacingHost = parsedProxyURL.Host
+	req, err := http.NewRequest(http.MethodGet, proxyURL+"/api/instances/"+instanceID+"/api/v3/system/status?term=dune&page=2", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	req.Header.Set("Authorization", "Bearer cantinarr-jwt-secret")
 	req.Header.Set("Cookie", "session=cantinarr-cookie-secret")
+	req.Header.Add("Cookie", "second=cantinarr-cookie-secret")
+	req.Header.Set("Cookie2", "session=cantinarr-cookie2-secret")
+	req.Header.Set("Forwarded", "for=192.0.2.1;host=client.invalid;proto=https")
+	req.Header.Add("Forwarded", "for=192.0.2.2")
+	req.Header.Set("CF-Connecting-IP", "192.0.2.6")
+	req.Header.Set("Client-IP", "192.0.2.7")
+	req.Header.Set("Fastly-Client-IP", "192.0.2.8")
+	req.Header.Set("Fly-Client-IP", "192.0.2.9")
+	req.Header.Set("True-Client-IP", "192.0.2.10")
+	req.Header.Set("Via", "1.1 internal-proxy.invalid")
+	req.Header.Set("X-Cluster-Client-IP", "192.0.2.11")
+	req.Header.Set("X-Envoy-External-Address", "192.0.2.12")
+	req.Header.Set("X-Forwarded", "for=192.0.2.3")
+	req.Header.Set("X-Forwarded-For", "192.0.2.4")
+	req.Header.Set("X-Forwarded-Host", "client.invalid")
+	req.Header.Set("X-Forwarded-Port", "443")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	req.Header.Set("X-Original-Forwarded-For", "192.0.2.13")
+	req.Header.Set("X-Real-IP", "192.0.2.5")
 	req.Header.Set("X-Session-Token", "custom-secret")
 	req.Header.Set("Proxy-Authorization", "Basic proxy-secret")
+	req.Header.Set("X-Api-Key", "attacker-controlled-api-key")
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set("X-Request-Id", "safe-correlation-id")
+	req.Header.Set("X-Connection-Only-Secret", "connection-nominated-secret")
+	// These hop-by-hop nominations previously removed the stored API key and
+	// identity encoding after Director injected them.
+	req.Header.Set("Connection", "X-Api-Key, Accept-Encoding, X-Connection-Only-Secret")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("proxy request: %v", err)
@@ -159,9 +234,15 @@ func TestJoinURLPathPreservesInstanceBasePath(t *testing.T) {
 // INST-018: Nested proxy JSON and secret-bearing URLs are recursively scrubbed.
 func TestInstanceProxyRedactsNestedSecretsAndURLQueries(t *testing.T) {
 	const (
-		objectSecret = "object-secret-value"
-		querySecret  = "query-secret-value"
-		tokenSecret  = "token-secret-value"
+		objectSecret        = "object-secret-value"
+		querySecret         = "query-secret-value"
+		tokenSecret         = "token-secret-value"
+		authorizationSecret = "authorization-secret-value"
+		cookieSecret        = "cookie-secret-value"
+		encodedQuerySecret  = "encoded-query-secret-value"
+		repeatedQuerySecret = "repeated-query-secret-value"
+		userinfoName        = "url-user-secret"
+		userinfoPassword    = "url-password-secret"
 	)
 	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Accept-Encoding"); got != "identity" {
@@ -181,7 +262,13 @@ func TestInstanceProxyRedactsNestedSecretsAndURLQueries(t *testing.T) {
 				},
 				"nested": [
 					{"access_token": "` + tokenSecret + `"},
-					{"name": "apiKey", "value": "` + querySecret + `"}
+					{"name": "apiKey", "value": "` + querySecret + `"},
+					{
+						"AuThOrIzAtIoN": "Bearer ` + authorizationSecret + `",
+						"cOoKiE": "session=` + cookieSecret + `",
+						"redirectUrl": "https://` + userinfoName + `:` + userinfoPassword + `@indexer.invalid/next?safe=kept&API%4bEY=` + encodedQuerySecret + `&ToKeN=` + tokenSecret + `&token=` + repeatedQuerySecret + `#result",
+						"ordinaryField": "preserved"
+					}
 				]
 			}]
 		}`))
@@ -196,7 +283,17 @@ func TestInstanceProxyRedactsNestedSecretsAndURLQueries(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
 	}
-	for _, secret := range []string{objectSecret, querySecret, tokenSecret} {
+	for _, secret := range []string{
+		objectSecret,
+		querySecret,
+		tokenSecret,
+		authorizationSecret,
+		cookieSecret,
+		encodedQuerySecret,
+		repeatedQuerySecret,
+		userinfoName,
+		userinfoPassword,
+	} {
 		if bytes.Contains(body, []byte(secret)) {
 			t.Fatal("proxied response retained a synthetic secret")
 		}
@@ -232,6 +329,19 @@ func TestInstanceProxyRedactsNestedSecretsAndURLQueries(t *testing.T) {
 	keyValue := record["nested"].([]any)[1].(map[string]any)
 	if keyValue["value"] != redactedValue {
 		t.Errorf("dynamic key/value credential was not redacted")
+	}
+	credentials := record["nested"].([]any)[2].(map[string]any)
+	if credentials["AuThOrIzAtIoN"] != redactedValue || credentials["cOoKiE"] != redactedValue {
+		t.Errorf("nested authorization/cookie fields were not redacted: %v", credentials)
+	}
+	if credentials["ordinaryField"] != "preserved" {
+		t.Errorf("ordinary nested field = %v, want preserved", credentials["ordinaryField"])
+	}
+	redirectURL := credentials["redirectUrl"].(string)
+	if !strings.Contains(redirectURL, "https://indexer.invalid/next?safe=kept") ||
+		!strings.HasSuffix(redirectURL, "#result") ||
+		strings.Count(redirectURL, url.QueryEscape(redactedValue)) != 3 {
+		t.Errorf("nested URL credentials were not selectively redacted: %q", redirectURL)
 	}
 }
 
@@ -300,40 +410,33 @@ func TestInstanceProxySanitizesMislabelledJSONBehindInstanceBasePath(t *testing.
 	}
 }
 
-// SEC-007: SSE stays usable while structured JSON streams fail closed.
-func TestInstanceProxyPreservesSSEAndRejectsStructuredJSONStreams(t *testing.T) {
-	t.Run("server-sent events remain streaming", func(t *testing.T) {
-		const want = "event: update\ndata: {\"safe\":true}\n\n"
-		proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "text/event-stream")
-			_, _ = w.Write([]byte(want))
-		}))
+// SEC-007: Wrong-route SSE and structured JSON streams fail closed without reflecting secrets.
+func TestInstanceProxyRejectsUnsanitizableStreamsWithoutReflectingThem(t *testing.T) {
+	tests := []struct {
+		name         string
+		contentTypes []string
+	}{
+		{"server-sent events", []string{"text/event-stream"}},
+		{"server-sent events with parameters", []string{"text/event-stream; charset=utf-8"}},
+		{"malformed server-sent events", []string{"text/event-stream; charset"}},
+		{"mixed server-sent events and json", []string{"text/event-stream", "application/json"}},
+		{"x-ndjson", []string{"application/x-ndjson"}},
+		{"ndjson", []string{"application/ndjson"}},
+		{"json sequence", []string{"application/json-seq"}},
+		{"stream json", []string{"application/stream+json"}},
+	}
 
-		resp, err := http.Get(proxyURL + "/api/instances/" + instanceID + "/api/v3/events")
-		if err != nil {
-			t.Fatalf("GET: %v", err)
-		}
-		defer resp.Body.Close()
-		body, _ := io.ReadAll(resp.Body)
-		if resp.StatusCode != http.StatusOK || string(body) != want {
-			t.Fatalf("SSE response = status %d body %q, want 200 %q", resp.StatusCode, body, want)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const syntheticSecret = "streaming-response-secret"
+			proxyURL, instanceID := startTestProxyWithBasePath(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				for _, contentType := range tt.contentTypes {
+					w.Header().Add("Content-Type", contentType)
+				}
+				_, _ = w.Write([]byte("data: {\"apiKey\":\"" + syntheticSecret + "\"}\n\n"))
+			}), "/sonarr")
 
-	for _, contentType := range []string{
-		"application/x-ndjson",
-		"application/ndjson",
-		"application/json-seq",
-		"application/stream+json",
-	} {
-		t.Run(contentType, func(t *testing.T) {
-			const syntheticSecret = "streaming-json-secret"
-			proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.Header().Set("Content-Type", contentType)
-				_, _ = w.Write([]byte("{\"apiKey\":\"" + syntheticSecret + "\"}\n"))
-			}))
-
-			resp, err := http.Get(proxyURL + "/api/instances/" + instanceID + "/api/v3/events")
+			resp, err := http.Get(proxyURL + "/api/instances/" + instanceID + "/api/v3/history")
 			if err != nil {
 				t.Fatalf("GET: %v", err)
 			}
@@ -343,33 +446,107 @@ func TestInstanceProxyPreservesSSEAndRejectsStructuredJSONStreams(t *testing.T) 
 				t.Fatalf("status = %d, want 502; body=%s", resp.StatusCode, body)
 			}
 			if bytes.Contains(body, []byte(syntheticSecret)) {
-				t.Fatal("error response reflected unsafe streaming JSON bytes")
+				t.Fatal("error response reflected unsafe streaming bytes")
 			}
 		})
 	}
 }
 
-// SEC-007: Intended non-JSON streams pass through unchanged.
+// SEC-007: Legitimate opaque text and binary streams pass through unbuffered.
 func TestInstanceProxyPassesNonJSONStreamUnchanged(t *testing.T) {
-	want := []byte{0x00, 0x01, 0xfe, 0xff, 'x'}
-	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/octet-stream")
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(want[:2])
-		if flusher, ok := w.(http.Flusher); ok {
-			flusher.Flush()
-		}
-		_, _ = w.Write(want[2:])
-	}))
-
-	resp, err := http.Get(proxyURL + "/api/instances/" + instanceID + "/download")
-	if err != nil {
-		t.Fatalf("GET: %v", err)
+	tests := []struct {
+		name        string
+		path        string
+		contentType string
+		first       []byte
+		second      []byte
+	}{
+		{
+			name:        "binary download",
+			path:        "/download",
+			contentType: "application/octet-stream",
+			first:       []byte{0x00, 0x01},
+			second:      []byte{0xfe, 0xff, 'x'},
+		},
+		{
+			name:        "arr log text",
+			path:        "/api/v3/log/file/server.txt",
+			contentType: "text/plain; charset=utf-8",
+			first:       []byte("first log line\n"),
+			second:      []byte("second log line\n"),
+		},
+		{
+			name:        "arr cover image",
+			path:        "/API/V3/MEDIACOVER/Movies/1/poster.jpg",
+			contentType: "application/octet-stream",
+			first:       []byte{0x89, 'P', 'N', 'G', '\r', '\n'},
+			second:      []byte{0x1a, '\n', 0x00, 0xff},
+		},
 	}
-	defer resp.Body.Close()
-	got, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != http.StatusOK || !bytes.Equal(got, want) {
-		t.Fatalf("non-JSON stream = status %d body %v, want 200 %v", resp.StatusCode, got, want)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			releaseSecondChunk := make(chan struct{})
+			released := false
+			defer func() {
+				if !released {
+					close(releaseSecondChunk)
+				}
+			}()
+
+			proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", tt.contentType)
+				w.Header().Set("Cache-Control", "public, max-age=86400")
+				w.Header().Set("CDN-Cache-Control", "public, s-maxage=86400")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(tt.first)
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					t.Error("upstream response writer does not support flushing")
+					return
+				}
+				flusher.Flush()
+				select {
+				case <-releaseSecondChunk:
+					_, _ = w.Write(tt.second)
+				case <-r.Context().Done():
+				}
+			}))
+
+			client := &http.Client{Timeout: 5 * time.Second}
+			resp, err := client.Get(proxyURL + "/api/instances/" + instanceID + tt.path)
+			if err != nil {
+				t.Fatalf("GET before upstream released second chunk: %v", err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want 200", resp.StatusCode)
+			}
+			if got := resp.Header.Get("Cache-Control"); got != "private, no-store" {
+				t.Errorf("opaque stream Cache-Control = %q, want private, no-store", got)
+			}
+			if got := resp.Header.Get("CDN-Cache-Control"); got != "" {
+				t.Errorf("opaque stream retained shared-cache policy %q", got)
+			}
+
+			first := make([]byte, len(tt.first))
+			if _, err := io.ReadFull(resp.Body, first); err != nil {
+				t.Fatalf("read flushed first chunk: %v", err)
+			}
+			if !bytes.Equal(first, tt.first) {
+				t.Fatalf("first chunk = %v, want %v", first, tt.first)
+			}
+
+			close(releaseSecondChunk)
+			released = true
+			second, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read second chunk: %v", err)
+			}
+			if !bytes.Equal(second, tt.second) {
+				t.Fatalf("second chunk = %v, want %v", second, tt.second)
+			}
+		})
 	}
 }
 

--- a/server/internal/proxy/sanitize.go
+++ b/server/internal/proxy/sanitize.go
@@ -30,6 +30,7 @@ var (
 	errMalformedJSONMediaType  = errors.New("malformed JSON media type")
 	errStreamingJSONResponse   = errors.New("streaming JSON response cannot be sanitized")
 	errJSONResponseSniffFailed = errors.New("could not classify upstream response")
+	errUnsanitizableUpgrade    = errors.New("protocol upgrade cannot be sanitized")
 )
 
 // sanitizeProxyResponse removes credentials that an arr (or one of its
@@ -38,6 +39,12 @@ var (
 // that indexer's API key.
 func sanitizeProxyResponse(resp *http.Response) error {
 	sanitizeResponseHeaders(resp.Header)
+	// An arr sits behind Cantinarr's authenticated boundary; its responses are
+	// per-user and must never be stored by a shared cache. Strip upstream
+	// cache negotiation and the nginx/lighttpd internal-redirect controls that
+	// would otherwise let a fronting reverse proxy re-serve or re-route the body.
+	sanitizeUpstreamControlHeaders(resp.Header)
+	enforcePrivateProxyCachePolicy(resp.Header)
 
 	if responseHasNoBody(resp) {
 		return nil
@@ -85,9 +92,37 @@ func sanitizeProxyResponse(resp *http.Response) error {
 	resp.Header.Del("Content-MD5")
 	resp.Header.Del("Digest")
 	resp.Header.Del("ETag")
+	resp.Header.Del("Last-Modified")
 	resp.Header.Del("Trailer")
 	resp.Trailer = nil
 	return nil
+}
+
+// sanitizeUpstreamControlHeaders removes reverse-proxy control headers that an
+// arr (or something it proxies) may emit. X-Accel-*/X-Sendfile/X-Lighttpd-* and
+// their siblings ask a fronting web server to serve a file or perform an
+// internal redirect, so forwarding them from an untrusted upstream is an
+// internal-redirect vector rather than a benign header.
+func sanitizeUpstreamControlHeaders(header http.Header) {
+	for name := range header {
+		if isUpstreamControlHeader(name) {
+			header.Del(name)
+		}
+	}
+}
+
+func isUpstreamControlHeader(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if strings.HasPrefix(name, "x-accel-") || strings.HasPrefix(name, "x-sendfile") ||
+		strings.HasPrefix(name, "x-lighttpd-send") {
+		return true
+	}
+	switch name {
+	case "x-reproxy-url":
+		return true
+	default:
+		return false
+	}
 }
 
 func responseHasNoBody(resp *http.Response) bool {
@@ -103,21 +138,22 @@ func responseHasNoBody(resp *http.Response) bool {
 // shouldSanitizeJSON classifies every Content-Type value. Explicit JSON is
 // always sanitized and malformed JSON-like types fail closed. For an arr API
 // response carrying an absent or misleading non-streaming type, it peeks at a
-// small prefix and restores those bytes before deciding. Server-sent events
-// remain streaming, while structured JSON stream formats fail closed because
-// forwarding them would bypass the recursive credential scrubber.
+// small prefix and restores those bytes before deciding. Server-sent event and
+// structured JSON stream formats fail closed because forwarding them unbuffered
+// would bypass the recursive credential scrubber; no arr API Cantinarr proxies
+// serves them, and the Flutter client never consumes a proxied stream.
 func shouldSanitizeJSON(resp *http.Response) (bool, error) {
 	isJSON, isEventStream, isJSONStream, malformedJSON := classifyContentTypes(resp.Header.Values("Content-Type"))
 	if malformedJSON {
 		return false, errMalformedJSONMediaType
 	}
-	if isJSONStream {
+	if isEventStream || isJSONStream {
 		return false, errStreamingJSONResponse
 	}
 	if isJSON {
 		return true, nil
 	}
-	if isEventStream || !isArrAPIResponse(resp) || isKnownOpaqueArrAPIResponse(resp) {
+	if !isArrAPIResponse(resp) || isKnownOpaqueArrAPIResponse(resp) {
 		return false, nil
 	}
 	// The proxy requested identity encoding. An encoded, ambiguously typed arr
@@ -141,8 +177,14 @@ func classifyContentTypes(values []string) (isJSON, isEventStream, isJSONStream,
 		for _, contentType := range splitContentTypeValues(headerValue) {
 			mediaType, _, err := mime.ParseMediaType(contentType)
 			if err != nil {
-				if strings.Contains(strings.ToLower(contentType), "json") {
+				lowered := strings.ToLower(contentType)
+				if strings.Contains(lowered, "json") {
 					malformedJSON = true
+				}
+				// A malformed streaming type cannot be classified, so treat it as
+				// a stream and fail closed rather than passing it through opaque.
+				if strings.Contains(lowered, "event-stream") {
+					isEventStream = true
 				}
 				continue
 			}
@@ -510,6 +552,32 @@ func redactURLQuery(raw string) string {
 		return raw
 	}
 	return raw[:question+1] + strings.Join(parts, "&") + raw[queryEnd:]
+}
+
+// enforcePrivateProxyCachePolicy marks a proxy-generated error response as
+// uncacheable and strips upstream shared-cache directives so an intermediary
+// cannot serve it to another client.
+func enforcePrivateProxyCachePolicy(header http.Header) {
+	for name := range header {
+		if isUpstreamSharedCacheDirective(name) {
+			header.Del(name)
+		}
+	}
+	header.Set("Cache-Control", "private, no-store")
+	header.Set("Pragma", "no-cache")
+}
+
+func isUpstreamSharedCacheDirective(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "cdn-cache-control" || strings.HasSuffix(name, "-cdn-cache-control") {
+		return true
+	}
+	switch name {
+	case "age", "akamai-cache-control", "cache-control", "edge-control", "expires", "pragma", "surrogate-control", "x-cache-control", "x-edge-control":
+		return true
+	default:
+		return false
+	}
 }
 
 func sanitizeResponseHeaders(header http.Header) {

--- a/server/internal/proxy/sanitize_test.go
+++ b/server/internal/proxy/sanitize_test.go
@@ -96,10 +96,11 @@ func TestShouldSanitizeJSONContentTypeAndSniffing(t *testing.T) {
 			body:         "2026-07-10 ordinary log output\n",
 		},
 		{
-			name:         "event stream remains streaming",
+			name:         "event stream fails closed",
 			path:         "/api/v3/events",
 			contentTypes: []string{"text/event-stream"},
 			body:         "data: {\"id\":1}\n\n",
+			wantErr:      errStreamingJSONResponse,
 		},
 		{
 			name:         "ndjson fails closed",

--- a/server/internal/proxy/transport_boundary_test.go
+++ b/server/internal/proxy/transport_boundary_test.go
@@ -1,0 +1,465 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func upstreamControlHeaderNames() []string {
+	return []string{
+		"Cloudflare-CDN-Cache-Control",
+		"X-Accel-Buffering",
+		"X-Accel-Charset",
+		"X-Accel-Expires",
+		"X-Accel-Limit-Rate",
+		"X-Accel-Redirect",
+		"X-Accel-Synthetic-Control",
+		"X-Lighttpd-Send-File",
+		"X-Lighttpd-Send-Private-File",
+		"X-Lighttpd-Send-Tempfile",
+		"X-Reproxy-URL",
+		"X-Sendfile",
+		"X-Sendfile-Temporary",
+		"X-Sendfile2",
+	}
+}
+
+func addUpstreamControlHeaders(header http.Header) {
+	for _, name := range upstreamControlHeaderNames() {
+		header.Set(name, "public-proxy-control-secret")
+	}
+}
+
+func upstreamSharedCacheHeaderNames() []string {
+	return []string{
+		"Age",
+		"Akamai-Cache-Control",
+		"Cache-Control",
+		"CDN-Cache-Control",
+		"Cloudflare-CDN-Cache-Control",
+		"Edge-Control",
+		"Expires",
+		"Netlify-CDN-Cache-Control",
+		"Pragma",
+		"Surrogate-Control",
+		"Vercel-CDN-Cache-Control",
+		"X-Cache-Control",
+		"X-Edge-Control",
+	}
+}
+
+func addUpstreamSharedCacheHeaders(header http.Header) {
+	for _, name := range upstreamSharedCacheHeaderNames() {
+		header.Set(name, "public, max-age=86400")
+	}
+}
+
+func assertPrivateProxyCachePolicy(t *testing.T, header http.Header) {
+	t.Helper()
+	if got := header.Get("Cache-Control"); got != "private, no-store" {
+		t.Errorf("Cache-Control=%q, want private, no-store", got)
+	}
+	if got := header.Get("Pragma"); got != "no-cache" {
+		t.Errorf("Pragma=%q, want no-cache", got)
+	}
+	for _, name := range []string{"Age", "Akamai-Cache-Control", "CDN-Cache-Control", "Cloudflare-CDN-Cache-Control", "Edge-Control", "Expires", "Netlify-CDN-Cache-Control", "Surrogate-Control", "Vercel-CDN-Cache-Control", "X-Cache-Control", "X-Edge-Control"} {
+		if values := header.Values(name); len(values) != 0 {
+			t.Errorf("response retained shared-cache header %s=%q", name, values)
+		}
+	}
+}
+
+func assertNoUpstreamControlHeaders(t *testing.T, header http.Header) {
+	t.Helper()
+	for _, name := range upstreamControlHeaderNames() {
+		if values := header.Values(name); len(values) != 0 {
+			t.Errorf("response retained upstream control header %s=%q", name, values)
+		}
+	}
+}
+
+// SEC-004: client identity, routing overrides, and trailers terminate before the upstream request.
+func TestInstanceProxyDropsClientRoutingMetadataAndRequestTrailers(t *testing.T) {
+	const trailerSecret = "synthetic-request-trailer-secret"
+	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		for _, name := range []string{
+			"Cf-Access-Jwt-Assertion",
+			"Dpop",
+			"Origin",
+			"Remote-Email",
+			"Remote-Name",
+			"Remote-User",
+			"Referer",
+			"Ssl-Client-Cert",
+			"Trailer",
+			"X-Authenticated-User",
+			"X-Authentik-Email",
+			"X-Client-Cert",
+			"X-Email",
+			"X-Envoy-Original-Path",
+			"X-Envoy-Peer-Metadata",
+			"X-Groups",
+			"X-Identity-Subject",
+			"X-Keycloak-User",
+			"X-Ms-Client-Principal",
+			"X-Pomerium-Claim-Email",
+			"X-Roles",
+			"X-Spiffe-Id",
+			"X-Ssl-Client-Cert",
+			"X-Tls-Client-Cert",
+			"X-User",
+			"X-User-Email",
+			"X-Amzn-Oidc-Data",
+			"X-Amzn-Oidc-Identity",
+			"X-Auth-Request-User",
+			"X-Goog-Authenticated-User-Email",
+			"X-Goog-Iap-Jwt-Assertion",
+			"X-Http-Method",
+			"X-Http-Method-Override",
+			"X-Method-Override",
+			"X-Original-Url",
+			"X-Rewrite-Url",
+		} {
+			if values := r.Header.Values(name); len(values) != 0 {
+				t.Errorf("upstream received client routing header %s=%q", name, values)
+			}
+		}
+		if len(r.Trailer) != 0 {
+			t.Errorf("upstream received client trailers: %#v", r.Trailer)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "test-instance-api-key" {
+			t.Errorf("upstream X-Api-Key=%q, want configured instance key", got)
+		}
+		if got := r.Header.Get("Accept-Encoding"); got != "identity" {
+			t.Errorf("upstream Accept-Encoding=%q, want identity", got)
+		}
+		if got := r.Header.Get("X-Request-Id"); got != "safe-request-id" {
+			t.Errorf("upstream X-Request-Id=%q, want safe-request-id", got)
+		}
+		if got := r.URL.Query().Get("page"); got != "2" {
+			t.Errorf("upstream safe query page=%q, want 2", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+
+	req, err := http.NewRequest(http.MethodPost, proxyURL+"/api/instances/"+instanceID+"/api/v3/movie?page=2", io.NopCloser(strings.NewReader("synthetic body")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.ContentLength = -1
+	req.Header.Set("Origin", "https://hostile.invalid")
+	req.Header.Set("CF-Access-JWT-Assertion", "synthetic-cloudflare-identity-jwt")
+	req.Header.Set("DPoP", "synthetic-proof-jwt")
+	req.Header.Set("Remote-Email", "private@example.invalid")
+	req.Header.Set("Remote-Name", "Synthetic Private Name")
+	req.Header.Set("Remote-User", "synthetic-private-identity")
+	req.Header.Set("Referer", "https://cantinarr.invalid/page?token=referer-secret")
+	req.Header.Set("SSL-Client-Cert", "synthetic-client-certificate")
+	req.Header.Set("X-Amzn-Oidc-Data", "synthetic-aws-identity-jwt")
+	req.Header.Set("X-Amzn-Oidc-Identity", "synthetic-aws-identity")
+	req.Header.Set("X-Auth-Request-User", "synthetic-oauth-proxy-identity")
+	req.Header.Set("X-Authenticated-User", "synthetic-authenticated-user")
+	req.Header.Set("X-Authentik-Email", "private@example.invalid")
+	req.Header.Set("X-Client-Cert", "synthetic-client-certificate")
+	req.Header.Set("X-Email", "private@example.invalid")
+	req.Header.Set("X-Goog-Authenticated-User-Email", "accounts.google.com:private@example.invalid")
+	req.Header.Set("X-Goog-IAP-JWT-Assertion", "synthetic-google-identity-jwt")
+	req.Header.Set("X-Groups", "synthetic-private-group")
+	req.Header.Set("X-Identity-Subject", "synthetic-private-subject")
+	req.Header.Set("X-Keycloak-User", "synthetic-keycloak-user")
+	req.Header.Set("X-MS-Client-Principal", "synthetic-azure-principal")
+	req.Header.Set("X-Pomerium-Claim-Email", "private@example.invalid")
+	req.Header.Set("X-Roles", "synthetic-private-role")
+	req.Header.Set("X-Spiffe-ID", "spiffe://private.invalid/workload")
+	req.Header.Set("X-SSL-Client-Cert", "synthetic-client-certificate")
+	req.Header.Set("X-TLS-Client-Cert", "synthetic-client-certificate")
+	req.Header.Set("X-User", "synthetic-private-user")
+	req.Header.Set("X-User-Email", "private@example.invalid")
+	req.Header.Set("X-Envoy-Original-Path", "/api/v3/config/host")
+	req.Header.Set("X-HTTP-Method", http.MethodDelete)
+	req.Header.Set("X-HTTP-Method-Override", http.MethodDelete)
+	req.Header.Set("X-Method-Override", http.MethodDelete)
+	req.Header.Set("X-Original-URL", "/api/v3/config/host")
+	req.Header.Set("X-Rewrite-URL", "/api/v3/config/host")
+	req.Header.Set("X-Request-ID", "safe-request-id")
+	req.Trailer = http.Header{
+		"Authorization": []string{"Bearer " + trailerSecret},
+		"X-Api-Key":     []string{trailerSecret},
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || !bytes.Equal(body, []byte(`{"ok":true}`)) {
+		t.Fatalf("response status=%d body=%q, want 200 JSON", resp.StatusCode, body)
+	}
+}
+
+// SEC-004: client protocol-upgrade metadata cannot turn the HTTP proxy into an opaque tunnel.
+func TestInstanceProxyDropsProtocolUpgradeRequest(t *testing.T) {
+	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, name := range []string{
+			"Connection",
+			"Upgrade",
+			"HTTP2-Settings",
+			"Sec-WebSocket-Extensions",
+			"Sec-WebSocket-Key",
+			"Sec-WebSocket-Protocol",
+			"Sec-WebSocket-Version",
+		} {
+			if values := r.Header.Values(name); len(values) != 0 {
+				t.Errorf("upstream received protocol-upgrade header %s=%q", name, values)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+
+	req, err := http.NewRequest(http.MethodGet, proxyURL+"/api/instances/"+instanceID+"/api/v3/movie", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Connection", "Upgrade, HTTP2-Settings")
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("HTTP2-Settings", "synthetic-settings")
+	req.Header.Set("Sec-WebSocket-Extensions", "permessage-deflate")
+	req.Header.Set("Sec-WebSocket-Key", "synthetic-websocket-key")
+	req.Header.Set("Sec-WebSocket-Protocol", "synthetic-protocol")
+	req.Header.Set("Sec-WebSocket-Version", "13")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || !bytes.Equal(body, []byte(`{"ok":true}`)) {
+		t.Fatalf("response status=%d body=%q, want 200 JSON", resp.StatusCode, body)
+	}
+}
+
+// SEC-004: CONNECT is rejected before instance resolution or an upstream round trip.
+func TestInstanceProxyRejectsConnectBeforeInstanceLookupOrUpstreamContact(t *testing.T) {
+	t.Run("nil store is never dereferenced", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodConnect, "/api/instances/synthetic/tunnel", nil)
+		NewHandler(nil).InstanceProxy().ServeHTTP(recorder, request)
+		if recorder.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("status=%d body=%q, want 405", recorder.Code, recorder.Body.Bytes())
+		}
+		assertPrivateProxyCachePolicy(t, recorder.Header())
+	})
+
+	contacted := make(chan struct{}, 1)
+	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		contacted <- struct{}{}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	for _, id := range []string{instanceID, "synthetic-missing-instance"} {
+		t.Run(id, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodConnect, proxyURL+"/api/instances/"+id+"/tunnel", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("CONNECT: %v", err)
+			}
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusMethodNotAllowed {
+				t.Fatalf("status=%d body=%q, want 405", resp.StatusCode, body)
+			}
+			if got := resp.Header.Get("Cache-Control"); got != "private, no-store" {
+				t.Errorf("Cache-Control=%q, want private, no-store", got)
+			}
+			select {
+			case <-contacted:
+				t.Fatal("CONNECT reached the configured upstream")
+			default:
+			}
+		})
+	}
+}
+
+// SEC-004: TRACE and TRACK cannot reflect the proxy-injected instance API key.
+func TestInstanceProxyRejectsTraceAndTrackBeforeInstanceLookupOrUpstreamContact(t *testing.T) {
+	for _, method := range []string{http.MethodTrace, "TRACK", "trace", "track"} {
+		t.Run(method+" nil store", func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(method, "/api/instances/synthetic/reflect", nil)
+			NewHandler(nil).InstanceProxy().ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("status=%d body=%q, want 405", recorder.Code, recorder.Body.Bytes())
+			}
+			assertPrivateProxyCachePolicy(t, recorder.Header())
+		})
+	}
+
+	var contacted atomic.Int64
+	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		contacted.Add(1)
+		_, _ = io.WriteString(w, r.Header.Get("X-Api-Key"))
+	}))
+
+	for _, method := range []string{http.MethodTrace, "TRACK", "trace", "track"} {
+		t.Run(method+" configured instance", func(t *testing.T) {
+			req, err := http.NewRequest(method, proxyURL+"/api/instances/"+instanceID+"/reflect", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("%s: %v", method, err)
+			}
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode != http.StatusMethodNotAllowed {
+				t.Fatalf("status=%d body=%q, want 405", resp.StatusCode, body)
+			}
+			if bytes.Contains(body, []byte("test-instance-api-key")) {
+				t.Fatalf("blocked reflection method exposed configured API key: %q", body)
+			}
+			// Only canonical TRACE reaches InstanceProxy and receives the handler's
+			// private-cache headers; chi rejects the other spellings at the router
+			// with its own 405 before the handler runs. The security invariant that
+			// matters — 405, no reflected key, no upstream contact — holds for all.
+			if method == http.MethodTrace {
+				assertPrivateProxyCachePolicy(t, resp.Header)
+			}
+		})
+	}
+	if got := contacted.Load(); got != 0 {
+		t.Fatalf("TRACE/TRACK contacted configured upstream %d times", got)
+	}
+}
+
+// SEC-004: an upstream 101 response is rejected before opaque tunnel bytes can reach the client.
+func TestInstanceProxyRejectsUpstreamProtocolUpgrade(t *testing.T) {
+	const tunnelSecret = "synthetic-upgrade-tunnel-secret"
+	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hijacker, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("upstream response writer does not support hijacking")
+			return
+		}
+		conn, rw, err := hijacker.Hijack()
+		if err != nil {
+			t.Errorf("hijack upstream connection: %v", err)
+			return
+		}
+		defer conn.Close()
+		_, _ = io.WriteString(rw,
+			"HTTP/1.1 101 Switching Protocols\r\n"+
+				"Connection: Upgrade\r\n"+
+				"Upgrade: websocket\r\n"+
+				"X-Api-Key: "+tunnelSecret+"\r\n\r\n"+
+				tunnelSecret,
+		)
+		_ = rw.Flush()
+	}))
+
+	req, err := http.NewRequest(http.MethodGet, proxyURL+"/api/instances/"+instanceID+"/api/v3/movie", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("response status=%d body=%q, want 502", resp.StatusCode, body)
+	}
+	if bytes.Contains(body, []byte(tunnelSecret)) || resp.Header.Get("X-Api-Key") != "" {
+		t.Fatalf("upgrade response exposed tunnel bytes or headers: header=%q body=%q", resp.Header.Get("X-Api-Key"), body)
+	}
+}
+
+func TestInstanceProxyDropsUpstreamResponseTrailers(t *testing.T) {
+	const trailerSecret = "synthetic-response-trailer-secret"
+	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Add("Trailer", "X-Api-Key")
+		w.Header().Add("Trailer", "X-Download-URL")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "safe opaque body")
+		w.Header().Set("X-Api-Key", trailerSecret)
+		w.Header().Set("X-Download-URL", "https://user:"+trailerSecret+"@download.invalid/file?token="+trailerSecret)
+	}))
+
+	resp, err := http.Get(proxyURL + "/api/instances/" + instanceID + "/download")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if string(body) != "safe opaque body" {
+		t.Fatalf("body=%q, want safe opaque body", body)
+	}
+	if len(resp.Trailer) != 0 || len(resp.Header.Values("Trailer")) != 0 {
+		t.Fatalf("upstream response trailers escaped boundary: header=%v trailer=%v", resp.Header.Values("Trailer"), resp.Trailer)
+	}
+	if bytes.Contains(body, []byte(trailerSecret)) {
+		t.Fatal("response body unexpectedly contains trailer secret")
+	}
+}
+
+func TestInstanceProxyStripsUpstreamProxyControlAndCacheHeaders(t *testing.T) {
+	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		addUpstreamControlHeaders(w.Header())
+		addUpstreamSharedCacheHeaders(w.Header())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"safe":true}`)
+	}))
+
+	resp, err := http.Get(proxyURL + "/api/instances/" + instanceID + "/api/v3/history")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || !bytes.Equal(body, []byte(`{"safe":true}`)) {
+		t.Fatalf("status=%d body=%q, want safe JSON", resp.StatusCode, body)
+	}
+	assertNoUpstreamControlHeaders(t, resp.Header)
+	assertPrivateProxyCachePolicy(t, resp.Header)
+}
+
+func TestInstanceProxyErrorStripsUpstreamProxyControlAndCacheHeaders(t *testing.T) {
+	proxyURL, instanceID := startTestProxy(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		addUpstreamControlHeaders(w.Header())
+		addUpstreamSharedCacheHeaders(w.Header())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"apiKey":"synthetic-invalid-json"`)
+	}))
+
+	resp, err := http.Get(proxyURL + "/api/instances/" + instanceID + "/api/v3/history")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status=%d body=%q, want 502", resp.StatusCode, body)
+	}
+	assertNoUpstreamControlHeaders(t, resp.Header)
+	assertPrivateProxyCachePolicy(t, resp.Header)
+}

--- a/server/internal/push/manager_test.go
+++ b/server/internal/push/manager_test.go
@@ -29,10 +29,12 @@ func testCipher(t *testing.T) *secrets.Cipher {
 // mockGateway records enroll calls and device registrations. enrollFails, when
 // set, makes /v1/enroll return 503 so the background-retry path can be driven.
 type mockGateway struct {
-	mu          sync.Mutex
-	enrollCalls int
-	registered  []string // device ids seen at /v1/devices
-	enrollFails bool
+	mu                sync.Mutex
+	enrollCalls       int
+	registered        []string // device ids seen at /v1/devices
+	enrollFails       bool
+	notificationCalls int
+	notificationAuth  string
 }
 
 func (g *mockGateway) setEnrollFails(v bool) {
@@ -53,6 +55,12 @@ func (g *mockGateway) registeredIDs() []string {
 	out := make([]string, len(g.registered))
 	copy(out, g.registered)
 	return out
+}
+
+func (g *mockGateway) notificationResult() (calls int, auth string) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.notificationCalls, g.notificationAuth
 }
 
 // newMockGatewayServer stands up the mock and returns it plus its base URL.
@@ -83,6 +91,13 @@ func newMockGatewayServer(t *testing.T) (*mockGateway, string) {
 			}
 			w.WriteHeader(http.StatusOK)
 			_, _ = io.WriteString(w, `{"id":"d","created":true}`)
+		case "/v1/notifications":
+			g.mu.Lock()
+			g.notificationCalls++
+			g.notificationAuth = r.Header.Get("Authorization")
+			g.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"sent":1,"failed":0,"results":[]}`)
 		default:
 			w.WriteHeader(http.StatusOK)
 			_, _ = io.WriteString(w, `{}`)
@@ -106,7 +121,8 @@ func storedPushKey(t *testing.T, database *sql.DB, cipher *secrets.Cipher) strin
 	return got
 }
 
-func TestManagerEnsureExplicitKeyWins(t *testing.T) {
+// PUSH-001: an explicit gateway key skips enrollment, authenticates a successful send, and is never persisted.
+func TestManagerExplicitKeySkipsEnrollmentAndAuthenticatesSend(t *testing.T) {
 	database, err := dbOpen(t)
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -122,12 +138,26 @@ func TestManagerEnsureExplicitKeyWins(t *testing.T) {
 	if client.apiKey != "pgk_explicit" {
 		t.Errorf("client key = %q, want pgk_explicit", client.apiKey)
 	}
+	resp, err := client.Send(context.Background(), []int64{42}, "Test", "Body", map[string]any{"type": "test"})
+	if err != nil {
+		t.Fatalf("send with explicit key: %v", err)
+	}
+	if resp == nil || resp.Sent != 1 || resp.Failed != 0 {
+		t.Fatalf("send response = %#v, want sent=1 failed=0", resp)
+	}
 	if g.enrollCount() != 0 {
 		t.Errorf("enroll calls = %d, want 0 (explicit key must not enroll)", g.enrollCount())
 	}
-	// An explicit key is never persisted.
-	if k := storedPushKey(t, database, cipher); k != "" {
-		t.Errorf("stored push key = %q, want empty (explicit key not persisted)", k)
+	calls, auth := g.notificationResult()
+	if calls != 1 || auth != "Bearer pgk_explicit" {
+		t.Errorf("notification calls/auth = %d, %q; want 1, %q", calls, auth, "Bearer pgk_explicit")
+	}
+	var persisted int
+	if err := database.QueryRow("SELECT COUNT(*) FROM settings WHERE key = 'push_api_key'").Scan(&persisted); err != nil {
+		t.Fatalf("count persisted push key: %v", err)
+	}
+	if persisted != 0 {
+		t.Errorf("persisted push key rows = %d, want 0", persisted)
 	}
 }
 

--- a/server/internal/secrets/migrate.go
+++ b/server/internal/secrets/migrate.go
@@ -32,6 +32,12 @@ func VerifyKeyIdentity(db *sql.DB, c *Cipher) error {
 	if err != nil {
 		return fmt.Errorf("read canary: %w", err)
 	}
+	// The canary has never had a legacy plaintext representation: it is created
+	// by VerifyKeyIdentity itself. Requiring the authenticated envelope prevents
+	// a known plaintext replacement from bypassing the wrong-key guard.
+	if !IsEncrypted(stored) {
+		return fmt.Errorf("encryption key does not match existing encrypted data — restore /config/encryption.key (or the original CANTINARR_ENCRYPTION_KEY); generating a new key would orphan all stored secrets")
+	}
 	plain, err := c.Decrypt(stored)
 	if err != nil || plain != canaryValue {
 		return fmt.Errorf("encryption key does not match existing encrypted data — restore /config/encryption.key (or the original CANTINARR_ENCRYPTION_KEY); generating a new key would orphan all stored secrets")

--- a/server/internal/secrets/migrate_test.go
+++ b/server/internal/secrets/migrate_test.go
@@ -1,0 +1,126 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	projectdb "github.com/windoze95/cantinarr-server/internal/db"
+)
+
+// SEC-002: authenticated canary failures must refuse the key without rewriting the stored bytes.
+func TestVerifyKeyIdentityRejectsTamperAndWrongKeyWithoutMutation(t *testing.T) {
+	tests := []struct {
+		name        string
+		storedValue func(t *testing.T, encrypted []byte, cipher *Cipher) []byte
+		verifyKey   byte
+	}{
+		{
+			name: "tampered ciphertext",
+			storedValue: func(t *testing.T, encrypted []byte, cipher *Cipher) []byte {
+				t.Helper()
+				encoded := strings.TrimPrefix(string(encrypted), prefix)
+				raw, err := base64.StdEncoding.DecodeString(encoded)
+				if err != nil {
+					t.Fatalf("decode canary: %v", err)
+				}
+				raw[cipher.aead.NonceSize()] ^= 0x01
+				return []byte(prefix + base64.StdEncoding.EncodeToString(raw))
+			},
+			verifyKey: 0x42,
+		},
+		{
+			name: "tampered authentication tag",
+			storedValue: func(t *testing.T, encrypted []byte, _ *Cipher) []byte {
+				t.Helper()
+				encoded := strings.TrimPrefix(string(encrypted), prefix)
+				raw, err := base64.StdEncoding.DecodeString(encoded)
+				if err != nil {
+					t.Fatalf("decode canary: %v", err)
+				}
+				raw[len(raw)-1] ^= 0x01
+				return []byte(prefix + base64.StdEncoding.EncodeToString(raw))
+			},
+			verifyKey: 0x42,
+		},
+		{
+			name: "wrong key",
+			storedValue: func(_ *testing.T, encrypted []byte, _ *Cipher) []byte {
+				return encrypted
+			},
+			verifyKey: 0x07,
+		},
+		{
+			name: "authenticated wrong canary value",
+			storedValue: func(t *testing.T, _ []byte, cipher *Cipher) []byte {
+				t.Helper()
+				encrypted, err := cipher.Encrypt("synthetic-wrong-canary")
+				if err != nil {
+					t.Fatalf("encrypt wrong canary: %v", err)
+				}
+				return []byte(encrypted)
+			},
+			verifyKey: 0x42,
+		},
+		{
+			name: "plaintext canary replacement",
+			storedValue: func(_ *testing.T, _ []byte, _ *Cipher) []byte {
+				return []byte(canaryValue)
+			},
+			verifyKey: 0x42,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			database, err := projectdb.Open(":memory:")
+			if err != nil {
+				t.Fatalf("open database: %v", err)
+			}
+			t.Cleanup(func() { _ = database.Close() })
+
+			initialCipher, err := NewCipher(bytes.Repeat([]byte{0x42}, 32))
+			if err != nil {
+				t.Fatalf("create initial cipher: %v", err)
+			}
+			if err := VerifyKeyIdentity(database, initialCipher); err != nil {
+				t.Fatalf("seed encrypted canary: %v", err)
+			}
+			if err := VerifyKeyIdentity(database, initialCipher); err != nil {
+				t.Fatalf("reverify valid encrypted canary: %v", err)
+			}
+
+			var encrypted []byte
+			if err := database.QueryRow(
+				"SELECT CAST(value AS BLOB) FROM settings WHERE key = ?", canaryKey,
+			).Scan(&encrypted); err != nil {
+				t.Fatalf("read encrypted canary: %v", err)
+			}
+			before := tt.storedValue(t, append([]byte(nil), encrypted...), initialCipher)
+			if _, err := database.Exec(
+				"UPDATE settings SET value = ? WHERE key = ?", string(before), canaryKey,
+			); err != nil {
+				t.Fatalf("replace canary: %v", err)
+			}
+
+			verificationCipher, err := NewCipher(bytes.Repeat([]byte{tt.verifyKey}, 32))
+			if err != nil {
+				t.Fatalf("create verification cipher: %v", err)
+			}
+			if err := VerifyKeyIdentity(database, verificationCipher); err == nil {
+				t.Fatal("VerifyKeyIdentity accepted an unauthenticated canary")
+			}
+
+			var after []byte
+			if err := database.QueryRow(
+				"SELECT CAST(value AS BLOB) FROM settings WHERE key = ?", canaryKey,
+			).Scan(&after); err != nil {
+				t.Fatalf("read rejected canary: %v", err)
+			}
+			if !bytes.Equal(after, before) {
+				t.Fatalf("rejected canary was mutated: before=%q after=%q", before, after)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Closes an arr-proxy **authorization fail-open** and hardens the reverse-proxy transport boundary. This is the salvaged, proportional subset of a larger wave of work: it keeps the proven security fixes and their regression tests, and deliberately drops a speculative ~1,100-line response-sanitizer rewrite that shipped a reproducible panic (Unicode path desync), a residual quadratic scan, and an event-by-event SSE scrubber for endpoints no shipped Radarr/Sonarr serves. `sanitize.go` grows by ~80 lines here (response-header hygiene), not ~1,270.

### Authorization (the substance)
- Requesters can reach only their **effective** instance — their pin, else the deterministic global default/fallback — and their exact Chaptarr grant. A sibling instance the admin has hidden can no longer be reached by guessing its UUID. Selection order is deterministic (sort order, name, ID).
- Instance service-type classification is **metadata-only**, so an undecryptable secret can never change an authorization decision.
- `/api/config` **fails closed** (opaque 503) if the defaults/grants lookup fails, instead of silently dropping pins and widening what a requester may browse; it exposes only secret-free effective shapes.
- Secret migration rejects a plaintext canary substituted for the wrong-key check.

### Transport boundary (cheap hardening on top of the existing scrubber)
- `CONNECT`/`TRACE`/`TRACK` rejected before instance lookup or upstream contact; upstream `101` upgrade refused — no tunnel, no `X-Api-Key` reflection.
- Inbound session cookies (incl. `Cookie2`) and forwarded credential / reverse-proxy identity (`X-Auth-*`/`Remote-*`/mTLS) / routing-override / trailer headers terminate at the boundary; only the instance key goes upstream.
- Responses marked private/non-cacheable; nginx/lighttpd internal-redirect controls (`X-Accel-*`, `X-Sendfile`, `X-Reproxy-URL`) and response trailers stripped. Unclassifiable streaming responses fail closed rather than passing through unsanitized (main previously forwarded `text/event-stream` unscrubbed).

## Verification
- `go vet ./...` — clean
- `go test ./...` — full suite passes
- `go test -race` on proxy/auth/instance/secrets/credentials/api/push — all pass
- `CGO_ENABLED=0 go build ./cmd/server` — clean
- `make check-test-automation` — catalog valid
- gofmt clean on touched files (`internal/plex/service_test.go` is a pre-existing local-gofmt-version divergence, not touched here)

## Docs
- [x] `server/README.md` — arr-proxy section updated: requester instance binding, metadata-only classification, and the transport boundary (methods, headers, cache/control-header stripping); feature bullet no longer claims unconditional admin passthrough
- [x] No other documented surface changed (no new route/env var/table/tool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jk485bRYxX32HiF9SNDpo