### PR TITLE
test(server): cover tautulli, discover, and the TTL cache

### DIFF
--- a/server/internal/cache/cache_test.go
+++ b/server/internal/cache/cache_test.go
@@ -1,0 +1,168 @@
+package cache
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// waitFor polls cond until it returns true or the deadline passes. It exists
+// so TTL tests never use a raw sleep as the assertion.
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("condition not met within %s: %s", timeout, msg)
+}
+
+func TestGetSetRoundTrip(t *testing.T) {
+	c := New()
+	t.Cleanup(c.Close)
+
+	if data, ok := c.Get("missing"); ok {
+		t.Fatalf("Get(missing) = (%q, true), want a miss", data)
+	}
+
+	c.Set("k", []byte(`{"a":1}`), time.Minute)
+	data, ok := c.Get("k")
+	if !ok || string(data) != `{"a":1}` {
+		t.Fatalf("Get(k) = (%q, %v), want the cached payload", data, ok)
+	}
+
+	// Set on an existing key replaces the payload.
+	c.Set("k", []byte("v2"), time.Minute)
+	if data, ok := c.Get("k"); !ok || string(data) != "v2" {
+		t.Fatalf("Get(k) after overwrite = (%q, %v), want v2", data, ok)
+	}
+
+	c.Delete("k")
+	if data, ok := c.Get("k"); ok {
+		t.Fatalf("Get(k) after Delete = (%q, true), want a miss", data)
+	}
+	// Deleting a missing key is a no-op, not a panic.
+	c.Delete("k")
+}
+
+func TestGetHonorsTTLExpiry(t *testing.T) {
+	c := New()
+	t.Cleanup(c.Close)
+
+	c.Set("k", []byte("v"), 20*time.Millisecond)
+	if _, ok := c.Get("k"); !ok {
+		t.Fatal("entry expired immediately after Set with a positive TTL")
+	}
+	waitFor(t, 2*time.Second, func() bool {
+		_, ok := c.Get("k")
+		return !ok
+	}, "entry to expire after its TTL")
+
+	// A non-positive TTL is already expired.
+	c.Set("dead", []byte("v"), -time.Second)
+	if data, ok := c.Get("dead"); ok {
+		t.Fatalf("Get(dead) = (%q, true), want an already-expired miss", data)
+	}
+}
+
+func TestSetRefreshesTTL(t *testing.T) {
+	c := New()
+	t.Cleanup(c.Close)
+
+	start := time.Now()
+	c.Set("k", []byte("v1"), 20*time.Millisecond)
+	// Re-set with a long TTL before the short one lapses.
+	c.Set("k", []byte("v2"), time.Hour)
+
+	// Wait until the original TTL has definitely lapsed, then confirm the
+	// refreshed entry is still served.
+	waitFor(t, 2*time.Second, func() bool {
+		return time.Since(start) > 50*time.Millisecond
+	}, "original TTL to lapse")
+	if data, ok := c.Get("k"); !ok || string(data) != "v2" {
+		t.Fatalf("Get(k) after TTL refresh = (%q, %v), want v2 still cached", data, ok)
+	}
+}
+
+// TestEvictRemovesOnlyExpiredEntries drives the eviction sweep directly (the
+// background loop runs it on a 60s ticker, far too slow for a test) and checks
+// that it drops expired entries while keeping live ones.
+func TestEvictRemovesOnlyExpiredEntries(t *testing.T) {
+	c := New()
+	t.Cleanup(c.Close)
+
+	c.Set("stale", []byte("old"), time.Nanosecond)
+	c.Set("live", []byte("new"), time.Hour)
+	waitFor(t, 2*time.Second, func() bool {
+		_, ok := c.Get("stale")
+		return !ok
+	}, "stale entry to expire")
+
+	c.evict()
+
+	c.mu.RLock()
+	_, staleKept := c.entries["stale"]
+	_, liveKept := c.entries["live"]
+	c.mu.RUnlock()
+	if staleKept {
+		t.Fatal("evict kept an expired entry in the map")
+	}
+	if !liveKept {
+		t.Fatal("evict dropped a live entry")
+	}
+}
+
+// TestCloseStopsEvictionGoroutine pins that Close terminates the background
+// loop New starts, so short-lived caches don't leak goroutines.
+func TestCloseStopsEvictionGoroutine(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	caches := make([]*Cache, 10)
+	for i := range caches {
+		caches[i] = New()
+	}
+	for _, c := range caches {
+		c.Close()
+	}
+
+	waitFor(t, 5*time.Second, func() bool {
+		return runtime.NumGoroutine() <= before
+	}, "eviction goroutines to exit after Close")
+}
+
+// TestConcurrentAccessIsRaceFree hammers Get/Set/Delete and the eviction
+// sweep from many goroutines over a shared key space; go test -race proves
+// the locking.
+func TestConcurrentAccessIsRaceFree(t *testing.T) {
+	c := New()
+	t.Cleanup(c.Close)
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < 8; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < 250; i++ {
+				key := fmt.Sprintf("k%d", i%10)
+				switch (worker + i) % 4 {
+				case 0:
+					c.Set(key, []byte("v"), time.Millisecond*time.Duration(i%3))
+				case 1:
+					if data, ok := c.Get(key); ok && string(data) != "v" {
+						t.Errorf("Get(%s) returned corrupted payload %q", key, data)
+					}
+				case 2:
+					c.Delete(key)
+				case 3:
+					c.evict()
+				}
+			}
+		}(worker)
+	}
+	wg.Wait()
+}

--- a/server/internal/discover/handler_test.go
+++ b/server/internal/discover/handler_test.go
@@ -1,0 +1,398 @@
+package discover
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/windoze95/cantinarr-server/internal/cache"
+	"github.com/windoze95/cantinarr-server/internal/credentials"
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+const (
+	testTMDBToken = "TMDB_TOKEN_SENTINEL"
+	testTraktID   = "TRAKT_CLIENT_ID_SENTINEL"
+)
+
+// upstreamHit records one intercepted outbound request.
+type upstreamHit struct {
+	host   string
+	path   string
+	query  url.Values
+	header http.Header
+}
+
+// fakeUpstream intercepts ALL outbound HTTP by standing in for
+// http.DefaultTransport: the tmdb/trakt clients hold zero-Transport
+// http.Clients, which consult http.DefaultTransport on every request, so the
+// swap reaches them without touching production code. Responses are
+// synthesized in-memory — no sockets, no TLS, no network.
+type fakeUpstream struct {
+	mu      sync.Mutex
+	hits    []upstreamHit
+	respond func(req *http.Request) (int, string)
+}
+
+func (f *fakeUpstream) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.mu.Lock()
+	f.hits = append(f.hits, upstreamHit{
+		host:   req.URL.Host,
+		path:   req.URL.Path,
+		query:  req.URL.Query(),
+		header: req.Header.Clone(),
+	})
+	respond := f.respond
+	f.mu.Unlock()
+
+	status, body := respond(req)
+	return &http.Response{
+		StatusCode:    status,
+		Status:        fmt.Sprintf("%d %s", status, http.StatusText(status)),
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}, nil
+}
+
+func (f *fakeUpstream) setRespond(respond func(req *http.Request) (int, string)) {
+	f.mu.Lock()
+	f.respond = respond
+	f.mu.Unlock()
+}
+
+func (f *fakeUpstream) hitCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.hits)
+}
+
+func (f *fakeUpstream) hit(t *testing.T, i int) upstreamHit {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if i >= len(f.hits) {
+		t.Fatalf("upstream hit %d requested, only %d recorded", i, len(f.hits))
+	}
+	return f.hits[i]
+}
+
+// echoUpstream answers 200 with a body derived from the full upstream URL, so
+// every distinct upstream request produces a distinct payload — which makes
+// cache collisions observable as one request receiving another's body.
+func echoUpstream(req *http.Request) (int, string) {
+	return http.StatusOK, fmt.Sprintf(`{"echo":%q}`, req.URL.String())
+}
+
+// --- test environment ---
+
+type env struct {
+	upstream *fakeUpstream
+	router   chi.Router
+}
+
+// newEnv wires the handler over a real credentials registry (in-memory DB,
+// credentials encrypted at rest) and a real TTL cache, and mounts the same
+// route patterns the API router uses. Auth middleware is deliberately absent:
+// authorization for these routes is covered by the api package's RBAC matrix
+// tests.
+func newEnv(t *testing.T, configured bool) *env {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x42}, 32))
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	creds := credentials.NewRegistry(database, cipher)
+	if configured {
+		if err := creds.SetCredential(credentials.KeyTMDBAccessToken, testTMDBToken); err != nil {
+			t.Fatalf("set TMDB credential: %v", err)
+		}
+		if err := creds.SetCredential(credentials.KeyTraktClientID, testTraktID); err != nil {
+			t.Fatalf("set Trakt credential: %v", err)
+		}
+	}
+	responseCache := cache.New()
+	t.Cleanup(responseCache.Close)
+	handler := NewHandler(creds, responseCache)
+
+	router := chi.NewRouter()
+	router.Get("/discover/trending", handler.Trending)
+	router.Get("/discover/movies", handler.DiscoverMovies)
+	router.Get("/discover/tv", handler.DiscoverTV)
+	router.Get("/search", handler.Search)
+	router.Get("/media/movie/{id}", handler.MovieDetail)
+	router.Get("/media/tv/{id}", handler.TVDetail)
+	router.Get("/trakt/trending", handler.TraktTrending)
+
+	upstream := &fakeUpstream{respond: echoUpstream}
+	previous := http.DefaultTransport
+	http.DefaultTransport = upstream
+	t.Cleanup(func() { http.DefaultTransport = previous })
+
+	return &env{upstream: upstream, router: router}
+}
+
+func (e *env) do(t *testing.T, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	e.router.ServeHTTP(rec, req)
+	return rec
+}
+
+func (e *env) doOK(t *testing.T, path string) string {
+	t.Helper()
+	rec := e.do(t, path)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s status = %d, body = %s", path, rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
+}
+
+// --- tests ---
+
+// TestTrendingPassesParamsAndAuthToUpstream pins the passthrough contract:
+// requester parameters reach TMDB on the right path with the stored bearer
+// token, and the raw upstream body comes back verbatim as JSON.
+func TestTrendingPassesParamsAndAuthToUpstream(t *testing.T) {
+	e := newEnv(t, true)
+	e.upstream.setRespond(func(*http.Request) (int, string) { return http.StatusOK, `{"results":["heat"]}` })
+
+	rec := e.do(t, "/discover/trending?time_window=week&page=2")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if rec.Body.String() != `{"results":["heat"]}` {
+		t.Errorf("body = %s, want the upstream payload verbatim", rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("content-type = %q, want application/json", got)
+	}
+
+	hit := e.upstream.hit(t, 0)
+	if hit.host != "api.themoviedb.org" {
+		t.Errorf("upstream host = %s, want api.themoviedb.org", hit.host)
+	}
+	if hit.path != "/3/trending/all/week" {
+		t.Errorf("upstream path = %s, want /3/trending/all/week", hit.path)
+	}
+	if hit.query.Get("page") != "2" || hit.query.Get("language") != "en-US" {
+		t.Errorf("upstream query = %v, want page=2 language=en-US", hit.query)
+	}
+	if got := hit.header.Get("Authorization"); got != "Bearer "+testTMDBToken {
+		t.Errorf("Authorization = %q, want the stored bearer token", got)
+	}
+}
+
+func TestTrendingDefaultsToDayPageOne(t *testing.T) {
+	e := newEnv(t, true)
+	e.doOK(t, "/discover/trending")
+	hit := e.upstream.hit(t, 0)
+	if hit.path != "/3/trending/all/day" || hit.query.Get("page") != "1" {
+		t.Errorf("upstream = %s?%v, want /3/trending/all/day with page=1", hit.path, hit.query)
+	}
+}
+
+// TestRepeatQueryIsServedFromCache pins the TTL cache: an identical query
+// within the TTL never reaches the upstream again, while a different page
+// does.
+func TestRepeatQueryIsServedFromCache(t *testing.T) {
+	e := newEnv(t, true)
+
+	first := e.doOK(t, "/discover/trending?page=1")
+	if e.upstream.hitCount() != 1 {
+		t.Fatalf("upstream hits = %d, want 1", e.upstream.hitCount())
+	}
+	second := e.doOK(t, "/discover/trending?page=1")
+	if e.upstream.hitCount() != 1 {
+		t.Errorf("upstream hits after repeat = %d, want 1 (served from cache)", e.upstream.hitCount())
+	}
+	if first != second {
+		t.Errorf("cached body diverged: %s vs %s", first, second)
+	}
+
+	e.doOK(t, "/discover/trending?page=2")
+	if e.upstream.hitCount() != 2 {
+		t.Errorf("upstream hits for a new page = %d, want 2", e.upstream.hitCount())
+	}
+}
+
+// TestAdjacentQueriesNeverShareCacheEntries crafts request pairs whose cache
+// keys would collide under naive string concatenation and proves each keeps
+// its own entry: every request is first served by the upstream (with its own
+// echo body) and every repeat returns its own body from cache.
+func TestAdjacentQueriesNeverShareCacheEntries(t *testing.T) {
+	e := newEnv(t, true)
+
+	pairs := [][2]string{
+		// "search:" + query + ":" + page — colon-separated free text.
+		{"/search?query=heat&page=12", "/search?query=heat:1&page=2"},
+		// "movie:" + id vs "tv:" + id — same numeric id, different media type.
+		{"/media/movie/603", "/media/tv/603"},
+		// disc_movies uses params.Encode(): a with_genres VALUE containing a
+		// literal "&page=2" must not collide with a genuine page=2 request.
+		{"/discover/movies?with_genres=28&page=2", "/discover/movies?with_genres=28%26page%3D2"},
+	}
+
+	expectedHits := 0
+	for _, pair := range pairs {
+		bodyA := e.doOK(t, pair[0])
+		bodyB := e.doOK(t, pair[1])
+		expectedHits += 2
+		if e.upstream.hitCount() != expectedHits {
+			t.Fatalf("upstream hits = %d, want %d (each of %q and %q must fetch separately)",
+				e.upstream.hitCount(), expectedHits, pair[0], pair[1])
+		}
+		if bodyA == bodyB {
+			t.Errorf("%q and %q returned the same body %s — cache keys collided", pair[0], pair[1], bodyA)
+		}
+		// Repeats are cache hits and each returns its own payload.
+		if again := e.doOK(t, pair[0]); again != bodyA {
+			t.Errorf("repeat of %q = %s, want its own cached body %s", pair[0], again, bodyA)
+		}
+		if again := e.doOK(t, pair[1]); again != bodyB {
+			t.Errorf("repeat of %q = %s, want its own cached body %s", pair[1], again, bodyB)
+		}
+		if e.upstream.hitCount() != expectedHits {
+			t.Errorf("upstream hits after repeats = %d, want %d", e.upstream.hitCount(), expectedHits)
+		}
+	}
+
+	// The media-type keys must also have fetched from distinct TMDB paths.
+	if p := e.upstream.hit(t, 2).path; p != "/3/movie/603" {
+		t.Errorf("movie detail upstream path = %s, want /3/movie/603", p)
+	}
+	if p := e.upstream.hit(t, 3).path; p != "/3/tv/603" {
+		t.Errorf("tv detail upstream path = %s, want /3/tv/603", p)
+	}
+	// The smuggled with_genres value must arrive as data, not as a page param.
+	smuggled := e.upstream.hit(t, 5)
+	if smuggled.query.Get("with_genres") != "28&page=2" || smuggled.query.Get("page") != "1" {
+		t.Errorf("upstream query = %v, want with_genres=%q page=1", smuggled.query, "28&page=2")
+	}
+}
+
+// TestUpstreamErrorsAreNotCached pins the failure contract: a TMDB error maps
+// to 502 without leaking the token, is NOT written to the cache (the next
+// request retries the upstream), and the first success after recovery is
+// cached as usual.
+func TestUpstreamErrorsAreNotCached(t *testing.T) {
+	e := newEnv(t, true)
+	e.upstream.setRespond(func(*http.Request) (int, string) { return http.StatusInternalServerError, `{"status_message":"boom"}` })
+
+	rec := e.do(t, "/discover/trending")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502, body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "TMDB API returned status 500") {
+		t.Errorf("body = %s, want the upstream status surfaced", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), testTMDBToken) {
+		t.Fatalf("error body leaked the TMDB token: %s", rec.Body.String())
+	}
+
+	// Upstream recovers: the same query must retry (error was not cached).
+	e.upstream.setRespond(func(*http.Request) (int, string) { return http.StatusOK, `{"results":["fresh"]}` })
+	if body := e.doOK(t, "/discover/trending"); body != `{"results":["fresh"]}` {
+		t.Errorf("body after recovery = %s, want the fresh upstream payload", body)
+	}
+	if e.upstream.hitCount() != 2 {
+		t.Errorf("upstream hits = %d, want 2 (the 502 must not have been cached)", e.upstream.hitCount())
+	}
+
+	// The success IS cached.
+	e.doOK(t, "/discover/trending")
+	if e.upstream.hitCount() != 2 {
+		t.Errorf("upstream hits after repeat = %d, want 2 (success cached)", e.upstream.hitCount())
+	}
+}
+
+// TestTraktPassthroughCacheAndAuth mirrors the TMDB contract for Trakt:
+// params and API-key headers reach api.trakt.tv, bodies pass through, repeats
+// hit the cache, and upstream errors map to 502 without caching or leakage.
+func TestTraktPassthroughCacheAndAuth(t *testing.T) {
+	e := newEnv(t, true)
+
+	body := e.doOK(t, "/trakt/trending?type=shows&page=3")
+	hit := e.upstream.hit(t, 0)
+	if hit.host != "api.trakt.tv" || hit.path != "/shows/trending" {
+		t.Errorf("upstream = %s%s, want api.trakt.tv/shows/trending", hit.host, hit.path)
+	}
+	if hit.query.Get("page") != "3" || hit.query.Get("limit") != "20" || hit.query.Get("extended") != "full" {
+		t.Errorf("upstream query = %v, want page=3 limit=20 extended=full", hit.query)
+	}
+	if hit.header.Get("trakt-api-key") != testTraktID || hit.header.Get("trakt-api-version") != "2" {
+		t.Errorf("trakt headers = %v, want the stored client id and API version 2", hit.header)
+	}
+
+	if again := e.doOK(t, "/trakt/trending?type=shows&page=3"); again != body || e.upstream.hitCount() != 1 {
+		t.Errorf("repeat = %s (hits=%d), want the cached body with no new upstream hit", again, e.upstream.hitCount())
+	}
+	// A different type is a different cache entry.
+	e.doOK(t, "/trakt/trending?type=movies&page=3")
+	if e.upstream.hitCount() != 2 {
+		t.Errorf("upstream hits = %d, want 2 for a different type", e.upstream.hitCount())
+	}
+
+	// Errors: 502, no client-id leakage, not cached.
+	e.upstream.setRespond(func(*http.Request) (int, string) { return http.StatusServiceUnavailable, `oops` })
+	rec := e.do(t, "/trakt/trending?type=movies&page=9")
+	if rec.Code != http.StatusBadGateway || !strings.Contains(rec.Body.String(), "trakt API returned status 503") {
+		t.Errorf("status = %d body = %s, want 502 with the trakt status", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), testTraktID) {
+		t.Fatalf("error body leaked the Trakt client id: %s", rec.Body.String())
+	}
+	e.upstream.setRespond(echoUpstream)
+	e.doOK(t, "/trakt/trending?type=movies&page=9")
+	if e.upstream.hitCount() != 4 {
+		t.Errorf("upstream hits = %d, want 4 (the trakt error must not have been cached)", e.upstream.hitCount())
+	}
+}
+
+// TestUnconfiguredCredentialsReturn503 pins the not-configured contract: the
+// handler answers 503 itself and never dials out.
+func TestUnconfiguredCredentialsReturn503(t *testing.T) {
+	e := newEnv(t, false)
+
+	rec := e.do(t, "/discover/trending")
+	if rec.Code != http.StatusServiceUnavailable || !strings.Contains(rec.Body.String(), "TMDB is not configured") {
+		t.Errorf("TMDB status = %d body = %s, want 503 not-configured", rec.Code, rec.Body.String())
+	}
+	rec = e.do(t, "/trakt/trending")
+	if rec.Code != http.StatusServiceUnavailable || !strings.Contains(rec.Body.String(), "trakt not configured") {
+		t.Errorf("Trakt status = %d body = %s, want 503 not-configured", rec.Code, rec.Body.String())
+	}
+	if e.upstream.hitCount() != 0 {
+		t.Fatalf("upstream hits = %d, want 0 without credentials", e.upstream.hitCount())
+	}
+}
+
+func TestSearchRequiresQueryParameter(t *testing.T) {
+	e := newEnv(t, true)
+	rec := e.do(t, "/search")
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "query parameter required") {
+		t.Errorf("status = %d body = %s, want 400 query-required", rec.Code, rec.Body.String())
+	}
+	if e.upstream.hitCount() != 0 {
+		t.Fatalf("upstream hits = %d, want 0 for a rejected request", e.upstream.hitCount())
+	}
+}

--- a/server/internal/tautulli/client_test.go
+++ b/server/internal/tautulli/client_test.go
@@ -1,0 +1,308 @@
+package tautulli
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+const testAPIKey = "TAUTULLI_KEY_SENTINEL"
+
+// successEnvelope wraps a data payload in Tautulli's response envelope.
+func successEnvelope(data string) string {
+	return `{"response":{"result":"success","message":null,"data":` + data + `}}`
+}
+
+// TestCallSendsCmdAndAPIKey pins Tautulli's command-style dialect: every call
+// is a GET to {base}/api/v2?apikey=...&cmd=..., with any trailing slash on the
+// configured base URL trimmed.
+func TestCallSendsCmdAndAPIKey(t *testing.T) {
+	var gotPath string
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query()
+		_, _ = io.WriteString(w, successEnvelope(`{"pms_name":"Cantina Plex","pms_version":"1.41.0"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	info, err := NewClient(srv.URL+"/", testAPIKey).GetServerInfo()
+	if err != nil {
+		t.Fatalf("GetServerInfo: %v", err)
+	}
+	if info.PMSName != "Cantina Plex" || info.PMSVersion != "1.41.0" {
+		t.Errorf("server info = %+v, want pms_name/pms_version mapped", info)
+	}
+	if gotPath != "/api/v2" {
+		t.Errorf("path = %s, want /api/v2 (trailing base slash must be trimmed)", gotPath)
+	}
+	if gotQuery.Get("apikey") != testAPIKey {
+		t.Errorf("apikey = %q, want %q", gotQuery.Get("apikey"), testAPIKey)
+	}
+	if gotQuery.Get("cmd") != "get_server_info" {
+		t.Errorf("cmd = %q, want get_server_info", gotQuery.Get("cmd"))
+	}
+}
+
+// TestGetActivityToleratesStringNumbers pins the flexInt mapping: Tautulli
+// encodes many numeric fields as strings (sometimes empty or junk), and the
+// client must map every session anyway.
+func TestGetActivityToleratesStringNumbers(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("cmd"); got != "get_activity" {
+			t.Errorf("cmd = %q, want get_activity", got)
+		}
+		_, _ = io.WriteString(w, successEnvelope(`{
+			"stream_count": "2",
+			"total_bandwidth": 12000,
+			"sessions": [
+				{"user":"julian","title":"Heat","full_title":"Heat (1995)","player":"Living Room TV","product":"Plex for Apple TV","state":"playing","progress_percent":"42","quality_profile":"1080p","transcode_decision":"direct play","bandwidth":"8000.9"},
+				{"user":"dex","title":"Andor","full_title":"Andor - S02E03","player":"phone","product":"Plex for iOS","state":"paused","progress_percent":"","quality_profile":"720p","transcode_decision":"transcode","bandwidth":null}
+			]
+		}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	activity, err := NewClient(srv.URL, testAPIKey).GetActivity()
+	if err != nil {
+		t.Fatalf("GetActivity: %v", err)
+	}
+	if activity.StreamCount != 2 || activity.TotalBandwidth != 12000 {
+		t.Errorf("counts = (%d, %d), want (2, 12000)", activity.StreamCount, activity.TotalBandwidth)
+	}
+	if len(activity.Sessions) != 2 {
+		t.Fatalf("sessions = %d, want 2", len(activity.Sessions))
+	}
+	first := activity.Sessions[0]
+	if first.User != "julian" || first.State != "playing" || first.ProgressPercent != 42 || first.Bandwidth != 8000 {
+		t.Errorf("session[0] = %+v, want string-encoded numbers parsed (bandwidth truncated to 8000)", first)
+	}
+	if first.QualityProfile != "1080p" || first.TranscodeDecision != "direct play" {
+		t.Errorf("session[0] quality/transcode = (%q, %q)", first.QualityProfile, first.TranscodeDecision)
+	}
+	second := activity.Sessions[1]
+	if second.ProgressPercent != 0 || second.Bandwidth != 0 {
+		t.Errorf("session[1] = %+v, want empty/null numbers mapped to 0", second)
+	}
+}
+
+func TestFlexIntToleratesTautulliNumberEncodings(t *testing.T) {
+	cases := map[string]flexInt{
+		`42`:       42,
+		`"42"`:     42,
+		`"8000.9"`: 8000,
+		`""`:       0,
+		`null`:     0,
+		`"n/a"`:    0,
+	}
+	for raw, want := range cases {
+		var got flexInt
+		if err := got.UnmarshalJSON([]byte(raw)); err != nil {
+			t.Errorf("UnmarshalJSON(%s) error: %v", raw, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("UnmarshalJSON(%s) = %d, want %d", raw, got, want)
+		}
+	}
+}
+
+// TestGetHistoryPassesLengthAndUnwrapsRows pins the nested get_history shape
+// (rows live under data.data) and the length parameter contract: sent when
+// positive, omitted entirely for 0 (server default).
+func TestGetHistoryPassesLengthAndUnwrapsRows(t *testing.T) {
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		_, _ = io.WriteString(w, successEnvelope(`{"data":[
+			{"user":"julian","full_title":"Heat (1995)","date":"1720000000","duration":3600,"percent_complete":"87","player":"TV","platform":"tvOS"}
+		]}`))
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(srv.URL, testAPIKey)
+
+	rows, err := client.GetHistory(25)
+	if err != nil {
+		t.Fatalf("GetHistory: %v", err)
+	}
+	if gotQuery.Get("cmd") != "get_history" || gotQuery.Get("length") != "25" {
+		t.Errorf("query = %v, want cmd=get_history length=25", gotQuery)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	row := rows[0]
+	if row.User != "julian" || row.FullTitle != "Heat (1995)" || row.Date != 1720000000 ||
+		row.Duration != 3600 || row.PercentComplete != 87 || row.Platform != "tvOS" {
+		t.Errorf("row = %+v, want all fields mapped", row)
+	}
+
+	if _, err := client.GetHistory(0); err != nil {
+		t.Fatalf("GetHistory(0): %v", err)
+	}
+	if gotQuery.Has("length") {
+		t.Errorf("GetHistory(0) sent length=%q, want the parameter omitted", gotQuery.Get("length"))
+	}
+}
+
+func TestGetHomeStatsPassesTimeRange(t *testing.T) {
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		_, _ = io.WriteString(w, successEnvelope(`[
+			{"stat_id":"top_movies","rows":[{"title":"Heat","total_plays":"9"}]},
+			{"stat_id":"top_users","rows":[{"user":"julian","friendly_name":"Julian","total_plays":4}]}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	stats, err := NewClient(srv.URL, testAPIKey).GetHomeStats(7)
+	if err != nil {
+		t.Fatalf("GetHomeStats: %v", err)
+	}
+	if gotQuery.Get("cmd") != "get_home_stats" || gotQuery.Get("time_range") != "7" {
+		t.Errorf("query = %v, want cmd=get_home_stats time_range=7", gotQuery)
+	}
+	if len(stats) != 2 {
+		t.Fatalf("stats = %d, want 2", len(stats))
+	}
+	if stats[0].StatID != "top_movies" || len(stats[0].Rows) != 1 || stats[0].Rows[0].TotalPlays != 9 {
+		t.Errorf("stats[0] = %+v, want top_movies with 9 plays", stats[0])
+	}
+	if stats[1].Rows[0].FriendlyName != "Julian" || stats[1].Rows[0].User != "julian" {
+		t.Errorf("stats[1] row = %+v, want user identities mapped", stats[1].Rows[0])
+	}
+}
+
+// TestNon2xxStatusIsAnError pins that HTTP-level failures surface only the
+// status code — never the response body, which a hostile or misconfigured
+// upstream could use to echo the API key back.
+func TestNon2xxStatusIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error while handling "+r.URL.Query().Get("apikey"), http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, testAPIKey).GetActivity()
+	if err == nil {
+		t.Fatal("GetActivity accepted a 500 response")
+	}
+	if !strings.Contains(err.Error(), "status 500") {
+		t.Errorf("error = %v, want the status surfaced", err)
+	}
+	if strings.Contains(err.Error(), testAPIKey) {
+		t.Fatalf("error echoed the API key: %v", err)
+	}
+}
+
+func TestMalformedBodyIsADecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "<html>login page, not an API</html>")
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, testAPIKey).GetServerInfo()
+	if err == nil {
+		t.Fatal("GetServerInfo accepted a non-JSON body")
+	}
+	if !strings.Contains(err.Error(), "decode response") {
+		t.Errorf("error = %v, want a decode-response error", err)
+	}
+	if strings.Contains(err.Error(), testAPIKey) {
+		t.Fatalf("error echoed the API key: %v", err)
+	}
+}
+
+func TestMismatchedDataShapeIsADecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, successEnvelope(`"not an object"`))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, testAPIKey).GetActivity()
+	if err == nil {
+		t.Fatal("GetActivity accepted a mismatched data payload")
+	}
+	if !strings.Contains(err.Error(), "decode data") {
+		t.Errorf("error = %v, want a decode-data error", err)
+	}
+}
+
+// TestErrorEnvelopeSurfacesMessage pins Tautulli's HTTP-200-but-failed
+// envelope: result != success must fail with the server's message, falling
+// back to "unknown error" when the message is empty.
+func TestErrorEnvelopeSurfacesMessage(t *testing.T) {
+	message := `"Invalid apikey"`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"response":{"result":"error","message":`+message+`,"data":null}}`)
+	}))
+	t.Cleanup(srv.Close)
+	client := NewClient(srv.URL, testAPIKey)
+
+	_, err := client.GetActivity()
+	if err == nil {
+		t.Fatal("GetActivity accepted an error envelope")
+	}
+	if !strings.Contains(err.Error(), "tautulli get_activity: Invalid apikey") {
+		t.Errorf("error = %v, want the envelope message surfaced with the cmd", err)
+	}
+
+	message = `""`
+	_, err = client.GetActivity()
+	if err == nil || !strings.Contains(err.Error(), "unknown error") {
+		t.Errorf("error = %v, want the unknown-error fallback for an empty message", err)
+	}
+}
+
+// TestClientDoesNotFollowRedirects pins the redirect guard: the client is
+// built with CheckRedirect returning ErrUseLastResponse, so a redirecting
+// upstream is treated as a plain non-2xx failure and the redirect target is
+// never fetched (the apikey is not replayed to an attacker-chosen location).
+func TestClientDoesNotFollowRedirects(t *testing.T) {
+	var followed atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		followed.Add(1)
+		_, _ = io.WriteString(w, successEnvelope(`{}`))
+	}))
+	t.Cleanup(target.Close)
+	redirector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/api/v2", http.StatusFound)
+	}))
+	t.Cleanup(redirector.Close)
+
+	_, err := NewClient(redirector.URL, testAPIKey).GetServerInfo()
+	if err == nil {
+		t.Fatal("GetServerInfo accepted a redirect response")
+	}
+	if !strings.Contains(err.Error(), "status 302") {
+		t.Errorf("error = %v, want the redirect surfaced as status 302", err)
+	}
+	if followed.Load() != 0 {
+		t.Fatalf("client followed the redirect %d times, want 0", followed.Load())
+	}
+}
+
+// TestTransportErrorRedactsAPIKey pins the redaction path: a transport-level
+// *url.Error embeds the full request URL, apikey query parameter included, so
+// the client must scrub the secret before the error can reach logs or API
+// responses.
+func TestTransportErrorRedactsAPIKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	addr := srv.URL
+	srv.Close() // guarantee a connection-refused transport error
+
+	_, err := NewClient(addr, testAPIKey).GetActivity()
+	if err == nil {
+		t.Fatal("GetActivity succeeded against a closed server")
+	}
+	if strings.Contains(err.Error(), testAPIKey) {
+		t.Fatalf("transport error leaked the API key: %v", err)
+	}
+	if !strings.Contains(err.Error(), "[redacted]") {
+		t.Errorf("error = %v, want the apikey replaced with [redacted]", err)
+	}
+}

--- a/server/internal/tautulli/handler_test.go
+++ b/server/internal/tautulli/handler_test.go
@@ -1,0 +1,443 @@
+// Handler tests live in tautulli_test because they drive the handler through
+// the real instance store/registry, and the instance package imports this one.
+package tautulli_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+	"github.com/windoze95/cantinarr-server/internal/tautulli"
+)
+
+const handlerAPIKey = "TAUTULLI_HANDLER_KEY_SENTINEL"
+
+// --- test environment ---
+
+type env struct {
+	store    *instance.Store
+	registry *instance.Registry
+	router   chi.Router
+}
+
+// newEnv builds the handler over a real in-memory instance store and mounts it
+// on the same route patterns the API router uses. Auth middleware is
+// deliberately absent: authorization for these routes is covered by the api
+// package's RBAC matrix tests.
+func newEnv(t *testing.T) *env {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x42}, 32))
+	if err != nil {
+		t.Fatalf("NewCipher: %v", err)
+	}
+	store := instance.NewStore(database, cipher)
+	registry := instance.NewRegistry(store)
+	handler := tautulli.NewHandler(store, registry)
+
+	router := chi.NewRouter()
+	router.Get("/tautulli/{instanceID}/activity", handler.GetActivity)
+	router.Get("/tautulli/{instanceID}/history", handler.GetHistory)
+	router.Get("/tautulli/{instanceID}/stats", handler.GetStats)
+
+	return &env{store: store, registry: registry, router: router}
+}
+
+func (e *env) mkInstance(t *testing.T, serviceType, baseURL string) string {
+	t.Helper()
+	inst := &instance.Instance{
+		ServiceType: serviceType,
+		Name:        serviceType + " test",
+		URL:         baseURL,
+		APIKey:      handlerAPIKey,
+	}
+	if err := e.store.Create(inst); err != nil {
+		t.Fatalf("create %s instance: %v", serviceType, err)
+	}
+	return inst.ID
+}
+
+func (e *env) do(t *testing.T, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	e.router.ServeHTTP(rec, req)
+	return rec
+}
+
+// --- Tautulli fake ---
+
+// tautulliFake serves Tautulli's command-based API: every request hits
+// /api/v2 and is dispatched on the cmd query parameter.
+type tautulliFake struct {
+	t    *testing.T
+	data map[string]string // cmd -> data payload wrapped in a success envelope
+
+	// status, when non-zero, forces a bare HTTP error whose body echoes the
+	// apikey — proving the handler never copies upstream bodies into
+	// client-facing errors.
+	status int
+
+	mu    sync.Mutex
+	calls []url.Values
+}
+
+func (f *tautulliFake) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2" {
+			f.t.Errorf("tautulli path = %s, want /api/v2", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("apikey") != handlerAPIKey {
+			f.t.Errorf("tautulli apikey = %q, want %q", q.Get("apikey"), handlerAPIKey)
+		}
+		f.mu.Lock()
+		f.calls = append(f.calls, q)
+		f.mu.Unlock()
+		if f.status != 0 {
+			http.Error(w, "upstream error while handling "+q.Get("apikey"), f.status)
+			return
+		}
+		data, ok := f.data[q.Get("cmd")]
+		if !ok {
+			f.t.Errorf("unexpected tautulli cmd %q", q.Get("cmd"))
+			data = "null"
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"response":{"result":"success","message":null,"data":`+data+`}}`)
+	}
+}
+
+func (f *tautulliFake) lastCall(t *testing.T) url.Values {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) == 0 {
+		t.Fatal("no calls reached the tautulli fake")
+	}
+	return f.calls[len(f.calls)-1]
+}
+
+func (f *tautulliFake) serve(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(f.handler())
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// --- tests ---
+
+func TestGetActivityShapesResponse(t *testing.T) {
+	fake := &tautulliFake{t: t, data: map[string]string{
+		"get_activity": `{
+			"stream_count": "1",
+			"total_bandwidth": "9500",
+			"sessions": [
+				{"user":"julian","title":"Heat","full_title":"Heat (1995)","player":"Living Room TV","product":"Plex for Apple TV","state":"playing","progress_percent":"42","quality_profile":"1080p","transcode_decision":"transcode","bandwidth":"9500"}
+			]
+		}`,
+	}}
+	e := newEnv(t)
+	id := e.mkInstance(t, "tautulli", fake.serve(t))
+
+	rec := e.do(t, "/tautulli/"+id+"/activity")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		StreamCount        int `json:"stream_count"`
+		TotalBandwidthKbps int `json:"total_bandwidth_kbps"`
+		Streams            []struct {
+			User            string `json:"user"`
+			Title           string `json:"title"`
+			FullTitle       string `json:"full_title"`
+			Player          string `json:"player"`
+			Product         string `json:"product"`
+			State           string `json:"state"`
+			ProgressPercent int    `json:"progress_percent"`
+			Quality         string `json:"quality"`
+			StreamType      string `json:"stream_type"`
+			BandwidthKbps   int    `json:"bandwidth_kbps"`
+		} `json:"streams"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode activity: %v", err)
+	}
+	if resp.StreamCount != 1 || resp.TotalBandwidthKbps != 9500 {
+		t.Errorf("counts = (%d, %d), want (1, 9500)", resp.StreamCount, resp.TotalBandwidthKbps)
+	}
+	if len(resp.Streams) != 1 {
+		t.Fatalf("streams = %d, want 1", len(resp.Streams))
+	}
+	s := resp.Streams[0]
+	if s.User != "julian" || s.FullTitle != "Heat (1995)" || s.State != "playing" || s.ProgressPercent != 42 {
+		t.Errorf("stream = %+v, want session fields mapped", s)
+	}
+	// The response renames arr-side vocabulary: quality_profile -> quality,
+	// transcode_decision -> stream_type, bandwidth -> bandwidth_kbps.
+	if s.Quality != "1080p" || s.StreamType != "transcode" || s.BandwidthKbps != 9500 {
+		t.Errorf("stream = %+v, want quality/stream_type/bandwidth_kbps renamed", s)
+	}
+}
+
+func TestGetHistoryShapesRowsAndLimit(t *testing.T) {
+	fake := &tautulliFake{t: t, data: map[string]string{
+		"get_history": `{"data":[
+			{"user":"julian","full_title":"Heat (1995)","date":"1720000000","duration":"3600","percent_complete":87,"player":"TV","platform":"tvOS"},
+			{"user":"dex","full_title":"Andor - S02E03","date":0,"duration":600,"percent_complete":10,"player":"phone","platform":"iOS"}
+		]}`,
+	}}
+	e := newEnv(t)
+	id := e.mkInstance(t, "tautulli", fake.serve(t))
+
+	rec := e.do(t, "/tautulli/"+id+"/history")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := fake.lastCall(t).Get("length"); got != "50" {
+		t.Errorf("default length = %q, want 50", got)
+	}
+	var resp struct {
+		Items []struct {
+			User            string `json:"user"`
+			FullTitle       string `json:"full_title"`
+			Date            string `json:"date"`
+			DurationSeconds int    `json:"duration_seconds"`
+			PercentComplete int    `json:"percent_complete"`
+			Player          string `json:"player"`
+			Platform        string `json:"platform"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode history: %v", err)
+	}
+	if len(resp.Items) != 2 {
+		t.Fatalf("items = %d, want 2", len(resp.Items))
+	}
+	if resp.Items[0].Date != "2024-07-03T09:46:40Z" {
+		t.Errorf("date = %q, want unix seconds rendered as RFC3339 UTC", resp.Items[0].Date)
+	}
+	if resp.Items[0].DurationSeconds != 3600 || resp.Items[0].PercentComplete != 87 {
+		t.Errorf("item[0] = %+v, want numbers mapped", resp.Items[0])
+	}
+	if resp.Items[1].Date != "" {
+		t.Errorf("unknown date = %q, want empty string", resp.Items[1].Date)
+	}
+
+	// ?limit=N is forwarded; junk and non-positive limits fall back to 50.
+	e.do(t, "/tautulli/"+id+"/history?limit=10")
+	if got := fake.lastCall(t).Get("length"); got != "10" {
+		t.Errorf("length = %q, want 10", got)
+	}
+	e.do(t, "/tautulli/"+id+"/history?limit=abc")
+	if got := fake.lastCall(t).Get("length"); got != "50" {
+		t.Errorf("length for junk limit = %q, want 50", got)
+	}
+	e.do(t, "/tautulli/"+id+"/history?limit=-3")
+	if got := fake.lastCall(t).Get("length"); got != "50" {
+		t.Errorf("length for negative limit = %q, want 50", got)
+	}
+}
+
+func TestGetStatsBucketsRowsByStatID(t *testing.T) {
+	fake := &tautulliFake{t: t, data: map[string]string{
+		"get_home_stats": `[
+			{"stat_id":"top_movies","rows":[{"title":"Heat","total_plays":"9"}]},
+			{"stat_id":"top_tv","rows":[{"title":"Andor","total_plays":5}]},
+			{"stat_id":"top_users","rows":[
+				{"user":"julian","friendly_name":"Julian","total_plays":4},
+				{"user":"dex","friendly_name":"","total_plays":2}
+			]},
+			{"stat_id":"top_platforms","rows":[{"title":"tvOS","total_plays":99}]}
+		]`,
+	}}
+	e := newEnv(t)
+	id := e.mkInstance(t, "tautulli", fake.serve(t))
+
+	rec := e.do(t, "/tautulli/"+id+"/stats?days=7")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if got := fake.lastCall(t).Get("time_range"); got != "7" {
+		t.Errorf("time_range = %q, want 7", got)
+	}
+	var resp struct {
+		TopMovies []struct {
+			Title string `json:"title"`
+			Plays int    `json:"plays"`
+		} `json:"top_movies"`
+		TopShows []struct {
+			Title string `json:"title"`
+			Plays int    `json:"plays"`
+		} `json:"top_shows"`
+		TopUsers []struct {
+			User  string `json:"user"`
+			Plays int    `json:"plays"`
+		} `json:"top_users"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode stats: %v", err)
+	}
+	if len(resp.TopMovies) != 1 || resp.TopMovies[0].Title != "Heat" || resp.TopMovies[0].Plays != 9 {
+		t.Errorf("top_movies = %+v, want Heat with 9 plays", resp.TopMovies)
+	}
+	if len(resp.TopShows) != 1 || resp.TopShows[0].Title != "Andor" || resp.TopShows[0].Plays != 5 {
+		t.Errorf("top_shows = %+v, want top_tv bucketed as top_shows", resp.TopShows)
+	}
+	// friendly_name wins when present; user is the fallback. Unknown stat
+	// blocks (top_platforms) are dropped.
+	if len(resp.TopUsers) != 2 || resp.TopUsers[0].User != "Julian" || resp.TopUsers[1].User != "dex" {
+		t.Errorf("top_users = %+v, want friendly-name fallback applied", resp.TopUsers)
+	}
+
+	// Default window is 30 days.
+	e.do(t, "/tautulli/"+id+"/stats")
+	if got := fake.lastCall(t).Get("time_range"); got != "30" {
+		t.Errorf("default time_range = %q, want 30", got)
+	}
+}
+
+func TestGetStatsEmptyBucketsAreArraysNotNull(t *testing.T) {
+	fake := &tautulliFake{t: t, data: map[string]string{"get_home_stats": `[]`}}
+	e := newEnv(t)
+	id := e.mkInstance(t, "tautulli", fake.serve(t))
+
+	rec := e.do(t, "/tautulli/"+id+"/stats")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, key := range []string{`"top_movies":[]`, `"top_shows":[]`, `"top_users":[]`} {
+		if !strings.Contains(body, key) {
+			t.Errorf("body = %s, want %s (empty arrays, not null)", body, key)
+		}
+	}
+}
+
+// TestUpstreamFailureMapsTo502 pins the failure boundary: a reachable-but-
+// broken Tautulli is the upstream's fault (502), and the error body never
+// contains the instance API key even when the upstream echoes it.
+func TestUpstreamFailureMapsTo502(t *testing.T) {
+	fake := &tautulliFake{t: t, status: http.StatusInternalServerError}
+	e := newEnv(t)
+	id := e.mkInstance(t, "tautulli", fake.serve(t))
+
+	for _, route := range []string{"activity", "history", "stats"} {
+		rec := e.do(t, "/tautulli/"+id+"/"+route)
+		if rec.Code != http.StatusBadGateway {
+			t.Errorf("%s status = %d, want 502", route, rec.Code)
+		}
+		var resp map[string]string
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("%s: decode error body: %v", route, err)
+		}
+		if !strings.Contains(resp["error"], "status 500") {
+			t.Errorf("%s error = %q, want the upstream status surfaced", route, resp["error"])
+		}
+		if strings.Contains(rec.Body.String(), handlerAPIKey) {
+			t.Fatalf("%s error body leaked the API key: %s", route, rec.Body.String())
+		}
+	}
+}
+
+// TestUnreachableUpstreamRedactsSecretIn502 pins that transport-level errors
+// (whose URLs embed the apikey) reach the client redacted.
+func TestUnreachableUpstreamRedactsSecretIn502(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	addr := srv.URL
+	srv.Close()
+
+	e := newEnv(t)
+	id := e.mkInstance(t, "tautulli", addr)
+
+	rec := e.do(t, "/tautulli/"+id+"/activity")
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502, body = %s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), handlerAPIKey) {
+		t.Fatalf("error body leaked the API key: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "[redacted]") {
+		t.Errorf("body = %s, want the apikey redacted in the transport error", rec.Body.String())
+	}
+}
+
+func TestUnknownInstanceReturns404(t *testing.T) {
+	e := newEnv(t)
+	rec := e.do(t, "/tautulli/tautulli-nope/activity")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404, body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "instance not found") {
+		t.Errorf("body = %s, want instance-not-found error", rec.Body.String())
+	}
+}
+
+func TestWrongServiceTypeReturns400(t *testing.T) {
+	e := newEnv(t)
+	id := e.mkInstance(t, "radarr", "http://radarr.internal")
+	rec := e.do(t, "/tautulli/"+id+"/activity")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body = %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "not a tautulli instance") {
+		t.Errorf("body = %s, want a wrong-service-type error", rec.Body.String())
+	}
+}
+
+// erroring fakes for the infrastructure (500) paths; the handler's interfaces
+// exist precisely so these can be simulated.
+type staticStore struct {
+	typ   string
+	found bool
+	err   error
+}
+
+func (s staticStore) LookupServiceType(string) (string, bool, error) { return s.typ, s.found, s.err }
+
+type erroringRegistry struct{}
+
+func (erroringRegistry) GetTautulliClient(string) (*tautulli.Client, error) {
+	return nil, errors.New("client cache exploded")
+}
+
+// TestInfrastructureErrorsMapTo500 pins the other half of the failure
+// boundary: store/registry failures are our fault (500), not the upstream's
+// (502).
+func TestInfrastructureErrorsMapTo500(t *testing.T) {
+	cases := []struct {
+		name    string
+		handler *tautulli.Handler
+	}{
+		{"store error", tautulli.NewHandler(staticStore{err: errors.New("db locked")}, erroringRegistry{})},
+		{"registry error", tautulli.NewHandler(staticStore{typ: "tautulli", found: true}, erroringRegistry{})},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := chi.NewRouter()
+			router.Get("/tautulli/{instanceID}/activity", tc.handler.GetActivity)
+			req := httptest.NewRequest(http.MethodGet, "/tautulli/tautulli-x/activity", nil)
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want 500, body = %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Test-only PR giving three previously zero-test packages hermetic, deterministic suites (no production-code changes):

- **`internal/tautulli` client** (`client_test.go`, in-package): pins the command-based `GET /api/v2?apikey=…&cmd=…` dialect against an httptest fake — activity/history/stats/server-info mapping, `flexInt` tolerance for Tautulli's string-encoded numbers, envelope errors (`result != success`, empty-message fallback), non-2xx and malformed-body failures, and two secret-safety properties: HTTP errors never copy an (echoing) upstream body into the error, and transport errors have the apikey scrubbed to `[redacted]`. The client already refuses redirects via `ErrUseLastResponse`; `TestClientDoesNotFollowRedirects` pins that the redirect target is never fetched.
- **`internal/tautulli` handler** (`handler_test.go`, external test package to avoid the `instance`→`tautulli` import cycle): drives the handler through the real in-memory instance store/registry on the same chi route patterns the API router uses, **without auth middleware — authorization for these routes is covered by the api package's RBAC matrix tests**. Covers requester-facing response shaping (quality/stream_type renames, RFC3339-UTC dates, empty arrays not null, friendly-name fallback), limit/days parameter clamping, and the failure boundary: upstream failures → 502 (never leaking the API key, even redacting it out of transport errors), infra failures (store/registry) → 500, unknown instance → 404, wrong service type → 400.
- **`internal/discover`** (`handler_test.go`): the handler is built over the concrete `*credentials.Registry`, whose tmdb/trakt clients have const base URLs (being made injectable separately — deliberately not refactored here). Since both clients hold zero-`Transport` `http.Client`s, the tests intercept upstream traffic by standing in for `http.DefaultTransport` with an in-memory RoundTripper — fully hermetic (no sockets/TLS), restored via `t.Cleanup`. Covers: param/path/auth-header passthrough to `api.themoviedb.org` and `api.trakt.tv` (credentials loaded from the encrypted settings store), cache behavior via upstream hit-counting, adjacent cache keys that must never collide (colon-embedded search queries, `movie:603` vs `tv:603`, and a `with_genres` value smuggling a literal `&page=2`), upstream errors → 502 that are **not cached** (verified: the next request retries and a recovery response is served fresh) with no token/client-id leakage, 503 when credentials are unset (no dial-out), and the search 400 guard.
- **`internal/cache`** (`cache_test.go`, in-package): Get/Set/Delete round-trips, TTL expiry and refresh via bounded condition polls (no raw sleeps as assertions), the eviction sweep driven directly (`evict()`, since the production ticker is 60s), `Close` terminating the background goroutine, and concurrent Get/Set/Delete/evict proven race-free.

## Verification

- `cd server && go vet ./...` — clean
- `cd server && go test ./...` — all packages pass (exit 0), including after rebasing onto current `main`
- `cd server && go test -race -count=5 ./internal/cache/...` and `go test -race -count=3 ./internal/discover/... ./internal/tautulli/...` — stable, no races, no flakes (Codex smoke self-skips locally — normal)

Test-only change: the new tests pass against unmodified production code by design; no fix-proving failing test applies.

## Docs checklist

- No docs impact (test-only; no routes, tools, env vars, tables, screens, or workflows changed).

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne