### PR TITLE
chore(ci): re-run CI on main pushes and weekly; document test environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,13 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 5 * * 1'
 
 concurrency:
-  group: ci-${{ github.ref }}
+  group: ci-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Operating manual for AI agents and human contributors. `CLAUDE.md` imports this 
 
 - Server changes: run `go vet ./...` and `go test ./...` from `server/`.
 - App changes: run `flutter analyze --no-fatal-infos` and `flutter test` from `app/`.
-- CI runs exactly those on every PR, plus a `CGO_ENABLED=0` server build and a `flutter build web --release`. A PR is not done if any of them fail.
+- CI runs exactly those on every PR, plus a `CGO_ENABLED=0` server build and a `flutter build web --release`. A PR is not done if any of them fail. The same suite re-runs on every push to `main` (merge-skew safety) and on a weekly schedule (toolchain drift); a red `main` run is a defect to fix promptly.
 - Codex integration changes are also proved against the checksum-verified pinned app-server in CI. The Docker workflow builds and smoke-tests both Dockerfiles, including bundled license notices, before publishing the root image to GHCR.
 - iOS release builds happen only in CI (`testflight.yml`, auto-deploys on `main` when iOS-relevant `app/**` paths change — web/android/desktop subdirs and store-listing metadata/screenshots are excluded; listing copy syncs via `storelisting.yml` instead). Don't assume a local iOS toolchain; when one isn't available, sanity-check Swift with `swiftc -parse` and let CI prove the build.
 - iOS signing is manual, via the `IOS_PROVISIONING_PROFILE_BASE64` secret. Changing app capabilities/entitlements invalidates the profile — regenerate it and update the secret.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,6 +1,6 @@
 # Cantinarr master test checklist
 
-This folder is the master list of end-to-end Cantinarr behavior to verify. Cases are grouped by product area, shared setup is listed in [fixtures](fixtures.md), and the [run template](run-template.md) can be copied when recording a test run.
+This folder is the master list of end-to-end Cantinarr behavior to verify. Cases are grouped by product area, shared setup is listed in [fixtures](fixtures.md), environment and credential needs per layer are in [environments](environments.md), and the [run template](run-template.md) can be copied when recording a test run.
 
 Machine-driven coverage lives in the ordinary test suites — `go test` under
 `server/`, `flutter test` under `app/`, and the private-lab Maestro smoke

--- a/docs/testing/automation.md
+++ b/docs/testing/automation.md
@@ -5,6 +5,19 @@ lives in the test suites themselves — there is no per-case coverage ledger or
 evidence manifest to maintain. `make check-test-automation` validates only
 the catalog line format, the README area counts, and Maestro flow safety.
 
+## CI lanes
+
+Every pull request runs the same three checks: `Test catalog` (this folder's
+lint plus Maestro flow safety), `Go` (`go vet`, `go test` with the pinned
+Codex app-server smoke, and a `CGO_ENABLED=0` build), and `Flutter`
+(`flutter analyze`, `flutter test`, and a release web build). The same suite
+re-runs on every push to `main` to catch merge skew between independently
+green PRs, and on a weekly schedule to catch toolchain drift — the Flutter
+`stable` channel and Go toolchain float forward even when the repo does not
+change. None of these lanes receive credentials of any kind; see
+[environments](environments.md) for what each layer needs, and does not
+need, to run.
+
 ## Layer ownership
 
 | Layer | Primary responsibility |
@@ -14,6 +27,13 @@ the catalog line format, the README area counts, and Maestro flow safety.
 | Maestro | A thin set of black-box web journeys across authentication and role-specific navigation against the disposable lab; add other surfaces only when the web driver can prove them reliably |
 | Patrol | Native-only boundaries that benefit from Dart assertions: passkeys, notification permissions/taps, deep links, external browser/WebView handoff, app lifecycle, and network controls |
 | Manual/external | Physical-device delivery, real Plex share truth, store submission, cross-browser/accessibility audits, low-end performance, and exploratory sessions |
+
+Go integration proof runs against in-process fakes, never live services:
+the service clients take constructor-injected base URLs (`radarr`, `sonarr`,
+`chaptarr`, the download clients, `tautulli`, `plex`, the push gateway) and
+the AI SDKs honor base-URL environment overrides, so tests point them at
+`httptest` servers replaying real API shapes. Contract, authorization, and
+failure vectors run deterministically with zero credentials.
 
 When adding coverage for a behavior, split its assertions by proof surface:
 add lower-level proof first where applicable, then one black-box journey only

--- a/docs/testing/environments.md
+++ b/docs/testing/environments.md
@@ -1,0 +1,66 @@
+# Test and dev environments
+
+What each testing layer needs to run — and where credentials actually live.
+
+## The automated suites need no credentials
+
+`go test ./...` (from `server/`), `flutter test` (from `app/`), and
+`make check-test-automation` are fully hermetic: integration behavior is
+proved against in-process `httptest` fakes and fixture payloads, the
+database is throwaway SQLite, and no network account is required. CI runs
+exactly these, credential-free. If a new test needs a real account or a
+live service, it belongs in the live-lab or manual layers described in
+[automation](automation.md), not in the suites.
+
+## Where real credentials live
+
+Cantinarr's integration credentials are not environment variables. Radarr,
+Sonarr, Chaptarr, download clients, Tautulli, TMDB, Trakt, AI provider
+keys, and the Plex account link are all entered through the admin UI at
+runtime and stored AES-256-GCM encrypted in the SQLite database
+(`service_instances` rows and the settings KV). Environment variables only
+tune boot and deployment (port, public URL, push gateway, passkey
+origins); the full table lives in the root
+[README](../../README.md#configuration), and none are required to boot —
+the JWT secret and encryption key auto-generate on first start.
+
+## Self-hostable with no account
+
+A fully functional *arr environment needs no third-party accounts. Every
+service below runs locally (the private `cantinarr-lab` repo provisions
+exactly this on a disposable droplet), each with only its own locally
+generated API key or local username/password:
+
+- Radarr, Sonarr, Chaptarr — local API key from each service's own settings
+- SABnzbd, NZBGet, qBittorrent, Transmission — local key or local credentials
+- Tautulli — local API key (meaningful data needs a Plex server feeding it)
+- Arr Connect webhooks — Cantinarr mints and installs its own per-instance
+  tokens
+- Push gateway enrollment — account-free against any reachable gateway
+  (delivery is different; see below)
+
+## Genuinely live-only
+
+Only these need a real account, and only for live verification — never for
+the suites:
+
+- **plex.tv** — the whole Plex integration (PIN link, server/library
+  listing, invites) is plex.tv-side; it needs a real Plex account owning a
+  claimed Plex Media Server.
+- **TMDB** — discovery/search needs a v4 read token from a free
+  themoviedb.org account.
+- **Trakt** (optional) — a Trakt account plus a registered app for the
+  client ID.
+- **AI provider keys** — Anthropic/OpenAI/Gemini keys are validated with a
+  real model turn at save time, so dummy keys cannot be configured; the
+  Codex provider needs a real ChatGPT account and the pinned app-server
+  binary.
+- **APNs delivery** — the push gateway holds the Apple credentials;
+  Cantinarr-side enrollment needs none, but a push reaching a device is
+  Apple-live.
+- **GitHub update check** — live but anonymous; disable with
+  `CANTINARR_DISABLE_UPDATE_CHECK`.
+
+Keep every real credential out of the repo, out of test code, and out of
+CI: the suites must stay runnable on a fresh clone with nothing but Go and
+Flutter installed.


### PR DESCRIPTION
## Summary

- `ci.yml` now also runs on every push to `main` (catches merge skew between independently green PRs — today tests never re-run after merge) and on a weekly schedule (catches toolchain drift from the floating Flutter `stable` channel / Go toolchain). Concurrency group is keyed by event so scheduled and push runs don't cancel each other.
- New `docs/testing/environments.md`: what each testing layer needs to run — the suites are fully hermetic (zero credentials), integration credentials are admin-entered and AES-encrypted in the DB (not env vars), which services are self-hostable with no account, and the short genuinely-live-only list (plex.tv, TMDB, Trakt, AI keys, APNs delivery).
- `docs/testing/automation.md`: new CI-lanes section and a paragraph pinning the established httptest fake-service pattern for Go integration proof.
- `AGENTS.md` Verification: notes the new main/scheduled lanes.

## Verification

- `make check-test-automation` — passes (584 cases, 3 flows safety-checked).
- No server or app code changed; Go/Flutter suites unaffected (CI will run them).

## Docs

- [x] AGENTS.md updated (Verification section)
- [x] docs/testing/ updated in the same PR (environments.md, automation.md, README.md link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne