### PR TITLE
test(server): harden two review-flagged test nits

### DIFF
--- a/server/internal/cache/cache_test.go
+++ b/server/internal/cache/cache_test.go
@@ -54,7 +54,9 @@ func TestGetHonorsTTLExpiry(t *testing.T) {
 	c := New()
 	t.Cleanup(c.Close)
 
-	c.Set("k", []byte("v"), 20*time.Millisecond)
+	// Generous TTL so a scheduler stall between Set and Get cannot flake the
+	// still-fresh assertion; expiry is then awaited, not raced.
+	c.Set("k", []byte("v"), 250*time.Millisecond)
 	if _, ok := c.Get("k"); !ok {
 		t.Fatal("entry expired immediately after Set with a positive TTL")
 	}

--- a/server/internal/discover/handler_test.go
+++ b/server/internal/discover/handler_test.go
@@ -243,8 +243,9 @@ func TestAdjacentQueriesNeverShareCacheEntries(t *testing.T) {
 	e := newEnv(t, true)
 
 	pairs := [][2]string{
-		// "search:" + query + ":" + page — colon-separated free text.
-		{"/search?query=heat&page=12", "/search?query=heat:1&page=2"},
+		// "search:" + query + ":" + page — under separator-less
+		// concatenation both would key as "searchheat12".
+		{"/search?query=heat1&page=2", "/search?query=heat&page=12"},
 		// "movie:" + id vs "tv:" + id — same numeric id, different media type.
 		{"/media/movie/603", "/media/tv/603"},
 		// disc_movies uses params.Encode(): a with_genres VALUE containing a


### PR DESCRIPTION
## Summary

Two non-blocking findings from the adversarial review of PR #218, fixed:

- `cache_test.go`: the TTL-expiry test asserted a Get immediately after a 20ms-TTL Set — a >20ms scheduler stall between adjacent statements would flake it. Now 250ms; expiry is still awaited via the bounded poll.
- `discover/handler_test.go`: the search leg of the collision test used a pair that collides under neither the real key scheme nor naive concatenation. Replaced with `query=heat1&page=2` vs `query=heat&page=12` (both key as `searchheat12` under separator-less concatenation). Verified by mutation: with the prod key format mutated to separator-less concat, the old pair passed and the new pair fails.

## Verification

- `go test -race -count=3 ./internal/cache/ ./internal/discover/` — green.
- Mutation check above; prod code untouched (verified restored).

## Docs

- [x] No docs impact — test-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne