### PR TITLE
test(app): cover request-status matrix, queue status pills, and push routing

### DIFF
--- a/app/test/chaptarr/chaptarr_queue_item_card_status_test.dart
+++ b/app/test/chaptarr/chaptarr_queue_item_card_status_test.dart
@@ -1,0 +1,162 @@
+import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/core/widgets/status_pill.dart';
+import 'package:cantinarr/features/chaptarr/data/chaptarr_models.dart';
+import 'package:cantinarr/features/chaptarr/ui/widgets/chaptarr_queue_item_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Mirrors the Sonarr/Radarr queue card matrix — the Chaptarr copy derives the
+/// same status grammar and must not drift from it.
+ChaptarrQueueItem _item({
+  String status = '',
+  String? state,
+  String? trackedStatus,
+  String protocol = 'torrent',
+  String? errorMessage,
+  List<String> statusMessages = const [],
+}) =>
+    ChaptarrQueueItem(
+      id: 1,
+      title: 'Author - Book (2024) EPUB',
+      status: status,
+      trackedDownloadState: state,
+      trackedDownloadStatus: trackedStatus,
+      protocol: protocol,
+      size: 8e9,
+      sizeleft: 2e9,
+      timeleft: '00:12:34',
+      errorMessage: errorMessage,
+      statusMessages: statusMessages,
+      quality: 'EPUB',
+    );
+
+Future<void> _pump(
+  WidgetTester tester,
+  ChaptarrQueueItem item, {
+  VoidCallback? onTap,
+}) {
+  return tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: ChaptarrQueueItemCard(item: item, onTap: onTap),
+    ),
+  ));
+}
+
+Color _pillColor(WidgetTester tester, String text) =>
+    tester.widget<StatusPill>(find.widgetWithText(StatusPill, text)).color;
+
+Color? _barColor(WidgetTester tester) => tester
+    .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator))
+    .valueColor
+    ?.value;
+
+void main() {
+  testWidgets('downloading item shows a Downloading pill in the info colour',
+      (tester) async {
+    await _pump(tester, _item(status: 'downloading'));
+    expect(_pillColor(tester, 'Downloading'), AppTheme.downloading);
+    expect(_barColor(tester), AppTheme.downloading);
+    final bar = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator));
+    expect(bar.value, closeTo(0.75, 1e-9));
+  });
+
+  testWidgets('import pending shows an amber pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'importPending'));
+    expect(_pillColor(tester, 'Import pending'), AppTheme.requested);
+  });
+
+  testWidgets('importing shows an amber pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'importing'));
+    expect(_pillColor(tester, 'Importing'), AppTheme.requested);
+  });
+
+  testWidgets('imported shows a green pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'imported'));
+    expect(_pillColor(tester, 'Imported'), AppTheme.available);
+  });
+
+  testWidgets('tracked warning outranks the downloading status',
+      (tester) async {
+    await _pump(
+        tester, _item(status: 'downloading', trackedStatus: 'warning'));
+    expect(find.text('Downloading'), findsNothing);
+    expect(_pillColor(tester, 'Warning'), AppTheme.requested);
+  });
+
+  testWidgets('tracked error outranks the import phase', (tester) async {
+    await _pump(tester,
+        _item(status: 'completed', state: 'importing', trackedStatus: 'error'));
+    expect(find.text('Importing'), findsNothing);
+    expect(_pillColor(tester, 'Error'), AppTheme.error);
+    expect(_barColor(tester), AppTheme.error);
+  });
+
+  testWidgets('failed import shows a red Failed pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'failedPending'));
+    expect(_pillColor(tester, 'Failed'), AppTheme.error);
+  });
+
+  testWidgets('stalled client shows a muted Client unavailable pill',
+      (tester) async {
+    await _pump(tester, _item(status: 'downloadClientUnavailable'));
+    expect(_pillColor(tester, 'Client unavailable'), AppTheme.unavailable);
+  });
+
+  testWidgets('queued item shows a muted pill', (tester) async {
+    await _pump(tester, _item(status: 'queued'));
+    expect(_pillColor(tester, 'Queued'), AppTheme.unavailable);
+  });
+
+  testWidgets('blank status falls back to Unknown', (tester) async {
+    await _pump(tester, _item());
+    expect(find.text('Unknown'), findsOneWidget);
+  });
+
+  testWidgets('protocol pill distinguishes torrent from usenet',
+      (tester) async {
+    await _pump(tester, _item(status: 'downloading'));
+    expect(_pillColor(tester, 'TORRENT'), AppTheme.downloading);
+
+    await _pump(
+        tester, _item(status: 'downloading', protocol: 'usenet'));
+    expect(_pillColor(tester, 'USENET'), AppTheme.available);
+  });
+
+  testWidgets('warning with messages shows the inline issues box',
+      (tester) async {
+    await _pump(
+      tester,
+      _item(
+        status: 'completed',
+        state: 'importPending',
+        trackedStatus: 'warning',
+        statusMessages: const ['Not an upgrade for existing book file'],
+      ),
+    );
+    expect(
+      find.text('Not an upgrade for existing book file'),
+      findsOneWidget,
+    );
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+  });
+
+  testWidgets('issues defer to the Import Doctor when a handler is set',
+      (tester) async {
+    var opened = 0;
+    await _pump(
+      tester,
+      _item(
+        status: 'completed',
+        state: 'importBlocked',
+        trackedStatus: 'warning',
+        statusMessages: const ['Sample file detected'],
+      ),
+      onTap: () => opened++,
+    );
+
+    expect(find.text('Sample file detected'), findsNothing);
+    await tester.tap(find.text('1 message — tap to resolve'));
+    expect(opened, 1);
+  });
+}

--- a/app/test/core/widgets/instance_dropdown_test.dart
+++ b/app/test/core/widgets/instance_dropdown_test.dart
@@ -1,0 +1,99 @@
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/widgets/instance_dropdown.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _main = ServiceInstance(
+  id: 'radarr-main',
+  serviceType: 'radarr',
+  name: 'Main Radarr',
+  isDefault: true,
+);
+const _fourK = ServiceInstance(
+  id: 'radarr-4k',
+  serviceType: 'radarr',
+  name: '4K Radarr',
+);
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required List<ServiceInstance> instances,
+  String? activeInstanceId,
+  ValueChanged<String>? onChanged,
+}) {
+  return tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: InstanceDropdown(
+        instances: instances,
+        activeInstanceId: activeInstanceId,
+        onChanged: onChanged ?? (_) {},
+      ),
+    ),
+  ));
+}
+
+void main() {
+  testWidgets('a single instance renders nothing to switch', (tester) async {
+    await _pump(
+      tester,
+      instances: const [_main],
+      activeInstanceId: 'radarr-main',
+    );
+
+    expect(find.byType(DropdownButton<String>), findsNothing);
+    expect(find.text('Main Radarr'), findsNothing);
+  });
+
+  testWidgets('multiple instances show only the active name collapsed',
+      (tester) async {
+    await _pump(
+      tester,
+      instances: const [_main, _fourK],
+      activeInstanceId: 'radarr-main',
+    );
+
+    expect(find.byType(DropdownButton<String>), findsOneWidget);
+    expect(find.text('Main Radarr'), findsOneWidget);
+    expect(find.text('4K Radarr'), findsNothing);
+  });
+
+  testWidgets('selecting another instance reports its id', (tester) async {
+    final changes = <String>[];
+    await _pump(
+      tester,
+      instances: const [_main, _fourK],
+      activeInstanceId: 'radarr-main',
+      onChanged: changes.add,
+    );
+
+    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.pumpAndSettle();
+    expect(find.text('4K Radarr'), findsOneWidget);
+
+    await tester.tap(find.text('4K Radarr'));
+    await tester.pumpAndSettle();
+
+    expect(changes, ['radarr-4k']);
+  });
+
+  testWidgets('re-selecting the active instance still reports it',
+      (tester) async {
+    final changes = <String>[];
+    await _pump(
+      tester,
+      instances: const [_main, _fourK],
+      activeInstanceId: 'radarr-4k',
+      onChanged: changes.add,
+    );
+
+    await tester.tap(find.byType(DropdownButton<String>));
+    await tester.pumpAndSettle();
+    // The open menu shows every choice, including the current one.
+    expect(find.text('Main Radarr'), findsOneWidget);
+
+    await tester.tap(find.text('4K Radarr').last);
+    await tester.pumpAndSettle();
+
+    expect(changes, ['radarr-4k']);
+  });
+}

--- a/app/test/notifications/push_service_test.dart
+++ b/app/test/notifications/push_service_test.dart
@@ -1,0 +1,454 @@
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/storage/secure_storage.dart';
+import 'package:cantinarr/features/notifications/push_service.dart';
+import 'package:cantinarr/navigation/app_router.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+const _channelName = 'codes.julian.cantinarr/push';
+
+/// Simulates the native side calling into Dart on the push channel, the same
+/// path AppDelegate uses for token delivery and notification taps. Awaiting
+/// this awaits the service's handler (including its backend call).
+Future<void> _emitNativeCall(String method, Object? arguments) {
+  const codec = StandardMethodCodec();
+  return TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .handlePlatformMessage(
+    _channelName,
+    codec.encodeMethodCall(MethodCall(method, arguments)),
+    (_) {},
+  );
+}
+
+/// A [GoRouter] that records pushed locations instead of navigating, so the
+/// notification-tap → route mapping can be asserted without a widget tree.
+class _RecordingRouter extends GoRouter {
+  _RecordingRouter()
+      : super.routingConfig(
+          routingConfig: ValueNotifier(
+            RoutingConfig(routes: [
+              GoRoute(path: '/', builder: (_, __) => const SizedBox.shrink()),
+            ]),
+          ),
+        );
+
+  final pushed = <String>[];
+
+  @override
+  Future<T?> push<T extends Object?>(String location, {Object? extra}) {
+    pushed.add(location);
+    return Future<T?>.value();
+  }
+}
+
+/// In-memory [StorageService] seeded with (or without) a device id.
+class _FakeStorage implements StorageService {
+  _FakeStorage(this._data);
+
+  final Map<String, String?> _data;
+
+  @override
+  Future<String?> read({required String key}) async => _data[key];
+
+  @override
+  Future<void> write({required String key, required String? value}) async {
+    _data[key] = value;
+  }
+
+  @override
+  Future<void> delete({required String key}) async => _data.remove(key);
+
+  @override
+  Future<void> hardenAuthKeys() async {}
+}
+
+/// Records every backend request; optionally fails the first [failFirst]
+/// requests with a 500 so the retry-after-failure path can be exercised.
+class _RecordingAdapter implements HttpClientAdapter {
+  _RecordingAdapter({this.failFirst = 0});
+
+  int failFirst;
+  final requests = <RequestOptions>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    if (failFirst > 0) {
+      failFirst--;
+      return ResponseBody.fromString(
+        '{"error":"boom"}',
+        500,
+        headers: {
+          'content-type': ['application/json'],
+        },
+      );
+    }
+    return ResponseBody.fromString(
+      '{}',
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _Harness {
+  _Harness({Map<String, String?>? storage, int failFirst = 0})
+      : router = _RecordingRouter(),
+        adapter = _RecordingAdapter(failFirst: failFirst) {
+    final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+      ..httpClientAdapter = adapter;
+    container = ProviderContainer(overrides: [
+      appRouterProvider.overrideWithValue(router),
+      storageServiceProvider.overrideWithValue(
+        _FakeStorage(storage ?? {StorageKeys.deviceId: 'device-1'}),
+      ),
+      backendClientProvider.overrideWithValue(dio),
+    ]);
+    addTearDown(container.dispose);
+    addTearDown(router.dispose);
+    // Constructing the service installs its handler on the push channel.
+    service = container.read(pushServiceProvider);
+  }
+
+  final _RecordingRouter router;
+  final _RecordingAdapter adapter;
+  late final ProviderContainer container;
+  late final PushService service;
+
+  List<RequestOptions> get tokenPosts => adapter.requests
+      .where((r) => r.method == 'POST' && r.path == '/api/devices/push-token')
+      .toList();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('notification tap routing', () {
+    const directRoutes = {
+      'request_pending': '/approvals',
+      'agent_action_pending': '/agent-actions',
+      'plex_access_request': '/settings/users',
+      'plex_invite_sent': '/plex-guide',
+      'remediation_autodispatch_disabled': '/settings/ai-remediation',
+    };
+
+    for (final entry in directRoutes.entries) {
+      test('${entry.key} routes to ${entry.value}', () async {
+        final h = _Harness();
+        await _emitNativeCall('onNotificationTap', {'type': entry.key});
+        expect(h.router.pushed, [entry.value]);
+      });
+    }
+
+    for (final type in const ['request_decision', 'new_movie', 'new_episode']) {
+      test('$type opens the media detail page', () async {
+        final h = _Harness();
+        await _emitNativeCall('onNotificationTap', {
+          'type': type,
+          'tmdb_id': 42,
+          'media_type': 'movie',
+        });
+        expect(h.router.pushed, ['/detail/movie/42']);
+      });
+    }
+
+    test('media_type tv routes to the tv detail page', () async {
+      final h = _Harness();
+      await _emitNativeCall('onNotificationTap', {
+        'type': 'new_episode',
+        'tmdb_id': 7,
+        'media_type': 'tv',
+      });
+      expect(h.router.pushed, ['/detail/tv/7']);
+    });
+
+    test('missing or unknown media_type falls back to movie', () async {
+      final h = _Harness();
+      await _emitNativeCall('onNotificationTap', {
+        'type': 'new_movie',
+        'tmdb_id': 9,
+      });
+      await _emitNativeCall('onNotificationTap', {
+        'type': 'new_movie',
+        'tmdb_id': 10,
+        'media_type': 'book',
+      });
+      expect(h.router.pushed, ['/detail/movie/9', '/detail/movie/10']);
+    });
+
+    test('tmdb_id survives string and double payload encodings', () async {
+      final h = _Harness();
+      await _emitNativeCall('onNotificationTap', {
+        'type': 'new_movie',
+        'tmdb_id': '77',
+      });
+      await _emitNativeCall('onNotificationTap', {
+        'type': 'new_movie',
+        'tmdb_id': 78.0,
+      });
+      expect(h.router.pushed, ['/detail/movie/77', '/detail/movie/78']);
+    });
+
+    test('media payloads without a usable tmdb_id do not navigate', () async {
+      final h = _Harness();
+      await _emitNativeCall('onNotificationTap', {'type': 'request_decision'});
+      await _emitNativeCall(
+          'onNotificationTap', {'type': 'new_movie', 'tmdb_id': 0});
+      await _emitNativeCall(
+          'onNotificationTap', {'type': 'new_movie', 'tmdb_id': -3});
+      await _emitNativeCall(
+          'onNotificationTap', {'type': 'new_movie', 'tmdb_id': 'nope'});
+      expect(h.router.pushed, isEmpty);
+    });
+
+    for (final type in const [
+      'issue_created',
+      'issue_updated',
+      'issue_resolved',
+      'agent_action_decided',
+      'agent_action_terminal',
+      'agent_action_superseded',
+    ]) {
+      test('$type opens the issue thread', () async {
+        final h = _Harness();
+        await _emitNativeCall('onNotificationTap', {
+          'type': type,
+          'issue_id': 12,
+        });
+        expect(h.router.pushed, ['/issues/12']);
+      });
+    }
+
+    test('issue payloads without a usable issue_id do not navigate', () async {
+      final h = _Harness();
+      await _emitNativeCall('onNotificationTap', {'type': 'issue_created'});
+      await _emitNativeCall(
+          'onNotificationTap', {'type': 'issue_updated', 'issue_id': 0});
+      expect(h.router.pushed, isEmpty);
+    });
+
+    test('unknown, missing-type, and non-map payloads are ignored', () async {
+      final h = _Harness();
+      await _emitNativeCall('onNotificationTap', {'type': 'shiny_new_thing'});
+      await _emitNativeCall('onNotificationTap', {'tmdb_id': 42});
+      await _emitNativeCall('onNotificationTap', 'not-a-map');
+      await _emitNativeCall('onNotificationTap', null);
+      expect(h.router.pushed, isEmpty);
+    });
+  });
+
+  group('APNs token registration', () {
+    test('a delivered token is registered once with the device identity',
+        () async {
+      final h = _Harness();
+      await _emitNativeCall('onApnsToken', 'token-a');
+      await _emitNativeCall('onApnsToken', 'token-a');
+
+      expect(h.tokenPosts, hasLength(1));
+      expect(h.tokenPosts.single.data, {
+        'device_id': 'device-1',
+        'apns_token': 'token-a',
+        'platform': 'ios',
+      });
+    });
+
+    test('a rotated token re-registers', () async {
+      final h = _Harness();
+      await _emitNativeCall('onApnsToken', 'token-a');
+      await _emitNativeCall('onApnsToken', 'token-b');
+
+      expect(
+        h.tokenPosts.map((r) => r.data['apns_token']).toList(),
+        ['token-a', 'token-b'],
+      );
+    });
+
+    test('empty and null tokens are ignored', () async {
+      final h = _Harness();
+      await _emitNativeCall('onApnsToken', '');
+      await _emitNativeCall('onApnsToken', null);
+      expect(h.adapter.requests, isEmpty);
+    });
+
+    test('registration is skipped when no device id is stored', () async {
+      final h = _Harness(storage: {});
+      await _emitNativeCall('onApnsToken', 'token-a');
+      expect(h.adapter.requests, isEmpty);
+    });
+
+    test('a failed registration is not deduped — the same token retries',
+        () async {
+      final h = _Harness(failFirst: 1);
+      await _emitNativeCall('onApnsToken', 'token-a');
+      await _emitNativeCall('onApnsToken', 'token-a');
+
+      expect(h.tokenPosts, hasLength(2));
+      expect(h.tokenPosts.last.data['apns_token'], 'token-a');
+    });
+
+    test('registerForPush is a no-op off iOS', () async {
+      final h = _Harness();
+      final outgoing = <String>[];
+      const channel = MethodChannel(_channelName);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+        outgoing.add(call.method);
+        return null;
+      });
+      addTearDown(() => TestDefaultBinaryMessengerBinding
+          .instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null));
+
+      await h.service.registerForPush();
+      expect(await h.service.authorizationStatus(), 'notDetermined');
+
+      expect(outgoing, isEmpty);
+      expect(h.adapter.requests, isEmpty);
+    });
+  });
+
+  group('PushTestResult.fromJson', () {
+    test('parses counts and per-device results', () {
+      final result = PushTestResult.fromJson({
+        'tokens': 2,
+        'sent': 1,
+        'failed': 1,
+        'results': [
+          {'ok': true, 'pruned': false, 'error': ''},
+          {'ok': false, 'pruned': true, 'error': 'BadDeviceToken'},
+        ],
+      });
+
+      expect(result.tokens, 2);
+      expect(result.sent, 1);
+      expect(result.failed, 1);
+      expect(result.results, hasLength(2));
+      expect(result.results.first.ok, isTrue);
+      expect(result.results.last.pruned, isTrue);
+      expect(result.results.last.error, 'BadDeviceToken');
+    });
+
+    test('defaults every field on an empty payload', () {
+      final result = PushTestResult.fromJson(const {});
+      expect(result.tokens, 0);
+      expect(result.sent, 0);
+      expect(result.failed, 0);
+      expect(result.results, isEmpty);
+      expect(result.firstError, isNull);
+    });
+
+    test('accepts double-encoded counts', () {
+      final result = PushTestResult.fromJson({'tokens': 2.0, 'sent': 1.0});
+      expect(result.tokens, 2);
+      expect(result.sent, 1);
+    });
+
+    test('firstError skips devices without an error', () {
+      final result = PushTestResult.fromJson({
+        'tokens': 2,
+        'results': [
+          {'ok': true, 'error': ''},
+          {'ok': false, 'error': 'Boom'},
+        ],
+      });
+      expect(result.firstError, 'Boom');
+    });
+  });
+
+  group('describePushTest', () {
+    PushTestResult result({
+      int tokens = 1,
+      int sent = 0,
+      int failed = 0,
+      List<PushTestDeviceResult> results = const [],
+    }) =>
+        PushTestResult(
+            tokens: tokens, sent: sent, failed: failed, results: results);
+
+    test('no registered devices — self and admin phrasing', () {
+      expect(
+        describePushTest(result(tokens: 0)),
+        startsWith('You have no registered push devices yet.'),
+      );
+      expect(
+        describePushTest(result(tokens: 0), username: 'alice'),
+        startsWith('alice has no registered push devices yet.'),
+      );
+    });
+
+    test('clean delivery — singular, plural, and admin phrasing', () {
+      expect(describePushTest(result(sent: 1)), 'Test sent to 1 device.');
+      expect(describePushTest(result(sent: 3)), 'Test sent to 3 devices.');
+      expect(
+        describePushTest(result(sent: 3), username: 'alice'),
+        'Test sent to alice (3 devices).',
+      );
+    });
+
+    test('tokens exist but nothing was reached — gateway desync message', () {
+      expect(
+        describePushTest(result(tokens: 2)),
+        contains('the push gateway has no active token for this account'),
+      );
+      expect(
+        describePushTest(result(tokens: 2), username: 'alice'),
+        contains('no active token for alice'),
+      );
+    });
+
+    test('partial failure carries the BadDeviceToken hint', () {
+      final r = result(
+        tokens: 3,
+        sent: 2,
+        failed: 1,
+        results: const [
+          PushTestDeviceResult(ok: false, pruned: false, error: 'BadDeviceToken'),
+        ],
+      );
+      final message = describePushTest(r);
+      expect(message, startsWith('Sent to 2, but 1 failed'));
+      expect(message, contains('Apple rejected the token'));
+    });
+
+    test('total failure carries the Unregistered hint', () {
+      final r = result(
+        tokens: 1,
+        failed: 1,
+        results: const [
+          PushTestDeviceResult(ok: false, pruned: true, error: 'Unregistered'),
+        ],
+      );
+      final message = describePushTest(r);
+      expect(message, startsWith('Delivery failed for 1 device'));
+      expect(message, contains('no longer valid'));
+    });
+
+    test('unrecognised errors are echoed verbatim', () {
+      final r = result(
+        tokens: 2,
+        failed: 2,
+        results: const [
+          PushTestDeviceResult(ok: false, pruned: false, error: 'TooMany'),
+        ],
+      );
+      expect(
+        describePushTest(r, username: 'alice'),
+        'alice: delivery failed for 2 devices (TooMany).',
+      );
+    });
+  });
+}

--- a/app/test/radarr/radarr_queue_item_card_status_test.dart
+++ b/app/test/radarr/radarr_queue_item_card_status_test.dart
@@ -1,0 +1,166 @@
+import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/core/widgets/status_pill.dart';
+import 'package:cantinarr/features/radarr/data/radarr_models.dart';
+import 'package:cantinarr/features/radarr/ui/widgets/radarr_queue_item_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Mirrors the Sonarr queue card matrix — the Radarr copy derives the same
+/// status grammar and must not drift from it.
+RadarrQueueItem _item({
+  String status = '',
+  String? state,
+  String? trackedStatus,
+  String protocol = 'torrent',
+  String? errorMessage,
+  List<String> statusMessages = const [],
+}) =>
+    RadarrQueueItem(
+      id: 1,
+      title: 'Movie.2024.1080p.WEB',
+      status: status,
+      trackedDownloadState: state,
+      trackedDownloadStatus: trackedStatus,
+      protocol: protocol,
+      size: 8e9,
+      sizeleft: 2e9,
+      timeleft: '00:12:34',
+      errorMessage: errorMessage,
+      statusMessages: statusMessages,
+      quality: 'WEBDL-1080p',
+    );
+
+Future<void> _pump(
+  WidgetTester tester,
+  RadarrQueueItem item, {
+  VoidCallback? onShowIssues,
+}) {
+  return tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: RadarrQueueItemCard(
+        item: item,
+        primaryTitle: 'Movie',
+        onShowIssues: onShowIssues,
+      ),
+    ),
+  ));
+}
+
+Color _pillColor(WidgetTester tester, String text) =>
+    tester.widget<StatusPill>(find.widgetWithText(StatusPill, text)).color;
+
+Color? _barColor(WidgetTester tester) => tester
+    .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator))
+    .valueColor
+    ?.value;
+
+void main() {
+  testWidgets('downloading item shows a Downloading pill in the info colour',
+      (tester) async {
+    await _pump(tester, _item(status: 'downloading'));
+    expect(_pillColor(tester, 'Downloading'), AppTheme.downloading);
+    expect(_barColor(tester), AppTheme.downloading);
+    final bar = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator));
+    expect(bar.value, closeTo(0.75, 1e-9));
+  });
+
+  testWidgets('import pending shows an amber pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'importPending'));
+    expect(_pillColor(tester, 'Import pending'), AppTheme.requested);
+  });
+
+  testWidgets('importing shows an amber pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'importing'));
+    expect(_pillColor(tester, 'Importing'), AppTheme.requested);
+  });
+
+  testWidgets('imported shows a green pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'imported'));
+    expect(_pillColor(tester, 'Imported'), AppTheme.available);
+  });
+
+  testWidgets('tracked warning outranks the downloading status',
+      (tester) async {
+    await _pump(
+        tester, _item(status: 'downloading', trackedStatus: 'warning'));
+    expect(find.text('Downloading'), findsNothing);
+    expect(_pillColor(tester, 'Warning'), AppTheme.requested);
+  });
+
+  testWidgets('tracked error outranks the import phase', (tester) async {
+    await _pump(tester,
+        _item(status: 'completed', state: 'importing', trackedStatus: 'error'));
+    expect(find.text('Importing'), findsNothing);
+    expect(_pillColor(tester, 'Error'), AppTheme.error);
+    expect(_barColor(tester), AppTheme.error);
+  });
+
+  testWidgets('failed import shows a red Failed pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'failedPending'));
+    expect(_pillColor(tester, 'Failed'), AppTheme.error);
+  });
+
+  testWidgets('stalled client shows a muted Client unavailable pill',
+      (tester) async {
+    await _pump(tester, _item(status: 'downloadClientUnavailable'));
+    expect(_pillColor(tester, 'Client unavailable'), AppTheme.unavailable);
+  });
+
+  testWidgets('queued item shows a muted pill', (tester) async {
+    await _pump(tester, _item(status: 'queued'));
+    expect(_pillColor(tester, 'Queued'), AppTheme.unavailable);
+  });
+
+  testWidgets('blank status falls back to Unknown', (tester) async {
+    await _pump(tester, _item());
+    expect(find.text('Unknown'), findsOneWidget);
+  });
+
+  testWidgets('protocol pill distinguishes torrent from usenet',
+      (tester) async {
+    await _pump(tester, _item(status: 'downloading'));
+    expect(_pillColor(tester, 'TORRENT'), AppTheme.downloading);
+
+    await _pump(
+        tester, _item(status: 'downloading', protocol: 'usenet'));
+    expect(_pillColor(tester, 'USENET'), AppTheme.available);
+  });
+
+  testWidgets('warning with messages shows the inline issues box',
+      (tester) async {
+    await _pump(
+      tester,
+      _item(
+        status: 'completed',
+        state: 'importPending',
+        trackedStatus: 'warning',
+        statusMessages: const ['Not an upgrade for existing movie file'],
+      ),
+    );
+    expect(
+      find.text('Not an upgrade for existing movie file'),
+      findsOneWidget,
+    );
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+  });
+
+  testWidgets('issues defer to the Import Doctor when a handler is set',
+      (tester) async {
+    var opened = 0;
+    await _pump(
+      tester,
+      _item(
+        status: 'completed',
+        state: 'importBlocked',
+        trackedStatus: 'warning',
+        statusMessages: const ['Sample file detected'],
+      ),
+      onShowIssues: () => opened++,
+    );
+
+    expect(find.text('Sample file detected'), findsNothing);
+    await tester.tap(find.text('1 message — tap to resolve'));
+    expect(opened, 1);
+  });
+}

--- a/app/test/request/request_button_matrix_test.dart
+++ b/app/test/request/request_button_matrix_test.dart
@@ -1,0 +1,163 @@
+import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/features/request/data/request_service.dart';
+import 'package:cantinarr/features/request/ui/request_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// One row of the status matrix: what the requester should see for a status.
+class _Case {
+  final RequestStatus status;
+  final String label;
+  final IconData icon;
+  final Color color;
+  final bool enabled;
+
+  const _Case(this.status, this.label, this.icon, this.color,
+      {required this.enabled});
+}
+
+/// The full requester-facing matrix. Labels are requester vocabulary
+/// (Request / Requested / Downloading / Available), never arr jargon.
+const _cases = [
+  _Case(RequestStatus.unavailable, 'Request', Icons.add, AppTheme.accent,
+      enabled: true),
+  _Case(RequestStatus.pending, 'Pending', Icons.hourglass_empty,
+      AppTheme.requested,
+      enabled: false),
+  _Case(RequestStatus.denied, 'Request', Icons.add, AppTheme.accent,
+      enabled: true),
+  _Case(RequestStatus.requested, 'Requested', Icons.hourglass_top,
+      AppTheme.requested,
+      enabled: false),
+  _Case(RequestStatus.downloading, 'Downloading', Icons.downloading,
+      AppTheme.downloading,
+      enabled: false),
+  _Case(RequestStatus.available, 'Available', Icons.check_circle_rounded,
+      AppTheme.available,
+      enabled: false),
+  _Case(RequestStatus.partial, 'Request More', Icons.add, AppTheme.accent,
+      enabled: true),
+];
+
+Future<void> _pump(
+  WidgetTester tester, {
+  required RequestStatus status,
+  bool isRequesting = false,
+  VoidCallback? onRequest,
+  String? error,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: RequestButton(
+          status: status,
+          isRequesting: isRequesting,
+          onRequest: onRequest,
+          error: error,
+        ),
+      ),
+    ),
+  );
+}
+
+ElevatedButton _button(WidgetTester tester) =>
+    tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+
+void main() {
+  test('button labels speak requester vocabulary, not arr jargon', () {
+    expect(
+      RequestStatus.values.map((s) => s.buttonLabel).toSet(),
+      {
+        'Request',
+        'Pending',
+        'Requested',
+        'Downloading',
+        'Available',
+        'Request More',
+      },
+    );
+  });
+
+  for (final c in _cases) {
+    testWidgets(
+        '${c.status.name} shows "${c.label}" and is '
+        '${c.enabled ? 'tappable' : 'non-interactive'}', (tester) async {
+      var taps = 0;
+      await _pump(tester, status: c.status, onRequest: () => taps++);
+
+      expect(find.text(c.label), findsOneWidget);
+      expect(find.byIcon(c.icon), findsOneWidget);
+
+      final button = _button(tester);
+      final style = button.style!;
+      if (c.enabled) {
+        expect(button.onPressed, isNotNull);
+        expect(style.backgroundColor!.resolve(const {}), c.color);
+        await tester.tap(find.byType(ElevatedButton));
+        expect(taps, 1);
+      } else {
+        // Disabled rendering keeps the status token as the visible hue.
+        expect(button.onPressed, isNull);
+        expect(
+          style.foregroundColor!.resolve(const {WidgetState.disabled}),
+          c.color,
+        );
+        expect(
+          style.backgroundColor!.resolve(const {WidgetState.disabled}),
+          c.color.withValues(alpha: 0.13),
+        );
+        await tester.tap(find.byType(ElevatedButton), warnIfMissed: false);
+        expect(taps, 0);
+      }
+    });
+  }
+
+  testWidgets('in-flight request disables the button and shows a spinner',
+      (tester) async {
+    var taps = 0;
+    await _pump(
+      tester,
+      status: RequestStatus.unavailable,
+      isRequesting: true,
+      onRequest: () => taps++,
+    );
+
+    expect(find.text('Requesting...'), findsOneWidget);
+    expect(find.text('Request'), findsNothing);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.byIcon(Icons.add), findsNothing);
+
+    expect(_button(tester).onPressed, isNull);
+    await tester.tap(find.byType(ElevatedButton), warnIfMissed: false);
+    expect(taps, 0);
+  });
+
+  testWidgets('partial availability stays requestable while in flight',
+      (tester) async {
+    await _pump(tester, status: RequestStatus.partial, isRequesting: true);
+
+    expect(find.text('Requesting...'), findsOneWidget);
+    expect(find.text('Request More'), findsNothing);
+    expect(_button(tester).onPressed, isNull);
+  });
+
+  testWidgets('error message renders under the button', (tester) async {
+    await _pump(
+      tester,
+      status: RequestStatus.unavailable,
+      error: 'Request failed. Please try again.',
+    );
+
+    final errorText = tester.widget<Text>(
+      find.text('Request failed. Please try again.'),
+    );
+    expect(errorText.style?.color, AppTheme.error);
+  });
+
+  testWidgets('no error row without an error', (tester) async {
+    await _pump(tester, status: RequestStatus.unavailable);
+
+    // Just the label inside the button — no trailing error text.
+    expect(find.byType(Text), findsOneWidget);
+  });
+}

--- a/app/test/sonarr/queue_item_card_status_test.dart
+++ b/app/test/sonarr/queue_item_card_status_test.dart
@@ -1,0 +1,167 @@
+import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/core/widgets/status_pill.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:cantinarr/features/sonarr/ui/widgets/queue_item_card.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The queue card derives one status pill from live queue data: tracked
+/// error/warning outranks the import phase, which outranks the raw download
+/// client status. Each state must keep its own label + colour token.
+SonarrQueueItem _item({
+  String status = '',
+  String? state,
+  String? trackedStatus,
+  String protocol = 'torrent',
+  String? errorMessage,
+  List<String> statusMessages = const [],
+}) =>
+    SonarrQueueItem(
+      id: 1,
+      title: 'Show.S01E01.1080p.WEB',
+      status: status,
+      trackedDownloadState: state,
+      trackedDownloadStatus: trackedStatus,
+      protocol: protocol,
+      size: 8e9,
+      sizeleft: 2e9,
+      timeleft: '00:12:34',
+      errorMessage: errorMessage,
+      statusMessages: statusMessages,
+      quality: 'WEBDL-1080p',
+    );
+
+Future<void> _pump(
+  WidgetTester tester,
+  SonarrQueueItem item, {
+  VoidCallback? onShowIssues,
+}) {
+  return tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: QueueItemCard(
+        item: item,
+        primaryTitle: 'Show',
+        onShowIssues: onShowIssues,
+      ),
+    ),
+  ));
+}
+
+Color _pillColor(WidgetTester tester, String text) =>
+    tester.widget<StatusPill>(find.widgetWithText(StatusPill, text)).color;
+
+Color? _barColor(WidgetTester tester) => tester
+    .widget<LinearProgressIndicator>(find.byType(LinearProgressIndicator))
+    .valueColor
+    ?.value;
+
+void main() {
+  testWidgets('downloading item shows a Downloading pill in the info colour',
+      (tester) async {
+    await _pump(tester, _item(status: 'downloading'));
+    expect(_pillColor(tester, 'Downloading'), AppTheme.downloading);
+    expect(_barColor(tester), AppTheme.downloading);
+    final bar = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator));
+    expect(bar.value, closeTo(0.75, 1e-9));
+  });
+
+  testWidgets('import pending shows an amber pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'importPending'));
+    expect(_pillColor(tester, 'Import pending'), AppTheme.requested);
+  });
+
+  testWidgets('importing shows an amber pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'importing'));
+    expect(_pillColor(tester, 'Importing'), AppTheme.requested);
+  });
+
+  testWidgets('imported shows a green pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'imported'));
+    expect(_pillColor(tester, 'Imported'), AppTheme.available);
+  });
+
+  testWidgets('tracked warning outranks the downloading status',
+      (tester) async {
+    await _pump(
+        tester, _item(status: 'downloading', trackedStatus: 'warning'));
+    expect(find.text('Downloading'), findsNothing);
+    expect(_pillColor(tester, 'Warning'), AppTheme.requested);
+  });
+
+  testWidgets('tracked error outranks the import phase', (tester) async {
+    await _pump(tester,
+        _item(status: 'completed', state: 'importing', trackedStatus: 'error'));
+    expect(find.text('Importing'), findsNothing);
+    expect(_pillColor(tester, 'Error'), AppTheme.error);
+    expect(_barColor(tester), AppTheme.error);
+  });
+
+  testWidgets('failed import shows a red Failed pill', (tester) async {
+    await _pump(tester, _item(status: 'completed', state: 'failedPending'));
+    expect(_pillColor(tester, 'Failed'), AppTheme.error);
+  });
+
+  testWidgets('stalled client shows a muted Client unavailable pill',
+      (tester) async {
+    await _pump(tester, _item(status: 'downloadClientUnavailable'));
+    expect(_pillColor(tester, 'Client unavailable'), AppTheme.unavailable);
+  });
+
+  testWidgets('queued item shows a muted pill', (tester) async {
+    await _pump(tester, _item(status: 'queued'));
+    expect(_pillColor(tester, 'Queued'), AppTheme.unavailable);
+  });
+
+  testWidgets('blank status falls back to Unknown', (tester) async {
+    await _pump(tester, _item());
+    expect(find.text('Unknown'), findsOneWidget);
+  });
+
+  testWidgets('protocol pill distinguishes torrent from usenet',
+      (tester) async {
+    await _pump(tester, _item(status: 'downloading'));
+    expect(_pillColor(tester, 'TORRENT'), AppTheme.downloading);
+
+    await _pump(
+        tester, _item(status: 'downloading', protocol: 'usenet'));
+    expect(_pillColor(tester, 'USENET'), AppTheme.available);
+  });
+
+  testWidgets('warning with messages shows the inline issues box',
+      (tester) async {
+    await _pump(
+      tester,
+      _item(
+        status: 'completed',
+        state: 'importPending',
+        trackedStatus: 'warning',
+        statusMessages: const ['Not an upgrade for existing episode file(s)'],
+      ),
+    );
+    expect(
+      find.text('Not an upgrade for existing episode file(s)'),
+      findsOneWidget,
+    );
+    expect(find.byIcon(Icons.warning_amber_rounded), findsOneWidget);
+  });
+
+  testWidgets('issues defer to the Import Doctor when a handler is set',
+      (tester) async {
+    var opened = 0;
+    await _pump(
+      tester,
+      _item(
+        status: 'completed',
+        state: 'importBlocked',
+        trackedStatus: 'warning',
+        statusMessages: const ['Sample file detected'],
+      ),
+      onShowIssues: () => opened++,
+    );
+
+    expect(find.text('Sample file detected'), findsNothing);
+    await tester.tap(find.text('1 message — tap to resolve'));
+    expect(opened, 1);
+  });
+}


### PR DESCRIPTION
## What

Test-only PR pinning the app's highest-risk untested UI state matrices. No production code changed.

- **RequestButton full matrix** (`app/test/request/request_button_matrix_test.dart`): all 7 `RequestStatus` values — label, distinguishing icon, colour token (including the disabled-state rendering that keeps the status hue), enabled/disabled, and tap behavior — plus the `isRequesting` in-flight spinner state, the error row, and a guard that button labels stay requester vocabulary (Request/Requested/Downloading/Available), never arr jargon.
- **Queue-card status pills** (`app/test/{sonarr,radarr,chaptarr}/*queue_item_card_status_test.dart`): the pill each card derives from live queue data — downloading, import pending/importing/imported, warning-outranks-status and error-outranks-import precedence, failed import, stalled client (`downloadClientUnavailable`), queued, Unknown fallback — pill label + colour per state, the protocol pill (torrent vs usenet), progress-bar colour/value, and the inline issues box vs the Import Doctor tap-to-resolve deferral. The three cards are deliberate near-copies, so each copy gets the same matrix to catch drift.
- **Push notification routing** (`app/test/notifications/push_service_test.dart`): payload-type → route mapping for all 14 payload types through the real `MethodChannel` path (`TestDefaultBinaryMessenger.handlePlatformMessage` into a recording `GoRouter` override of `appRouterProvider`) — no production seam needed. Covers tmdb_id/issue_id int/string/double coercion, missing/zero/negative-id ignore paths, unknown/typeless/non-map payloads, APNs token registration dedupe, token rotation, empty-token and missing-device-id skips, retry after a failed POST (dedupe latches only on success), the off-iOS no-op, plus `PushTestResult.fromJson` and `describePushTest` phrasing with the BadDeviceToken/Unregistered APNs hints.
- **InstanceDropdown** (`app/test/core/widgets/instance_dropdown_test.dart`): hidden with a single instance, collapsed shows only the active name, and selection reports the chosen id.

## Verification

From `app/`:

- `flutter analyze --no-fatal-infos` — No issues found.
- `flutter test` — All tests passed (433, including the 91 new ones).

Server checks not run — no server changes.

## Docs

Docs are part of the change, not a follow-up. Tick what you updated, or tick the last box and say why nothing needed it:

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne