### PR TITLE
chore(server): make TMDB/Trakt/update-checker endpoints injectable; cover their HTTP paths

### DIFF
--- a/server/internal/tmdb/bridge_test.go
+++ b/server/internal/tmdb/bridge_test.go
@@ -1,0 +1,233 @@
+package tmdb
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/trakt"
+)
+
+// fakeServiceClients satisfies ServiceClients with fixed clients.
+type fakeServiceClients struct {
+	tmdb  *Client
+	trakt *trakt.Client
+}
+
+func (f fakeServiceClients) TMDB() *Client        { return f.tmdb }
+func (f fakeServiceClients) Trakt() *trakt.Client { return f.trakt }
+
+func newBridgeDB(t *testing.T) *sql.DB {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+	return database
+}
+
+// fakeTraktUpstream reroutes requests for api.trakt.tv to a local fake server.
+// trakt.Client hardcodes its base URL (only trakt's own tests can repoint it),
+// so the bridge's Trakt-fallback leg is faked at the transport layer: the
+// trakt client uses http.DefaultTransport, which the returned cleanup-scoped
+// swap intercepts. No request ever leaves the test process.
+func fakeTraktUpstream(t *testing.T, handler http.Handler) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	target, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse fake trakt url: %v", err)
+	}
+	original := http.DefaultTransport
+	http.DefaultTransport = rerouteTransport{host: target.Host, next: original}
+	t.Cleanup(func() { http.DefaultTransport = original })
+}
+
+type rerouteTransport struct {
+	host string
+	next http.RoundTripper
+}
+
+func (rt rerouteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host != "api.trakt.tv" {
+		return rt.next.RoundTrip(req)
+	}
+	clone := req.Clone(req.Context())
+	clone.URL.Scheme = "http"
+	clone.URL.Host = rt.host
+	return rt.next.RoundTrip(clone)
+}
+
+func TestResolveTVDBIDCacheHitSkipsHTTP(t *testing.T) {
+	database := newBridgeDB(t)
+	if _, err := database.Exec(
+		"INSERT INTO tmdb_tvdb_cache (tmdb_id, tvdb_id, imdb_id, cached_at) VALUES (?, ?, ?, ?)",
+		1399, 121361, "tt0944947", time.Now(),
+	); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	var requests atomic.Int32
+	tmdbClient := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Error(w, "cache hit must not fetch", http.StatusInternalServerError)
+	}))
+	bridge := NewBridge(fakeServiceClients{tmdb: tmdbClient}, database)
+
+	got, err := bridge.ResolveTVDBID(1399)
+	if err != nil {
+		t.Fatalf("ResolveTVDBID: %v", err)
+	}
+	if got.TVDBID != 121361 || got.IMDBID != "tt0944947" {
+		t.Fatalf("result = %+v", got)
+	}
+	if n := requests.Load(); n != 0 {
+		t.Fatalf("cache hit made %d HTTP requests, want 0", n)
+	}
+}
+
+func TestResolveTVDBIDCacheMissResolvesViaTMDBAndCaches(t *testing.T) {
+	database := newBridgeDB(t)
+	tmdbClient := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tv/1399/external_ids" {
+			t.Errorf("path = %q, want /tv/1399/external_ids", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"id":1399,"imdb_id":"tt0944947","tvdb_id":121361}`))
+	}))
+	bridge := NewBridge(fakeServiceClients{tmdb: tmdbClient}, database)
+
+	got, err := bridge.ResolveTVDBID(1399)
+	if err != nil {
+		t.Fatalf("ResolveTVDBID: %v", err)
+	}
+	if got.TVDBID != 121361 || got.IMDBID != "tt0944947" {
+		t.Fatalf("result = %+v", got)
+	}
+
+	var cachedTVDB int
+	var cachedIMDB string
+	if err := database.QueryRow(
+		"SELECT tvdb_id, imdb_id FROM tmdb_tvdb_cache WHERE tmdb_id = 1399",
+	).Scan(&cachedTVDB, &cachedIMDB); err != nil {
+		t.Fatalf("read cache row: %v", err)
+	}
+	if cachedTVDB != 121361 || cachedIMDB != "tt0944947" {
+		t.Fatalf("cache row = (%d, %q), want (121361, tt0944947)", cachedTVDB, cachedIMDB)
+	}
+}
+
+func TestResolveTVDBIDExpiredCacheReResolves(t *testing.T) {
+	database := newBridgeDB(t)
+	if _, err := database.Exec(
+		"INSERT INTO tmdb_tvdb_cache (tmdb_id, tvdb_id, imdb_id, cached_at) VALUES (?, ?, ?, ?)",
+		1399, 111, "tt-stale", time.Now().Add(-31*24*time.Hour),
+	); err != nil {
+		t.Fatalf("seed stale cache: %v", err)
+	}
+	tmdbClient := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":1399,"imdb_id":"tt0944947","tvdb_id":121361}`))
+	}))
+	bridge := NewBridge(fakeServiceClients{tmdb: tmdbClient}, database)
+
+	got, err := bridge.ResolveTVDBID(1399)
+	if err != nil {
+		t.Fatalf("ResolveTVDBID: %v", err)
+	}
+	if got.TVDBID != 121361 {
+		t.Fatalf("tvdb id = %d, want the freshly resolved 121361, not the stale 111", got.TVDBID)
+	}
+
+	var cachedTVDB int
+	if err := database.QueryRow(
+		"SELECT tvdb_id FROM tmdb_tvdb_cache WHERE tmdb_id = 1399",
+	).Scan(&cachedTVDB); err != nil {
+		t.Fatalf("read cache row: %v", err)
+	}
+	if cachedTVDB != 121361 {
+		t.Fatalf("cache row tvdb = %d, want refreshed 121361", cachedTVDB)
+	}
+}
+
+func TestResolveTVDBIDFallsBackToTraktAndCaches(t *testing.T) {
+	database := newBridgeDB(t)
+	// TMDB answers but has no TVDB mapping, forcing the Trakt fallback.
+	tmdbClient := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":1399,"imdb_id":null,"tvdb_id":null}`))
+	}))
+	fakeTraktUpstream(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search/tmdb/1399" {
+			t.Errorf("path = %q, want /search/tmdb/1399", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("type"); got != "show" {
+			t.Errorf("type = %q, want show", got)
+		}
+		_, _ = w.Write([]byte(`[{"show":{"ids":{"tvdb":121361,"imdb":"tt0944947"}}}]`))
+	}))
+	bridge := NewBridge(fakeServiceClients{tmdb: tmdbClient, trakt: trakt.NewClient("trakt-client-id")}, database)
+
+	got, err := bridge.ResolveTVDBID(1399)
+	if err != nil {
+		t.Fatalf("ResolveTVDBID: %v", err)
+	}
+	if got.TVDBID != 121361 || got.IMDBID != "tt0944947" {
+		t.Fatalf("result = %+v", got)
+	}
+
+	var cachedTVDB int
+	if err := database.QueryRow(
+		"SELECT tvdb_id FROM tmdb_tvdb_cache WHERE tmdb_id = 1399",
+	).Scan(&cachedTVDB); err != nil {
+		t.Fatalf("read cache row: %v", err)
+	}
+	if cachedTVDB != 121361 {
+		t.Fatalf("cache row tvdb = %d, want the trakt-resolved 121361", cachedTVDB)
+	}
+}
+
+func TestResolveTVDBIDEverythingFails(t *testing.T) {
+	database := newBridgeDB(t)
+	tmdbClient := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "down", http.StatusInternalServerError)
+	}))
+	fakeTraktUpstream(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[]`)) // no results
+	}))
+	bridge := NewBridge(fakeServiceClients{tmdb: tmdbClient, trakt: trakt.NewClient("trakt-client-id")}, database)
+
+	_, err := bridge.ResolveTVDBID(1399)
+	if err == nil {
+		t.Fatal("ResolveTVDBID succeeded with every upstream failing")
+	}
+	if !strings.Contains(err.Error(), "could not resolve TVDB ID for TMDB ID 1399") {
+		t.Fatalf("error = %v, want the unresolved-id message", err)
+	}
+
+	var count int
+	if err := database.QueryRow("SELECT COUNT(*) FROM tmdb_tvdb_cache").Scan(&count); err != nil {
+		t.Fatalf("count cache rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("failed resolution wrote %d cache rows, want 0", count)
+	}
+}
+
+func TestResolveTVDBIDWithoutTMDBClient(t *testing.T) {
+	database := newBridgeDB(t)
+	bridge := NewBridge(fakeServiceClients{}, database)
+
+	_, err := bridge.ResolveTVDBID(1399)
+	if err == nil {
+		t.Fatal("ResolveTVDBID succeeded without a TMDB client")
+	}
+	if !strings.Contains(err.Error(), "TMDB client not configured") {
+		t.Fatalf("error = %v, want the not-configured message", err)
+	}
+}

--- a/server/internal/tmdb/client.go
+++ b/server/internal/tmdb/client.go
@@ -11,16 +11,18 @@ import (
 	"time"
 )
 
-const baseURL = "https://api.themoviedb.org/3"
-
+// Client talks to the TMDB v3 API. baseURL is a field so tests can point it
+// at a fake TMDB server.
 type Client struct {
 	accessToken string
+	baseURL     string
 	httpClient  *http.Client
 }
 
 func NewClient(accessToken string) *Client {
 	return &Client{
 		accessToken: accessToken,
+		baseURL:     "https://api.themoviedb.org/3",
 		httpClient: &http.Client{
 			Timeout:       10 * time.Second,
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
@@ -67,7 +69,7 @@ type TVDetails struct {
 // DoGetRaw fetches a TMDB API path and returns the raw JSON bytes.
 // Used by the discover handler for passthrough caching.
 func (c *Client) DoGetRaw(path string, params url.Values) ([]byte, error) {
-	u := fmt.Sprintf("%s%s?language=en-US", baseURL, path)
+	u := fmt.Sprintf("%s%s?language=en-US", c.baseURL, path)
 	if params != nil {
 		u += "&" + params.Encode()
 	}
@@ -83,7 +85,7 @@ func (c *Client) DoGetRaw(path string, params url.Values) ([]byte, error) {
 }
 
 func (c *Client) GetTVExternalIDs(tmdbID int) (*ExternalIDs, error) {
-	u := fmt.Sprintf("%s/tv/%d/external_ids", baseURL, tmdbID)
+	u := fmt.Sprintf("%s/tv/%d/external_ids", c.baseURL, tmdbID)
 	resp, err := c.doGet(u)
 	if err != nil {
 		return nil, fmt.Errorf("request external IDs: %w", err)
@@ -102,7 +104,7 @@ func (c *Client) GetTVExternalIDs(tmdbID int) (*ExternalIDs, error) {
 }
 
 func (c *Client) GetMovieDetails(tmdbID int) (*MovieDetails, error) {
-	u := fmt.Sprintf("%s/movie/%d", baseURL, tmdbID)
+	u := fmt.Sprintf("%s/movie/%d", c.baseURL, tmdbID)
 	resp, err := c.doGet(u)
 	if err != nil {
 		return nil, fmt.Errorf("request movie details: %w", err)
@@ -121,7 +123,7 @@ func (c *Client) GetMovieDetails(tmdbID int) (*MovieDetails, error) {
 }
 
 func (c *Client) GetTVDetails(tmdbID int) (*TVDetails, error) {
-	u := fmt.Sprintf("%s/tv/%d", baseURL, tmdbID)
+	u := fmt.Sprintf("%s/tv/%d", c.baseURL, tmdbID)
 	resp, err := c.doGet(u)
 	if err != nil {
 		return nil, fmt.Errorf("request TV details: %w", err)
@@ -178,7 +180,7 @@ type collectionSearchResponse struct {
 }
 
 func (c *Client) SearchMovies(query string) ([]SearchResult, error) {
-	u := fmt.Sprintf("%s/search/movie?query=%s", baseURL, url.QueryEscape(query))
+	u := fmt.Sprintf("%s/search/movie?query=%s", c.baseURL, url.QueryEscape(query))
 	resp, err := c.doGet(u)
 	if err != nil {
 		return nil, fmt.Errorf("search movies: %w", err)
@@ -198,7 +200,7 @@ func (c *Client) SearchMovies(query string) ([]SearchResult, error) {
 }
 
 func (c *Client) SearchMovieCollections(query string) ([]CollectionSearchResult, error) {
-	u := fmt.Sprintf("%s/search/collection?query=%s", baseURL, url.QueryEscape(query))
+	u := fmt.Sprintf("%s/search/collection?query=%s", c.baseURL, url.QueryEscape(query))
 	resp, err := c.doGet(u)
 	if err != nil {
 		return nil, fmt.Errorf("search movie collections: %w", err)
@@ -217,7 +219,7 @@ func (c *Client) SearchMovieCollections(query string) ([]CollectionSearchResult,
 }
 
 func (c *Client) GetMovieCollection(collectionID int) (*MovieCollection, error) {
-	u := fmt.Sprintf("%s/collection/%d", baseURL, collectionID)
+	u := fmt.Sprintf("%s/collection/%d", c.baseURL, collectionID)
 	resp, err := c.doGet(u)
 	if err != nil {
 		return nil, fmt.Errorf("get movie collection: %w", err)
@@ -248,7 +250,7 @@ func (c *Client) GetMovieCollection(collectionID int) (*MovieCollection, error) 
 }
 
 func (c *Client) SearchTV(query string) ([]SearchResult, error) {
-	u := fmt.Sprintf("%s/search/tv?query=%s", baseURL, url.QueryEscape(query))
+	u := fmt.Sprintf("%s/search/tv?query=%s", c.baseURL, url.QueryEscape(query))
 	resp, err := c.doGet(u)
 	if err != nil {
 		return nil, fmt.Errorf("search TV: %w", err)
@@ -285,7 +287,7 @@ func (c *Client) GetTrending(mediaType, timeWindow string) ([]SearchResult, erro
 }
 
 func (c *Client) getTrendingByType(mediaType, timeWindow string) ([]SearchResult, error) {
-	u := fmt.Sprintf("%s/trending/%s/%s", baseURL, mediaType, timeWindow)
+	u := fmt.Sprintf("%s/trending/%s/%s", c.baseURL, mediaType, timeWindow)
 	resp, err := c.doGet(u)
 	if err != nil {
 		return nil, fmt.Errorf("get trending: %w", err)
@@ -358,7 +360,7 @@ func balancedTrendingResults(movies, tv []SearchResult, limit int) []SearchResul
 }
 
 func (c *Client) GetRecommendations(tmdbID int, mediaType string) ([]SearchResult, error) {
-	u := fmt.Sprintf("%s/%s/%d/recommendations", baseURL, mediaType, tmdbID)
+	u := fmt.Sprintf("%s/%s/%d/recommendations", c.baseURL, mediaType, tmdbID)
 	resp, err := c.doGet(u)
 	if err != nil {
 		return nil, fmt.Errorf("get recommendations: %w", err)

--- a/server/internal/tmdb/client_http_test.go
+++ b/server/internal/tmdb/client_http_test.go
@@ -1,0 +1,266 @@
+package tmdb
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// testHTTPClient returns a Client pointed at a fake TMDB server.
+func testHTTPClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := NewClient("tmdb-secret")
+	c.baseURL = srv.URL
+	return c
+}
+
+func TestDoGetRawSendsAuthAndParams(t *testing.T) {
+	c := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/discover/movie" {
+			t.Errorf("path = %q, want /discover/movie", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tmdb-secret" {
+			t.Errorf("Authorization = %q, want Bearer token", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("Accept = %q", got)
+		}
+		q := r.URL.Query()
+		if q.Get("language") != "en-US" {
+			t.Errorf("language = %q, want en-US", q.Get("language"))
+		}
+		if q.Get("page") != "2" {
+			t.Errorf("page = %q, want 2", q.Get("page"))
+		}
+		_, _ = w.Write([]byte(`{"results":[{"id":7}]}`))
+	}))
+
+	body, err := c.DoGetRaw("/discover/movie", url.Values{"page": []string{"2"}})
+	if err != nil {
+		t.Fatalf("DoGetRaw: %v", err)
+	}
+	if string(body) != `{"results":[{"id":7}]}` {
+		t.Fatalf("body = %s, want the raw upstream JSON", body)
+	}
+}
+
+func TestSearchMoviesEscapesQueryAndStampsMediaType(t *testing.T) {
+	c := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search/movie" {
+			t.Errorf("path = %q, want /search/movie", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("query"); got != "the matrix & co" {
+			t.Errorf("query = %q, want the raw query decoded", got)
+		}
+		_, _ = w.Write([]byte(`{"results":[{"id":603,"title":"The Matrix"},{"id":604,"title":"Reloaded"}]}`))
+	}))
+
+	got, err := c.SearchMovies("the matrix & co")
+	if err != nil {
+		t.Fatalf("SearchMovies: %v", err)
+	}
+	if len(got) != 2 || got[0].ID != 603 || got[0].Title != "The Matrix" {
+		t.Fatalf("results = %+v", got)
+	}
+	for i, r := range got {
+		if r.MediaType != "movie" {
+			t.Fatalf("result %d media type = %q, want movie", i, r.MediaType)
+		}
+	}
+}
+
+func TestSearchTVStampsMediaType(t *testing.T) {
+	c := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/search/tv" {
+			t.Errorf("path = %q, want /search/tv", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"results":[{"id":1399,"name":"Game of Thrones"}]}`))
+	}))
+
+	got, err := c.SearchTV("game of thrones")
+	if err != nil {
+		t.Fatalf("SearchTV: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != 1399 || got[0].Name != "Game of Thrones" || got[0].MediaType != "tv" {
+		t.Fatalf("results = %+v", got)
+	}
+}
+
+func TestGetTrendingNormalizesTypeAndWindow(t *testing.T) {
+	var path atomic.Value
+	c := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path.Store(r.URL.Path)
+		_, _ = w.Write([]byte(`{"results":[{"id":1399,"name":"Game of Thrones"}]}`))
+	}))
+
+	// "shows" normalizes to tv, and an unknown window falls back to day.
+	got, err := c.GetTrending("shows", "fortnight")
+	if err != nil {
+		t.Fatalf("GetTrending: %v", err)
+	}
+	if p := path.Load(); p != "/trending/tv/day" {
+		t.Fatalf("request path = %v, want /trending/tv/day", p)
+	}
+	if len(got) != 1 || got[0].MediaType != "tv" {
+		t.Fatalf("results = %+v", got)
+	}
+}
+
+func TestGetTrendingAllInterleavesBothFeeds(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/trending/movie/week", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results":[{"id":1},{"id":2},{"id":3},{"id":4},{"id":5},{"id":6}]}`))
+	})
+	mux.HandleFunc("/trending/tv/week", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results":[{"id":101},{"id":102},{"id":103},{"id":104},{"id":105},{"id":106}]}`))
+	})
+	c := testHTTPClient(t, mux)
+
+	got, err := c.GetTrending("all", "week")
+	if err != nil {
+		t.Fatalf("GetTrending: %v", err)
+	}
+	if len(got) != 10 {
+		t.Fatalf("expected 10 balanced results, got %d", len(got))
+	}
+	for i, item := range got {
+		want := "movie"
+		if i%2 == 1 {
+			want = "tv"
+		}
+		if item.MediaType != want {
+			t.Fatalf("result %d media type = %q, want %q", i, item.MediaType, want)
+		}
+	}
+}
+
+func TestGetMovieAndTVDetails(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/movie/603", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":603,"title":"The Matrix","release_date":"1999-03-31","imdb_id":"tt0133093"}`))
+	})
+	mux.HandleFunc("/tv/1399", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":1399,"name":"Game of Thrones","first_air_date":"2011-04-17"}`))
+	})
+	c := testHTTPClient(t, mux)
+
+	movie, err := c.GetMovieDetails(603)
+	if err != nil {
+		t.Fatalf("GetMovieDetails: %v", err)
+	}
+	if movie.ID != 603 || movie.Title != "The Matrix" || movie.IMDBID != "tt0133093" {
+		t.Fatalf("movie = %+v", movie)
+	}
+
+	tv, err := c.GetTVDetails(1399)
+	if err != nil {
+		t.Fatalf("GetTVDetails: %v", err)
+	}
+	if tv.ID != 1399 || tv.Name != "Game of Thrones" || tv.FirstAir != "2011-04-17" {
+		t.Fatalf("tv = %+v", tv)
+	}
+}
+
+func TestGetTVExternalIDs(t *testing.T) {
+	c := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tv/1399/external_ids" {
+			t.Errorf("path = %q, want /tv/1399/external_ids", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"id":1399,"imdb_id":"tt0944947","tvdb_id":121361}`))
+	}))
+
+	ids, err := c.GetTVExternalIDs(1399)
+	if err != nil {
+		t.Fatalf("GetTVExternalIDs: %v", err)
+	}
+	if ids.TVDBID == nil || *ids.TVDBID != 121361 {
+		t.Fatalf("tvdb id = %v, want 121361", ids.TVDBID)
+	}
+	if ids.IMDBID == nil || *ids.IMDBID != "tt0944947" {
+		t.Fatalf("imdb id = %v, want tt0944947", ids.IMDBID)
+	}
+}
+
+func TestGetMovieCollectionSortsPartsByReleaseDate(t *testing.T) {
+	c := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/collection/2344" {
+			t.Errorf("path = %q, want /collection/2344", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"id":2344,"name":"The Matrix Collection","parts":[` +
+			`{"id":605,"title":"Revolutions","release_date":"2003-11-05"},` +
+			`{"id":999,"title":"Unreleased"},` +
+			`{"id":603,"title":"The Matrix","release_date":"1999-03-31"}]}`))
+	}))
+
+	got, err := c.GetMovieCollection(2344)
+	if err != nil {
+		t.Fatalf("GetMovieCollection: %v", err)
+	}
+	if got.Name != "The Matrix Collection" || len(got.Parts) != 3 {
+		t.Fatalf("collection = %+v", got)
+	}
+	// Dated parts sort ascending; undated parts sink to the end.
+	if got.Parts[0].ID != 603 || got.Parts[1].ID != 605 || got.Parts[2].ID != 999 {
+		t.Fatalf("part order = %d, %d, %d; want 603, 605, 999", got.Parts[0].ID, got.Parts[1].ID, got.Parts[2].ID)
+	}
+	if got.Parts[0].MediaType != "movie" {
+		t.Fatalf("part media type = %q, want movie", got.Parts[0].MediaType)
+	}
+}
+
+func TestNon200SurfacesStatusWithoutEchoingToken(t *testing.T) {
+	c := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "upstream broke", http.StatusInternalServerError)
+	}))
+
+	calls := map[string]func() error{
+		"DoGetRaw":           func() error { _, err := c.DoGetRaw("/discover/movie", nil); return err },
+		"GetTVExternalIDs":   func() error { _, err := c.GetTVExternalIDs(1); return err },
+		"GetMovieDetails":    func() error { _, err := c.GetMovieDetails(1); return err },
+		"GetTVDetails":       func() error { _, err := c.GetTVDetails(1); return err },
+		"SearchMovies":       func() error { _, err := c.SearchMovies("q"); return err },
+		"SearchTV":           func() error { _, err := c.SearchTV("q"); return err },
+		"GetTrending":        func() error { _, err := c.GetTrending("movie", "day"); return err },
+		"GetRecommendations": func() error { _, err := c.GetRecommendations(1, "movie"); return err },
+	}
+	for name, call := range calls {
+		err := call()
+		if err == nil {
+			t.Fatalf("%s accepted a 500 response", name)
+		}
+		if !strings.Contains(err.Error(), "TMDB API returned status 500") {
+			t.Fatalf("%s error = %v, want the upstream status surfaced", name, err)
+		}
+		if strings.Contains(err.Error(), "tmdb-secret") {
+			t.Fatalf("%s error echoed the access token: %v", name, err)
+		}
+	}
+}
+
+func TestClientDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("redirect destination received Authorization %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(destination.Close)
+
+	c := testHTTPClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL+"/credential-sink", http.StatusTemporaryRedirect)
+	}))
+
+	if _, err := c.GetMovieDetails(603); err == nil {
+		t.Fatal("GetMovieDetails accepted an upstream redirect")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect destination received %d requests, want 0", got)
+	}
+}

--- a/server/internal/trakt/client.go
+++ b/server/internal/trakt/client.go
@@ -9,16 +9,18 @@ import (
 	"time"
 )
 
-const baseURL = "https://api.trakt.tv"
-
+// Client talks to the Trakt API. baseURL is a field so tests can point it at
+// a fake Trakt server.
 type Client struct {
 	clientID   string
+	baseURL    string
 	httpClient *http.Client
 }
 
 func NewClient(clientID string) *Client {
 	return &Client{
 		clientID: clientID,
+		baseURL:  "https://api.trakt.tv",
 		httpClient: &http.Client{
 			Timeout:       10 * time.Second,
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
@@ -43,7 +45,7 @@ type searchResult struct {
 // DoGetRaw fetches a Trakt API path and returns the raw JSON bytes.
 // Used by the discover handler for passthrough caching.
 func (c *Client) DoGetRaw(path string, params url.Values) ([]byte, error) {
-	u := baseURL + path
+	u := c.baseURL + path
 	if len(params) > 0 {
 		u += "?" + params.Encode()
 	}
@@ -67,7 +69,7 @@ func (c *Client) DoGetRaw(path string, params url.Values) ([]byte, error) {
 }
 
 func (c *Client) SearchByTMDB(tmdbID int, mediaType string) (*IDResult, error) {
-	url := fmt.Sprintf("%s/search/tmdb/%d?type=%s", baseURL, tmdbID, mediaType)
+	url := fmt.Sprintf("%s/search/tmdb/%d?type=%s", c.baseURL, tmdbID, mediaType)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {

--- a/server/internal/trakt/client_test.go
+++ b/server/internal/trakt/client_test.go
@@ -1,0 +1,162 @@
+package trakt
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// testClient returns a Client pointed at a fake Trakt server.
+func testClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := NewClient("trakt-client-id")
+	c.baseURL = srv.URL
+	return c
+}
+
+// requireTraktHeaders asserts the API headers Trakt demands on every call,
+// including the client id key.
+func requireTraktHeaders(t *testing.T, r *http.Request) {
+	t.Helper()
+	if got := r.Header.Get("trakt-api-key"); got != "trakt-client-id" {
+		t.Errorf("trakt-api-key = %q, want the client id", got)
+	}
+	if got := r.Header.Get("trakt-api-version"); got != "2" {
+		t.Errorf("trakt-api-version = %q, want 2", got)
+	}
+	if got := r.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}
+
+func TestSearchByTMDBSendsHeadersAndParsesShow(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requireTraktHeaders(t, r)
+		if r.URL.Path != "/search/tmdb/1399" {
+			t.Errorf("path = %q, want /search/tmdb/1399", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("type"); got != "show" {
+			t.Errorf("type = %q, want show", got)
+		}
+		_, _ = w.Write([]byte(`[{"show":{"ids":{"tvdb":121361,"imdb":"tt0944947"}}}]`))
+	}))
+
+	got, err := c.SearchByTMDB(1399, "show")
+	if err != nil {
+		t.Fatalf("SearchByTMDB: %v", err)
+	}
+	if got.TVDBID != 121361 || got.IMDBID != "tt0944947" {
+		t.Fatalf("result = %+v", got)
+	}
+}
+
+func TestSearchByTMDBNoUsableResult(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty result set", `[]`},
+		{"first result is not a show", `[{"movie":{"ids":{"tmdb":603}}}]`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			_, err := c.SearchByTMDB(603, "show")
+			if err == nil {
+				t.Fatal("SearchByTMDB accepted a result set without a show")
+			}
+			if !strings.Contains(err.Error(), "no results found") {
+				t.Fatalf("error = %v, want no-results message", err)
+			}
+		})
+	}
+}
+
+func TestSearchByTMDBNon200WithoutEchoingClientID(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "slow down", http.StatusTooManyRequests)
+	}))
+
+	_, err := c.SearchByTMDB(1399, "show")
+	if err == nil {
+		t.Fatal("SearchByTMDB accepted a 429 response")
+	}
+	if !strings.Contains(err.Error(), "trakt API returned status 429") {
+		t.Fatalf("error = %v, want the upstream status surfaced", err)
+	}
+	if strings.Contains(err.Error(), "trakt-client-id") {
+		t.Fatalf("error echoed the client id: %v", err)
+	}
+}
+
+func TestDoGetRawPassthrough(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requireTraktHeaders(t, r)
+		if r.URL.Path != "/movies/trending" {
+			t.Errorf("path = %q, want /movies/trending", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("page") != "2" || q.Get("limit") != "10" {
+			t.Errorf("query = %q, want page=2 and limit=10", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`[{"watchers":42}]`))
+	}))
+
+	body, err := c.DoGetRaw("/movies/trending", url.Values{"page": []string{"2"}, "limit": []string{"10"}})
+	if err != nil {
+		t.Fatalf("DoGetRaw: %v", err)
+	}
+	if string(body) != `[{"watchers":42}]` {
+		t.Fatalf("body = %s, want the raw upstream JSON", body)
+	}
+}
+
+func TestDoGetRawNon200WithoutEchoingClientID(t *testing.T) {
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "broken", http.StatusInternalServerError)
+	}))
+
+	_, err := c.DoGetRaw("/movies/trending", nil)
+	if err == nil {
+		t.Fatal("DoGetRaw accepted a 500 response")
+	}
+	if !strings.Contains(err.Error(), "trakt API returned status 500") {
+		t.Fatalf("error = %v, want the upstream status surfaced", err)
+	}
+	if strings.Contains(err.Error(), "trakt-client-id") {
+		t.Fatalf("error echoed the client id: %v", err)
+	}
+}
+
+func TestClientDoesNotFollowRedirects(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		redirectedRequests.Add(1)
+		if got := r.Header.Get("trakt-api-key"); got != "" {
+			t.Errorf("redirect destination received trakt-api-key %q", got)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(destination.Close)
+
+	c := testClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, destination.URL+"/credential-sink", http.StatusTemporaryRedirect)
+	}))
+
+	if _, err := c.SearchByTMDB(1399, "show"); err == nil {
+		t.Fatal("SearchByTMDB accepted an upstream redirect")
+	}
+	if _, err := c.DoGetRaw("/movies/trending", nil); err == nil {
+		t.Fatal("DoGetRaw accepted an upstream redirect")
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("redirect destination received %d requests, want 0", got)
+	}
+}

--- a/server/internal/update/update.go
+++ b/server/internal/update/update.go
@@ -44,6 +44,9 @@ type Checker struct {
 	current  string
 	disabled bool
 	client   *http.Client
+	// apiBase is the GitHub API root; a field so tests can point the checker
+	// at a fake GitHub.
+	apiBase string
 
 	mu        sync.Mutex
 	cached    Status
@@ -60,6 +63,7 @@ func NewChecker(current string, disable bool) *Checker {
 		current:  current,
 		disabled: disable || !ok,
 		client:   &http.Client{Timeout: 15 * time.Second},
+		apiBase:  "https://api.github.com",
 		cached:   Status{Current: current},
 	}
 }
@@ -110,7 +114,7 @@ func (c *Checker) fetchLatest() (tag, url string, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	endpoint := "https://api.github.com/repos/" + repoSlug + "/releases/latest"
+	endpoint := c.apiBase + "/repos/" + repoSlug + "/releases/latest"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return "", "", err

--- a/server/internal/update/update_test.go
+++ b/server/internal/update/update_test.go
@@ -1,6 +1,13 @@
 package update
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
 
 func TestIsNewer(t *testing.T) {
 	cases := []struct {
@@ -54,6 +61,145 @@ func TestNewCheckerDisabledExplicitly(t *testing.T) {
 	}
 	if got := c.Status(); got.Available {
 		t.Fatal("a disabled checker must never report an update available")
+	}
+}
+
+// testChecker returns an enabled checker pointed at a fake GitHub API.
+func testChecker(t *testing.T, current string, handler http.Handler) *Checker {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	c := NewChecker(current, false)
+	c.apiBase = srv.URL
+	return c
+}
+
+func TestFetchLatestParsesRelease(t *testing.T) {
+	c := testChecker(t, "1.2.3", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/windoze95/cantinarr/releases/latest" {
+			t.Errorf("path = %q, want /repos/windoze95/cantinarr/releases/latest", r.URL.Path)
+		}
+		if got := r.Header.Get("User-Agent"); got != "cantinarr-update-check" {
+			t.Errorf("User-Agent = %q, want cantinarr-update-check", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Errorf("Accept = %q, want application/vnd.github+json", got)
+		}
+		_, _ = w.Write([]byte(`{"tag_name":"v1.3.0","html_url":"https://github.com/windoze95/cantinarr/releases/tag/v1.3.0"}`))
+	}))
+
+	tag, url, err := c.fetchLatest()
+	if err != nil {
+		t.Fatalf("fetchLatest: %v", err)
+	}
+	if tag != "v1.3.0" {
+		t.Fatalf("tag = %q, want v1.3.0", tag)
+	}
+	if url != "https://github.com/windoze95/cantinarr/releases/tag/v1.3.0" {
+		t.Fatalf("url = %q, want the release page", url)
+	}
+}
+
+func TestRefreshGatesAvailabilityOnSemver(t *testing.T) {
+	release := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v1.3.0","html_url":"https://example.test/release"}`))
+	})
+
+	older := testChecker(t, "1.2.3", release)
+	older.refresh()
+	st := older.Status()
+	if !st.Available {
+		t.Fatal("1.2.3 -> v1.3.0 should report an update available")
+	}
+	if st.Latest != "1.3.0" {
+		t.Fatalf("Latest = %q, want the v prefix trimmed to 1.3.0", st.Latest)
+	}
+	if st.Current != "1.2.3" || st.URL != "https://example.test/release" {
+		t.Fatalf("status = %+v", st)
+	}
+
+	current := testChecker(t, "1.3.0", release)
+	current.refresh()
+	if st := current.Status(); st.Available {
+		t.Fatalf("1.3.0 -> v1.3.0 must not report an update: %+v", st)
+	}
+}
+
+func TestRefreshKeepsZeroStatusOnMalformedJSON(t *testing.T) {
+	c := testChecker(t, "1.2.3", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name": not-json`))
+	}))
+
+	c.refresh()
+
+	st := c.Status()
+	if st.Available || st.Latest != "" {
+		t.Fatalf("failed refresh changed the cached status: %+v", st)
+	}
+	if st.Current != "1.2.3" {
+		t.Fatalf("Current = %q, want 1.2.3", st.Current)
+	}
+	until := time.Until(c.nextCheck)
+	if until <= 0 || until > errorBackoff {
+		t.Fatalf("next check in %v, want the %v error backoff (not the %v success interval)", until, errorBackoff, checkInterval)
+	}
+}
+
+func TestRefreshKeepsPreviousResultOnHTTPError(t *testing.T) {
+	var failing atomic.Bool
+	c := testChecker(t, "1.2.3", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if failing.Load() {
+			http.Error(w, "rate limited", http.StatusForbidden)
+			return
+		}
+		_, _ = w.Write([]byte(`{"tag_name":"v1.3.0","html_url":"https://example.test/release"}`))
+	}))
+
+	c.refresh()
+	if st := c.Status(); !st.Available || st.Latest != "1.3.0" {
+		t.Fatalf("seed refresh did not populate the cache: %+v", st)
+	}
+
+	failing.Store(true)
+	c.refresh()
+
+	st := c.Status()
+	if !st.Available || st.Latest != "1.3.0" {
+		t.Fatalf("failed refresh dropped the previous result: %+v", st)
+	}
+	until := time.Until(c.nextCheck)
+	if until <= 0 || until > errorBackoff {
+		t.Fatalf("next check in %v, want the %v error backoff", until, errorBackoff)
+	}
+}
+
+func TestFetchLatestRejectsEmptyTag(t *testing.T) {
+	c := testChecker(t, "1.2.3", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"","html_url":"https://example.test"}`))
+	}))
+
+	if _, _, err := c.fetchLatest(); err == nil {
+		t.Fatal("fetchLatest accepted a release without a tag")
+	} else if !strings.Contains(err.Error(), "empty tag_name") {
+		t.Fatalf("error = %v, want empty tag_name message", err)
+	}
+}
+
+func TestDisabledCheckerNeverContactsServer(t *testing.T) {
+	var requests atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte(`{"tag_name":"v9.9.9"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewChecker("dev", false) // non-semver build: disabled
+	c.apiBase = srv.URL
+	if st := c.Status(); st.Available {
+		t.Fatalf("disabled checker reported an update: %+v", st)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("disabled checker made %d requests, want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Makes the three metadata/upstream clients test-injectable and covers their HTTP paths, per #205:

- `internal/tmdb`: the package-const `baseURL` becomes an unexported field on `Client` set in `NewClient` (the `internal/plex` client pattern), so same-package tests can repoint it at an httptest fake.
- `internal/trakt`: same const-to-field conversion.
- `internal/update`: the inline `https://api.github.com` in `fetchLatest` becomes an unexported `apiBase` field defaulting to the real URL.

The refactor is mechanical: no exported signature changes, no config/env additions, zero behavior change.

New tests (all hermetic, httptest fakes + in-memory SQLite via `db.Open(":memory:")`):

- **tmdb client**: `DoGetRaw` params/auth headers, search query escaping + media-type stamping, trending type/window normalization and the `all` interleave across both feeds, movie/TV details, external IDs, collection part ordering, non-200 status surfacing without echoing the bearer token, redirect no-follow (credential-sink idiom).
- **tmdb bridge** (`ResolveTVDBID`): cache hit answers from the seeded `tmdb_tvdb_cache` row with zero HTTP; cache miss resolves via TMDB external IDs and writes the cache row; a 31-day-old row is re-resolved; TMDB-without-a-TVDB-mapping falls back to Trakt and caches the result; everything-fails surfaces the unresolved-id error and writes no cache row; missing TMDB client errors cleanly. The Trakt fallback leg is faked by rerouting `api.trakt.tv` at the default-transport layer inside the test (restored via `t.Cleanup`), because `trakt.Client`'s base URL is deliberately same-package injectable only — no request leaves the test process.
- **trakt client**: `SearchByTMDB` path/query and required headers (`trakt-api-key` client id, `trakt-api-version: 2`), show parsing, no-result mapping, `DoGetRaw` passthrough, non-200 mapping without echoing the client id, redirect no-follow.
- **update checker**: latest-release fetch/parse incl. the GitHub `Accept`/`User-Agent` headers, semver gating through `refresh()` (`v` prefix trimmed, same-version not available), malformed JSON and a non-200 keep the previously cached result and schedule the 1h error backoff (pinning the documented best-effort behavior), empty `tag_name` rejection, and a disabled checker never contacting the server.

## Verification

- `cd server && go vet ./...` — clean.
- `cd server && go test ./...` — all packages pass (Codex smoke self-skips locally — normal).
- `cd server && go test -race ./internal/tmdb/ ./internal/trakt/ ./internal/update/` — pass (the update checker has mutex/goroutine state).
- Stash check: with the production refactor stashed, all three new test files fail to build (`c.baseURL undefined`, `c.apiBase undefined`) — the tests depend on the injectability seam and could not have passed against the old code.

## Docs checklist

- [x] No docs impact — no exported API, route, tool, env var, table, or screen changed; README env tables untouched.

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne