### PR TITLE
fix(auth): make OAuth code, refresh, and connect-token redemption atomic single-use claims

### DIFF
--- a/server/internal/auth/concurrency_test.go
+++ b/server/internal/auth/concurrency_test.go
@@ -1,0 +1,195 @@
+package auth
+
+import (
+	"net/url"
+	"sync"
+	"testing"
+)
+
+// raceN runs fn from n goroutines released together and returns how many
+// returned nil. A single-use claim must let exactly one caller through no
+// matter how their statements interleave.
+func raceN(n int, fn func() error) (successes int) {
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make([]error, n)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errs[i] = fn()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	for _, err := range errs {
+		if err == nil {
+			successes++
+		}
+	}
+	return successes
+}
+
+// SEC/AUTH: one authorization code yields at most one token set even when the
+// same client replays it concurrently (regression: select-then-delete let two
+// racers both consume a single code).
+func TestOAuthAuthorizationCodeRedemptionIsSingleUseUnderReplay(t *testing.T) {
+	svc := setupTestService(t)
+	loginResp, err := svc.Login("admin", "testpass123", "", "")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	redirectURI := "http://127.0.0.1:12345/callback"
+	resource := "http://example.com/mcp"
+	verifier := "replay-race-verifier-value"
+	client, err := svc.RegisterOAuthClient("Replay Agent", []string{redirectURI})
+	if err != nil {
+		t.Fatalf("register oauth client: %v", err)
+	}
+	code, err := svc.CreateOAuthAuthorizationCode(client, loginResp.User.ID, redirectURI, pkceChallenge(verifier), resource, defaultOAuthScope)
+	if err != nil {
+		t.Fatalf("create auth code: %v", err)
+	}
+
+	successes := raceN(8, func() error {
+		_, err := svc.ExchangeOAuthAuthorizationCode(client.ClientID, code, redirectURI, verifier, resource)
+		return err
+	})
+	if successes != 1 {
+		t.Fatalf("concurrent exchanges succeeded %d times, want exactly 1", successes)
+	}
+}
+
+// SEC/AUTH: a wrong-client exchange attempt must not delete a victim's still
+// valid authorization code (regression: the code was consumed before the
+// client_id was checked, so an attacker-registered client could burn it).
+func TestOAuthAuthorizationCodeSurvivesWrongClientAttempt(t *testing.T) {
+	svc := setupTestService(t)
+	loginResp, err := svc.Login("admin", "testpass123", "", "")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	redirectURI := "http://127.0.0.1:12345/callback"
+	resource := "http://example.com/mcp"
+	verifier := "wrong-client-verifier-value"
+	victim, err := svc.RegisterOAuthClient("Victim Agent", []string{redirectURI})
+	if err != nil {
+		t.Fatalf("register victim client: %v", err)
+	}
+	attacker, err := svc.RegisterOAuthClient("Attacker Agent", []string{redirectURI})
+	if err != nil {
+		t.Fatalf("register attacker client: %v", err)
+	}
+	code, err := svc.CreateOAuthAuthorizationCode(victim, loginResp.User.ID, redirectURI, pkceChallenge(verifier), resource, defaultOAuthScope)
+	if err != nil {
+		t.Fatalf("create auth code: %v", err)
+	}
+
+	if _, err := svc.ExchangeOAuthAuthorizationCode(attacker.ClientID, code, redirectURI, verifier, resource); err == nil {
+		t.Fatal("attacker client exchanged the victim's code")
+	}
+	// The legitimate client can still redeem its untouched code.
+	if _, err := svc.ExchangeOAuthAuthorizationCode(victim.ClientID, code, redirectURI, verifier, resource); err != nil {
+		t.Fatalf("victim exchange after wrong-client attempt: %v", err)
+	}
+}
+
+// SEC/AUTH: rotating a refresh token concurrently mints at most one successor
+// (regression: blind delete-then-create let two racers both mint successors and
+// defeated refresh-token reuse detection).
+func TestOAuthRefreshRotationIsSingleUseUnderReplay(t *testing.T) {
+	svc := setupTestService(t)
+	loginResp, err := svc.Login("admin", "testpass123", "", "")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	redirectURI := "http://127.0.0.1:12345/callback"
+	resource := "http://example.com/mcp"
+	verifier := "refresh-race-verifier-value"
+	client, err := svc.RegisterOAuthClient("Refresh Agent", []string{redirectURI})
+	if err != nil {
+		t.Fatalf("register oauth client: %v", err)
+	}
+	code, err := svc.CreateOAuthAuthorizationCode(client, loginResp.User.ID, redirectURI, pkceChallenge(verifier), resource, defaultOAuthScope)
+	if err != nil {
+		t.Fatalf("create auth code: %v", err)
+	}
+	tokenResp, err := svc.ExchangeOAuthAuthorizationCode(client.ClientID, code, redirectURI, verifier, resource)
+	if err != nil {
+		t.Fatalf("exchange code: %v", err)
+	}
+
+	successes := raceN(8, func() error {
+		_, err := svc.RefreshOAuthToken(client.ClientID, tokenResp.RefreshToken, resource)
+		return err
+	})
+	if successes != 1 {
+		t.Fatalf("concurrent refreshes succeeded %d times, want exactly 1", successes)
+	}
+}
+
+// SEC/AUTH: a leaked single-use connect link redeemed concurrently mints at most
+// one device session (regression: select-then-update without an atomic guard let
+// two racers both redeem one invite).
+func TestRedeemConnectTokenIsSingleUseUnderReplay(t *testing.T) {
+	svc := setupTestService(t)
+	admin, err := svc.getUserByUsername("admin")
+	if err != nil {
+		t.Fatalf("load admin: %v", err)
+	}
+	created, err := svc.CreateConnectToken(admin.ID, "race-invitee", "https://cantinarr.example.com")
+	if err != nil {
+		t.Fatalf("create connect token: %v", err)
+	}
+	token := connectTokenFromLink(t, created.Link)
+
+	successes := raceN(8, func() error {
+		_, err := svc.RedeemConnectToken(token, "Race Device", "")
+		return err
+	})
+	if successes != 1 {
+		t.Fatalf("concurrent redemptions succeeded %d times, want exactly 1", successes)
+	}
+}
+
+// SEC/AUTH: concurrent first-time invites for the same new username converge on
+// one user row instead of racing the username UNIQUE constraint and failing one
+// caller (regression: lookup-then-insert without ON CONFLICT).
+func TestCreateConnectTokenConvergesConcurrentFirstInvites(t *testing.T) {
+	svc := setupTestService(t)
+	admin, err := svc.getUserByUsername("admin")
+	if err != nil {
+		t.Fatalf("load admin: %v", err)
+	}
+	const username = "brand-new-invitee"
+
+	successes := raceN(8, func() error {
+		_, err := svc.CreateConnectToken(admin.ID, username, "https://cantinarr.example.com")
+		return err
+	})
+	if successes != 8 {
+		t.Fatalf("concurrent first invites succeeded %d times, want all 8 to converge", successes)
+	}
+
+	var count int
+	if err := svc.db.QueryRow("SELECT COUNT(*) FROM users WHERE username = ?", username).Scan(&count); err != nil {
+		t.Fatalf("count users: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("username %q has %d user rows, want exactly 1", username, count)
+	}
+}
+
+func connectTokenFromLink(t *testing.T, link string) string {
+	t.Helper()
+	parsed, err := url.Parse(link)
+	if err != nil {
+		t.Fatalf("parse connect link %q: %v", link, err)
+	}
+	token := parsed.Query().Get("token")
+	if token == "" {
+		t.Fatalf("connect link %q has no token", link)
+	}
+	return token
+}

--- a/server/internal/auth/oauth.go
+++ b/server/internal/auth/oauth.go
@@ -192,12 +192,13 @@ func (s *Service) ExchangeOAuthAuthorizationCode(clientID, code, redirectURI, co
 		return nil, ErrOAuthInvalidRedirectURI
 	}
 
-	stored, err := s.consumeOAuthAuthorizationCode(code)
+	// Claim the code atomically, matched to this client and redirect URI. A
+	// wrong-client or replayed attempt matches zero rows and never deletes a
+	// still-valid code, so it can neither burn a victim's pending grant nor
+	// mint a second token set from one code.
+	stored, err := s.consumeOAuthAuthorizationCode(code, clientID, redirectURI)
 	if err != nil {
 		return nil, err
-	}
-	if stored.ClientID != clientID || stored.RedirectURI != redirectURI {
-		return nil, ErrOAuthInvalidCode
 	}
 	if time.Now().After(stored.ExpiresAt) {
 		return nil, ErrOAuthInvalidCode
@@ -254,7 +255,17 @@ func (s *Service) RefreshOAuthToken(clientID, refreshToken, resource string) (*O
 		return nil, err
 	}
 
-	_, _ = s.db.Exec("DELETE FROM oauth_refresh_tokens WHERE token_hash = ?", tokenHash)
+	// Rotate atomically: only the caller whose DELETE actually removes the row
+	// may mint a successor. A concurrent refresh of the same token deletes zero
+	// rows and is rejected here instead of minting a second valid successor and
+	// silently defeating refresh-token reuse detection.
+	result, err := s.db.Exec("DELETE FROM oauth_refresh_tokens WHERE token_hash = ?", tokenHash)
+	if err != nil {
+		return nil, fmt.Errorf("rotate refresh token: %w", err)
+	}
+	if affected, err := result.RowsAffected(); err != nil || affected == 0 {
+		return nil, ErrOAuthInvalidRefreshToken
+	}
 	nextRefreshToken, err := s.createOAuthRefreshToken(stored.ClientID, stored.UserID, stored.DeviceID, stored.Resource, stored.Scope)
 	if err != nil {
 		return nil, err
@@ -272,18 +283,23 @@ func (s *Service) RefreshOAuthToken(clientID, refreshToken, resource string) (*O
 	}, nil
 }
 
-func (s *Service) consumeOAuthAuthorizationCode(code string) (*oauthAuthorizationCode, error) {
+// consumeOAuthAuthorizationCode deletes and returns the authorization code in a
+// single statement, matched to the presenting client and redirect URI. Doing
+// the match in the DELETE (rather than selecting, then checking, then deleting)
+// makes redemption a single-use atomic claim: only one concurrent caller wins
+// the row, and a caller with the wrong client_id/redirect_uri deletes nothing.
+func (s *Service) consumeOAuthAuthorizationCode(code, clientID, redirectURI string) (*oauthAuthorizationCode, error) {
 	codeHash := hashToken(code)
 	var stored oauthAuthorizationCode
 	err := s.db.QueryRow(
-		`SELECT code_hash, client_id, user_id, redirect_uri, code_challenge, resource, scope, expires_at
-		 FROM oauth_authorization_codes WHERE code_hash = ?`,
-		codeHash,
+		`DELETE FROM oauth_authorization_codes
+		 WHERE code_hash = ? AND client_id = ? AND redirect_uri = ?
+		 RETURNING code_hash, client_id, user_id, redirect_uri, code_challenge, resource, scope, expires_at`,
+		codeHash, clientID, redirectURI,
 	).Scan(&stored.CodeHash, &stored.ClientID, &stored.UserID, &stored.RedirectURI, &stored.CodeChallenge, &stored.Resource, &stored.Scope, &stored.ExpiresAt)
 	if err != nil {
 		return nil, ErrOAuthInvalidCode
 	}
-	_, _ = s.db.Exec("DELETE FROM oauth_authorization_codes WHERE code_hash = ?", codeHash)
 	return &stored, nil
 }
 

--- a/server/internal/auth/service.go
+++ b/server/internal/auth/service.go
@@ -523,22 +523,24 @@ func (s *Service) GetUser(userID int64) (*User, error) {
 }
 
 func (s *Service) CreateConnectToken(createdBy int64, name, serverURL string) (*CreateConnectTokenResponse, error) {
-	// Find or create user
-	var userID int64
+	// Find or create the passwordless user this invite links to. Two admins
+	// (or one admin double-submitting) creating the first invite for the same
+	// new username must converge on one user row rather than racing the
+	// username UNIQUE constraint and failing one caller with a 500.
 	user, err := s.getUserByUsername(name)
 	if err != nil {
-		// Create new user with empty password hash (no password login)
-		result, err := s.db.Exec(
-			"INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?)",
+		if _, err := s.db.Exec(
+			"INSERT INTO users (username, password_hash, role) VALUES (?, ?, ?) ON CONFLICT(username) DO NOTHING",
 			name, "", "user",
-		)
-		if err != nil {
+		); err != nil {
 			return nil, fmt.Errorf("create user: %w", err)
 		}
-		userID, _ = result.LastInsertId()
-	} else {
-		userID = user.ID
+		user, err = s.getUserByUsername(name)
+		if err != nil {
+			return nil, fmt.Errorf("load connect user: %w", err)
+		}
 	}
+	userID := user.ID
 
 	// Generate 32-byte random token (64 hex chars)
 	tokenBytes := make([]byte, 32)
@@ -617,11 +619,19 @@ func (s *Service) RedeemConnectToken(token, deviceName, hardwareID string) (*Tok
 		return nil, ErrTokenExpired
 	}
 
-	// Mark as redeemed
+	// Claim the single-use token atomically. The redeemed_at IS NULL guard means
+	// only the first of two concurrent redemptions of the same leaked link marks
+	// the row; the loser affects zero rows and is rejected before it can mint a
+	// second authenticated device session.
 	now := time.Now()
-	_, err = s.db.Exec("UPDATE connect_tokens SET redeemed_at = ? WHERE token = ?", now, token)
+	result, err := s.db.Exec(
+		"UPDATE connect_tokens SET redeemed_at = ? WHERE token = ? AND redeemed_at IS NULL", now, token,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("mark token redeemed: %w", err)
+	}
+	if affected, err := result.RowsAffected(); err != nil || affected == 0 {
+		return nil, ErrTokenRedeemed
 	}
 
 	deviceID, err := s.upsertDevice(ct.UserID, deviceName, hardwareID)


### PR DESCRIPTION
## What

Four token-lifecycle operations used **select-then-mutate across separate statements**, so a concurrent (or hostile) second caller could slip between the read and the write. SQLite's single writer serializes each *statement* but not a multi-*statement* claim — the connection is released between the SELECT and the DELETE/UPDATE, letting another caller observe the not-yet-claimed row. Each is now a single atomic statement, using the compare-and-swap idiom already present in `remediation/autodispatch.go`.

These were independently verified as real (all four confirmed against the code); severity is **low** for a single-admin deployment, but the fixes are small, idiomatic, and now regression-guarded. Highest real-world impact is the connect-token double-redemption.

| Operation | Before | After |
|---|---|---|
| OAuth auth code | consumed before client/PKCE checks → replay + wrong-client burn | `DELETE … WHERE code_hash=? AND client_id=? AND redirect_uri=? RETURNING` |
| OAuth refresh rotation | blind delete-then-create → two successors, no reuse detection | reject when DELETE affects 0 rows before minting |
| Connect-token redeem | select-then-update, no guard → two device sessions from one link | `UPDATE … WHERE redeemed_at IS NULL`, require 1 row |
| Connect user create | lookup-then-insert → UNIQUE race fails one caller | `INSERT … ON CONFLICT(username) DO NOTHING` + re-read |

## Tests

New `concurrency_test.go` — **verified to fail on the pre-fix code** (5/3 concurrent exchanges, 6–8 refresh mints, 3–5 double-redeems, burned victim code, 7/6-of-8 convergence) and pass on the fix. Each races N callers at one code/token and asserts exactly one wins; plus a deterministic wrong-client-doesn't-burn check and a converge-on-one-user check.

## Verification
- `go vet ./...`, `CGO_ENABLED=0 go build ./cmd/server` — clean
- `go test ./...` — full suite passes
- `go test -race ./internal/auth` — passes (43s)
- gofmt clean on touched files

## Docs
- [x] No documented surface changed — internal token-redemption semantics only; no route, env var, DB table, or MCP tool added or renamed. Behavior is unchanged for the normal single-caller path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jk485bRYxX32HiF9SNDpo