### PR TITLE
test(server): cover movie/TV request write path and availability computation

### DIFF
--- a/server/internal/request/service_approval_test.go
+++ b/server/internal/request/service_approval_test.go
@@ -1,0 +1,407 @@
+package request
+
+import (
+	"testing"
+)
+
+// recordingNotifier records notifier events, mirroring the fake in
+// internal/push/composite_test.go but keeping the payloads for assertions.
+type recordingNotifier struct {
+	userEvents  []notifierEvent
+	adminEvents []notifierEvent
+}
+
+type notifierEvent struct {
+	userID    int64
+	eventType string
+	data      map[string]interface{}
+}
+
+func (r *recordingNotifier) NotifyUser(userID int64, eventType string, data map[string]interface{}) {
+	r.userEvents = append(r.userEvents, notifierEvent{userID: userID, eventType: eventType, data: data})
+}
+
+func (r *recordingNotifier) NotifyAdmins(eventType string, data map[string]interface{}) {
+	r.adminEvents = append(r.adminEvents, notifierEvent{eventType: eventType, data: data})
+}
+
+// createTestAdmin inserts an admin user (decisions record approved_by, which
+// references users.id) and returns its id.
+func createTestAdmin(t *testing.T, s *Service) int64 {
+	t.Helper()
+	res, err := s.db.Exec("INSERT INTO users (username, password_hash, role) VALUES ('boss', '', 'admin')")
+	if err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+	adminID, _ := res.LastInsertId()
+	return adminID
+}
+
+// requireApproval flips the global request policy to approval-required.
+func requireApproval(t *testing.T, s *Service) {
+	t.Helper()
+	if err := s.SetGlobalSettings(GlobalSettings{
+		RequireApproval:    true,
+		AllowSeasonChoice:  true,
+		DefaultSeasonScope: SeasonScopeAll,
+	}); err != nil {
+		t.Fatalf("SetGlobalSettings: %v", err)
+	}
+}
+
+// TestCreateMediaRequestPendingDedupe covers the approval-required movie/TV
+// path: the request queues as pending without touching any arr, an identical
+// re-submit is deduped (one row, one admin notification), and a denied row
+// does NOT block a fresh request — the user may re-request after a denial,
+// creating a new pending row alongside the denied one.
+func TestCreateMediaRequestPendingDedupe(t *testing.T) {
+	s, uid := newHistoryTestService(t, "", "", "") // no arrs: pending must not need them
+	rec := &recordingNotifier{}
+	s.notifier = rec
+	requireApproval(t, s)
+	adminID := createTestAdmin(t, s)
+
+	resp, err := s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "Fight Club"})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if resp.Status != StatusPending || resp.Title != "Fight Club" {
+		t.Fatalf("response = %+v, want pending/Fight Club", resp)
+	}
+	if len(rec.adminEvents) != 1 || rec.adminEvents[0].eventType != "request_pending" {
+		t.Fatalf("admin events = %+v, want one request_pending", rec.adminEvents)
+	}
+	if got := rec.adminEvents[0].data["pending_count"]; got != 1 {
+		t.Errorf("pending_count = %v, want 1", got)
+	}
+
+	// Exact duplicate: same status back, no second row, no second notification.
+	resp, err = s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "Fight Club"})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest dup: %v", err)
+	}
+	if resp.Status != StatusPending {
+		t.Fatalf("dup status = %s, want pending", resp.Status)
+	}
+	countRows := func(status string) int {
+		t.Helper()
+		var n int
+		if err := s.db.QueryRow(
+			"SELECT COUNT(*) FROM request_log WHERE user_id = ? AND tmdb_id = 550 AND media_type = 'movie' AND status = ?",
+			uid, status,
+		).Scan(&n); err != nil {
+			t.Fatalf("count %s rows: %v", status, err)
+		}
+		return n
+	}
+	if got := countRows(StatusPending); got != 1 {
+		t.Fatalf("pending rows after dup = %d, want 1", got)
+	}
+	if len(rec.adminEvents) != 1 {
+		t.Errorf("admin events after dup = %d, want still 1 (no duplicate notify)", len(rec.adminEvents))
+	}
+
+	// Deny it, then re-request: the denied row must not dedupe-block a fresh
+	// pending row (denial is re-requestable).
+	pending, err := s.ListPending()
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("ListPending = %+v err=%v, want exactly 1", pending, err)
+	}
+	if pending[0].UserID != uid || pending[0].TmdbID != 550 || pending[0].Username != "requester" {
+		t.Errorf("pending row = %+v, want requester's tmdb 550", pending[0])
+	}
+	if err := s.DenyRequest(adminID, pending[0].ID, "not now"); err != nil {
+		t.Fatalf("DenyRequest: %v", err)
+	}
+
+	resp, err = s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "Fight Club"})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest after deny: %v", err)
+	}
+	if resp.Status != StatusPending {
+		t.Fatalf("re-request status = %s, want pending", resp.Status)
+	}
+	if got := countRows(StatusPending); got != 1 {
+		t.Errorf("pending rows after re-request = %d, want 1", got)
+	}
+	if got := countRows(StatusDenied); got != 1 {
+		t.Errorf("denied rows after re-request = %d, want 1 (kept alongside the new pending)", got)
+	}
+}
+
+// TestCreateTVRequestPendingCachesTvdbID: a pending TV request stores the
+// supplied TVDB id mapping so status checks resolve while it waits, and the
+// resolved season scope rides along for the approval queue.
+func TestCreateTVRequestPendingCachesTvdbID(t *testing.T) {
+	s, uid := newHistoryTestService(t, "", "", "")
+	requireApproval(t, s)
+
+	resp, err := s.CreateMediaRequest(uid, &CreateRequest{
+		TmdbID: 1399, TvdbID: 121361, MediaType: "tv", Title: "Andor",
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if resp.Status != StatusPending {
+		t.Fatalf("status = %s, want pending", resp.Status)
+	}
+
+	var cachedTvdb int
+	if err := s.db.QueryRow("SELECT tvdb_id FROM tmdb_tvdb_cache WHERE tmdb_id = 1399").Scan(&cachedTvdb); err != nil {
+		t.Fatalf("read tmdb_tvdb_cache: %v", err)
+	}
+	if cachedTvdb != 121361 {
+		t.Errorf("cached tvdb_id = %d, want 121361", cachedTvdb)
+	}
+
+	pending, err := s.ListPending()
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("ListPending = %+v err=%v, want exactly 1", pending, err)
+	}
+	if pending[0].TvdbID != 121361 || pending[0].SeasonScope != SeasonScopeAll {
+		t.Errorf("pending row = %+v, want tvdb 121361 + season scope all", pending[0])
+	}
+}
+
+// TestApproveRequestPerformsArrAdd covers the approve transition: the arr add
+// actually runs (Radarr receives the movie), the row flips pending ->
+// requested with the canonical title and decision audit fields, the requester
+// is notified, and a second approve of the same row fails.
+func TestApproveRequestPerformsArrAdd(t *testing.T) {
+	f := &fakeRadarr{
+		lookupJSON: `[{"title":"Fight Club","tmdbId":550,"year":1999}]`,
+	}
+	srv := newFakeRadarrServer(t, f)
+
+	s, uid := newHistoryTestService(t, srv.URL, "", "")
+	rec := &recordingNotifier{}
+	s.notifier = rec
+	requireApproval(t, s)
+	adminID := createTestAdmin(t, s)
+
+	if _, err := s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "fight club (client title)"}); err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if f.addBody != nil {
+		t.Fatal("pending request must not touch Radarr before approval")
+	}
+	pending, err := s.ListPending()
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("ListPending = %+v err=%v, want exactly 1", pending, err)
+	}
+
+	resp, err := s.ApproveRequest(adminID, pending[0].ID, nil)
+	if err != nil {
+		t.Fatalf("ApproveRequest: %v", err)
+	}
+	if !resp.Success || resp.Status != StatusRequested || resp.Title != "Fight Club" {
+		t.Fatalf("response = %+v, want requested/Fight Club", resp)
+	}
+	if f.addBody == nil {
+		t.Fatal("approval did not add the movie to Radarr")
+	}
+	if f.addBody["tmdbId"] != float64(550) || f.addBody["qualityProfileId"] != float64(1) {
+		t.Errorf("add body = %#v, want tmdbId 550 with first-profile fallback (no stored profile)", f.addBody)
+	}
+
+	var status, title string
+	var approvedBy int64
+	var decidedAt any
+	if err := s.db.QueryRow(
+		"SELECT status, title, approved_by, decided_at FROM request_log WHERE id = ?", pending[0].ID,
+	).Scan(&status, &title, &approvedBy, &decidedAt); err != nil {
+		t.Fatalf("read decided row: %v", err)
+	}
+	if status != StatusRequested || title != "Fight Club" || approvedBy != adminID || decidedAt == nil {
+		t.Errorf("decided row = %s/%s by %d at %v, want requested/Fight Club by admin with a decided_at",
+			status, title, approvedBy, decidedAt)
+	}
+
+	if len(rec.userEvents) != 1 {
+		t.Fatalf("user events = %+v, want exactly one decision", rec.userEvents)
+	}
+	ev := rec.userEvents[0]
+	if ev.userID != uid || ev.eventType != "request_decision" {
+		t.Errorf("event = %+v, want request_decision to the requester", ev)
+	}
+	if ev.data["decision"] != "approved" || ev.data["status"] != StatusRequested || ev.data["title"] != "Fight Club" {
+		t.Errorf("event data = %#v, want approved/requested/Fight Club", ev.data)
+	}
+
+	// The row is no longer pending: a second decision must be rejected.
+	if _, err := s.ApproveRequest(adminID, pending[0].ID, nil); err == nil {
+		t.Error("second ApproveRequest succeeded, want 'request is not pending' error")
+	}
+}
+
+// TestApproveRequestQualityOverride: an admin quality override replaces the
+// stored profile in both the arr payload and the decided row.
+func TestApproveRequestQualityOverride(t *testing.T) {
+	f := &fakeRadarr{
+		lookupJSON: `[{"title":"Fight Club","tmdbId":550,"year":1999}]`,
+	}
+	srv := newFakeRadarrServer(t, f)
+
+	s, uid := newHistoryTestService(t, srv.URL, "", "")
+	requireApproval(t, s)
+	adminID := createTestAdmin(t, s)
+
+	if _, err := s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "Fight Club"}); err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	pending, _ := s.ListPending()
+	if len(pending) != 1 {
+		t.Fatalf("pending = %+v, want exactly 1", pending)
+	}
+
+	if _, err := s.ApproveRequest(adminID, pending[0].ID, &DecisionOverride{QualityProfileID: 7}); err != nil {
+		t.Fatalf("ApproveRequest: %v", err)
+	}
+	if got := f.addBody["qualityProfileId"]; got != float64(7) {
+		t.Errorf("qualityProfileId = %v, want the override (7)", got)
+	}
+	var storedProfile int
+	if err := s.db.QueryRow("SELECT quality_profile_id FROM request_log WHERE id = ?", pending[0].ID).Scan(&storedProfile); err != nil {
+		t.Fatalf("read quality_profile_id: %v", err)
+	}
+	if storedProfile != 7 {
+		t.Errorf("stored quality_profile_id = %d, want 7", storedProfile)
+	}
+}
+
+// TestApproveRequestSeasonScopeOverrideReplacesExplicitSeasons: an admin
+// choosing a coarse scope on approval discards the requester's explicit season
+// list — the add uses addOptions.monitor, not per-season flags — and the
+// decided row stores the coarse scope.
+func TestApproveRequestSeasonScopeOverrideReplacesExplicitSeasons(t *testing.T) {
+	f := &fakeSonarrTV{
+		lookupJSON: `[{"title":"Andor","tvdbId":121361,"year":2022,"seasons":[
+			{"seasonNumber":1},{"seasonNumber":2},{"seasonNumber":3}]}]`,
+	}
+	srv := newFakeSonarrServer(t, f)
+
+	s, uid := newHistoryTestService(t, "", srv.URL, "")
+	requireApproval(t, s)
+	adminID := createTestAdmin(t, s)
+
+	if _, err := s.CreateMediaRequest(uid, &CreateRequest{
+		TmdbID: 1399, TvdbID: 121361, MediaType: "tv", Title: "Andor", Seasons: []int{2, 3},
+	}); err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	pending, _ := s.ListPending()
+	if len(pending) != 1 {
+		t.Fatalf("pending = %+v, want exactly 1", pending)
+	}
+	if pending[0].SeasonScope != "[2,3]" {
+		t.Fatalf("stored season_scope = %q, want the explicit list [2,3]", pending[0].SeasonScope)
+	}
+
+	resp, err := s.ApproveRequest(adminID, pending[0].ID, &DecisionOverride{SeasonScope: SeasonScopeFirst})
+	if err != nil {
+		t.Fatalf("ApproveRequest: %v", err)
+	}
+	if resp.Status != StatusRequested || resp.Title != "Andor" {
+		t.Fatalf("response = %+v, want requested/Andor", resp)
+	}
+
+	addOptions, _ := f.addBody["addOptions"].(map[string]any)
+	if addOptions["monitor"] != "firstSeason" {
+		t.Errorf("addOptions.monitor = %v, want firstSeason (override replaces the explicit list)", addOptions["monitor"])
+	}
+	if _, present := f.addBody["seasons"]; present {
+		t.Errorf("seasons = %v, want omitted once the explicit list is overridden", f.addBody["seasons"])
+	}
+	var storedScope string
+	if err := s.db.QueryRow("SELECT season_scope FROM request_log WHERE id = ?", pending[0].ID).Scan(&storedScope); err != nil {
+		t.Fatalf("read season_scope: %v", err)
+	}
+	if storedScope != SeasonScopeFirst {
+		t.Errorf("stored season_scope = %q, want first", storedScope)
+	}
+}
+
+// TestApproveRequestArrFailureLeavesPending: when the arr add fails the row
+// must stay pending (so the admin can retry after fixing config) and the
+// requester must not be notified of a decision.
+func TestApproveRequestArrFailureLeavesPending(t *testing.T) {
+	s, uid := newHistoryTestService(t, "", "", "") // no radarr: the add must fail
+	rec := &recordingNotifier{}
+	s.notifier = rec
+	requireApproval(t, s)
+	adminID := createTestAdmin(t, s)
+
+	if _, err := s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "Fight Club"}); err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	pending, _ := s.ListPending()
+	if len(pending) != 1 {
+		t.Fatalf("pending = %+v, want exactly 1", pending)
+	}
+
+	if _, err := s.ApproveRequest(adminID, pending[0].ID, nil); err == nil {
+		t.Fatal("ApproveRequest succeeded without a configured Radarr, want error")
+	}
+	var status string
+	if err := s.db.QueryRow("SELECT status FROM request_log WHERE id = ?", pending[0].ID).Scan(&status); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != StatusPending {
+		t.Errorf("status after failed approve = %s, want still pending (admin can retry)", status)
+	}
+	if len(rec.userEvents) != 0 {
+		t.Errorf("user events = %+v, want none for a failed approval", rec.userEvents)
+	}
+}
+
+// TestDenyRequest covers the deny transition: the row flips pending -> denied
+// with the reason and audit fields, the requester is notified with the reason,
+// the user-facing status reads denied, and a second decision is rejected.
+func TestDenyRequest(t *testing.T) {
+	s, uid := newHistoryTestService(t, "", "", "")
+	rec := &recordingNotifier{}
+	s.notifier = rec
+	requireApproval(t, s)
+	adminID := createTestAdmin(t, s)
+
+	if _, err := s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "Fight Club"}); err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	pending, _ := s.ListPending()
+	if len(pending) != 1 {
+		t.Fatalf("pending = %+v, want exactly 1", pending)
+	}
+
+	if err := s.DenyRequest(adminID, pending[0].ID, "library full"); err != nil {
+		t.Fatalf("DenyRequest: %v", err)
+	}
+
+	var status, reason string
+	var approvedBy int64
+	if err := s.db.QueryRow(
+		"SELECT status, COALESCE(deny_reason, ''), approved_by FROM request_log WHERE id = ?", pending[0].ID,
+	).Scan(&status, &reason, &approvedBy); err != nil {
+		t.Fatalf("read denied row: %v", err)
+	}
+	if status != StatusDenied || reason != "library full" || approvedBy != adminID {
+		t.Errorf("denied row = %s/%q by %d, want denied/library full by admin", status, reason, approvedBy)
+	}
+
+	if len(rec.userEvents) != 1 {
+		t.Fatalf("user events = %+v, want exactly one decision", rec.userEvents)
+	}
+	ev := rec.userEvents[0]
+	if ev.userID != uid || ev.data["decision"] != "denied" || ev.data["reason"] != "library full" {
+		t.Errorf("event = %+v, want denied with the reason", ev)
+	}
+
+	// The requester's own status now reads denied (nothing landed in any arr).
+	if st, err := s.GetUserStatus(uid, 550, "movie"); err != nil || st.Status != StatusDenied {
+		t.Errorf("GetUserStatus = %+v err=%v, want denied", st, err)
+	}
+
+	// Already decided: a second deny is rejected.
+	if err := s.DenyRequest(adminID, pending[0].ID, "again"); err == nil {
+		t.Error("second DenyRequest succeeded, want 'request is not pending' error")
+	}
+}

--- a/server/internal/request/service_movie_test.go
+++ b/server/internal/request/service_movie_test.go
@@ -1,0 +1,315 @@
+package request
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeRadarr simulates the Radarr endpoints the movie request flow touches and
+// records what was written, mirroring fakeSonarr in service_monitor_test.go.
+type fakeRadarr struct {
+	libraryJSON string // GET /api/v3/movie?tmdbId= body; "" means empty library
+	lookupJSON  string // GET /api/v3/movie/lookup body
+	queueJSON   string // records array for GET /api/v3/queue; "" means empty
+
+	addBody    map[string]any
+	editorBody map[string]any
+	commands   []map[string]any
+}
+
+func (f *fakeRadarr) handler(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/movie":
+			body := f.libraryJSON
+			if body == "" {
+				body = "[]"
+			}
+			_, _ = w.Write([]byte(body))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/movie/lookup":
+			_, _ = w.Write([]byte(f.lookupJSON))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/qualityprofile":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"Any"},{"id":7,"name":"HD-1080p"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/rootfolder":
+			_, _ = w.Write([]byte(`[{"id":1,"path":"/movies"}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/movie":
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &f.addBody)
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v3/movie/editor":
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &f.editorBody)
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/command":
+			var cmd map[string]any
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &cmd)
+			f.commands = append(f.commands, cmd)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/queue":
+			records := f.queueJSON
+			if records == "" {
+				records = "[]"
+			}
+			_, _ = w.Write([]byte(`{"records":` + records + `}`))
+		default:
+			t.Errorf("unexpected radarr request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+func newFakeRadarrServer(t *testing.T, f *fakeRadarr) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(f.handler(t))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestCreateMovieRequestAddsToRadarr covers the auto-approve movie path end to
+// end: the add payload must carry the canonical lookup title/year, the
+// effective per-user quality profile (an admin-set default applies even though
+// the user may not choose quality — the request's own choice is ignored), the
+// first root folder, and searchForMovie so the grab starts immediately.
+func TestCreateMovieRequestAddsToRadarr(t *testing.T) {
+	f := &fakeRadarr{
+		lookupJSON: `[{"title":"Fight Club","tmdbId":550,"year":1999}]`,
+	}
+	srv := newFakeRadarrServer(t, f)
+
+	s, uid := newHistoryTestService(t, srv.URL, "", "")
+	profile := 7
+	if err := s.SetUserSettings(uid, UserSettingsDTO{QualityProfileRadarr: &profile}); err != nil {
+		t.Fatalf("SetUserSettings: %v", err)
+	}
+
+	resp, err := s.CreateMediaRequest(uid, &CreateRequest{
+		TmdbID:    550,
+		MediaType: "movie",
+		Title:     "fight club (client title)",
+		// Quality choice is not allowed out of the box, so this must be ignored
+		// in favor of the admin-set per-user default (7).
+		QualityProfileID: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if !resp.Success || resp.Status != StatusRequested {
+		t.Fatalf("response = %+v, want success + requested", resp)
+	}
+	if resp.Title != "Fight Club" {
+		t.Fatalf("title = %q, want the canonical lookup title", resp.Title)
+	}
+
+	if f.addBody == nil {
+		t.Fatal("AddMovie was not called")
+	}
+	if f.addBody["title"] != "Fight Club" || f.addBody["tmdbId"] != float64(550) || f.addBody["year"] != float64(1999) {
+		t.Errorf("add identity = %v/%v/%v, want Fight Club/550/1999",
+			f.addBody["title"], f.addBody["tmdbId"], f.addBody["year"])
+	}
+	if got := f.addBody["qualityProfileId"]; got != float64(7) {
+		t.Errorf("qualityProfileId = %v, want 7 (admin-set per-user default)", got)
+	}
+	if got := f.addBody["rootFolderPath"]; got != "/movies" {
+		t.Errorf("rootFolderPath = %v, want /movies", got)
+	}
+	if f.addBody["monitored"] != true {
+		t.Errorf("monitored = %v, want true", f.addBody["monitored"])
+	}
+	addOptions, _ := f.addBody["addOptions"].(map[string]any)
+	if addOptions["searchForMovie"] != true {
+		t.Errorf("addOptions = %#v, want searchForMovie true", f.addBody["addOptions"])
+	}
+	if len(f.commands) != 0 {
+		t.Errorf("commands = %v, want none (search rides on addOptions)", f.commands)
+	}
+
+	// The fulfilled request is logged with the canonical title + status.
+	var title, status string
+	if err := s.db.QueryRow(
+		"SELECT title, status FROM request_log WHERE user_id = ? AND tmdb_id = 550 AND media_type = 'movie'", uid,
+	).Scan(&title, &status); err != nil {
+		t.Fatalf("read request_log: %v", err)
+	}
+	if title != "Fight Club" || status != StatusRequested {
+		t.Errorf("logged row = %s/%s, want Fight Club/requested", title, status)
+	}
+}
+
+// TestCreateMovieRequestUnknownProfileFallsBack pins the profile guard: an
+// effective profile id Radarr doesn't actually have must fall back to Radarr's
+// first profile rather than sending a broken add.
+func TestCreateMovieRequestUnknownProfileFallsBack(t *testing.T) {
+	f := &fakeRadarr{
+		lookupJSON: `[{"title":"Fight Club","tmdbId":550,"year":1999}]`,
+	}
+	srv := newFakeRadarrServer(t, f)
+
+	s, uid := newHistoryTestService(t, srv.URL, "", "")
+	profile := 99 // not in the fake's [1, 7]
+	if err := s.SetUserSettings(uid, UserSettingsDTO{QualityProfileRadarr: &profile}); err != nil {
+		t.Fatalf("SetUserSettings: %v", err)
+	}
+
+	if _, err := s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "Fight Club"}); err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if got := f.addBody["qualityProfileId"]; got != float64(1) {
+		t.Errorf("qualityProfileId = %v, want 1 (first profile fallback)", got)
+	}
+}
+
+// TestCreateMovieRequestExistingMovie covers the three in-library outcomes: a
+// movie with a file is simply available, a monitored movie without a file is
+// already being worked on (no writes), and an unmonitored one must be revived
+// (monitor + search) instead of reporting "requested" while nothing would ever
+// happen.
+func TestCreateMovieRequestExistingMovie(t *testing.T) {
+	t.Run("has file reads available with no writes", func(t *testing.T) {
+		f := &fakeRadarr{
+			libraryJSON: `[{"id":12,"tmdbId":550,"title":"Fight Club","hasFile":true,"monitored":true}]`,
+		}
+		srv := newFakeRadarrServer(t, f)
+		s, uid := newHistoryTestService(t, srv.URL, "", "")
+
+		resp, err := s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "Fight Club"})
+		if err != nil {
+			t.Fatalf("CreateMediaRequest: %v", err)
+		}
+		if resp.Status != StatusAvailable || resp.Title != "Fight Club" {
+			t.Errorf("response = %+v, want available/Fight Club", resp)
+		}
+		if f.addBody != nil || f.editorBody != nil || len(f.commands) != 0 {
+			t.Errorf("unexpected writes: add=%v editor=%v commands=%v", f.addBody, f.editorBody, f.commands)
+		}
+	})
+
+	t.Run("monitored without file reads requested with no writes", func(t *testing.T) {
+		f := &fakeRadarr{
+			libraryJSON: `[{"id":12,"tmdbId":550,"title":"Fight Club","hasFile":false,"monitored":true}]`,
+		}
+		srv := newFakeRadarrServer(t, f)
+		s, uid := newHistoryTestService(t, srv.URL, "", "")
+
+		resp, err := s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "Fight Club"})
+		if err != nil {
+			t.Fatalf("CreateMediaRequest: %v", err)
+		}
+		if resp.Status != StatusRequested {
+			t.Errorf("status = %s, want requested", resp.Status)
+		}
+		if f.editorBody != nil || len(f.commands) != 0 {
+			t.Errorf("unexpected writes for already-monitored movie: editor=%v commands=%v", f.editorBody, f.commands)
+		}
+	})
+
+	t.Run("unmonitored is revived with monitor and search", func(t *testing.T) {
+		f := &fakeRadarr{
+			libraryJSON: `[{"id":12,"tmdbId":550,"title":"Fight Club","hasFile":false,"monitored":false}]`,
+		}
+		srv := newFakeRadarrServer(t, f)
+		s, uid := newHistoryTestService(t, srv.URL, "", "")
+
+		resp, err := s.CreateMediaRequest(uid, &CreateRequest{TmdbID: 550, MediaType: "movie", Title: "Fight Club"})
+		if err != nil {
+			t.Fatalf("CreateMediaRequest: %v", err)
+		}
+		if resp.Status != StatusRequested {
+			t.Errorf("status = %s, want requested", resp.Status)
+		}
+		if f.addBody != nil {
+			t.Errorf("AddMovie called for an in-library movie: %v", f.addBody)
+		}
+		ids, _ := f.editorBody["movieIds"].([]any)
+		if f.editorBody["monitored"] != true || len(ids) != 1 || ids[0] != float64(12) {
+			t.Errorf("editor body = %#v, want movieIds [12] monitored true", f.editorBody)
+		}
+		if len(f.commands) != 1 || f.commands[0]["name"] != "MoviesSearch" {
+			t.Fatalf("commands = %v, want exactly one MoviesSearch", f.commands)
+		}
+		cmdIDs, _ := f.commands[0]["movieIds"].([]any)
+		if len(cmdIDs) != 1 || cmdIDs[0] != float64(12) {
+			t.Errorf("MoviesSearch movieIds = %v, want [12]", f.commands[0]["movieIds"])
+		}
+	})
+}
+
+// TestGetMovieStatusMatrix covers the availability computation for movies:
+// file on disk -> available, queued download -> downloading with byte-derived
+// progress, monitored without a file -> requested, and unmonitored or absent
+// -> unavailable.
+func TestGetMovieStatusMatrix(t *testing.T) {
+	cases := []struct {
+		name         string
+		fake         *fakeRadarr
+		wantStatus   string
+		wantProgress float64
+	}{
+		{
+			name:       "not in radarr",
+			fake:       &fakeRadarr{},
+			wantStatus: StatusUnavailable,
+		},
+		{
+			name: "file on disk",
+			fake: &fakeRadarr{
+				libraryJSON: `[{"id":12,"tmdbId":550,"title":"Fight Club","hasFile":true,"monitored":true}]`,
+			},
+			wantStatus:   StatusAvailable,
+			wantProgress: 1.0,
+		},
+		{
+			name: "in download queue",
+			fake: &fakeRadarr{
+				libraryJSON: `[{"id":12,"tmdbId":550,"title":"Fight Club","hasFile":false,"monitored":true}]`,
+				queueJSON:   `[{"movieId":12,"title":"Fight Club","status":"downloading","size":2000,"sizeleft":500}]`,
+			},
+			wantStatus:   StatusDownloading,
+			wantProgress: 0.75,
+		},
+		{
+			name: "monitored without file",
+			fake: &fakeRadarr{
+				libraryJSON: `[{"id":12,"tmdbId":550,"title":"Fight Club","hasFile":false,"monitored":true}]`,
+			},
+			wantStatus: StatusRequested,
+		},
+		{
+			name: "unmonitored without file",
+			fake: &fakeRadarr{
+				libraryJSON: `[{"id":12,"tmdbId":550,"title":"Fight Club","hasFile":false,"monitored":false}]`,
+			},
+			wantStatus: StatusUnavailable,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			srv := newFakeRadarrServer(t, c.fake)
+			s, uid := newHistoryTestService(t, srv.URL, "", "")
+			st, err := s.getMovieStatus(uid, 550)
+			if err != nil {
+				t.Fatalf("getMovieStatus: %v", err)
+			}
+			if st.Status != c.wantStatus {
+				t.Errorf("status = %s, want %s", st.Status, c.wantStatus)
+			}
+			if st.Progress != c.wantProgress {
+				t.Errorf("progress = %v, want %v", st.Progress, c.wantProgress)
+			}
+		})
+	}
+
+	t.Run("no radarr source", func(t *testing.T) {
+		s, uid := newHistoryTestService(t, "", "", "")
+		st, err := s.getMovieStatus(uid, 550)
+		if err != nil || st.Status != StatusUnavailable {
+			t.Errorf("status = %+v err=%v, want unavailable", st, err)
+		}
+	})
+}

--- a/server/internal/request/service_tv_test.go
+++ b/server/internal/request/service_tv_test.go
@@ -1,0 +1,465 @@
+package request
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeSonarrTV simulates the Sonarr endpoints the TV request/status flows
+// touch and records what was written. It complements fakeSonarr in
+// service_monitor_test.go, which drives the monitoring helpers directly; this
+// fake serves the full CreateMediaRequest / getTVStatus surface (library
+// lookup by tvdbId, series lookup, add, episodes, monitoring, commands).
+type fakeSonarrTV struct {
+	libraryJSON  string            // GET /api/v3/series?tvdbId= body; "" means not in library
+	seriesJSON   string            // GET /api/v3/series/42 body (UpdateSeriesMonitoring round-trip)
+	lookupJSON   string            // GET /api/v3/series/lookup body
+	episodesJSON map[string]string // GET /api/v3/episode keyed by seasonNumber query ("" = all)
+	episodesFail bool              // force the episode fetch to fail (statistics fallback)
+
+	addBody     map[string]any
+	seriesPut   map[string]any
+	monitorBody map[string]any
+	commands    []map[string]any
+}
+
+func (f *fakeSonarrTV) handler(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/series":
+			body := f.libraryJSON
+			if body == "" {
+				body = "[]"
+			}
+			_, _ = w.Write([]byte(body))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/series/lookup":
+			_, _ = w.Write([]byte(f.lookupJSON))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/series/42":
+			_, _ = w.Write([]byte(f.seriesJSON))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v3/series/42":
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &f.seriesPut)
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/qualityprofile":
+			_, _ = w.Write([]byte(`[{"id":2,"name":"Any"},{"id":9,"name":"HD-1080p"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/rootfolder":
+			_, _ = w.Write([]byte(`[{"id":1,"path":"/tv"}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/series":
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &f.addBody)
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v3/episode":
+			if f.episodesFail {
+				http.Error(w, "boom", http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write([]byte(f.episodesJSON[r.URL.Query().Get("seasonNumber")]))
+		case r.Method == http.MethodPut && r.URL.Path == "/api/v3/episode/monitor":
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &f.monitorBody)
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v3/command":
+			var cmd map[string]any
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &cmd)
+			f.commands = append(f.commands, cmd)
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Errorf("unexpected sonarr request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+func newFakeSonarrServer(t *testing.T, f *fakeSonarrTV) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(f.handler(t))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestCreateTVRequestAddsSeriesWithCoarseScope covers the auto-approve add of
+// a series not yet in Sonarr: the payload carries the effective per-user
+// quality profile, the first root folder, season folders, the coarse scope
+// mapped onto addOptions.monitor, and an immediate missing-episode search. The
+// supplied TVDB id must also be cached so later status checks skip the bridge.
+func TestCreateTVRequestAddsSeriesWithCoarseScope(t *testing.T) {
+	f := &fakeSonarrTV{
+		lookupJSON: `[{"title":"Andor","tvdbId":121361,"year":2022,"seasons":[{"seasonNumber":1},{"seasonNumber":2}]}]`,
+	}
+	srv := newFakeSonarrServer(t, f)
+
+	s, uid := newHistoryTestService(t, "", srv.URL, "")
+	profile := 9
+	if err := s.SetUserSettings(uid, UserSettingsDTO{QualityProfileSonarr: &profile}); err != nil {
+		t.Fatalf("SetUserSettings: %v", err)
+	}
+
+	resp, err := s.CreateMediaRequest(uid, &CreateRequest{
+		TmdbID:      1399,
+		TvdbID:      121361,
+		MediaType:   "tv",
+		Title:       "andor (client title)",
+		SeasonScope: SeasonScopeFirst,
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if resp.Status != StatusRequested || resp.Title != "Andor" {
+		t.Fatalf("response = %+v, want requested/Andor", resp)
+	}
+
+	if f.addBody == nil {
+		t.Fatal("AddSeries was not called")
+	}
+	if f.addBody["title"] != "Andor" || f.addBody["tvdbId"] != float64(121361) || f.addBody["year"] != float64(2022) {
+		t.Errorf("add identity = %v/%v/%v, want Andor/121361/2022",
+			f.addBody["title"], f.addBody["tvdbId"], f.addBody["year"])
+	}
+	if got := f.addBody["qualityProfileId"]; got != float64(9) {
+		t.Errorf("qualityProfileId = %v, want 9 (admin-set per-user default)", got)
+	}
+	if f.addBody["rootFolderPath"] != "/tv" || f.addBody["monitored"] != true || f.addBody["seasonFolder"] != true {
+		t.Errorf("add body = %#v, want /tv + monitored + seasonFolder", f.addBody)
+	}
+	addOptions, _ := f.addBody["addOptions"].(map[string]any)
+	if addOptions["monitor"] != "firstSeason" || addOptions["searchForMissingEpisodes"] != true {
+		t.Errorf("addOptions = %#v, want monitor firstSeason + search", addOptions)
+	}
+	if _, present := f.addBody["seasons"]; present {
+		t.Errorf("seasons = %v, want omitted for a coarse-scope add", f.addBody["seasons"])
+	}
+
+	// The tmdb->tvdb mapping is cached so the status path never needs the bridge.
+	var cachedTvdb int
+	if err := s.db.QueryRow("SELECT tvdb_id FROM tmdb_tvdb_cache WHERE tmdb_id = 1399").Scan(&cachedTvdb); err != nil {
+		t.Fatalf("read tmdb_tvdb_cache: %v", err)
+	}
+	if cachedTvdb != 121361 {
+		t.Errorf("cached tvdb_id = %d, want 121361", cachedTvdb)
+	}
+
+	var status, scope string
+	if err := s.db.QueryRow(
+		"SELECT status, COALESCE(season_scope, '') FROM request_log WHERE user_id = ? AND tmdb_id = 1399 AND media_type = 'tv'", uid,
+	).Scan(&status, &scope); err != nil {
+		t.Fatalf("read request_log: %v", err)
+	}
+	if status != StatusRequested || scope != SeasonScopeFirst {
+		t.Errorf("logged row = %s/%s, want requested/first", status, scope)
+	}
+}
+
+// TestCreateTVRequestExplicitSeasonsNewSeries covers the explicit-season add:
+// the payload must carry per-season monitored flags (only the chosen seasons
+// true) with NO addOptions.monitor enum, and the stored season_scope must be
+// the JSON-encoded season list so approval flows can replay it.
+func TestCreateTVRequestExplicitSeasonsNewSeries(t *testing.T) {
+	f := &fakeSonarrTV{
+		lookupJSON: `[{"title":"Andor","tvdbId":121361,"year":2022,"seasons":[
+			{"seasonNumber":0,"monitored":true},{"seasonNumber":1,"monitored":true},{"seasonNumber":2},{"seasonNumber":3}]}]`,
+	}
+	srv := newFakeSonarrServer(t, f)
+	s, uid := newHistoryTestService(t, "", srv.URL, "")
+
+	resp, err := s.CreateMediaRequest(uid, &CreateRequest{
+		TmdbID:    1399,
+		TvdbID:    121361,
+		MediaType: "tv",
+		Title:     "Andor",
+		Seasons:   []int{3, 2, 3}, // unsorted + duplicate: must normalize to [2,3]
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if resp.Status != StatusRequested {
+		t.Fatalf("status = %s, want requested", resp.Status)
+	}
+
+	addOptions, _ := f.addBody["addOptions"].(map[string]any)
+	if _, present := addOptions["monitor"]; present {
+		t.Errorf("addOptions.monitor = %v, want absent (season flags drive monitoring)", addOptions["monitor"])
+	}
+	if addOptions["searchForMissingEpisodes"] != true {
+		t.Errorf("addOptions = %#v, want searchForMissingEpisodes true", addOptions)
+	}
+	seasons, _ := f.addBody["seasons"].([]any)
+	if len(seasons) != 4 {
+		t.Fatalf("seasons = %#v, want all 4 known seasons present", f.addBody["seasons"])
+	}
+	wantFlags := map[int]bool{0: false, 1: false, 2: true, 3: true}
+	for _, raw := range seasons {
+		m := raw.(map[string]any)
+		n := int(m["seasonNumber"].(float64))
+		if m["monitored"] != wantFlags[n] {
+			t.Errorf("season %d monitored = %v, want %v", n, m["monitored"], wantFlags[n])
+		}
+	}
+
+	var scope string
+	if err := s.db.QueryRow(
+		"SELECT COALESCE(season_scope, '') FROM request_log WHERE user_id = ? AND tmdb_id = 1399", uid,
+	).Scan(&scope); err != nil {
+		t.Fatalf("read request_log: %v", err)
+	}
+	if scope != "[2,3]" {
+		t.Errorf("stored season_scope = %q, want [2,3]", scope)
+	}
+}
+
+// TestCreateTVRequestExistingSeriesExplicitSeasons routes a "request more
+// seasons" through the full CreateMediaRequest path: for a series already in
+// Sonarr an explicit season list must NOT re-add the series; it monitors the
+// chosen season (series flags + episodes) and fires a SeasonSearch.
+func TestCreateTVRequestExistingSeriesExplicitSeasons(t *testing.T) {
+	seriesObj := `{"id":42,"title":"Existing Show","tvdbId":121361,"monitored":true,"seasons":[
+		{"seasonNumber":1,"monitored":true},{"seasonNumber":2,"monitored":false}]}`
+	f := &fakeSonarrTV{
+		libraryJSON: `[` + seriesObj + `]`,
+		seriesJSON:  seriesObj,
+		episodesJSON: map[string]string{
+			"2": `[{"id":201,"seriesId":42,"seasonNumber":2,"episodeNumber":1,"monitored":false},
+			       {"id":202,"seriesId":42,"seasonNumber":2,"episodeNumber":2,"monitored":false}]`,
+		},
+	}
+	srv := newFakeSonarrServer(t, f)
+	s, uid := newHistoryTestService(t, "", srv.URL, "")
+
+	resp, err := s.CreateMediaRequest(uid, &CreateRequest{
+		TmdbID:    1399,
+		TvdbID:    121361,
+		MediaType: "tv",
+		Title:     "Existing Show",
+		Seasons:   []int{2},
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if resp.Status != StatusRequested || resp.Title != "Existing Show" {
+		t.Fatalf("response = %+v, want requested/Existing Show", resp)
+	}
+	if f.addBody != nil {
+		t.Errorf("AddSeries called for an in-library series: %v", f.addBody)
+	}
+
+	// Season 2 must now be flagged monitored (season 1 untouched)...
+	seasons, _ := f.seriesPut["seasons"].([]any)
+	flags := map[int]bool{}
+	for _, raw := range seasons {
+		m := raw.(map[string]any)
+		flags[int(m["seasonNumber"].(float64))] = m["monitored"].(bool)
+	}
+	if !flags[1] || !flags[2] {
+		t.Errorf("series PUT season flags = %v, want both season 1 (kept) and 2 (added) monitored", flags)
+	}
+	// ...its episodes explicitly monitored...
+	ids, _ := f.monitorBody["episodeIds"].([]any)
+	if f.monitorBody["monitored"] != true || len(ids) != 2 {
+		t.Errorf("episode monitor body = %#v, want both season-2 episodes monitored", f.monitorBody)
+	}
+	// ...and a SeasonSearch fired for it.
+	if len(f.commands) != 1 || f.commands[0]["name"] != "SeasonSearch" ||
+		f.commands[0]["seriesId"] != float64(42) || f.commands[0]["seasonNumber"] != float64(2) {
+		t.Errorf("commands = %v, want one SeasonSearch for series 42 season 2", f.commands)
+	}
+}
+
+// TestCreateTVRequestExistingSeriesPilotScope covers monitorPilot: a pilot
+// request on an in-library series monitors exactly S1E1 (never the season
+// flag, matching Sonarr's own pilot handling) and fires an EpisodeSearch.
+func TestCreateTVRequestExistingSeriesPilotScope(t *testing.T) {
+	f := &fakeSonarrTV{
+		libraryJSON: `[{"id":42,"title":"Pilot Show","tvdbId":121361,"monitored":true,"seasons":[
+			{"seasonNumber":1,"monitored":false}]}]`,
+		episodesJSON: map[string]string{
+			"1": `[{"id":301,"seriesId":42,"seasonNumber":1,"episodeNumber":1,"monitored":false},
+			       {"id":302,"seriesId":42,"seasonNumber":1,"episodeNumber":2,"monitored":false}]`,
+		},
+	}
+	srv := newFakeSonarrServer(t, f)
+	s, uid := newHistoryTestService(t, "", srv.URL, "")
+
+	resp, err := s.CreateMediaRequest(uid, &CreateRequest{
+		TmdbID:      1399,
+		TvdbID:      121361,
+		MediaType:   "tv",
+		Title:       "Pilot Show",
+		SeasonScope: SeasonScopePilot,
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if resp.Status != StatusRequested || resp.Title != "Pilot Show" {
+		t.Fatalf("response = %+v, want requested/Pilot Show", resp)
+	}
+
+	ids, _ := f.monitorBody["episodeIds"].([]any)
+	if f.monitorBody["monitored"] != true || len(ids) != 1 || ids[0] != float64(301) {
+		t.Errorf("episode monitor body = %#v, want only the pilot (301) monitored", f.monitorBody)
+	}
+	if f.seriesPut != nil {
+		t.Errorf("series PUT = %v, want none (series already monitored; pilot never flips the season flag)", f.seriesPut)
+	}
+	if len(f.commands) != 1 || f.commands[0]["name"] != "EpisodeSearch" {
+		t.Fatalf("commands = %v, want exactly one EpisodeSearch", f.commands)
+	}
+	cmdIDs, _ := f.commands[0]["episodeIds"].([]any)
+	if len(cmdIDs) != 1 || cmdIDs[0] != float64(301) {
+		t.Errorf("EpisodeSearch episodeIds = %v, want [301]", f.commands[0]["episodeIds"])
+	}
+}
+
+// seedTvdbCache pre-seeds the tmdb->tvdb mapping so getTVStatus resolves the
+// id from the 30-day DB cache and never needs the live tmdb.Bridge (which the
+// tests leave nil — any bridge use would read unavailable and fail the
+// assertions below).
+func seedTvdbCache(t *testing.T, s *Service, tmdbID, tvdbID int) {
+	t.Helper()
+	if _, err := s.db.Exec("INSERT OR REPLACE INTO tmdb_tvdb_cache (tmdb_id, tvdb_id) VALUES (?, ?)", tmdbID, tvdbID); err != nil {
+		t.Fatalf("seed tmdb_tvdb_cache: %v", err)
+	}
+}
+
+// TestGetTVStatusFromEpisodeList covers the primary TV availability path: the
+// per-season and series rollups derive from the real episode list (files vs
+// aired), yielding available / partial / requested / unavailable seasons and a
+// partial series with true progress — immune to Sonarr's monitored-only stats.
+func TestGetTVStatusFromEpisodeList(t *testing.T) {
+	f := &fakeSonarrTV{
+		libraryJSON: `[{"id":7,"title":"Matrix Show","tvdbId":999,"monitored":true,"seasons":[
+			{"seasonNumber":1,"monitored":true},
+			{"seasonNumber":2,"monitored":true},
+			{"seasonNumber":3,"monitored":true},
+			{"seasonNumber":4,"monitored":false}]}]`,
+		episodesJSON: map[string]string{
+			// Season 1: fully downloaded. Season 2: one file, one aired-missing,
+			// one unaired (excluded from "aired"). Season 3: monitored, aired,
+			// nothing on disk. Season 4: unmonitored, aired, nothing on disk.
+			"": `[
+				{"id":1,"seriesId":7,"seasonNumber":1,"episodeNumber":1,"hasFile":true,"monitored":true},
+				{"id":2,"seriesId":7,"seasonNumber":1,"episodeNumber":2,"hasFile":true,"monitored":true},
+				{"id":3,"seriesId":7,"seasonNumber":2,"episodeNumber":1,"hasFile":true,"monitored":true},
+				{"id":4,"seriesId":7,"seasonNumber":2,"episodeNumber":2,"hasFile":false,"monitored":true,"airDateUtc":"2020-01-01T00:00:00Z"},
+				{"id":5,"seriesId":7,"seasonNumber":2,"episodeNumber":3,"hasFile":false,"monitored":true,"airDateUtc":"2100-01-01T00:00:00Z"},
+				{"id":6,"seriesId":7,"seasonNumber":3,"episodeNumber":1,"hasFile":false,"monitored":true,"airDateUtc":"2020-06-01T00:00:00Z"},
+				{"id":7,"seriesId":7,"seasonNumber":4,"episodeNumber":1,"hasFile":false,"monitored":false,"airDateUtc":"2020-06-01T00:00:00Z"}
+			]`,
+		},
+	}
+	srv := newFakeSonarrServer(t, f)
+	s, uid := newHistoryTestService(t, "", srv.URL, "")
+	seedTvdbCache(t, s, 300, 999)
+
+	st, err := s.getTVStatus(uid, 300)
+	if err != nil {
+		t.Fatalf("getTVStatus: %v", err)
+	}
+	if st.Status != StatusPartial {
+		t.Errorf("status = %s, want partial (3 of 6 aired episodes on disk)", st.Status)
+	}
+	if st.Progress != 0.5 {
+		t.Errorf("progress = %v, want 0.5", st.Progress)
+	}
+
+	want := map[int]struct {
+		status string
+		files  int
+		eps    int
+	}{
+		1: {StatusAvailable, 2, 2},
+		2: {StatusPartial, 1, 2}, // unaired episode excluded from the aired count
+		3: {StatusRequested, 0, 1},
+		4: {StatusUnavailable, 0, 1},
+	}
+	if len(st.Seasons) != len(want) {
+		t.Fatalf("got %d seasons, want %d: %+v", len(st.Seasons), len(want), st.Seasons)
+	}
+	for _, ss := range st.Seasons {
+		w, ok := want[ss.SeasonNumber]
+		if !ok {
+			t.Errorf("unexpected season %d", ss.SeasonNumber)
+			continue
+		}
+		if ss.Status != w.status || ss.EpisodeFileCount != w.files || ss.EpisodeCount != w.eps {
+			t.Errorf("season %d = %s %d/%d, want %s %d/%d",
+				ss.SeasonNumber, ss.Status, ss.EpisodeFileCount, ss.EpisodeCount, w.status, w.files, w.eps)
+		}
+	}
+}
+
+// TestGetTVStatusSeasonStatisticsFallback covers the branch taken when the
+// episode fetch fails: availability falls back to seasons[].statistics using
+// totalEpisodeCount (never the monitored-only episodeCount), so a
+// partially-monitored season still reads partial.
+func TestGetTVStatusSeasonStatisticsFallback(t *testing.T) {
+	f := &fakeSonarrTV{
+		libraryJSON: `[{"id":7,"title":"Stats Show","tvdbId":999,"monitored":true,"seasons":[
+			{"seasonNumber":1,"monitored":true,"statistics":{"episodeFileCount":8,"episodeCount":8,"totalEpisodeCount":8}},
+			{"seasonNumber":2,"monitored":true,"statistics":{"episodeFileCount":2,"episodeCount":2,"totalEpisodeCount":10,"percentOfEpisodes":100}}]}]`,
+		episodesFail: true,
+	}
+	srv := newFakeSonarrServer(t, f)
+	s, uid := newHistoryTestService(t, "", srv.URL, "")
+	seedTvdbCache(t, s, 300, 999)
+
+	st, err := s.getTVStatus(uid, 300)
+	if err != nil {
+		t.Fatalf("getTVStatus: %v", err)
+	}
+	if st.Status != StatusPartial {
+		t.Errorf("status = %s, want partial (10 of 18 known episodes)", st.Status)
+	}
+	if st.Progress != 10.0/18.0 {
+		t.Errorf("progress = %v, want %v", st.Progress, 10.0/18.0)
+	}
+	if len(st.Seasons) != 2 {
+		t.Fatalf("got %d seasons, want 2: %+v", len(st.Seasons), st.Seasons)
+	}
+	for _, ss := range st.Seasons {
+		switch ss.SeasonNumber {
+		case 1:
+			if ss.Status != StatusAvailable || ss.EpisodeFileCount != 8 || ss.EpisodeCount != 8 {
+				t.Errorf("season 1 = %s %d/%d, want available 8/8", ss.Status, ss.EpisodeFileCount, ss.EpisodeCount)
+			}
+		case 2:
+			// The percentOfEpisodes trap: 2/2 monitored episodes are done (100%)
+			// but 10 episodes exist -> partial, counted against the true total.
+			if ss.Status != StatusPartial || ss.EpisodeFileCount != 2 || ss.EpisodeCount != 10 {
+				t.Errorf("season 2 = %s %d/%d, want partial 2/10", ss.Status, ss.EpisodeFileCount, ss.EpisodeCount)
+			}
+		default:
+			t.Errorf("unexpected season %d", ss.SeasonNumber)
+		}
+	}
+}
+
+// TestGetTVStatusUnresolvable pins the unavailable outcomes: a cached mapping
+// pointing at a series Sonarr doesn't have, and a missing mapping with no
+// bridge configured (no HTTP may happen at all in that case).
+func TestGetTVStatusUnresolvable(t *testing.T) {
+	t.Run("not in sonarr", func(t *testing.T) {
+		f := &fakeSonarrTV{} // empty library
+		srv := newFakeSonarrServer(t, f)
+		s, uid := newHistoryTestService(t, "", srv.URL, "")
+		seedTvdbCache(t, s, 300, 999)
+		st, err := s.getTVStatus(uid, 300)
+		if err != nil || st.Status != StatusUnavailable {
+			t.Errorf("status = %+v err=%v, want unavailable", st, err)
+		}
+	})
+
+	t.Run("no tvdb mapping and no bridge", func(t *testing.T) {
+		f := &fakeSonarrTV{} // any request would fail the test via t.Errorf
+		srv := newFakeSonarrServer(t, f)
+		s, uid := newHistoryTestService(t, "", srv.URL, "")
+		st, err := s.getTVStatus(uid, 300)
+		if err != nil || st.Status != StatusUnavailable {
+			t.Errorf("status = %+v err=%v, want unavailable", st, err)
+		}
+	})
+}


### PR DESCRIPTION
## What

Test-only PR: direct coverage for the movie/TV core of `server/internal/request/service.go`, which had none (the books flows were already covered by `service_book_test.go`). Three new same-package test files follow the sibling idiom (Service over httptest arr fakes + in-memory DB, recording notifier mirroring `internal/push/composite_test.go`):

- **`service_movie_test.go`** — `CreateMediaRequest` movie auto-approve: Radarr add payload correctness (canonical lookup title/year, effective per-user quality profile with the client's disallowed choice ignored, unknown-profile fallback, root folder, `searchForMovie`); the three existing-movie outcomes (has file → available, monitored-no-file → requested with no writes, unmonitored → revived via monitor + `MoviesSearch`); and the full `getMovieStatus` matrix (file → available, queued → downloading with byte-derived progress, monitored → requested, absent/unmonitored → unavailable).
- **`service_tv_test.go`** — `addSeries` coarse-scope vs explicit-season add payloads (`addOptions.monitor` mapping, per-season monitored flags with no monitor enum, tvdb cache seeding, `season_scope` persistence); existing-series paths through `CreateMediaRequest` (`monitorAndSearchSeasons` request-more-seasons, `monitorPilot`); and `getTVStatus` with `tmdb_tvdb_cache` pre-seeded so the live `tmdb.Bridge` is never touched — episode-list `SeriesCompletion` rollup (available/partial/requested/unavailable seasons, true progress) plus the season-statistics fallback branch when the episode fetch fails.
- **`service_approval_test.go`** — `createPending` dedupe (duplicate pending collapses to one row and one admin notification; a denied row stays re-requestable alongside a fresh pending row); pending TV requests cache the tvdb mapping; `ApproveRequest` (the arr add actually runs, pending → requested with audit fields, requester notification, `DecisionOverride` for quality and for a coarse season scope replacing an explicit season list, arr failure leaves the row pending with no notification); `DenyRequest` (reason + audit fields, notification, user status reads denied, double decisions rejected).

No production code changed. Existing coverage in `service_monitor_test.go` / `service_test.go` / `service_book_test.go` is extended, not duplicated.

## Verification

From `server/`:

- `go vet ./...` — clean
- `go test ./...` — all packages pass (the Codex protocol smoke self-skips locally, as expected)

No app changes, so no Flutter checks were needed.

## Docs

Docs are part of the change, not a follow-up. Tick what you updated, or tick the last box and say why nothing needed it:

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne