### PR TITLE
test(server): cover downloads service and download-client protocol clients

### DIFF
--- a/server/internal/downloads/handler_test.go
+++ b/server/internal/downloads/handler_test.go
@@ -1,0 +1,1207 @@
+package downloads
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+// --- test environment ---
+
+type env struct {
+	store    *instance.Store
+	registry *instance.Registry
+	handler  *Handler
+	router   chi.Router
+}
+
+// newEnv builds a handler over an in-memory instance store and mounts it on
+// the same route patterns the API router uses (without auth middleware, which
+// is covered elsewhere).
+func newEnv(t *testing.T) *env {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x42}, 32))
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	store := instance.NewStore(database, cipher)
+	registry := instance.NewRegistry(store)
+	handler := NewHandler(store, registry)
+
+	router := chi.NewRouter()
+	router.Get("/downloads/{instanceID}/queue", handler.GetQueue)
+	router.Post("/downloads/{instanceID}/queue/{itemID}/pause", handler.PauseItem)
+	router.Post("/downloads/{instanceID}/queue/{itemID}/resume", handler.ResumeItem)
+	router.Delete("/downloads/{instanceID}/queue/{itemID}", handler.DeleteItem)
+	router.Post("/downloads/{instanceID}/pause", handler.PauseAll)
+	router.Post("/downloads/{instanceID}/resume", handler.ResumeAll)
+	router.Get("/downloads/{instanceID}/history", handler.GetHistory)
+
+	return &env{store: store, registry: registry, handler: handler, router: router}
+}
+
+func (e *env) mkInstance(t *testing.T, serviceType, baseURL, apiKey, username, password string) instance.Instance {
+	t.Helper()
+	inst := &instance.Instance{
+		ServiceType: serviceType,
+		Name:        serviceType + " test",
+		URL:         baseURL,
+		APIKey:      apiKey,
+		Username:    username,
+		Password:    password,
+	}
+	if err := e.store.Create(inst); err != nil {
+		t.Fatalf("create %s instance: %v", serviceType, err)
+	}
+	return *inst
+}
+
+func (e *env) do(t *testing.T, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	rec := httptest.NewRecorder()
+	e.router.ServeHTTP(rec, req)
+	return rec
+}
+
+func decodeView(t *testing.T, rec *httptest.ResponseRecorder) QueueView {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var view QueueView
+	if err := json.Unmarshal(rec.Body.Bytes(), &view); err != nil {
+		t.Fatalf("decode queue view: %v", err)
+	}
+	return view
+}
+
+func decodeHistory(t *testing.T, rec *httptest.ResponseRecorder) []historyItem {
+	t.Helper()
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp historyResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	return resp.Items
+}
+
+// --- SABnzbd fake ---
+
+type sabFake struct {
+	t       *testing.T
+	apiKey  string
+	queue   string
+	history string
+
+	mu    sync.Mutex
+	calls []url.Values
+}
+
+func (f *sabFake) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api" {
+			f.t.Errorf("sabnzbd path = %s, want /api", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("output") != "json" {
+			f.t.Errorf("sabnzbd output = %q, want json", q.Get("output"))
+		}
+		if q.Get("apikey") != f.apiKey {
+			f.t.Errorf("sabnzbd apikey = %q, want %q", q.Get("apikey"), f.apiKey)
+		}
+		f.mu.Lock()
+		f.calls = append(f.calls, q)
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case q.Get("mode") == "queue" && q.Get("name") == "":
+			_, _ = io.WriteString(w, f.queue)
+		case q.Get("mode") == "history":
+			_, _ = io.WriteString(w, f.history)
+		default:
+			_, _ = io.WriteString(w, `{"status": true}`)
+		}
+	}
+}
+
+func (f *sabFake) lastCall(t *testing.T) url.Values {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) == 0 {
+		t.Fatal("sabnzbd fake received no calls")
+	}
+	return f.calls[len(f.calls)-1]
+}
+
+// --- qBittorrent fake ---
+
+type qbitForm struct {
+	path string
+	form url.Values
+}
+
+type qbitFake struct {
+	t        *testing.T
+	username string
+	password string
+	torrents string
+	transfer string
+
+	mu      sync.Mutex
+	sid     string
+	logins  int
+	actions []qbitForm
+}
+
+func (f *qbitFake) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/auth/login" {
+			_ = r.ParseForm()
+			if r.PostForm.Get("username") != f.username || r.PostForm.Get("password") != f.password {
+				_, _ = io.WriteString(w, "Fails.")
+				return
+			}
+			f.mu.Lock()
+			f.logins++
+			f.sid = "sid-" + strings.Repeat("x", f.logins)
+			sid := f.sid
+			f.mu.Unlock()
+			http.SetCookie(w, &http.Cookie{Name: "SID", Value: sid})
+			_, _ = io.WriteString(w, "Ok.")
+			return
+		}
+
+		cookie, err := r.Cookie("SID")
+		f.mu.Lock()
+		valid := err == nil && cookie.Value == f.sid
+		f.mu.Unlock()
+		if !valid {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		switch r.URL.Path {
+		case "/api/v2/torrents/info":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, f.torrents)
+		case "/api/v2/transfer/info":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, f.transfer)
+		case "/api/v2/torrents/stop", "/api/v2/torrents/start",
+			"/api/v2/torrents/pause", "/api/v2/torrents/resume",
+			"/api/v2/torrents/delete":
+			_ = r.ParseForm()
+			f.mu.Lock()
+			f.actions = append(f.actions, qbitForm{path: r.URL.Path, form: r.PostForm})
+			f.mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func (f *qbitFake) lastAction(t *testing.T) qbitForm {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.actions) == 0 {
+		t.Fatal("qbittorrent fake received no action calls")
+	}
+	return f.actions[len(f.actions)-1]
+}
+
+// --- NZBGet fake ---
+
+type rpcCall struct {
+	Method string        `json:"method"`
+	Params []interface{} `json:"params"`
+}
+
+type nzbgetFake struct {
+	t        *testing.T
+	username string
+	password string
+	groups   string
+	status   string
+	history  string
+
+	mu    sync.Mutex
+	calls []rpcCall
+}
+
+func (f *nzbgetFake) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/jsonrpc" {
+			f.t.Errorf("nzbget path = %s, want /jsonrpc", r.URL.Path)
+		}
+		user, pass, ok := r.BasicAuth()
+		if !ok || user != f.username || pass != f.password {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var call rpcCall
+		if err := json.NewDecoder(r.Body).Decode(&call); err != nil {
+			f.t.Errorf("nzbget decode request: %v", err)
+		}
+		f.mu.Lock()
+		f.calls = append(f.calls, call)
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch call.Method {
+		case "listgroups":
+			_, _ = io.WriteString(w, `{"result": `+f.groups+`}`)
+		case "status":
+			_, _ = io.WriteString(w, `{"result": `+f.status+`}`)
+		case "history":
+			_, _ = io.WriteString(w, `{"result": `+f.history+`}`)
+		default: // editqueue, pausedownload, resumedownload
+			_, _ = io.WriteString(w, `{"result": true}`)
+		}
+	}
+}
+
+func (f *nzbgetFake) lastCall(t *testing.T) rpcCall {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) == 0 {
+		t.Fatal("nzbget fake received no calls")
+	}
+	return f.calls[len(f.calls)-1]
+}
+
+// --- Transmission fake ---
+
+type transRPC struct {
+	Method    string                 `json:"method"`
+	Arguments map[string]interface{} `json:"arguments"`
+}
+
+type transFake struct {
+	t        *testing.T
+	torrents string // JSON array for the torrent-get "torrents" field
+	stats    string
+
+	mu    sync.Mutex
+	calls []transRPC
+}
+
+const transSessionID = "fake-session-id-123"
+
+func (f *transFake) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/transmission/rpc" {
+			f.t.Errorf("transmission path = %s, want /transmission/rpc", r.URL.Path)
+		}
+		if r.Header.Get("X-Transmission-Session-Id") != transSessionID {
+			w.Header().Set("X-Transmission-Session-Id", transSessionID)
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		var call transRPC
+		if err := json.NewDecoder(r.Body).Decode(&call); err != nil {
+			f.t.Errorf("transmission decode request: %v", err)
+		}
+		f.mu.Lock()
+		f.calls = append(f.calls, call)
+		torrents, stats := f.torrents, f.stats
+		f.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch call.Method {
+		case "torrent-get":
+			_, _ = io.WriteString(w, `{"result":"success","arguments":{"torrents":`+torrents+`}}`)
+		case "session-stats":
+			_, _ = io.WriteString(w, `{"result":"success","arguments":`+stats+`}`)
+		default: // torrent-stop, torrent-start, torrent-remove
+			_, _ = io.WriteString(w, `{"result":"success"}`)
+		}
+	}
+}
+
+func (f *transFake) callsOf(method string) []transRPC {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []transRPC
+	for _, c := range f.calls {
+		if c.Method == method {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// --- Snapshot normalization ---
+
+func TestSnapshotSabnzbdNormalization(t *testing.T) {
+	fake := &sabFake{
+		t:      t,
+		apiKey: "sab-key",
+		queue: `{"queue":{
+			"paused": false,
+			"kbpersec": "2048.00",
+			"speed": "2.0 M",
+			"slots": [
+				{"nzo_id":"SABnzbd_nzo_p86tE","filename":"Andor.S02E03.1080p.WEB","mb":"1400.00","mbleft":"350.00","percentage":"75","timeleft":"0:07:30","status":"Downloading","cat":"tv"},
+				{"nzo_id":"SABnzbd_nzo_zq9xY","filename":"Rogue.One.2016.2160p","mb":"8192.00","mbleft":"8192.00","percentage":"0","timeleft":"","status":"Queued","cat":"*"}
+			]
+		}}`,
+	}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "sabnzbd", srv.URL, "sab-key", "", "")
+
+	view, err := Snapshot(e.registry, inst)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if view.Paused {
+		t.Error("Paused = true, want false")
+	}
+	if view.SpeedBPS != 2048*1024 {
+		t.Errorf("SpeedBPS = %d, want %d", view.SpeedBPS, 2048*1024)
+	}
+	if len(view.Items) != 2 {
+		t.Fatalf("items = %d, want 2", len(view.Items))
+	}
+	got := view.Items[0]
+	want := QueueItem{
+		ID:            "SABnzbd_nzo_p86tE",
+		Name:          "Andor.S02E03.1080p.WEB",
+		SizeBytes:     1400 * 1024 * 1024,
+		SizeLeftBytes: 350 * 1024 * 1024,
+		Progress:      75,
+		SpeedBPS:      0, // SABnzbd has no per-item speed
+		ETASeconds:    450,
+		Status:        "Downloading",
+		Category:      "tv",
+	}
+	if got != want {
+		t.Errorf("item[0] = %+v, want %+v", got, want)
+	}
+	// SABnzbd's "*" wildcard category normalizes to empty, and a blank
+	// timeleft normalizes to ETA 0.
+	if view.Items[1].Category != "" {
+		t.Errorf("item[1].Category = %q, want \"\" (from \"*\")", view.Items[1].Category)
+	}
+	if view.Items[1].ETASeconds != 0 {
+		t.Errorf("item[1].ETASeconds = %d, want 0", view.Items[1].ETASeconds)
+	}
+}
+
+func TestSnapshotQbittorrentNormalization(t *testing.T) {
+	fake := &qbitFake{
+		t:        t,
+		username: "admin",
+		password: "qbit-pass",
+		torrents: `[
+			{"name":"ubuntu-live","hash":"aaa111","size":1000000,"progress":0.25,"dlspeed":52428,"eta":3600,"state":"downloading","category":"movies","completion_on":0},
+			{"name":"done-torrent","hash":"bbb222","size":2000000,"progress":1.0,"dlspeed":0,"eta":8640000,"state":"uploading","category":"tv","completion_on":1752700000},
+			{"name":"stalled","hash":"ccc333","size":2000000,"progress":0.5,"dlspeed":0,"eta":8640000,"state":"stalledDL","category":"","completion_on":0}
+		]`,
+		transfer: `{"dl_info_speed":123456,"up_info_speed":0,"dl_rate_limit":0}`,
+	}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "qbittorrent", srv.URL, "", "admin", "qbit-pass")
+
+	view, err := Snapshot(e.registry, inst)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if view.SpeedBPS != 123456 {
+		t.Errorf("SpeedBPS = %d, want 123456", view.SpeedBPS)
+	}
+	// Completed torrents (progress >= 1) belong to /history, not the queue.
+	if len(view.Items) != 2 {
+		t.Fatalf("items = %d, want 2 (completed torrent must be excluded)", len(view.Items))
+	}
+	got := view.Items[0]
+	want := QueueItem{
+		ID:            "aaa111",
+		Name:          "ubuntu-live",
+		SizeBytes:     1000000,
+		SizeLeftBytes: 750000,
+		Progress:      25,
+		SpeedBPS:      52428,
+		ETASeconds:    3600,
+		Status:        "downloading",
+		Category:      "movies",
+	}
+	if got != want {
+		t.Errorf("item[0] = %+v, want %+v", got, want)
+	}
+	// qBittorrent's 8640000 "infinite" ETA sentinel normalizes to 0.
+	if view.Items[1].ETASeconds != 0 {
+		t.Errorf("item[1].ETASeconds = %d, want 0 (8640000 sentinel)", view.Items[1].ETASeconds)
+	}
+	if view.Items[1].SizeLeftBytes != 1000000 {
+		t.Errorf("item[1].SizeLeftBytes = %d, want 1000000", view.Items[1].SizeLeftBytes)
+	}
+	// stalledDL counts as active, so the queue is not paused.
+	if view.Paused {
+		t.Error("Paused = true, want false")
+	}
+}
+
+func TestSnapshotQbittorrentAllPausedMarksQueuePaused(t *testing.T) {
+	fake := &qbitFake{
+		t:        t,
+		username: "admin",
+		password: "qbit-pass",
+		torrents: `[
+			{"name":"a","hash":"aaa","size":100,"progress":0.5,"dlspeed":0,"eta":-1,"state":"pausedDL","category":"","completion_on":0},
+			{"name":"b","hash":"bbb","size":100,"progress":0.5,"dlspeed":0,"eta":0,"state":"stoppedDL","category":"","completion_on":0}
+		]`,
+		transfer: `{"dl_info_speed":0,"up_info_speed":0,"dl_rate_limit":0}`,
+	}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "qbittorrent", srv.URL, "", "admin", "qbit-pass")
+
+	view, err := Snapshot(e.registry, inst)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if !view.Paused {
+		t.Error("Paused = false, want true when every queued torrent is paused/stopped")
+	}
+	// A negative ETA (qBittorrent 5.x paused torrents) normalizes to 0.
+	if view.Items[0].ETASeconds != 0 {
+		t.Errorf("item[0].ETASeconds = %d, want 0", view.Items[0].ETASeconds)
+	}
+}
+
+func TestSnapshotNzbgetNormalization(t *testing.T) {
+	fake := &nzbgetFake{
+		t:        t,
+		username: "nzbget",
+		password: "tegbzn6789",
+		groups: `[
+			{"NZBID":42,"NZBName":"Show.S01E01","FileSizeLo":1073741824,"FileSizeHi":0,"FileSizeMB":1024,"RemainingSizeLo":268435456,"RemainingSizeHi":0,"RemainingSizeMB":256,"Status":"DOWNLOADING","Category":"tv"},
+			{"NZBID":43,"NZBName":"Big.Movie.2160p","FileSizeLo":705032704,"FileSizeHi":1,"FileSizeMB":4768,"RemainingSizeLo":705032704,"RemainingSizeHi":1,"RemainingSizeMB":4768,"Status":"QUEUED","Category":"movies"}
+		]`,
+		status: `{"DownloadRate":10485760,"DownloadPaused":false,"RemainingSizeLo":0,"RemainingSizeHi":0,"RemainingSizeMB":0}`,
+	}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "nzbget", srv.URL, "", "nzbget", "tegbzn6789")
+
+	view, err := Snapshot(e.registry, inst)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if view.Paused {
+		t.Error("Paused = true, want false")
+	}
+	if view.SpeedBPS != 10485760 {
+		t.Errorf("SpeedBPS = %d, want 10485760", view.SpeedBPS)
+	}
+	if len(view.Items) != 2 {
+		t.Fatalf("items = %d, want 2", len(view.Items))
+	}
+	got := view.Items[0]
+	want := QueueItem{
+		ID:            "42", // NZBID is stringified for the unified ID field
+		Name:          "Show.S01E01",
+		SizeBytes:     1073741824,
+		SizeLeftBytes: 268435456,
+		Progress:      75,
+		SpeedBPS:      0,  // NZBGet has no per-item speed
+		ETASeconds:    25, // 268435456 / 10485760, integer division
+		Status:        "DOWNLOADING",
+		Category:      "tv",
+	}
+	if got != want {
+		t.Errorf("item[0] = %+v, want %+v", got, want)
+	}
+	// The 32-bit Lo/Hi pair reassembles sizes beyond 4 GiB.
+	if view.Items[1].SizeBytes != 5000000000 {
+		t.Errorf("item[1].SizeBytes = %d, want 5000000000 (Lo/Hi reassembly)", view.Items[1].SizeBytes)
+	}
+}
+
+func TestSnapshotTransmissionNormalization(t *testing.T) {
+	fake := &transFake{
+		t: t,
+		torrents: `[
+			{"id":1,"hashString":"deadbeef01","name":"Fedora","totalSize":1000000,"leftUntilDone":250000,"percentDone":0.75,"rateDownload":250000,"eta":12,"status":4,"error":0,"errorString":"","labels":["linux","iso"],"doneDate":0},
+			{"id":2,"hashString":"deadbeef02","name":"Done","totalSize":5000,"leftUntilDone":0,"percentDone":1.0,"rateDownload":0,"eta":-1,"status":6,"error":0,"errorString":"","labels":[],"doneDate":1752600000},
+			{"id":3,"hashString":"deadbeef03","name":"Stopped","totalSize":800,"leftUntilDone":800,"percentDone":0,"rateDownload":0,"eta":-2,"status":0,"error":0,"errorString":"","labels":[],"doneDate":0}
+		]`,
+		stats: `{"downloadSpeed":314159,"uploadSpeed":0}`,
+	}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "transmission", srv.URL, "", "trans", "trans-pass")
+
+	view, err := Snapshot(e.registry, inst)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if view.SpeedBPS != 314159 {
+		t.Errorf("SpeedBPS = %d, want 314159", view.SpeedBPS)
+	}
+	// Completed torrents (percentDone >= 1) belong to /history, not the queue.
+	if len(view.Items) != 2 {
+		t.Fatalf("items = %d, want 2 (completed torrent must be excluded)", len(view.Items))
+	}
+	got := view.Items[0]
+	want := QueueItem{
+		ID:            "deadbeef01",
+		Name:          "Fedora",
+		SizeBytes:     1000000,
+		SizeLeftBytes: 250000,
+		Progress:      75,
+		SpeedBPS:      250000,
+		ETASeconds:    12,
+		Status:        "downloading", // numeric status 4 mapped to a string
+		Category:      "linux",       // first label becomes the category
+	}
+	if got != want {
+		t.Errorf("item[0] = %+v, want %+v", got, want)
+	}
+	stopped := view.Items[1]
+	if stopped.Status != "stopped" || stopped.ETASeconds != 0 || stopped.Category != "" {
+		t.Errorf("stopped item = %+v, want status stopped, ETA 0 (negative sentinel), empty category", stopped)
+	}
+	// One downloading torrent means the queue is not paused.
+	if view.Paused {
+		t.Error("Paused = true, want false")
+	}
+}
+
+func TestSnapshotTransmissionAllStoppedMarksQueuePaused(t *testing.T) {
+	fake := &transFake{
+		t: t,
+		torrents: `[
+			{"id":3,"hashString":"deadbeef03","name":"Stopped","totalSize":800,"leftUntilDone":800,"percentDone":0,"rateDownload":0,"eta":-2,"status":0,"error":0,"errorString":"","labels":[],"doneDate":0}
+		]`,
+		stats: `{"downloadSpeed":0,"uploadSpeed":0}`,
+	}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "transmission", srv.URL, "", "", "")
+
+	view, err := Snapshot(e.registry, inst)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if !view.Paused {
+		t.Error("Paused = false, want true when every queued torrent is stopped")
+	}
+}
+
+func TestSnapshotEmptyQueues(t *testing.T) {
+	sab := &sabFake{t: t, apiKey: "k", queue: `{"queue":{"paused":false,"kbpersec":"0.00","slots":[]}}`}
+	sabSrv := httptest.NewServer(sab.handler())
+	t.Cleanup(sabSrv.Close)
+
+	qbit := &qbitFake{t: t, username: "u", password: "p", torrents: `[]`, transfer: `{"dl_info_speed":0}`}
+	qbitSrv := httptest.NewServer(qbit.handler())
+	t.Cleanup(qbitSrv.Close)
+
+	nzb := &nzbgetFake{t: t, username: "u", password: "p", groups: `[]`,
+		status: `{"DownloadRate":0,"DownloadPaused":false}`}
+	nzbSrv := httptest.NewServer(nzb.handler())
+	t.Cleanup(nzbSrv.Close)
+
+	trans := &transFake{t: t, torrents: `[]`, stats: `{"downloadSpeed":0,"uploadSpeed":0}`}
+	transSrv := httptest.NewServer(trans.handler())
+	t.Cleanup(transSrv.Close)
+
+	e := newEnv(t)
+	cases := []struct {
+		serviceType string
+		inst        instance.Instance
+	}{
+		{"sabnzbd", e.mkInstance(t, "sabnzbd", sabSrv.URL, "k", "", "")},
+		{"qbittorrent", e.mkInstance(t, "qbittorrent", qbitSrv.URL, "", "u", "p")},
+		{"nzbget", e.mkInstance(t, "nzbget", nzbSrv.URL, "", "u", "p")},
+		{"transmission", e.mkInstance(t, "transmission", transSrv.URL, "", "", "")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.serviceType, func(t *testing.T) {
+			view, err := Snapshot(e.registry, tc.inst)
+			if err != nil {
+				t.Fatalf("Snapshot: %v", err)
+			}
+			// Items must be a non-nil empty slice so the JSON payload is []
+			// rather than null.
+			if view.Items == nil || len(view.Items) != 0 {
+				t.Errorf("Items = %#v, want non-nil empty slice", view.Items)
+			}
+			// An empty queue is never reported as paused for the torrent
+			// backends (paused is derived from item states).
+			if tc.serviceType != "sabnzbd" && view.Paused {
+				t.Error("Paused = true, want false for an empty queue")
+			}
+		})
+	}
+}
+
+func TestSnapshotRejectsNonDownloadInstance(t *testing.T) {
+	e := newEnv(t)
+	inst := e.mkInstance(t, "radarr", "http://radarr.invalid", "key", "", "")
+	if _, err := Snapshot(e.registry, inst); err == nil {
+		t.Fatal("Snapshot accepted a radarr instance")
+	}
+}
+
+// TestSnapshotFailureIsPerInstance pins the degradation contract: multiple
+// configured clients never cross-wire, and an unreachable backend fails only
+// its own instance's snapshot — the healthy client's snapshot is unaffected.
+func TestSnapshotFailureIsPerInstance(t *testing.T) {
+	sab := &sabFake{t: t, apiKey: "sab-key", queue: `{"queue":{"paused":false,"kbpersec":"1.00","slots":[
+		{"nzo_id":"NZO1","filename":"Sab.Item","mb":"1.00","mbleft":"1.00","percentage":"0","timeleft":"","status":"Queued","cat":""}
+	]}}`}
+	sabSrv := httptest.NewServer(sab.handler())
+	t.Cleanup(sabSrv.Close)
+
+	trans := &transFake{t: t, torrents: `[
+		{"id":1,"hashString":"hash-t","name":"Trans.Item","totalSize":10,"leftUntilDone":10,"percentDone":0,"rateDownload":0,"eta":-1,"status":4,"labels":[],"doneDate":0}
+	]`, stats: `{"downloadSpeed":0}`}
+	transSrv := httptest.NewServer(trans.handler())
+
+	e := newEnv(t)
+	sabInst := e.mkInstance(t, "sabnzbd", sabSrv.URL, "sab-key", "", "")
+	transInst := e.mkInstance(t, "transmission", transSrv.URL, "", "", "")
+
+	// Both healthy: each snapshot returns its own backend's items.
+	sabView, err := Snapshot(e.registry, sabInst)
+	if err != nil {
+		t.Fatalf("sab Snapshot: %v", err)
+	}
+	transView, err := Snapshot(e.registry, transInst)
+	if err != nil {
+		t.Fatalf("transmission Snapshot: %v", err)
+	}
+	if len(sabView.Items) != 1 || sabView.Items[0].Name != "Sab.Item" {
+		t.Errorf("sab items = %+v, want the SABnzbd item", sabView.Items)
+	}
+	if len(transView.Items) != 1 || transView.Items[0].Name != "Trans.Item" {
+		t.Errorf("transmission items = %+v, want the Transmission item", transView.Items)
+	}
+
+	// Kill Transmission: its snapshot errors, SABnzbd's still succeeds.
+	transSrv.Close()
+	if _, err := Snapshot(e.registry, transInst); err == nil {
+		t.Fatal("Snapshot of unreachable transmission succeeded")
+	}
+	if _, err := Snapshot(e.registry, sabInst); err != nil {
+		t.Fatalf("sab Snapshot after sibling died: %v", err)
+	}
+}
+
+// --- queue endpoint ---
+
+func TestGetQueueEndpointAndErrors(t *testing.T) {
+	sab := &sabFake{t: t, apiKey: "sab-key", queue: `{"queue":{"paused":true,"kbpersec":"0.00","slots":[]}}`}
+	sabSrv := httptest.NewServer(sab.handler())
+	t.Cleanup(sabSrv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "sabnzbd", sabSrv.URL, "sab-key", "", "")
+
+	view := decodeView(t, e.do(t, "GET", "/downloads/"+inst.ID+"/queue"))
+	if !view.Paused || len(view.Items) != 0 {
+		t.Errorf("view = %+v, want paused empty queue", view)
+	}
+
+	// Unknown instance → 404.
+	if rec := e.do(t, "GET", "/downloads/no-such-instance/queue"); rec.Code != http.StatusNotFound {
+		t.Errorf("unknown instance status = %d, want 404", rec.Code)
+	}
+
+	// Non-download-client instance → 400.
+	radarrInst := e.mkInstance(t, "radarr", "http://radarr.invalid", "key", "", "")
+	if rec := e.do(t, "GET", "/downloads/"+radarrInst.ID+"/queue"); rec.Code != http.StatusBadRequest {
+		t.Errorf("radarr instance status = %d, want 400", rec.Code)
+	}
+}
+
+// TestGetQueueUnreachableBackendReturns502 pins the degradation surface: an
+// unreachable backend errors the whole snapshot as a 502, and the error body
+// never leaks the instance API key (SABnzbd embeds it in the request URL).
+func TestGetQueueUnreachableBackendReturns502(t *testing.T) {
+	const secret = "SAB_API_KEY_SENTINEL"
+	deadSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadSrv.Close()
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "sabnzbd", deadSrv.URL, secret, "", "")
+
+	rec := e.do(t, "GET", "/downloads/"+inst.ID+"/queue")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), secret) {
+		t.Fatalf("502 body leaked the API key: %s", rec.Body.String())
+	}
+}
+
+// TestGetQueueGarbageBackendReturns502 pins that a backend replying 200 with
+// non-JSON garbage fails the snapshot instead of returning a bogus queue.
+func TestGetQueueGarbageBackendReturns502(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "<html>login page</html>")
+	}))
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "sabnzbd", srv.URL, "key", "", "")
+
+	if rec := e.do(t, "GET", "/downloads/"+inst.ID+"/queue"); rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+}
+
+// --- destructive item/queue actions ---
+
+func TestSabnzbdActions(t *testing.T) {
+	fake := &sabFake{t: t, apiKey: "sab-key"}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "sabnzbd", srv.URL, "sab-key", "", "")
+	base := "/downloads/" + inst.ID
+
+	steps := []struct {
+		name   string
+		method string
+		path   string
+		want   map[string]string
+	}{
+		{"pause item", "POST", base + "/queue/SABnzbd_nzo_1/pause",
+			map[string]string{"mode": "queue", "name": "pause", "value": "SABnzbd_nzo_1"}},
+		{"resume item", "POST", base + "/queue/SABnzbd_nzo_1/resume",
+			map[string]string{"mode": "queue", "name": "resume", "value": "SABnzbd_nzo_1"}},
+		{"delete item keeps files", "DELETE", base + "/queue/SABnzbd_nzo_1",
+			map[string]string{"mode": "queue", "name": "delete", "value": "SABnzbd_nzo_1", "del_files": "0"}},
+		{"delete item removes files", "DELETE", base + "/queue/SABnzbd_nzo_1?deleteData=true",
+			map[string]string{"mode": "queue", "name": "delete", "value": "SABnzbd_nzo_1", "del_files": "1"}},
+		{"pause all", "POST", base + "/pause", map[string]string{"mode": "pause"}},
+		{"resume all", "POST", base + "/resume", map[string]string{"mode": "resume"}},
+	}
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			rec := e.do(t, step.method, step.path)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204 (body %s)", rec.Code, rec.Body.String())
+			}
+			got := fake.lastCall(t)
+			for key, want := range step.want {
+				if got.Get(key) != want {
+					t.Errorf("query %s = %q, want %q (full query %v)", key, got.Get(key), want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestQbittorrentActions(t *testing.T) {
+	fake := &qbitFake{t: t, username: "admin", password: "qbit-pass"}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "qbittorrent", srv.URL, "", "admin", "qbit-pass")
+	base := "/downloads/" + inst.ID
+
+	steps := []struct {
+		name     string
+		method   string
+		path     string
+		wantPath string
+		wantForm map[string]string
+	}{
+		// The client targets the qBittorrent 5.x stop/start names first;
+		// the 4.x pause/resume fallback is covered in the qbittorrent package.
+		{"pause item", "POST", base + "/queue/aaa111/pause",
+			"/api/v2/torrents/stop", map[string]string{"hashes": "aaa111"}},
+		{"resume item", "POST", base + "/queue/aaa111/resume",
+			"/api/v2/torrents/start", map[string]string{"hashes": "aaa111"}},
+		{"delete item keeps files", "DELETE", base + "/queue/aaa111",
+			"/api/v2/torrents/delete", map[string]string{"hashes": "aaa111", "deleteFiles": "false"}},
+		{"delete item removes files", "DELETE", base + "/queue/aaa111?deleteData=true",
+			"/api/v2/torrents/delete", map[string]string{"hashes": "aaa111", "deleteFiles": "true"}},
+		{"pause all", "POST", base + "/pause",
+			"/api/v2/torrents/stop", map[string]string{"hashes": "all"}},
+		{"resume all", "POST", base + "/resume",
+			"/api/v2/torrents/start", map[string]string{"hashes": "all"}},
+	}
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			rec := e.do(t, step.method, step.path)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204 (body %s)", rec.Code, rec.Body.String())
+			}
+			got := fake.lastAction(t)
+			if got.path != step.wantPath {
+				t.Errorf("upstream path = %s, want %s", got.path, step.wantPath)
+			}
+			for key, want := range step.wantForm {
+				if got.form.Get(key) != want {
+					t.Errorf("form %s = %q, want %q", key, got.form.Get(key), want)
+				}
+			}
+		})
+	}
+}
+
+func TestNzbgetActions(t *testing.T) {
+	fake := &nzbgetFake{t: t, username: "nzbget", password: "pass"}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "nzbget", srv.URL, "", "nzbget", "pass")
+	base := "/downloads/" + inst.ID
+
+	assertEditQueue := func(t *testing.T, got rpcCall, command string) {
+		t.Helper()
+		if got.Method != "editqueue" {
+			t.Fatalf("method = %s, want editqueue", got.Method)
+		}
+		// Modern 3-parameter signature: [Command, Param, IDs].
+		if len(got.Params) != 3 || got.Params[0] != command || got.Params[1] != "" {
+			t.Fatalf("params = %v, want [%s \"\" [42]]", got.Params, command)
+		}
+		ids, ok := got.Params[2].([]interface{})
+		if !ok || len(ids) != 1 || ids[0] != float64(42) {
+			t.Fatalf("ids = %v, want [42]", got.Params[2])
+		}
+	}
+
+	rec := e.do(t, "POST", base+"/queue/42/pause")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("pause status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	assertEditQueue(t, fake.lastCall(t), "GroupPause")
+
+	rec = e.do(t, "POST", base+"/queue/42/resume")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("resume status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	assertEditQueue(t, fake.lastCall(t), "GroupResume")
+
+	// NZBGet's dialect has no remove-data flag: ?deleteData=true still maps
+	// to a plain GroupDelete with no extra parameter.
+	rec = e.do(t, "DELETE", base+"/queue/42?deleteData=true")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	assertEditQueue(t, fake.lastCall(t), "GroupDelete")
+
+	rec = e.do(t, "POST", base+"/pause")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("pause-all status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	if got := fake.lastCall(t); got.Method != "pausedownload" {
+		t.Errorf("pause-all method = %s, want pausedownload", got.Method)
+	}
+
+	rec = e.do(t, "POST", base+"/resume")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("resume-all status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	if got := fake.lastCall(t); got.Method != "resumedownload" {
+		t.Errorf("resume-all method = %s, want resumedownload", got.Method)
+	}
+
+	// A non-numeric item ID is rejected before any RPC is issued.
+	fake.mu.Lock()
+	before := len(fake.calls)
+	fake.mu.Unlock()
+	rec = e.do(t, "POST", base+"/queue/not-a-number/pause")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("non-numeric id status = %d, want 400", rec.Code)
+	}
+	fake.mu.Lock()
+	after := len(fake.calls)
+	fake.mu.Unlock()
+	if after != before {
+		t.Errorf("non-numeric id reached the backend (%d new calls)", after-before)
+	}
+}
+
+func TestTransmissionItemActions(t *testing.T) {
+	fake := &transFake{t: t}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "transmission", srv.URL, "", "", "")
+	base := "/downloads/" + inst.ID
+
+	rec := e.do(t, "POST", base+"/queue/deadbeef01/pause")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("pause status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	stops := fake.callsOf("torrent-stop")
+	if len(stops) != 1 {
+		t.Fatalf("torrent-stop calls = %d, want 1", len(stops))
+	}
+	if ids, _ := stops[0].Arguments["ids"].([]interface{}); len(ids) != 1 || ids[0] != "deadbeef01" {
+		t.Errorf("torrent-stop ids = %v, want [deadbeef01]", stops[0].Arguments["ids"])
+	}
+
+	rec = e.do(t, "POST", base+"/queue/deadbeef01/resume")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("resume status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	starts := fake.callsOf("torrent-start")
+	if len(starts) != 1 {
+		t.Fatalf("torrent-start calls = %d, want 1", len(starts))
+	}
+	if ids, _ := starts[0].Arguments["ids"].([]interface{}); len(ids) != 1 || ids[0] != "deadbeef01" {
+		t.Errorf("torrent-start ids = %v, want [deadbeef01]", starts[0].Arguments["ids"])
+	}
+
+	rec = e.do(t, "DELETE", base+"/queue/deadbeef01")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	removes := fake.callsOf("torrent-remove")
+	if len(removes) != 1 {
+		t.Fatalf("torrent-remove calls = %d, want 1", len(removes))
+	}
+	if removes[0].Arguments["delete-local-data"] != false {
+		t.Errorf("delete-local-data = %v, want false", removes[0].Arguments["delete-local-data"])
+	}
+
+	rec = e.do(t, "DELETE", base+"/queue/deadbeef01?deleteData=true")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("delete-with-data status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	removes = fake.callsOf("torrent-remove")
+	if len(removes) != 2 {
+		t.Fatalf("torrent-remove calls = %d, want 2", len(removes))
+	}
+	last := removes[1]
+	if last.Arguments["delete-local-data"] != true {
+		t.Errorf("delete-local-data = %v, want true", last.Arguments["delete-local-data"])
+	}
+	if ids, _ := last.Arguments["ids"].([]interface{}); len(ids) != 1 || ids[0] != "deadbeef01" {
+		t.Errorf("torrent-remove ids = %v, want [deadbeef01]", last.Arguments["ids"])
+	}
+}
+
+// TestTransmissionQueueActionsOnlyTouchIncompleteTorrents pins the guardrail
+// in transmissionQueueAction: pause/resume-all must never send a bare (all
+// torrents) command — completed/seeding torrents stay untouched, and when the
+// visible queue is empty no torrent-stop/start is issued at all.
+func TestTransmissionQueueActionsOnlyTouchIncompleteTorrents(t *testing.T) {
+	fake := &transFake{t: t, torrents: `[
+		{"id":1,"hashString":"incomplete-1","name":"A","totalSize":10,"leftUntilDone":5,"percentDone":0.5,"rateDownload":0,"eta":-1,"status":4,"labels":[],"doneDate":0},
+		{"id":2,"hashString":"seeding-1","name":"B","totalSize":10,"leftUntilDone":0,"percentDone":1.0,"rateDownload":0,"eta":-1,"status":6,"labels":[],"doneDate":1752600000}
+	]`, stats: `{"downloadSpeed":0}`}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "transmission", srv.URL, "", "", "")
+	base := "/downloads/" + inst.ID
+
+	rec := e.do(t, "POST", base+"/pause")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("pause-all status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	stops := fake.callsOf("torrent-stop")
+	if len(stops) != 1 {
+		t.Fatalf("torrent-stop calls = %d, want 1", len(stops))
+	}
+	ids, _ := stops[0].Arguments["ids"].([]interface{})
+	if len(ids) != 1 || ids[0] != "incomplete-1" {
+		t.Fatalf("torrent-stop ids = %v, want only the incomplete torrent", stops[0].Arguments["ids"])
+	}
+
+	rec = e.do(t, "POST", base+"/resume")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("resume-all status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	starts := fake.callsOf("torrent-start")
+	if len(starts) != 1 {
+		t.Fatalf("torrent-start calls = %d, want 1", len(starts))
+	}
+	ids, _ = starts[0].Arguments["ids"].([]interface{})
+	if len(ids) != 1 || ids[0] != "incomplete-1" {
+		t.Fatalf("torrent-start ids = %v, want only the incomplete torrent", starts[0].Arguments["ids"])
+	}
+
+	// All torrents complete: pause-all succeeds without issuing any stop.
+	fake.mu.Lock()
+	fake.torrents = `[
+		{"id":2,"hashString":"seeding-1","name":"B","totalSize":10,"leftUntilDone":0,"percentDone":1.0,"rateDownload":0,"eta":-1,"status":6,"labels":[],"doneDate":1752600000}
+	]`
+	fake.mu.Unlock()
+	rec = e.do(t, "POST", base+"/pause")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("pause-all (empty queue) status = %d (body %s)", rec.Code, rec.Body.String())
+	}
+	if got := len(fake.callsOf("torrent-stop")); got != 1 {
+		t.Fatalf("torrent-stop calls = %d, want still 1 (no bare stop-all)", got)
+	}
+}
+
+// --- history ---
+
+func TestSabnzbdHistory(t *testing.T) {
+	fake := &sabFake{t: t, apiKey: "sab-key", history: `{"history":{"slots":[
+		{"name":"Old.Show","status":"Completed","fail_message":"","bytes":734003200.0,"size":"700 MB","completed":1752500000,"category":"tv"},
+		{"name":"Bad.Nzb","status":"Failed","fail_message":"Aborted, cannot be completed","bytes":0,"size":"","completed":0,"category":"movies"}
+	]}}`}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "sabnzbd", srv.URL, "sab-key", "", "")
+
+	items := decodeHistory(t, e.do(t, "GET", "/downloads/"+inst.ID+"/history?limit=5"))
+	if got := fake.lastCall(t); got.Get("mode") != "history" || got.Get("limit") != "5" {
+		t.Errorf("upstream query = %v, want mode=history limit=5", got)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	wantCompleted := time.Unix(1752500000, 0).UTC().Format(time.RFC3339)
+	got := items[0]
+	if got.Name != "Old.Show" || got.Status != "Completed" || got.SizeBytes != 734003200 ||
+		got.CompletedAt != wantCompleted || got.Category != "tv" || got.Error != "" {
+		t.Errorf("item[0] = %+v", got)
+	}
+	// Zero completed timestamp stays empty; fail_message maps to error.
+	if items[1].CompletedAt != "" || items[1].Error != "Aborted, cannot be completed" {
+		t.Errorf("item[1] = %+v", items[1])
+	}
+}
+
+func TestQbittorrentHistoryFiltersSortsAndLimits(t *testing.T) {
+	fake := &qbitFake{t: t, username: "admin", password: "pass", torrents: `[
+		{"name":"incomplete","hash":"h0","size":10,"progress":0.5,"state":"downloading","category":"","completion_on":0},
+		{"name":"oldest","hash":"h1","size":100,"progress":1.0,"state":"uploading","category":"tv","completion_on":1752400000},
+		{"name":"newest","hash":"h2","size":200,"progress":1.0,"state":"error","category":"movies","completion_on":1752600000},
+		{"name":"middle","hash":"h3","size":300,"progress":1.0,"state":"missingFiles","category":"","completion_on":1752500000}
+	]`}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "qbittorrent", srv.URL, "", "admin", "pass")
+
+	items := decodeHistory(t, e.do(t, "GET", "/downloads/"+inst.ID+"/history?limit=2"))
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2 (limit applied)", len(items))
+	}
+	// Only completed torrents, newest first.
+	if items[0].Name != "newest" || items[1].Name != "middle" {
+		t.Errorf("order = [%s, %s], want [newest, middle]", items[0].Name, items[1].Name)
+	}
+	// error/missingFiles states surface as the error field.
+	if items[0].Error != "error" || items[1].Error != "missingFiles" {
+		t.Errorf("errors = [%q, %q], want [error, missingFiles]", items[0].Error, items[1].Error)
+	}
+	if items[0].CompletedAt != time.Unix(1752600000, 0).UTC().Format(time.RFC3339) {
+		t.Errorf("CompletedAt = %s", items[0].CompletedAt)
+	}
+}
+
+func TestNzbgetHistoryStatusMappingAndLimit(t *testing.T) {
+	fake := &nzbgetFake{t: t, username: "u", password: "p", history: `[
+		{"NZBID":7,"Name":"Success.Item","Status":"SUCCESS/ALL","FileSizeLo":52428800,"FileSizeHi":0,"FileSizeMB":50,"HistoryTime":1752500000,"Category":"tv"},
+		{"NZBID":8,"Name":"Failed.Item","Status":"FAILURE/PAR","FileSizeLo":0,"FileSizeHi":0,"FileSizeMB":10,"HistoryTime":1752600000,"Category":""}
+	]`}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "nzbget", srv.URL, "", "u", "p")
+
+	items := decodeHistory(t, e.do(t, "GET", "/downloads/"+inst.ID+"/history"))
+	// The history RPC asks for visible entries only (hidden=false).
+	if got := fake.lastCall(t); got.Method != "history" || len(got.Params) != 1 || got.Params[0] != false {
+		t.Errorf("upstream call = %+v, want history [false]", got)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2", len(items))
+	}
+	// Newest first; requester vocabulary: SUCCESS/* → Completed, FAILURE/* →
+	// Failed with the raw status preserved as the error.
+	if items[0].Name != "Failed.Item" || items[0].Status != "Failed" || items[0].Error != "FAILURE/PAR" {
+		t.Errorf("item[0] = %+v", items[0])
+	}
+	if items[1].Name != "Success.Item" || items[1].Status != "Completed" || items[1].Error != "" {
+		t.Errorf("item[1] = %+v", items[1])
+	}
+	if items[1].SizeBytes != 52428800 {
+		t.Errorf("item[1].SizeBytes = %d, want 52428800", items[1].SizeBytes)
+	}
+
+	// limit=1 keeps only the most recent entry.
+	items = decodeHistory(t, e.do(t, "GET", "/downloads/"+inst.ID+"/history?limit=1"))
+	if len(items) != 1 || items[0].Name != "Failed.Item" {
+		t.Fatalf("limited items = %+v, want only Failed.Item", items)
+	}
+}
+
+func TestTransmissionHistoryCompletedOnly(t *testing.T) {
+	fake := &transFake{t: t, torrents: `[
+		{"id":1,"hashString":"h1","name":"incomplete","totalSize":10,"leftUntilDone":5,"percentDone":0.5,"status":4,"error":0,"errorString":"","labels":[],"doneDate":0},
+		{"id":2,"hashString":"h2","name":"older-done","totalSize":100,"leftUntilDone":0,"percentDone":1.0,"status":6,"error":0,"errorString":"","labels":["linux"],"doneDate":1752400000},
+		{"id":3,"hashString":"h3","name":"newer-done","totalSize":200,"leftUntilDone":0,"percentDone":1.0,"status":0,"error":3,"errorString":"No data found","labels":[],"doneDate":1752600000}
+	]`, stats: `{"downloadSpeed":0}`}
+	srv := httptest.NewServer(fake.handler())
+	t.Cleanup(srv.Close)
+
+	e := newEnv(t)
+	inst := e.mkInstance(t, "transmission", srv.URL, "", "", "")
+
+	items := decodeHistory(t, e.do(t, "GET", "/downloads/"+inst.ID+"/history"))
+	if len(items) != 2 {
+		t.Fatalf("items = %d, want 2 (incomplete excluded)", len(items))
+	}
+	got := items[0]
+	if got.Name != "newer-done" || got.Status != "stopped" || got.Error != "No data found" ||
+		got.CompletedAt != time.Unix(1752600000, 0).UTC().Format(time.RFC3339) {
+		t.Errorf("item[0] = %+v", got)
+	}
+	if items[1].Name != "older-done" || items[1].Status != "seeding" ||
+		items[1].Error != "" || items[1].Category != "linux" {
+		t.Errorf("item[1] = %+v", items[1])
+	}
+}

--- a/server/internal/nzbget/client_test.go
+++ b/server/internal/nzbget/client_test.go
@@ -1,0 +1,206 @@
+package nzbget
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type rpcRequest struct {
+	JSONRPC string        `json:"jsonrpc"`
+	Method  string        `json:"method"`
+	Params  []interface{} `json:"params"`
+	ID      int           `json:"id"`
+}
+
+// TestCallSendsJSONRPCEnvelopeWithBasicAuth pins NZBGet's dialect: a POST to
+// /jsonrpc carrying a JSON-RPC 2.0 envelope and HTTP Basic auth.
+func TestCallSendsJSONRPCEnvelopeWithBasicAuth(t *testing.T) {
+	var gotPath, gotContentType string
+	var gotReq rpcRequest
+	var gotUser, gotPass string
+	var gotAuth bool
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		gotUser, gotPass, gotAuth = r.BasicAuth()
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotReq)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"result":"21.1"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	version, err := NewClient(srv.URL, "nzbget", "tegbzn6789").Version()
+	if err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+	if version != "21.1" {
+		t.Errorf("version = %q, want 21.1", version)
+	}
+	if gotPath != "/jsonrpc" {
+		t.Errorf("path = %s, want /jsonrpc", gotPath)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("content-type = %s, want application/json", gotContentType)
+	}
+	if !gotAuth || gotUser != "nzbget" || gotPass != "tegbzn6789" {
+		t.Errorf("basic auth = (%q, %q, %v), want (nzbget, tegbzn6789, true)", gotUser, gotPass, gotAuth)
+	}
+	if gotReq.JSONRPC != "2.0" || gotReq.Method != "version" || gotReq.Params == nil || len(gotReq.Params) != 0 {
+		t.Errorf("request = %+v, want jsonrpc 2.0 method=version params=[]", gotReq)
+	}
+}
+
+// TestNoAuthHeaderWhenCredentialsBlank pins that a credential-less NZBGet
+// (control ip whitelisting) gets no Authorization header at all.
+func TestNoAuthHeaderWhenCredentialsBlank(t *testing.T) {
+	var gotAuthHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuthHeader = r.Header.Get("Authorization")
+		_, _ = io.WriteString(w, `{"result":"21.1"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := NewClient(srv.URL, "", "").Version(); err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+	if gotAuthHeader != "" {
+		t.Errorf("Authorization header = %q, want empty", gotAuthHeader)
+	}
+}
+
+// TestRPCErrorEnvelopeSurfaced pins the JSON-RPC error envelope handling: an
+// HTTP 200 with an error object must fail with the server's message.
+func TestRPCErrorEnvelopeSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"result":null,"error":{"name":"AccessDenied","code":403,"message":"Access denied"}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, "u", "p").ListGroups()
+	if err == nil {
+		t.Fatal("ListGroups accepted a JSON-RPC error envelope")
+	}
+	if !strings.Contains(err.Error(), "Access denied") {
+		t.Fatalf("error = %v, want the RPC error message surfaced", err)
+	}
+}
+
+// TestUnauthorizedDoesNotEchoCredentials pins the credential-echo property on
+// the 401 path.
+func TestUnauthorizedDoesNotEchoCredentials(t *testing.T) {
+	const password = "NZBGET_PASSWORD_SENTINEL"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "401 unauthorized for "+password, http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, "nzbget", password).GetStatus()
+	if err == nil {
+		t.Fatal("GetStatus accepted a 401 response")
+	}
+	if !strings.Contains(err.Error(), "invalid credentials") {
+		t.Errorf("error = %v, want invalid-credentials message", err)
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Fatalf("error echoed the password: %v", err)
+	}
+}
+
+func TestClientDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(destination.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL+"/credential-sink", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(source.Close)
+
+	client := NewClient(source.URL, "nzbget", "nzbget-secret")
+	if _, err := client.ListGroups(); err == nil {
+		t.Fatal("ListGroups accepted an upstream redirect")
+	}
+	if _, err := client.GetStatus(); err == nil {
+		t.Fatal("GetStatus accepted an upstream redirect")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect destination received %d requests, want 0", got)
+	}
+}
+
+// TestEditQueueFallsBackToLegacySignature pins the v16+/pre-v16 shim: the
+// modern 3-parameter editqueue is tried first, and on an RPC error the legacy
+// 4-parameter signature (with the Offset param) is used.
+func TestEditQueueFallsBackToLegacySignature(t *testing.T) {
+	var mu sync.Mutex
+	var calls []rpcRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req rpcRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		mu.Lock()
+		calls = append(calls, req)
+		mu.Unlock()
+		if len(req.Params) == 3 {
+			// Pre-v16 server: reject the modern signature.
+			_, _ = io.WriteString(w, `{"error":{"name":"InvalidParams","code":-32602,"message":"invalid params"}}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"result": true}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := NewClient(srv.URL, "u", "p").PauseGroups([]int{7, 8}); err != nil {
+		t.Fatalf("PauseGroups: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 2 {
+		t.Fatalf("calls = %d, want 2 (modern then legacy)", len(calls))
+	}
+	modern, legacy := calls[0], calls[1]
+	if modern.Method != "editqueue" || len(modern.Params) != 3 ||
+		modern.Params[0] != "GroupPause" || modern.Params[1] != "" {
+		t.Errorf("modern call = %+v, want editqueue [GroupPause \"\" ids]", modern)
+	}
+	if legacy.Method != "editqueue" || len(legacy.Params) != 4 ||
+		legacy.Params[0] != "GroupPause" || legacy.Params[1] != float64(0) || legacy.Params[2] != "" {
+		t.Errorf("legacy call = %+v, want editqueue [GroupPause 0 \"\" ids]", legacy)
+	}
+	ids, ok := legacy.Params[3].([]interface{})
+	if !ok || len(ids) != 2 || ids[0] != float64(7) || ids[1] != float64(8) {
+		t.Errorf("legacy ids = %v, want [7 8]", legacy.Params[3])
+	}
+}
+
+// TestLoHiSizeReassembly pins the 32-bit Lo/Hi split NZBGet uses for byte
+// counts, including the fallback to the rounded MB field when the pair is zero.
+func TestLoHiSizeReassembly(t *testing.T) {
+	over4GiB := Group{FileSizeLo: 705032704, FileSizeHi: 1}
+	if got := over4GiB.SizeBytes(); got != 5000000000 {
+		t.Errorf("SizeBytes = %d, want 5000000000", got)
+	}
+	mbOnly := Group{FileSizeMB: 50}
+	if got := mbOnly.SizeBytes(); got != 50*1024*1024 {
+		t.Errorf("SizeBytes (MB fallback) = %d, want %d", got, int64(50*1024*1024))
+	}
+	remaining := Group{RemainingSizeLo: 268435456}
+	if got := remaining.RemainingBytes(); got != 268435456 {
+		t.Errorf("RemainingBytes = %d, want 268435456", got)
+	}
+	entry := HistoryEntry{FileSizeLo: 4294967295, FileSizeHi: 2}
+	if got := entry.SizeBytes(); got != 2*4294967296+4294967295 {
+		t.Errorf("history SizeBytes = %d, want %d", got, int64(2*4294967296+4294967295))
+	}
+}

--- a/server/internal/qbittorrent/client_test.go
+++ b/server/internal/qbittorrent/client_test.go
@@ -1,0 +1,234 @@
+package qbittorrent
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// qbitAuthFake models the qBittorrent WebUI cookie-auth flow: POST
+// /api/v2/auth/login issues an SID cookie, every other endpoint requires the
+// current cookie and returns 403 otherwise.
+type qbitAuthFake struct {
+	username string
+	password string
+
+	mu     sync.Mutex
+	sid    string
+	logins int
+}
+
+func (f *qbitAuthFake) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/auth/login" {
+			if r.Header.Get("Referer") == "" {
+				t.Error("login request missing Referer header")
+			}
+			_ = r.ParseForm()
+			if r.PostForm.Get("username") != f.username || r.PostForm.Get("password") != f.password {
+				_, _ = io.WriteString(w, "Fails.")
+				return
+			}
+			f.mu.Lock()
+			f.logins++
+			f.sid = fmt.Sprintf("sid-%d", f.logins)
+			sid := f.sid
+			f.mu.Unlock()
+			http.SetCookie(w, &http.Cookie{Name: "SID", Value: sid})
+			_, _ = io.WriteString(w, "Ok.")
+			return
+		}
+
+		cookie, err := r.Cookie("SID")
+		f.mu.Lock()
+		valid := err == nil && cookie.Value == f.sid
+		f.mu.Unlock()
+		if !valid {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		switch r.URL.Path {
+		case "/api/v2/torrents/info":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `[{"name":"t1","hash":"aaa","size":10,"progress":0.5,"state":"downloading"}]`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func (f *qbitAuthFake) loginCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.logins
+}
+
+// expireSession invalidates the issued cookie, simulating a WebUI session
+// expiring server-side.
+func (f *qbitAuthFake) expireSession() {
+	f.mu.Lock()
+	f.sid = "expired"
+	f.mu.Unlock()
+}
+
+// TestLoginOnceAndReuseCookie pins the login flow: the first API call logs in
+// and stores the SID cookie; subsequent calls reuse it without re-logging-in.
+func TestLoginOnceAndReuseCookie(t *testing.T) {
+	fake := &qbitAuthFake{username: "admin", password: "adminadmin"}
+	srv := httptest.NewServer(fake.handler(t))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, "admin", "adminadmin")
+	for i := 0; i < 3; i++ {
+		torrents, err := client.GetTorrents()
+		if err != nil {
+			t.Fatalf("GetTorrents call %d: %v", i, err)
+		}
+		if len(torrents) != 1 || torrents[0].Hash != "aaa" {
+			t.Fatalf("torrents = %+v, want the fake torrent", torrents)
+		}
+	}
+	if got := fake.loginCount(); got != 1 {
+		t.Fatalf("logins = %d, want exactly 1 across repeated calls", got)
+	}
+}
+
+// TestExpiredSessionTriggersReloginRetry pins the 403 recovery path: when the
+// stored cookie has expired, the client re-logs-in once and retries the call
+// instead of surfacing the 403.
+func TestExpiredSessionTriggersReloginRetry(t *testing.T) {
+	fake := &qbitAuthFake{username: "admin", password: "adminadmin"}
+	srv := httptest.NewServer(fake.handler(t))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, "admin", "adminadmin")
+	if _, err := client.GetTorrents(); err != nil {
+		t.Fatalf("initial GetTorrents: %v", err)
+	}
+
+	fake.expireSession()
+	if _, err := client.GetTorrents(); err != nil {
+		t.Fatalf("GetTorrents after session expiry: %v", err)
+	}
+	if got := fake.loginCount(); got != 2 {
+		t.Fatalf("logins = %d, want 2 (initial + re-login after 403)", got)
+	}
+}
+
+// TestLoginFailuresDoNotEchoCredentials pins both rejection shapes (the
+// "Fails." body and a non-200 status) and the credential-echo property:
+// error strings never contain the username or password.
+func TestLoginFailuresDoNotEchoCredentials(t *testing.T) {
+	const password = "QBIT_PASSWORD_SENTINEL"
+
+	badCreds := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "Fails.")
+	}))
+	t.Cleanup(badCreds.Close)
+	err := NewClient(badCreds.URL, "admin", password).Login()
+	if err == nil {
+		t.Fatal("Login accepted a Fails. response")
+	}
+	if !strings.Contains(err.Error(), "invalid credentials") {
+		t.Errorf("error = %v, want invalid-credentials message", err)
+	}
+	if strings.Contains(err.Error(), password) || strings.Contains(err.Error(), "admin") {
+		t.Fatalf("login error echoed credentials: %v", err)
+	}
+
+	serverError := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "banned: too many attempts for "+password, http.StatusForbidden)
+	}))
+	t.Cleanup(serverError.Close)
+	err = NewClient(serverError.URL, "admin", password).Login()
+	if err == nil {
+		t.Fatal("Login accepted a 403 response")
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Fatalf("login error echoed the upstream body secret: %v", err)
+	}
+}
+
+func TestClientDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(destination.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL+"/credential-sink", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(source.Close)
+
+	client := NewClient(source.URL, "admin", "qbit-secret")
+	if err := client.Login(); err == nil {
+		t.Fatal("Login accepted an upstream redirect")
+	}
+	if _, err := client.GetTorrents(); err == nil {
+		t.Fatal("GetTorrents accepted an upstream redirect")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect destination received %d requests, want 0", got)
+	}
+}
+
+// TestPauseResumeFallbackOn404 pins the 4.x/5.x rename shim: stop/start are
+// tried first and pause/resume are used only when the modern path 404s.
+func TestPauseResumeFallbackOn404(t *testing.T) {
+	var mu sync.Mutex
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/auth/login" {
+			http.SetCookie(w, &http.Cookie{Name: "SID", Value: "sid-1"})
+			_, _ = io.WriteString(w, "Ok.")
+			return
+		}
+		_ = r.ParseForm()
+		if r.PostForm.Get("hashes") != "all" {
+			t.Errorf("%s hashes = %q, want all", r.URL.Path, r.PostForm.Get("hashes"))
+		}
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+		switch r.URL.Path {
+		case "/api/v2/torrents/stop", "/api/v2/torrents/start":
+			w.WriteHeader(http.StatusNotFound) // pre-5.x server
+		case "/api/v2/torrents/pause", "/api/v2/torrents/resume":
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, "admin", "adminadmin")
+	if err := client.PauseTorrents("all"); err != nil {
+		t.Fatalf("PauseTorrents: %v", err)
+	}
+	if err := client.ResumeTorrents("all"); err != nil {
+		t.Fatalf("ResumeTorrents: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{
+		"/api/v2/torrents/stop", "/api/v2/torrents/pause",
+		"/api/v2/torrents/start", "/api/v2/torrents/resume",
+	}
+	if len(paths) != len(want) {
+		t.Fatalf("paths = %v, want %v", paths, want)
+	}
+	for i := range want {
+		if paths[i] != want[i] {
+			t.Fatalf("paths = %v, want %v (modern endpoint first, legacy fallback second)", paths, want)
+		}
+	}
+}

--- a/server/internal/sabnzbd/client_test.go
+++ b/server/internal/sabnzbd/client_test.go
@@ -1,0 +1,147 @@
+package sabnzbd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func mustParseQuery(t *testing.T, raw string) url.Values {
+	t.Helper()
+	q, err := url.ParseQuery(raw)
+	if err != nil {
+		t.Fatalf("parse query %q: %v", raw, err)
+	}
+	return q
+}
+
+// TestCallSendsAPIKeyQueryParam pins SABnzbd's auth dialect: every call is a
+// GET against /api carrying output=json, the apikey query parameter, and the
+// mode selector.
+func TestCallSendsAPIKeyQueryParam(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"4.3.2"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	version, err := NewClient(srv.URL, "sab-api-key").Version()
+	if err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+	if version != "4.3.2" {
+		t.Errorf("version = %q, want 4.3.2", version)
+	}
+	if gotPath != "/api" {
+		t.Errorf("path = %s, want /api", gotPath)
+	}
+	q := mustParseQuery(t, gotQuery)
+	if q.Get("output") != "json" || q.Get("apikey") != "sab-api-key" || q.Get("mode") != "version" {
+		t.Errorf("query = %s, want output=json apikey=sab-api-key mode=version", gotQuery)
+	}
+}
+
+// TestTransportErrorRedactsAPIKey pins the credential-echo property: SABnzbd
+// is the one client whose secret rides in the request URL, and Go transport
+// errors embed the full URL — the client must redact the key before the error
+// can reach logs or HTTP responses.
+func TestTransportErrorRedactsAPIKey(t *testing.T) {
+	const secret = "SABNZBD_APIKEY_SENTINEL"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // unreachable: the transport error carries the request URL
+
+	_, err := NewClient(srv.URL, secret).Version()
+	if err == nil {
+		t.Fatal("Version against a dead server returned nil error")
+	}
+	if strings.Contains(err.Error(), secret) {
+		t.Fatalf("transport error echoed the API key: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[redacted]") {
+		t.Fatalf("transport error did not mark the redaction: %v", err)
+	}
+}
+
+// TestErrorEnvelopeSurfacedAsError pins SABnzbd's failure dialect: errors are
+// reported with HTTP 200 and a {"status": false, "error": ...} envelope.
+func TestErrorEnvelopeSurfacedAsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status": false, "error": "API Key Incorrect"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := NewClient(srv.URL, "key").GetQueue(); err == nil {
+		t.Fatal("GetQueue accepted an error envelope")
+	} else if !strings.Contains(err.Error(), "API Key Incorrect") {
+		t.Fatalf("error = %v, want the SABnzbd error message surfaced", err)
+	}
+}
+
+func TestClientDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(destination.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL+"/credential-sink", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(source.Close)
+
+	client := NewClient(source.URL, "sabnzbd-secret")
+	if _, err := client.GetQueue(); err == nil {
+		t.Fatal("GetQueue accepted an upstream redirect")
+	}
+	if err := client.PauseQueue(); err == nil {
+		t.Fatal("PauseQueue accepted an upstream redirect")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect destination received %d requests, want 0", got)
+	}
+}
+
+// TestQueueSlotDerivedFields pins the string-typed numeric parsing SABnzbd
+// forces on clients, in particular the "[dd:]hh:mm:ss" timeleft format.
+func TestQueueSlotDerivedFields(t *testing.T) {
+	etaCases := []struct {
+		timeLeft string
+		want     int64
+	}{
+		{"0:07:30", 450},
+		{"12:03", 723},
+		{"1:02:03:04", 93784}, // dd:hh:mm:ss
+		{"", 0},
+		{"junk", 0},
+	}
+	for _, tc := range etaCases {
+		slot := QueueSlot{TimeLeft: tc.timeLeft}
+		if got := slot.ETASeconds(); got != tc.want {
+			t.Errorf("ETASeconds(%q) = %d, want %d", tc.timeLeft, got, tc.want)
+		}
+	}
+
+	slot := QueueSlot{MB: "1400.00", MBLeft: "350.00", Percentage: "75"}
+	if got := slot.SizeBytes(); got != 1400*1024*1024 {
+		t.Errorf("SizeBytes = %d, want %d", got, int64(1400*1024*1024))
+	}
+	if got := slot.SizeLeftBytes(); got != 350*1024*1024 {
+		t.Errorf("SizeLeftBytes = %d, want %d", got, int64(350*1024*1024))
+	}
+	if got := slot.Progress(); got != 75 {
+		t.Errorf("Progress = %v, want 75", got)
+	}
+
+	queue := Queue{KBPerSec: "2048.00"}
+	if got := queue.SpeedBPS(); got != 2048*1024 {
+		t.Errorf("SpeedBPS = %d, want %d", got, int64(2048*1024))
+	}
+}

--- a/server/internal/transmission/client_test.go
+++ b/server/internal/transmission/client_test.go
@@ -1,0 +1,233 @@
+package transmission
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+type rpcRequest struct {
+	Method    string                 `json:"method"`
+	Arguments map[string]interface{} `json:"arguments"`
+}
+
+// TestSessionIDHandshake pins the X-Transmission-Session-Id CSRF flow: the
+// first request 409s, the client adopts the header value and retries once,
+// and later calls reuse the cached session id without another 409.
+func TestSessionIDHandshake(t *testing.T) {
+	const sessionID = "csrf-session-42"
+	var conflicts atomic.Int32
+	var mu sync.Mutex
+	var methods []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/transmission/rpc" {
+			t.Errorf("path = %s, want /transmission/rpc", r.URL.Path)
+		}
+		if r.Header.Get("X-Transmission-Session-Id") != sessionID {
+			conflicts.Add(1)
+			w.Header().Set("X-Transmission-Session-Id", sessionID)
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		var req rpcRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		mu.Lock()
+		methods = append(methods, req.Method)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		switch req.Method {
+		case "session-get":
+			_, _ = io.WriteString(w, `{"result":"success","arguments":{"version":"4.0.5","rpc-version":17}}`)
+		case "session-stats":
+			_, _ = io.WriteString(w, `{"result":"success","arguments":{"downloadSpeed":100,"uploadSpeed":5}}`)
+		default:
+			_, _ = io.WriteString(w, `{"result":"success"}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, "", "")
+	session, err := client.SessionGet()
+	if err != nil {
+		t.Fatalf("SessionGet: %v", err)
+	}
+	if session.Version != "4.0.5" || session.RPCVersion != 17 {
+		t.Errorf("session = %+v, want version 4.0.5 rpc 17", session)
+	}
+	stats, err := client.GetSessionStats()
+	if err != nil {
+		t.Fatalf("GetSessionStats: %v", err)
+	}
+	if stats.DownloadSpeed != 100 {
+		t.Errorf("DownloadSpeed = %d, want 100", stats.DownloadSpeed)
+	}
+
+	if got := conflicts.Load(); got != 1 {
+		t.Errorf("409 handshakes = %d, want exactly 1 (session id must be cached)", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(methods) != 2 || methods[0] != "session-get" || methods[1] != "session-stats" {
+		t.Errorf("served methods = %v, want [session-get session-stats]", methods)
+	}
+}
+
+// Test409WithoutSessionHeaderFails pins that a 409 with no session id header
+// is an error rather than an infinite retry.
+func Test409WithoutSessionHeaderFails(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusConflict)
+	}))
+	t.Cleanup(srv.Close)
+
+	if _, err := NewClient(srv.URL, "", "").SessionGet(); err == nil {
+		t.Fatal("SessionGet accepted a 409 without a session id header")
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1 (no blind retry)", got)
+	}
+}
+
+// TestUnauthorizedDoesNotEchoCredentials pins the credential-echo property on
+// the 401 path.
+func TestUnauthorizedDoesNotEchoCredentials(t *testing.T) {
+	const password = "TRANSMISSION_PASSWORD_SENTINEL"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "401 rejected credentials "+password, http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, "admin", password).GetTorrents()
+	if err == nil {
+		t.Fatal("GetTorrents accepted a 401 response")
+	}
+	if !strings.Contains(err.Error(), "invalid credentials") {
+		t.Errorf("error = %v, want invalid-credentials message", err)
+	}
+	if strings.Contains(err.Error(), password) {
+		t.Fatalf("error echoed the password: %v", err)
+	}
+}
+
+func TestClientDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(destination.Close)
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL+"/credential-sink", http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(source.Close)
+
+	client := NewClient(source.URL, "admin", "transmission-secret")
+	if _, err := client.GetTorrents(); err == nil {
+		t.Fatal("GetTorrents accepted an upstream redirect")
+	}
+	if _, err := client.SessionGet(); err == nil {
+		t.Fatal("SessionGet accepted an upstream redirect")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect destination received %d requests, want 0", got)
+	}
+}
+
+// TestRemoveTorrentsGuardsEmptyList pins the destructive-op guard: an empty
+// hash list must be rejected client-side, because a bare torrent-remove would
+// remove every torrent Transmission knows.
+func TestRemoveTorrentsGuardsEmptyList(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = io.WriteString(w, `{"result":"success"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, "", "")
+	if err := client.RemoveTorrents(nil, true); err == nil {
+		t.Fatal("RemoveTorrents(nil) succeeded")
+	}
+	if err := client.RemoveTorrents([]string{}, false); err == nil {
+		t.Fatal("RemoveTorrents(empty) succeeded")
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("requests = %d, want 0 (guard must fire before any RPC)", got)
+	}
+}
+
+// TestRemoveTorrentsSendsIdsAndDeleteFlag pins the torrent-remove argument
+// shape, including the delete-local-data flag.
+func TestRemoveTorrentsSendsIdsAndDeleteFlag(t *testing.T) {
+	var mu sync.Mutex
+	var got rpcRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		mu.Unlock()
+		_, _ = io.WriteString(w, `{"result":"success"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := NewClient(srv.URL, "", "").RemoveTorrents([]string{"hash-a", "hash-b"}, true); err != nil {
+		t.Fatalf("RemoveTorrents: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got.Method != "torrent-remove" {
+		t.Errorf("method = %s, want torrent-remove", got.Method)
+	}
+	if got.Arguments["delete-local-data"] != true {
+		t.Errorf("delete-local-data = %v, want true", got.Arguments["delete-local-data"])
+	}
+	ids, ok := got.Arguments["ids"].([]interface{})
+	if !ok || len(ids) != 2 || ids[0] != "hash-a" || ids[1] != "hash-b" {
+		t.Errorf("ids = %v, want [hash-a hash-b]", got.Arguments["ids"])
+	}
+}
+
+// TestResultFailureSurfaced pins that a non-"success" result string fails the
+// call even on HTTP 200.
+func TestResultFailureSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"result":"unrecognized method"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := NewClient(srv.URL, "", "").StartTorrents([]string{"h"}); err == nil {
+		t.Fatal("StartTorrents accepted a failure result")
+	} else if !strings.Contains(err.Error(), "unrecognized method") {
+		t.Fatalf("error = %v, want the result string surfaced", err)
+	}
+}
+
+func TestStatusString(t *testing.T) {
+	cases := []struct {
+		status int
+		want   string
+	}{
+		{StatusStopped, "stopped"},
+		{StatusCheckWaiting, "checkWaiting"},
+		{StatusChecking, "checking"},
+		{StatusDownloadQueue, "downloadWaiting"},
+		{StatusDownloading, "downloading"},
+		{StatusSeedQueue, "seedWaiting"},
+		{StatusSeeding, "seeding"},
+		{99, "unknown (99)"},
+	}
+	for _, tc := range cases {
+		if got := StatusString(tc.status); got != tc.want {
+			t.Errorf("StatusString(%d) = %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Test-only PR: first coverage for the five zero-test download packages — `internal/downloads` (the `Snapshot()` normalizer behind the admin queue endpoint, the websocket `downloads_queue` event, and remediation dispatch, plus its destructive item/queue actions and history endpoints) and the four protocol clients (`sabnzbd`, `qbittorrent`, `nzbget`, `transmission`). All tests run against hermetic `httptest` fakes speaking each backend's real dialect; no production code changed.

Highlights:

- **Snapshot normalization per backend**: SABnzbd string-numerics/`"*"` category/`[dd:]hh:mm:ss` ETA; qBittorrent 0–1→0–100 progress, `8640000` infinite-ETA sentinel, completed-torrent exclusion, derived paused state; NZBGet 32-bit Lo/Hi size reassembly and rate-derived ETA; Transmission numeric-status mapping, negative-ETA sentinel, first-label category.
- **Degradation contract pinned**: an unreachable or garbage backend errors only its own instance's snapshot (surfaced as 502), sibling instances keep working, and the 502 body never echoes the instance API key.
- **Destructive routing per protocol dialect**: SABnzbd `del_files`, qBittorrent `deleteFiles` + 5.x `stop`/`start` names, NZBGet `editqueue` `Group*` commands (its dialect has no remove-data flag — `?deleteData=true` is pinned as a plain delete), Transmission `delete-local-data`, and the guard keeping pause/resume-all off completed/seeding Transmission torrents.
- **Protocol quirks that regress easiest**: qBittorrent cookie login (login-once, SID reuse, re-login retry on 403, 4.x fallback order), Transmission `X-Transmission-Session-Id` 409 handshake + empty-list `torrent-remove` guard, NZBGet JSON-RPC envelope/basic-auth/legacy `editqueue` fallback, SABnzbd apikey param + HTTP-200 error envelope + transport-error key redaction.
- **Credential-echo + redirect refusal** for all four clients, following the `radarr`/`chaptarr` client-test idiom.

## Verification

From `server/`:

- `gofmt -l` on the five touched packages — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass (the Codex protocol smoke self-skips locally, as expected)
- `go test -race -count=1` on the five new test packages — pass

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne