### PR TITLE
chore(ci): run Go tests with the race detector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           echo "CANTINARR_CODEX_APP_SERVER_SMOKE_BINARY=$RUNNER_TEMP/codex-app-server" >> "$GITHUB_ENV"
 
       - name: Test
-        run: go test ./...
+        run: go test -race ./...
 
       - name: Build
         run: CGO_ENABLED=0 go build -o cantinarr ./cmd/server

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ Operating manual for AI agents and human contributors. `CLAUDE.md` imports this 
 
 - Server changes: run `go vet ./...` and `go test ./...` from `server/`.
 - App changes: run `flutter analyze --no-fatal-infos` and `flutter test` from `app/`.
-- CI runs exactly those on every PR, plus a `CGO_ENABLED=0` server build and a `flutter build web --release`. A PR is not done if any of them fail. The same suite re-runs on every push to `main` (merge-skew safety) and on a weekly schedule (toolchain drift); a red `main` run is a defect to fix promptly.
+- CI runs exactly those on every PR (Go tests with `-race`), plus a `CGO_ENABLED=0` server build and a `flutter build web --release`. A PR is not done if any of them fail. The same suite re-runs on every push to `main` (merge-skew safety) and on a weekly schedule (toolchain drift); a red `main` run is a defect to fix promptly.
 - Codex integration changes are also proved against the checksum-verified pinned app-server in CI. The Docker workflow builds and smoke-tests both Dockerfiles, including bundled license notices, before publishing the root image to GHCR.
 - iOS release builds happen only in CI (`testflight.yml`, auto-deploys on `main` when iOS-relevant `app/**` paths change — web/android/desktop subdirs, `app/test/**`, `app/tool/**`, and store-listing metadata/screenshots are excluded; listing copy syncs via `storelisting.yml` instead). Don't assume a local iOS toolchain; when one isn't available, sanity-check Swift with `swiftc -parse` and let CI prove the build.
 - iOS signing is manual, via the `IOS_PROVISIONING_PROFILE_BASE64` secret. Changing app capabilities/entitlements invalidates the profile — regenerate it and update the secret.


### PR DESCRIPTION
## Summary

The suite now contains deliberate race-detection tests (the websocket eviction test from #216 among them) that only bite under `-race`, but CI ran plain `go test` — so the race detector never executed in the place it matters most. This flips the CI Go test step to `go test -race ./...` and notes it in AGENTS.md. Local guidance stays plain `go test ./...` for speed; `-race` remains available locally when touching concurrency.

Surfaced by the adversarial review of PR #216.

## Verification

- `go test -race ./...` passes locally from `server/` (Codex smoke self-skips locally, as expected).
- CI on this PR proves the runner cost: watch the Go job duration.

## Docs

- [x] AGENTS.md Verification section updated in the same PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne