### PR TITLE
fix(app): route book request-decision notifications to the book surface

### DIFF
--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -122,9 +122,11 @@ class PushService {
 
   /// Routes a tapped notification to the right screen from its custom payload:
   /// the approvals queue for `request_pending`; the media detail page for an
-  /// approval decision or a new-content alert; the agent approval queue for a
-  /// pending fix; the issue thread for an issue/decision update; and the
-  /// remediation settings for the auto-dispatch circuit-breaker notice.
+  /// approval decision or a new-content alert (book decisions open the Books
+  /// tab instead — books have no TMDB id and no id-addressable detail route);
+  /// the agent approval queue for a pending fix; the issue thread for an
+  /// issue/decision update; and the remediation settings for the auto-dispatch
+  /// circuit-breaker notice.
   void _routeNotification(Object? arguments) {
     final data = _asStringMap(arguments);
     final type = data['type'] as String?;
@@ -150,6 +152,15 @@ class PushService {
       case 'request_decision':
       case 'new_movie':
       case 'new_episode':
+        // Books never carry a TMDB id (the server sends tmdb_id 0; a book is
+        // keyed on its Chaptarr foreignBookId, which isn't in the payload) and
+        // the app has no id-addressable book detail route, so a book decision
+        // lands on the requester-facing Books tab. Movie/TV open media detail;
+        // an unknown media_type keeps the movie fallback.
+        if (data['media_type'] == 'book') {
+          router.push('/dashboard/books');
+          return;
+        }
         final tmdbId = _asInt(data['tmdb_id']);
         if (tmdbId == null || tmdbId <= 0) return;
         final mediaType = data['media_type'] == 'tv' ? 'tv' : 'movie';

--- a/app/test/notifications/push_service_test.dart
+++ b/app/test/notifications/push_service_test.dart
@@ -185,9 +185,38 @@ void main() {
       await _emitNativeCall('onNotificationTap', {
         'type': 'new_movie',
         'tmdb_id': 10,
-        'media_type': 'book',
+        'media_type': 'comic',
       });
       expect(h.router.pushed, ['/detail/movie/9', '/detail/movie/10']);
+    });
+
+    // A book decision's custom payload is {type, tmdb_id: 0, media_type} —
+    // the server's passthrough forwards no decision/reason, and a book row
+    // stores tmdb_id 0 (books key on the Chaptarr foreignBookId, which isn't
+    // in the payload). With no id-addressable book detail route, approved and
+    // denied both land on the requester-facing Books tab.
+    for (final decision in const ['approved', 'denied']) {
+      test('book request_decision ($decision) opens the Books tab', () async {
+        final h = _Harness();
+        await _emitNativeCall('onNotificationTap', {
+          'type': 'request_decision',
+          'tmdb_id': 0,
+          'media_type': 'book',
+          // Not part of the real push payload; routing must not depend on it.
+          'decision': decision,
+        });
+        expect(h.router.pushed, ['/dashboard/books']);
+      });
+    }
+
+    test('media_type book wins over a stray positive tmdb_id', () async {
+      final h = _Harness();
+      await _emitNativeCall('onNotificationTap', {
+        'type': 'request_decision',
+        'tmdb_id': 10,
+        'media_type': 'book',
+      });
+      expect(h.router.pushed, ['/dashboard/books']);
     });
 
     test('tmdb_id survives string and double payload encodings', () async {


### PR DESCRIPTION
## Summary

- A tapped `request_decision` push for a **book** never navigated anywhere: the server stores `tmdb_id = 0` for book requests (`server/internal/request/service.go` books insert) and the push `passthrough` (`server/internal/push/notifier.go`) forwards only `{type, tmdb_id, media_type}` — no `foreign_id`, no decision/reason — so the app's tap handler bailed on its `tmdbId <= 0` guard. Had a positive id arrived, the old `media_type == 'tv' ? 'tv' : 'movie'` fallback would have opened the wrong (movie) detail page.
- `_routeNotification` now routes `media_type: 'book'` to `/dashboard/books` before the TMDB id check. Movie/TV routing and the unknown-media-type movie fallback are unchanged.

### Why the Books tab, not a book detail page

There is no id-addressable book detail route to target: `MediaDetailScreen` (`/detail/:type/:id`) is movie/TV-only by design, the Chaptarr book screens are imperatively navigated admin-module surfaces, and — decisively — the push payload carries no book identity at all (`tmdb_id` is 0 and the Chaptarr `foreignBookId` is not in the passthrough). `/dashboard/books` is the requester-facing books surface, reachable by a plain requester with a books (chaptarr) grant; if the grant was revoked meanwhile, the router's existing redirect degrades gracefully to `/dashboard/movies`. Per the task guidance, no new screen was invented; the tests pin this choice.

## Verification

- `cd app && flutter analyze --no-fatal-infos` — No issues found.
- `cd app && flutter test` — All 436 tests passed.
- Fix proven: with the `push_service.dart` change stashed (old code), the three new tests in `app/test/notifications/push_service_test.dart` fail — `book request_decision (approved) opens the Books tab`, `book request_decision (denied) opens the Books tab`, and `media_type book wins over a stray positive tmdb_id`. With the fix restored, all pass.
- The previous pinned-behavior assertion (book → movie fallback) was replaced: the unknown-media-type fallback test now uses a genuinely unknown type (`comic`) and still pins the movie fallback.
- Server code untouched; no server checks required.

## Docs

- No docs impact (no documented route, tool, env var, table, or screen changed; notification tap routing is not an enumerated doc surface — `docs/testing/automation.md` only notes Maestro cannot exercise native notification taps).

Fixes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne