### PR TITLE
fix(app): stop offering 'delete files' for NZBGet downloads

### DIFF
--- a/app/lib/features/downloads/ui/downloads_queue_screen.dart
+++ b/app/lib/features/downloads/ui/downloads_queue_screen.dart
@@ -143,9 +143,12 @@ class _DownloadsQueueScreenState extends ConsumerState<DownloadsQueueScreen> {
   }
 
   Future<void> _removeItem(DownloadQueueItem item) async {
+    final serviceType =
+        ref.read(instanceProvider).activeDownloadInstance?.serviceType ?? '';
     final deleteData = await showDialog<bool>(
       context: context,
-      builder: (_) => _RemoveDownloadDialog(name: item.name),
+      builder: (_) =>
+          _RemoveDownloadDialog(name: item.name, serviceType: serviceType),
     );
     if (deleteData == null || !mounted) return;
 
@@ -314,10 +317,15 @@ class _GlobalQueueHeader extends StatelessWidget {
 
 /// Confirmation dialog for removing a download, with an optional checkbox to
 /// also delete downloaded data (default OFF).
+///
+/// NZBGet has no way to remove downloaded files together with the queue item,
+/// so for NZBGet instances the checkbox is replaced by a factual hint and the
+/// dialog always resolves to `false`.
 class _RemoveDownloadDialog extends StatefulWidget {
   final String name;
+  final String serviceType;
 
-  const _RemoveDownloadDialog({required this.name});
+  const _RemoveDownloadDialog({required this.name, required this.serviceType});
 
   @override
   State<_RemoveDownloadDialog> createState() => _RemoveDownloadDialogState();
@@ -325,6 +333,8 @@ class _RemoveDownloadDialog extends StatefulWidget {
 
 class _RemoveDownloadDialogState extends State<_RemoveDownloadDialog> {
   bool _deleteData = false;
+
+  bool get _supportsDeleteData => widget.serviceType != 'nzbget';
 
   @override
   Widget build(BuildContext context) {
@@ -342,15 +352,23 @@ class _RemoveDownloadDialogState extends State<_RemoveDownloadDialog> {
             overflow: TextOverflow.ellipsis,
           ),
           const SizedBox(height: 12),
-          CheckboxListTile(
-            value: _deleteData,
-            onChanged: (v) => setState(() => _deleteData = v ?? false),
-            title: const Text('Also delete downloaded data',
-                style: TextStyle(color: AppTheme.textPrimary, fontSize: 14)),
-            controlAffinity: ListTileControlAffinity.leading,
-            contentPadding: EdgeInsets.zero,
-            activeColor: AppTheme.accent,
-          ),
+          if (_supportsDeleteData)
+            CheckboxListTile(
+              value: _deleteData,
+              onChanged: (v) => setState(() => _deleteData = v ?? false),
+              title: const Text('Also delete downloaded data',
+                  style: TextStyle(color: AppTheme.textPrimary, fontSize: 14)),
+              controlAffinity: ListTileControlAffinity.leading,
+              contentPadding: EdgeInsets.zero,
+              activeColor: AppTheme.accent,
+            )
+          else
+            const Text(
+              'NZBGet removes the queue item only; '
+              'downloaded files stay on disk.',
+              style:
+                  TextStyle(color: AppTheme.textSecondary, fontSize: 12.5),
+            ),
         ],
       ),
       actions: [
@@ -358,7 +376,8 @@ class _RemoveDownloadDialogState extends State<_RemoveDownloadDialog> {
             onPressed: () => Navigator.pop(context),
             child: const Text('Cancel')),
         TextButton(
-          onPressed: () => Navigator.pop(context, _deleteData),
+          onPressed: () =>
+              Navigator.pop(context, _supportsDeleteData && _deleteData),
           style: TextButton.styleFrom(foregroundColor: AppTheme.error),
           child: const Text('Remove'),
         ),

--- a/app/test/downloads/downloads_queue_remove_test.dart
+++ b/app/test/downloads/downloads_queue_remove_test.dart
@@ -1,0 +1,179 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/network/websocket_client.dart';
+import 'package:cantinarr/core/providers/realtime_provider.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/downloads/ui/downloads_queue_screen.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fake Dio adapter: serves the queue with a single item and records every
+/// request (method, path, query) so the tests can assert the DELETE and its
+/// deleteData flag.
+class _FakeAdapter implements HttpClientAdapter {
+  final List<({String method, String path, Map<String, dynamic> query})>
+      requests = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add((
+      method: options.method,
+      path: options.uri.path,
+      query: options.uri.queryParameters,
+    ));
+    final Map<String, dynamic> body;
+    if (options.method == 'GET' && options.uri.path.endsWith('/queue')) {
+      body = {
+        'paused': false,
+        'speed_bps': 0,
+        'items': [
+          {
+            'id': 'item-1',
+            'name': 'Example Download',
+            'size_bytes': 1000,
+            'size_left_bytes': 500,
+            'progress': 50.0,
+            'status': 'downloading',
+          },
+        ],
+      };
+    } else {
+      body = <String, dynamic>{};
+    }
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _FakeAuthNotifier extends AuthNotifier {
+  final AuthState authState;
+
+  _FakeAuthNotifier(this.authState);
+
+  @override
+  Future<AuthState> build() async => authState;
+}
+
+AuthState _stateWithDownloadClient(String serviceType) => AuthState(
+      connection: BackendConnection(
+        serverUrl: 'http://localhost',
+        accessToken: 'access',
+        refreshToken: 'refresh',
+        instances: [
+          ServiceInstance(
+            id: 'dl-1',
+            serviceType: serviceType,
+            name: 'Download Client',
+            isDefault: true,
+          ),
+        ],
+      ),
+      user: const UserProfile(id: 1, username: 'admin', role: 'admin'),
+    );
+
+const _nzbgetHint =
+    'NZBGet removes the queue item only; downloaded files stay on disk.';
+
+void main() {
+  late _FakeAdapter adapter;
+
+  Future<void> pumpQueue(WidgetTester tester, String serviceType) async {
+    adapter = _FakeAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+      ..httpClientAdapter = adapter;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith(
+            () => _FakeAuthNotifier(_stateWithDownloadClient(serviceType)),
+          ),
+          backendClientProvider.overrideWithValue(dio),
+          realtimeEventsProvider
+              .overrideWithValue(const Stream<WsEvent>.empty()),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: DownloadsQueueScreen()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Example Download'), findsOneWidget);
+  }
+
+  Future<void> openRemoveDialog(WidgetTester tester) async {
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Remove'));
+    await tester.pumpAndSettle();
+    expect(find.text('Remove Download'), findsOneWidget);
+  }
+
+  List<({String method, String path, Map<String, dynamic> query})> deletes() =>
+      adapter.requests.where((r) => r.method == 'DELETE').toList();
+
+  for (final serviceType in ['sabnzbd', 'qbittorrent', 'transmission']) {
+    testWidgets('$serviceType remove dialog offers the delete-data option',
+        (tester) async {
+      await pumpQueue(tester, serviceType);
+      await openRemoveDialog(tester);
+      expect(find.text('Also delete downloaded data'), findsOneWidget);
+      expect(find.text(_nzbgetHint), findsNothing);
+      final box =
+          tester.widget<CheckboxListTile>(find.byType(CheckboxListTile));
+      expect(box.value, isFalse);
+    });
+  }
+
+  testWidgets('sabnzbd opting in sends deleteData=true', (tester) async {
+    await pumpQueue(tester, 'sabnzbd');
+    await openRemoveDialog(tester);
+    await tester.tap(find.text('Also delete downloaded data'));
+    await tester.pump();
+    await tester.tap(find.text('Remove').last);
+    await tester.pumpAndSettle();
+
+    final d = deletes();
+    expect(d, hasLength(1));
+    expect(d.single.path, endsWith('/queue/item-1'));
+    expect(d.single.query['deleteData'], 'true');
+  });
+
+  testWidgets('nzbget remove dialog hides the option and explains why',
+      (tester) async {
+    await pumpQueue(tester, 'nzbget');
+    await openRemoveDialog(tester);
+    expect(find.byType(CheckboxListTile), findsNothing);
+    expect(find.text('Also delete downloaded data'), findsNothing);
+    expect(find.text(_nzbgetHint), findsOneWidget);
+  });
+
+  testWidgets('nzbget remove never requests data deletion', (tester) async {
+    await pumpQueue(tester, 'nzbget');
+    await openRemoveDialog(tester);
+    await tester.tap(find.text('Remove').last);
+    await tester.pumpAndSettle();
+
+    final d = deletes();
+    expect(d, hasLength(1));
+    expect(d.single.path, endsWith('/queue/item-1'));
+    expect(d.single.query['deleteData'], 'false');
+  });
+}


### PR DESCRIPTION
## Summary

NZBGet's protocol has no remove-data flag — the server maps `DELETE ?deleteData=true` to a plain `GroupDelete` (pinned in the server tests from #202), so the queue item vanishes but the files stay on disk. The app's remove-download dialog offered the same "Also delete downloaded data" checkbox for every client, which was dishonest for NZBGet.

- The remove dialog now knows the active download client's service type. The screen already had it via `instanceProvider.activeDownloadInstance`; the only plumbing added is one `serviceType` constructor param on the (private) dialog widget.
- For NZBGet instances the checkbox is hidden and replaced with a short factual hint: *"NZBGet removes the queue item only; downloaded files stay on disk."* The dialog always resolves to `deleteData=false`, and the Remove action defensively coerces the flag to false for NZBGet.
- SABnzbd, qBittorrent, and Transmission behavior is unchanged: checkbox present, default off, opt-in sends `deleteData=true`.

## Verification

- `cd app && flutter analyze --no-fatal-infos` — No issues found.
- `cd app && flutter test` — all 439 tests passed, including the new `test/downloads/downloads_queue_remove_test.dart`:
  - remove dialog offers the delete-data option (default off) for sabnzbd / qbittorrent / transmission,
  - sabnzbd opt-in sends `deleteData=true`,
  - nzbget dialog hides the option and shows the hint,
  - nzbget remove sends the DELETE with `deleteData=false`.

The tests exercise the real `DownloadsQueueScreen` flow (provider overrides + a recording Dio adapter), asserting the actual query the API layer sends.

## Docs checklist

- [x] No documented surface changed: no new route, tool, env var, table, or screen. `app/README.md`'s "remove (optionally with data)" line remains accurate for the clients that honor it (3 of 4); left untouched per this task's scope.

Fixes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne