### PR TITLE
fix(websocket): evict slow clients under the write lock; echo the negotiated subprotocol

### DIFF
--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -173,6 +173,12 @@ func (h *Hub) Run(ctx context.Context) {
 			}
 			h.mu.Unlock()
 		case msg := <-h.broadcast:
+			// Deliver under the read lock, but only collect clients whose
+			// send buffer is full — evicting them in place would mutate the
+			// client map (and close a channel) while other readers may hold
+			// the same read lock, which is exactly the concurrency RLock
+			// promises to allow.
+			var stalled []*Client
 			h.mu.RLock()
 			for client := range h.clients {
 				if msg.adminOnly && !client.isAdmin {
@@ -184,11 +190,23 @@ func (h *Hub) Run(ctx context.Context) {
 				select {
 				case client.send <- msg.data:
 				default:
-					close(client.send)
-					delete(h.clients, client)
+					stalled = append(stalled, client)
 				}
 			}
 			h.mu.RUnlock()
+			if len(stalled) > 0 {
+				// Evict under the write lock. The presence check mirrors the
+				// unregister case so a client can never be double-closed no
+				// matter which path removes it first.
+				h.mu.Lock()
+				for _, client := range stalled {
+					if _, ok := h.clients[client]; ok {
+						delete(h.clients, client)
+						close(client.send)
+					}
+				}
+				h.mu.Unlock()
+			}
 		}
 	}
 }
@@ -259,8 +277,16 @@ func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Upgrade with the Bearer subprotocol so the client knows auth succeeded
+	// Upgrade echoing the Bearer subprotocol so the client knows auth
+	// succeeded. Echoing one of the offered subprotocols is required for the
+	// web build: browsers fail a WebSocket connection outright when the
+	// client offered subprotocols but the server selected none. Native
+	// clients (dart:io) accept any echoed value they offered. "Bearer" is the
+	// static member of the client's ["Bearer", <token>] offer — never echo
+	// the token, which would copy a credential into a response header.
+	// (http.Header.Set canonicalizes the key to the form gorilla reads.)
 	header := http.Header{}
+	header.Set("Sec-WebSocket-Protocol", "Bearer")
 	conn, err := h.upgrader.Upgrade(w, r, header)
 	if err != nil {
 		log.Printf("websocket: upgrade: %v", err)

--- a/server/internal/websocket/serve_ws_test.go
+++ b/server/internal/websocket/serve_ws_test.go
@@ -202,11 +202,15 @@ func TestServeWSHandshakeRegistersAuthenticatedClients(t *testing.T) {
 			clients[0].userID, clients[0].isAdmin, alice.User.ID)
 	}
 
-	// Pin current behavior: ServeWS upgrades with an empty response header, so
-	// no subprotocol is echoed back despite the client offering ["Bearer",
-	// token]. If a future change starts echoing one, that should be deliberate.
-	if got := userResp.Header.Get("Sec-WebSocket-Protocol"); got != "" {
-		t.Fatalf("negotiated subprotocol = %q, want none (current behavior)", got)
+	// The upgrade must echo the static "Bearer" subprotocol from the client's
+	// ["Bearer", token] offer: browsers (the web build) fail the connection
+	// when the server selects none of the offered subprotocols, and the token
+	// must never be copied into a response header.
+	if got := userResp.Header.Get("Sec-WebSocket-Protocol"); got != "Bearer" {
+		t.Fatalf("negotiated subprotocol = %q, want %q", got, "Bearer")
+	}
+	if got := userConn.Subprotocol(); got != "Bearer" {
+		t.Fatalf("client-side negotiated subprotocol = %q, want %q", got, "Bearer")
 	}
 
 	adminConn := env.mustDial(t, env.adminToken(t))
@@ -353,6 +357,101 @@ func TestDisconnectUnregistersClient(t *testing.T) {
 	remaining := env.clientsSnapshot()
 	if len(remaining) != 1 || remaining[0].userID != bob.User.ID {
 		t.Fatalf("remaining clients = %+v, want only bob's", remaining)
+	}
+}
+
+// TestBroadcastEvictsStalledClient proves a client whose send buffer is full
+// is evicted by the next broadcast: removed from the hub, its send channel
+// closed exactly once (buffered messages stay readable), other clients
+// unaffected, and the hub still routing afterwards — even when a late
+// unregister races the eviction.
+//
+// The stalled client is constructed directly (same package) with a 1-slot
+// send buffer and no running writePump, so "buffer full" is a deterministic
+// state rather than a timing accident. A background reader continuously
+// iterates the client set under RLock for the duration, exactly as the read
+// lock permits: under the old code, which deleted from the map while holding
+// only RLock, that overlap is a data race the -race detector reports; the fix
+// re-acquires the write lock to evict, so `go test -race` stays clean.
+func TestBroadcastEvictsStalledClient(t *testing.T) {
+	env := newWSTestEnv(t)
+	alice := env.userToken(t, "alice", "hw-alice")
+
+	healthyConn := env.mustDial(t, alice.AccessToken)
+	defer healthyConn.Close()
+	env.waitForClients(t, 1)
+
+	// A stalled client: registered like any other, but with a tiny send
+	// buffer and no writePump draining it.
+	stalledClient := &Client{hub: env.hub, userID: alice.User.ID, send: make(chan []byte, 1)}
+	env.hub.register <- stalledClient
+	env.waitForClients(t, 2)
+
+	// A concurrent reader of the client set, holding the read lock exactly
+	// as RLock allows. It runs until the eviction below has been observed.
+	stopReader := make(chan struct{})
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			select {
+			case <-stopReader:
+				return
+			default:
+			}
+			env.hub.mu.RLock()
+			for c := range env.hub.clients {
+				_ = c.userID
+			}
+			env.hub.mu.RUnlock()
+		}
+	}()
+
+	env.hub.Broadcast(Event{Type: "first"})  // fills the stalled client's buffer
+	env.hub.Broadcast(Event{Type: "second"}) // finds it full -> eviction
+
+	env.waitForClients(t, 1)
+	close(stopReader)
+	<-readerDone
+
+	// The evicted client's channel retains the delivered message and is then
+	// closed.
+	select {
+	case msg, ok := <-stalledClient.send:
+		if !ok {
+			t.Fatalf("stalled client's buffered message was dropped by eviction")
+		}
+		if !strings.Contains(string(msg), "first") {
+			t.Fatalf("stalled client's buffered message = %q, want the first event", msg)
+		}
+	default:
+		t.Fatalf("stalled client's send channel is empty, want the buffered first event")
+	}
+	if _, ok := <-stalledClient.send; ok {
+		t.Fatalf("stalled client's send channel still open after eviction, want closed")
+	}
+
+	// A late unregister for the evicted client (its readPump exiting after
+	// the connection actually drops) must not close the channel a second
+	// time — a double close would panic the hub goroutine.
+	env.hub.unregister <- stalledClient
+
+	// The healthy client received both events in order and the hub is still
+	// routing.
+	if ev := readEvent(t, healthyConn); ev.Type != "first" {
+		t.Fatalf("healthy client first event = %+v, want first", ev)
+	}
+	if ev := readEvent(t, healthyConn); ev.Type != "second" {
+		t.Fatalf("healthy client second event = %+v, want second", ev)
+	}
+	env.hub.Broadcast(Event{Type: "fence"})
+	if ev := readEvent(t, healthyConn); ev.Type != "fence" {
+		t.Fatalf("post-eviction event = %+v, want fence (hub goroutine dead?)", ev)
+	}
+
+	remaining := env.clientsSnapshot()
+	if len(remaining) != 1 || remaining[0] == stalledClient {
+		t.Fatalf("remaining clients = %+v, want only the healthy client", remaining)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes the two hub defects from #203 (found during PR #199):

**1. Eviction race.** The broadcast path deleted from `h.clients` and closed `client.send` while holding only `mu.RLock()` — mutating the map (and closing a channel) under a lock mode whose whole purpose is to allow other concurrent readers. The broadcast now collects stalled clients under the read lock, then re-acquires with `Lock()` to evict them (least-invasive of the two designs suggested in the issue: routing eviction through the `unregister` channel from inside `Run` would deadlock, since `Run` is that unbuffered channel's only reader). The eviction carries the same presence guard as the unregister case, so a send channel can never be closed twice regardless of which path removes the client first.

**2. Subprotocol echo.** `ServeWS`'s comment claimed the upgrade responds "with the Bearer subprotocol so the client knows auth succeeded", but `Upgrade` was called with an empty header — nothing was echoed. The server now echoes `Sec-WebSocket-Protocol: Bearer`, making the comment true in the compatible direction:

- The Flutter client (`app/lib/core/network/websocket_client.dart`) offers `protocols: ['Bearer', accessToken]` on every platform and never inspects the negotiated protocol itself.
- **Native (dart:io)**: the SDK's client (`websocket_impl.dart`) reads the echoed `Sec-WebSocket-Protocol` and stores it without validation — it accepts a missing echo and any echoed value alike, so nothing native can break.
- **Web (browser WebSocket API via `web_socket_channel`)**: browsers enforce the WHATWG rule that when the client offers subprotocols, the server must select one of them or the connection is *failed*. That means echoing nothing (the old behavior) is the risky state for the web build, while echoing `Bearer` — a member of the offered list — is the one response every platform accepts. Echoing the token instead would also satisfy RFC 6455, but would copy a credential into a response header (proxy/log exposure) for no benefit.
- gorilla's `Upgrade` picks the subprotocol from the response header when `Upgrader.Subprotocols` is unset; the header key is set via `Header.Set` so it matches the canonical form gorilla reads.

No production behavior other than these two paths is touched. The poll-loop cadence seam mentioned at the end of #203 is intentionally out of scope.

## Verification

From `server/`:

- `go vet ./...` — clean
- `go test ./...` — all packages pass (Codex pinned-app-server smoke self-skips locally, as usual)
- `go test -race -count=2 ./internal/websocket/` — clean on the fixed code

**Proof the tests catch the old code** (verified by reverting `hub.go` to `origin/main` and re-running with the new tests):

- `TestBroadcastEvictsStalledClient` **fails under `-race`** on the unfixed code: the detector reports the broadcast-path map write at old `hub.go:188` racing the test's concurrent `RLock` reader. It pins eviction deterministically — an in-package `Client` with a 1-slot send buffer and no running `writePump` is registered, one broadcast fills the buffer, the next evicts — and asserts the client is removed, its channel closed exactly once (buffered message retained, late `unregister` doesn't double-close), and the other client receives every event in order.
- `TestServeWSHandshakeRegistersAuthenticatedClients` **fails** on the unfixed code with `negotiated subprotocol = "", want "Bearer"` (it previously pinned the no-echo behavior; that pin is deliberately replaced).

## Docs checklist

No docs impact — `server/README.md`'s route line ("WebSocket (JWT via subprotocol header)") remains accurate; no route, tool, env var, table, screen, or workflow changed.

Fixes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne