### PR TITLE
test(server): cover websocket hub auth handshake and broadcast routing

### DIFF
--- a/server/internal/websocket/serve_ws_test.go
+++ b/server/internal/websocket/serve_ws_test.go
@@ -1,0 +1,397 @@
+package websocket
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/radarr"
+)
+
+// wsTestEnv wires a real auth service (in-memory SQLite) behind a running hub
+// that serves ServeWS over httptest — the production wiring minus the pollers,
+// so handshake and routing tests exercise the real HTTP upgrade path.
+type wsTestEnv struct {
+	hub    *Hub
+	auth   *auth.Service
+	server *httptest.Server
+}
+
+func newWSTestEnv(t *testing.T) *wsTestEnv {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	svc := auth.NewService(database, "test-secret-key")
+	if err := svc.EnsureAdmin("testpass123"); err != nil {
+		t.Fatalf("ensure admin: %v", err)
+	}
+
+	h := NewHub(svc, nil, nil, nil, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	go h.Run(ctx)
+
+	server := httptest.NewServer(http.HandlerFunc(h.ServeWS))
+	t.Cleanup(func() {
+		server.Close()
+		cancel()
+	})
+	return &wsTestEnv{hub: h, auth: svc, server: server}
+}
+
+// adminToken logs in the bootstrap admin (user id 1) and returns its bearer token.
+func (e *wsTestEnv) adminToken(t *testing.T) string {
+	t.Helper()
+	resp, err := e.auth.Login("admin", "testpass123", "admin-desktop", "hw-admin")
+	if err != nil {
+		t.Fatalf("admin login: %v", err)
+	}
+	return resp.AccessToken
+}
+
+// userToken invites a passwordless user via a connect link and redeems it,
+// exactly like the app does. Repeat calls with the same username mint extra
+// sessions (devices) for the same user.
+func (e *wsTestEnv) userToken(t *testing.T, username, hardwareID string) *auth.TokenResponse {
+	t.Helper()
+	created, err := e.auth.CreateConnectToken(1, username, "http://cantinarr.test")
+	if err != nil {
+		t.Fatalf("create connect token: %v", err)
+	}
+	link, err := url.Parse(created.Link)
+	if err != nil {
+		t.Fatalf("parse connect link: %v", err)
+	}
+	resp, err := e.auth.RedeemConnectToken(link.Query().Get("token"), username+"-device", hardwareID)
+	if err != nil {
+		t.Fatalf("redeem connect token: %v", err)
+	}
+	return resp
+}
+
+// dial opens a websocket connection against ServeWS with the given subprotocol
+// list (the app sends ["Bearer", token]).
+func (e *wsTestEnv) dial(t *testing.T, protocols []string) (*websocket.Conn, *http.Response, error) {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(e.server.URL, "http")
+	dialer := websocket.Dialer{Subprotocols: protocols, HandshakeTimeout: 5 * time.Second}
+	return dialer.Dial(wsURL, nil)
+}
+
+// mustDial is dial for connections the test expects to succeed.
+func (e *wsTestEnv) mustDial(t *testing.T, token string) *websocket.Conn {
+	t.Helper()
+	conn, _, err := e.dial(t, []string{"Bearer", token})
+	if err != nil {
+		t.Fatalf("dial with valid token: %v", err)
+	}
+	return conn
+}
+
+// waitForClients blocks until the hub's client set reaches want. Registration
+// happens on the hub goroutine after the 101 response, so a successful Dial
+// alone does not guarantee the client is routable yet. Uses the write lock so
+// the read can never overlap Run's broadcast-side map mutation.
+func (e *wsTestEnv) waitForClients(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		e.hub.mu.Lock()
+		n := len(e.hub.clients)
+		e.hub.mu.Unlock()
+		if n == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("hub clients = %d, want %d", n, want)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// clientsSnapshot copies the registered client set for identity assertions.
+func (e *wsTestEnv) clientsSnapshot() []*Client {
+	e.hub.mu.Lock()
+	defer e.hub.mu.Unlock()
+	out := make([]*Client, 0, len(e.hub.clients))
+	for c := range e.hub.clients {
+		out = append(out, c)
+	}
+	return out
+}
+
+func readEvent(t *testing.T, conn *websocket.Conn) Event {
+	t.Helper()
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read event: %v", err)
+	}
+	var ev Event
+	if err := json.Unmarshal(data, &ev); err != nil {
+		t.Fatalf("decode event %q: %v", data, err)
+	}
+	return ev
+}
+
+// TestServeWSHandshakeRejectsBadAuth proves the upgrade never happens without a
+// valid ["Bearer", token] subprotocol pair: no header, a wrong scheme (even
+// with a perfectly valid token), a bare scheme, and a garbage token are all
+// refused with 401 before any client is registered.
+func TestServeWSHandshakeRejectsBadAuth(t *testing.T) {
+	env := newWSTestEnv(t)
+	validToken := env.userToken(t, "alice", "hw-alice").AccessToken
+
+	cases := []struct {
+		name      string
+		protocols []string
+	}{
+		{"no subprotocols", nil},
+		{"wrong scheme with valid token", []string{"Basic", validToken}},
+		{"scheme without token", []string{"Bearer"}},
+		{"invalid token", []string{"Bearer", "not-a-real-token"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, resp, err := env.dial(t, tc.protocols)
+			if err == nil {
+				conn.Close()
+				t.Fatalf("handshake succeeded, want rejection")
+			}
+			if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("handshake response = %+v, want HTTP 401", resp)
+			}
+		})
+	}
+
+	if got := len(env.clientsSnapshot()); got != 0 {
+		t.Fatalf("rejected handshakes registered %d client(s), want 0", got)
+	}
+}
+
+// TestServeWSHandshakeRegistersAuthenticatedClients proves a valid user token
+// upgrades and registers a client bound to that user with isAdmin=false, and a
+// valid admin token registers with isAdmin=true.
+func TestServeWSHandshakeRegistersAuthenticatedClients(t *testing.T) {
+	env := newWSTestEnv(t)
+	alice := env.userToken(t, "alice", "hw-alice")
+
+	userConn, userResp, err := env.dial(t, []string{"Bearer", alice.AccessToken})
+	if err != nil {
+		t.Fatalf("dial with user token: %v", err)
+	}
+	defer userConn.Close()
+	env.waitForClients(t, 1)
+
+	clients := env.clientsSnapshot()
+	if clients[0].userID != alice.User.ID || clients[0].isAdmin {
+		t.Fatalf("user client = {userID:%d isAdmin:%t}, want {userID:%d isAdmin:false}",
+			clients[0].userID, clients[0].isAdmin, alice.User.ID)
+	}
+
+	// Pin current behavior: ServeWS upgrades with an empty response header, so
+	// no subprotocol is echoed back despite the client offering ["Bearer",
+	// token]. If a future change starts echoing one, that should be deliberate.
+	if got := userResp.Header.Get("Sec-WebSocket-Protocol"); got != "" {
+		t.Fatalf("negotiated subprotocol = %q, want none (current behavior)", got)
+	}
+
+	adminConn := env.mustDial(t, env.adminToken(t))
+	defer adminConn.Close()
+	env.waitForClients(t, 2)
+
+	var adminClient *Client
+	for _, c := range env.clientsSnapshot() {
+		if c.userID != alice.User.ID {
+			adminClient = c
+		}
+	}
+	if adminClient == nil || !adminClient.isAdmin || adminClient.userID != 1 {
+		t.Fatalf("admin client = %+v, want {userID:1 isAdmin:true}", adminClient)
+	}
+}
+
+// TestServeWSHandshakeRejectsRevokedDeviceToken proves a token that worked is
+// refused after its device is revoked: 401 strictly means the session is gone.
+func TestServeWSHandshakeRejectsRevokedDeviceToken(t *testing.T) {
+	env := newWSTestEnv(t)
+	alice := env.userToken(t, "alice", "hw-alice")
+
+	conn := env.mustDial(t, alice.AccessToken)
+	conn.Close()
+
+	if err := env.auth.RevokeDevice(alice.DeviceID); err != nil {
+		t.Fatalf("revoke device: %v", err)
+	}
+
+	retry, resp, err := env.dial(t, []string{"Bearer", alice.AccessToken})
+	if err == nil {
+		retry.Close()
+		t.Fatalf("handshake with revoked device token succeeded, want 401")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("handshake response = %+v, want HTTP 401", resp)
+	}
+}
+
+// TestBroadcastUserReachesOnlyThatUsersConnections is the cross-user privacy
+// boundary: a user-targeted event reaches every connection of that user (two
+// devices here) and nothing else — not another user, and not admins either
+// (admin visibility is a separate channel, not a duplicate of user traffic).
+//
+// Non-delivery is asserted deterministically via ordering rather than timing:
+// the hub drains its broadcast channel FIFO into per-client FIFO send channels,
+// so a global "fence" event enqueued after the targeted event must arrive
+// after it on any connection that (incorrectly) received the targeted one.
+func TestBroadcastUserReachesOnlyThatUsersConnections(t *testing.T) {
+	env := newWSTestEnv(t)
+	alice := env.userToken(t, "alice", "hw-alice")
+	bob := env.userToken(t, "bob", "hw-bob")
+
+	alicePhone := env.mustDial(t, alice.AccessToken)
+	defer alicePhone.Close()
+	aliceTablet := env.mustDial(t, alice.AccessToken)
+	defer aliceTablet.Close()
+	bobConn := env.mustDial(t, bob.AccessToken)
+	defer bobConn.Close()
+	adminConn := env.mustDial(t, env.adminToken(t))
+	defer adminConn.Close()
+	env.waitForClients(t, 4)
+
+	env.hub.BroadcastUser(alice.User.ID, Event{
+		Type: "request_status_changed",
+		Data: map[string]interface{}{"for": "alice"},
+	})
+	env.hub.Broadcast(Event{Type: "fence"})
+
+	for name, conn := range map[string]*websocket.Conn{"phone": alicePhone, "tablet": aliceTablet} {
+		ev := readEvent(t, conn)
+		if ev.Type != "request_status_changed" || ev.Data["for"] != "alice" {
+			t.Fatalf("alice %s first event = %+v, want her targeted event", name, ev)
+		}
+		if ev := readEvent(t, conn); ev.Type != "fence" {
+			t.Fatalf("alice %s second event = %+v, want fence", name, ev)
+		}
+	}
+	if ev := readEvent(t, bobConn); ev.Type != "fence" {
+		t.Fatalf("bob's first event = %+v, want only the fence (alice's event leaked)", ev)
+	}
+	if ev := readEvent(t, adminConn); ev.Type != "fence" {
+		t.Fatalf("admin's first event = %+v, want only the fence (user event duplicated to admin)", ev)
+	}
+}
+
+// TestBroadcastAdminReachesOnlyAdmins proves admin-only payloads (queue
+// contents whose REST equivalents sit behind admin middleware) never reach
+// non-admin connections. Same fence technique as the user-routing test.
+func TestBroadcastAdminReachesOnlyAdmins(t *testing.T) {
+	env := newWSTestEnv(t)
+	alice := env.userToken(t, "alice", "hw-alice")
+
+	aliceConn := env.mustDial(t, alice.AccessToken)
+	defer aliceConn.Close()
+	adminConn := env.mustDial(t, env.adminToken(t))
+	defer adminConn.Close()
+	env.waitForClients(t, 2)
+
+	env.hub.BroadcastAdmin(Event{
+		Type: "downloads_queue",
+		Data: map[string]interface{}{"instance_id": "sab-1"},
+	})
+	env.hub.Broadcast(Event{Type: "fence"})
+
+	ev := readEvent(t, adminConn)
+	if ev.Type != "downloads_queue" || ev.Data["instance_id"] != "sab-1" {
+		t.Fatalf("admin first event = %+v, want downloads_queue", ev)
+	}
+	if ev := readEvent(t, adminConn); ev.Type != "fence" {
+		t.Fatalf("admin second event = %+v, want fence", ev)
+	}
+	if ev := readEvent(t, aliceConn); ev.Type != "fence" {
+		t.Fatalf("alice's first event = %+v, want only the fence (admin event leaked)", ev)
+	}
+}
+
+// TestDisconnectUnregistersClient proves closing a connection removes its
+// client from the hub, and that broadcasting afterwards neither panics (the
+// send channel is closed on unregister) nor resurrects the dead client, while
+// surviving connections keep receiving.
+func TestDisconnectUnregistersClient(t *testing.T) {
+	env := newWSTestEnv(t)
+	alice := env.userToken(t, "alice", "hw-alice")
+	bob := env.userToken(t, "bob", "hw-bob")
+
+	aliceConn := env.mustDial(t, alice.AccessToken)
+	bobConn := env.mustDial(t, bob.AccessToken)
+	defer bobConn.Close()
+	env.waitForClients(t, 2)
+
+	aliceConn.Close()
+	env.waitForClients(t, 1)
+
+	// Target the departed user, then fence. A send to alice's closed channel
+	// would panic the hub goroutine and fail the whole test process.
+	env.hub.BroadcastUser(alice.User.ID, Event{Type: "request_status_changed"})
+	env.hub.Broadcast(Event{Type: "fence"})
+
+	if ev := readEvent(t, bobConn); ev.Type != "fence" {
+		t.Fatalf("bob's first event = %+v, want only the fence", ev)
+	}
+	remaining := env.clientsSnapshot()
+	if len(remaining) != 1 || remaining[0].userID != bob.User.ID {
+		t.Fatalf("remaining clients = %+v, want only bob's", remaining)
+	}
+}
+
+// TestPollResultReachesSubscribedClients drives one manual tick of the radarr
+// poll body (the 30s ticker interval is a package const, so the loop itself is
+// not instantiable with a tiny interval) against an httptest Radarr and proves
+// the resulting download_progress event reaches a connected client end to end.
+func TestPollResultReachesSubscribedClients(t *testing.T) {
+	env := newWSTestEnv(t)
+	alice := env.userToken(t, "alice", "hw-alice")
+
+	conn := env.mustDial(t, alice.AccessToken)
+	defer conn.Close()
+	env.waitForClients(t, 1)
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v3/queue":
+			_, _ = w.Write([]byte(`{"records":[{"movieId":7,"title":"Heat","status":"downloading","size":1000,"sizeleft":250}]}`))
+		case "/api/v3/movie/7":
+			_, _ = w.Write([]byte(`{"id":7,"title":"Heat","tmdbId":949,"hasFile":false}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer backend.Close()
+
+	env.hub.pollRadarrInstance("radarr-1", radarr.NewClient(backend.URL, "test-key"))
+
+	ev := readEvent(t, conn)
+	if ev.Type != "download_progress" {
+		t.Fatalf("event type = %q, want download_progress", ev.Type)
+	}
+	if ev.Data["tmdb_id"] != float64(949) || ev.Data["media_type"] != "movie" ||
+		ev.Data["status"] != "downloading" || ev.Data["instance_id"] != "radarr-1" {
+		t.Fatalf("download_progress data = %+v", ev.Data)
+	}
+	if ev.Data["progress"] != 0.75 {
+		t.Fatalf("progress = %v, want 0.75 (size 1000, sizeleft 250)", ev.Data["progress"])
+	}
+}


### PR DESCRIPTION
## What

Test-only PR adding coverage for the untested security-relevant core of `server/internal/websocket/hub.go`: the `ServeWS` auth handshake, the hub's audience routing (`BroadcastUser` / `BroadcastAdmin`), unregister-on-disconnect, and the poll→subscriber delivery path. Existing tests only covered `dispatchDetailedItems` and the radarr/sonarr queue-signal mappers; none of that is duplicated.

New `server/internal/websocket/serve_ws_test.go` (same package, real HTTP upgrade path via `httptest` + gorilla dialer, real `auth.Service` on in-memory SQLite):

- **Handshake auth** — no subprotocols, wrong scheme (with an otherwise-valid token), bare `Bearer`, and a garbage token are all rejected with HTTP 401 before any client registers; a valid user token registers a client with the correct `userID` and `isAdmin=false`; an admin token registers `isAdmin=true`; a previously working token is rejected with 401 after its device is revoked. Also pins current behavior that the upgrade response echoes **no** subprotocol.
- **Broadcast routing (privacy boundary)** — with user A on two connections, user B, and an admin all connected, `BroadcastUser(A, …)` reaches both of A's connections and nobody else (not B, no admin duplication); `BroadcastAdmin` reaches only the admin. Non-delivery is proven deterministically with FIFO "fence" events rather than timing assertions.
- **Unregister on disconnect** — closing a connection removes the client from the hub; a subsequent broadcast targeted at the departed user neither panics (closed send channel) nor delivers, and surviving connections keep receiving.
- **Poll → subscriber** — one manual tick of the radarr poll body (`pollRadarrInstance`) against an httptest Radarr delivers a `download_progress` event end to end over the websocket, with correct tmdb_id/progress/instance_id.

All tests are hermetic: in-memory SQLite, httptest servers, no sleeps for delivery assertions (bounded condition-polling only for hub registration, which has no exported synchronization primitive).

## Verification

From `server/`:

- `go vet ./...` — clean
- `go test ./...` — all packages pass (Codex protocol smoke self-skips locally, as expected)
- `go test -race -count=2 ./internal/websocket/` — pass, no races

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne