### PR TITLE
chore(app): test seams for deep links, passkeys, and device identity — with unit coverage

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:app_links/app_links.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'core/network/websocket_client.dart';
 import 'core/providers/realtime_provider.dart';
@@ -17,6 +16,62 @@ import 'features/request/logic/pending_approvals_provider.dart';
 import 'features/settings/logic/update_status_provider.dart';
 import 'navigation/app_router.dart';
 
+/// Source of platform deep links: the link that launched the app (if any)
+/// plus the stream of links delivered while it runs. The default
+/// implementation wraps [AppLinks]; tests override [deepLinkSourceProvider]
+/// to inject links without the platform channel.
+abstract class DeepLinkSource {
+  Future<Uri?> getInitialLink();
+  Stream<Uri> get uriLinkStream;
+}
+
+class _AppLinksSource implements DeepLinkSource {
+  final AppLinks _appLinks = AppLinks();
+
+  @override
+  Future<Uri?> getInitialLink() => _appLinks.getInitialLink();
+
+  @override
+  Stream<Uri> get uriLinkStream => _appLinks.uriLinkStream;
+}
+
+/// App-wide [DeepLinkSource].
+final deepLinkSourceProvider =
+    Provider<DeepLinkSource>((_) => _AppLinksSource());
+
+/// True when two user-entered server URLs point at the same server, ignoring
+/// cosmetic differences (case, trailing slashes, an omitted scheme, a default
+/// port).
+@visibleForTesting
+bool sameServer(String left, String right) =>
+    normalizeServer(left) == normalizeServer(right);
+
+/// Canonicalizes a user-entered server URL for comparison: trims whitespace,
+/// assumes https:// when no scheme is given, strips trailing slashes, and
+/// lowercases the scheme and host. Never throws — unparseable input falls
+/// back to a lowercased string compare.
+@visibleForTesting
+String normalizeServer(String value) {
+  var normalized = value.trim();
+  if (!normalized.startsWith('http://') &&
+      !normalized.startsWith('https://')) {
+    normalized = 'https://$normalized';
+  }
+  while (normalized.endsWith('/')) {
+    normalized = normalized.substring(0, normalized.length - 1);
+  }
+  final parsed = Uri.tryParse(normalized);
+  if (parsed == null || parsed.host.isEmpty) {
+    return normalized.toLowerCase();
+  }
+  return parsed
+      .replace(
+        scheme: parsed.scheme.toLowerCase(),
+        host: parsed.host.toLowerCase(),
+      )
+      .toString();
+}
+
 class CantinarrApp extends ConsumerStatefulWidget {
   const CantinarrApp({super.key});
 
@@ -26,7 +81,6 @@ class CantinarrApp extends ConsumerStatefulWidget {
 
 class _CantinarrAppState extends ConsumerState<CantinarrApp>
     with WidgetsBindingObserver {
-  late final AppLinks _appLinks;
   StreamSubscription<Uri>? _linkSubscription;
   final _scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
 
@@ -34,7 +88,6 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    _appLinks = AppLinks();
     _initDeepLinks();
     // Reading the push service wires its native tap handler (for warm taps);
     // once the first frame is up (router exists) route any cold-start tap.
@@ -63,16 +116,17 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
   }
 
   Future<void> _initDeepLinks() async {
+    final links = ref.read(deepLinkSourceProvider);
     // Handle initial link (app opened via link)
     try {
-      final initialLink = await _appLinks.getInitialLink();
+      final initialLink = await links.getInitialLink();
       if (initialLink != null) {
         _handleLink(initialLink);
       }
     } catch (_) {}
 
     // Handle links while app is running
-    _linkSubscription = _appLinks.uriLinkStream.listen(_handleLink);
+    _linkSubscription = links.uriLinkStream.listen(_handleLink);
   }
 
   void _handleLink(Uri uri) {
@@ -93,39 +147,18 @@ class _CantinarrAppState extends ConsumerState<CantinarrApp>
     final currentServer = auth.connection?.serverUrl;
     final matchesServer = targetServer == null ||
         currentServer == null ||
-        _sameServer(targetServer, currentServer);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      if (auth.isAuthenticated && matchesServer) {
-        context.go('/settings/passkeys/new');
-      } else {
-        context.go('/login');
-      }
-    });
-  }
-
-  bool _sameServer(String left, String right) =>
-      _normalizeServer(left) == _normalizeServer(right);
-
-  String _normalizeServer(String value) {
-    var normalized = value.trim();
-    if (!normalized.startsWith('http://') &&
-        !normalized.startsWith('https://')) {
-      normalized = 'https://$normalized';
+        sameServer(targetServer, currentServer);
+    // Navigate through the router instance (the same pattern as
+    // _showAutodispatchDisabledSnack below): this state sits ABOVE
+    // MaterialApp.router, so `context.go` cannot see the router — GoRouter.of
+    // walks up the tree and asserts. And a post-frame deferral would wait on a
+    // frame nothing schedules when the app is idle; router.go needs neither.
+    final router = ref.read(appRouterProvider);
+    if (auth.isAuthenticated && matchesServer) {
+      router.go('/settings/passkeys/new');
+    } else {
+      router.go('/login');
     }
-    while (normalized.endsWith('/')) {
-      normalized = normalized.substring(0, normalized.length - 1);
-    }
-    final parsed = Uri.tryParse(normalized);
-    if (parsed == null || parsed.host.isEmpty) {
-      return normalized.toLowerCase();
-    }
-    return parsed
-        .replace(
-          scheme: parsed.scheme.toLowerCase(),
-          host: parsed.host.toLowerCase(),
-        )
-        .toString();
   }
 
   @override

--- a/app/lib/core/device/device_identity.dart
+++ b/app/lib/core/device/device_identity.dart
@@ -44,26 +44,33 @@ class DeviceIdentityService {
 
     DeviceIdentity raw;
     try {
-      raw = await _read();
+      raw = await readDeviceInfo();
     } catch (e) {
       debugPrint('DeviceIdentity: read failed: $e');
       raw = DeviceIdentity(displayName: _fallbackName(), hardwareId: '');
     }
 
     final hardwareId =
-        raw.hardwareId.isNotEmpty ? raw.hardwareId : await _persistedId();
+        raw.hardwareId.isNotEmpty ? raw.hardwareId : await persistedId();
     final identity =
         DeviceIdentity(displayName: raw.displayName, hardwareId: hardwareId);
     _cached = identity;
     return identity;
   }
 
-  Future<DeviceIdentity> _read() async {
+  /// Reads the raw platform identity via `device_info_plus`. Overridable in
+  /// tests (the platform branch taken depends on the host OS, so unit tests
+  /// stub this seam instead of the plugin); behavior-identical to the previous
+  /// private helper.
+  @protected
+  @visibleForTesting
+  Future<DeviceIdentity> readDeviceInfo() async {
     if (kIsWeb) {
       final info = await _plugin.webBrowserInfo;
-      final browser = _capitalize(info.browserName.name);
-      final os = _webOs(info.platform ?? info.userAgent ?? '');
-      final label = os.isEmpty ? browser : '$browser on $os';
+      final label = webDisplayName(
+        info.browserName.name,
+        info.platform ?? info.userAgent ?? '',
+      );
       // Browsers expose no stable hardware id; the persisted UUID fallback
       // makes web dedup best-effort (per browser profile).
       return DeviceIdentity(displayName: label, hardwareId: '');
@@ -71,7 +78,7 @@ class DeviceIdentityService {
     if (Platform.isIOS) {
       final info = await _plugin.iosInfo;
       return DeviceIdentity(
-        displayName: _appleModelName(info.utsname.machine),
+        displayName: appleModelName(info.utsname.machine),
         hardwareId: info.identifierForVendor ?? '',
       );
     }
@@ -104,7 +111,12 @@ class DeviceIdentityService {
     return DeviceIdentity(displayName: _fallbackName(), hardwareId: '');
   }
 
-  Future<String> _persistedId() async {
+  /// Reads (or mints and persists) the fallback UUID used as [hardwareId] on
+  /// platforms without a native device identifier (web, Android). Stored under
+  /// [StorageKeys.hardwareId], which the logout purge deliberately skips, so
+  /// the same physical device dedupes across sessions.
+  @visibleForTesting
+  Future<String> persistedId() async {
     final existing = await _storage.read(key: StorageKeys.hardwareId);
     if (existing != null && existing.isNotEmpty) return existing;
     final generated = const Uuid().v4();
@@ -122,6 +134,16 @@ class DeviceIdentityService {
       if (Platform.isLinux) return 'Linux';
     } catch (_) {}
     return 'Unknown Device';
+  }
+
+  /// Builds the web display label ("Chrome on macOS") from the reported
+  /// browser name and a platform/user-agent hint. Exposed for tests; the OS
+  /// part is omitted when the hint matches nothing.
+  @visibleForTesting
+  String webDisplayName(String browserName, String platformHint) {
+    final browser = _capitalize(browserName);
+    final os = _webOs(platformHint);
+    return os.isEmpty ? browser : '$browser on $os';
   }
 
   String _webOs(String raw) {
@@ -142,7 +164,8 @@ class DeviceIdentityService {
   /// Maps an iOS hardware identifier (`utsname.machine`, e.g. "iPhone17,2") to a
   /// marketing name ("Apple iPhone 16 Pro Max"). Unmapped models fall back to
   /// the device class; extend this table as new devices ship.
-  String _appleModelName(String machine) {
+  @visibleForTesting
+  String appleModelName(String machine) {
     const models = <String, String>{
       'iPhone12,1': 'iPhone 11',
       'iPhone12,3': 'iPhone 11 Pro',

--- a/app/lib/features/auth/data/passkey_service_native.dart
+++ b/app/lib/features/auth/data/passkey_service_native.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:passkeys_platform_interface/passkeys_platform_interface.dart';
 import 'package:passkeys_platform_interface/types/types.dart';
@@ -32,19 +33,19 @@ Future<bool> isAvailableAsync() async {
 Future<Map<String, dynamic>> create(Map<String, dynamic> options) async {
   try {
     await _platform.cancelCurrentAuthenticatorOperation();
-    final publicKey = _normalizeCreationOptions(_publicKeyOptions(options));
+    final publicKey = normalizeCreationOptions(_publicKeyOptions(options));
     final request = RegisterRequestType.fromJson(publicKey);
     final response = await _platform.register(request);
     return response.toJson();
   } on PlatformException catch (e) {
-    throw Exception(_messageForPlatformException(e, isLogin: false));
+    throw Exception(messageForPlatformException(e, isLogin: false));
   }
 }
 
 Future<Map<String, dynamic>> get(Map<String, dynamic> options) async {
   try {
     await _platform.cancelCurrentAuthenticatorOperation();
-    final publicKey = _normalizeRequestOptions(_publicKeyOptions(options));
+    final publicKey = normalizeRequestOptions(_publicKeyOptions(options));
     final request = AuthenticateRequestType.fromJson(
       publicKey,
       mediation: MediationType.Required,
@@ -53,7 +54,7 @@ Future<Map<String, dynamic>> get(Map<String, dynamic> options) async {
     final response = await _platform.authenticate(request);
     return response.toJson();
   } on PlatformException catch (e) {
-    throw Exception(_messageForPlatformException(e, isLogin: true));
+    throw Exception(messageForPlatformException(e, isLogin: true));
   }
 }
 
@@ -68,10 +69,14 @@ Map<String, dynamic> _publicKeyOptions(Map<String, dynamic> options) {
   throw const FormatException('Missing passkey options');
 }
 
-Map<String, dynamic> _normalizeCreationOptions(Map<String, dynamic> options) {
+/// Fills in the optional WebAuthn creation fields the native authenticator
+/// libraries require (exposed for tests; behavior-identical to the previous
+/// private helper).
+@visibleForTesting
+Map<String, dynamic> normalizeCreationOptions(Map<String, dynamic> options) {
   final normalized = Map<String, dynamic>.from(options);
   normalized['excludeCredentials'] =
-      _credentialDescriptors(normalized['excludeCredentials']);
+      credentialDescriptors(normalized['excludeCredentials']);
 
   final authenticatorSelection = normalized['authenticatorSelection'];
   if (authenticatorSelection is Map) {
@@ -87,9 +92,13 @@ Map<String, dynamic> _normalizeCreationOptions(Map<String, dynamic> options) {
   return normalized;
 }
 
-Map<String, dynamic> _normalizeRequestOptions(Map<String, dynamic> options) {
+/// Normalizes WebAuthn request (login) options: defaults credential
+/// transports and drops an empty allowCredentials list entirely (exposed for
+/// tests; behavior-identical to the previous private helper).
+@visibleForTesting
+Map<String, dynamic> normalizeRequestOptions(Map<String, dynamic> options) {
   final normalized = Map<String, dynamic>.from(options);
-  final allowCredentials = _credentialDescriptors(
+  final allowCredentials = credentialDescriptors(
     normalized['allowCredentials'],
   );
   if (allowCredentials.isEmpty) {
@@ -100,7 +109,11 @@ Map<String, dynamic> _normalizeRequestOptions(Map<String, dynamic> options) {
   return normalized;
 }
 
-List<Map<String, dynamic>> _credentialDescriptors(Object? value) {
+/// Coerces a raw excludeCredentials/allowCredentials value into descriptor
+/// maps with `transports` always present (exposed for tests;
+/// behavior-identical to the previous private helper).
+@visibleForTesting
+List<Map<String, dynamic>> credentialDescriptors(Object? value) {
   if (value is! List) {
     return const [];
   }
@@ -111,7 +124,10 @@ List<Map<String, dynamic>> _credentialDescriptors(Object? value) {
   }).toList();
 }
 
-String _messageForPlatformException(
+/// Maps a passkeys plugin [PlatformException] code to a user-facing message
+/// (exposed for tests; behavior-identical to the previous private helper).
+@visibleForTesting
+String messageForPlatformException(
   PlatformException error, {
   required bool isLogin,
 }) {

--- a/app/test/app_deep_links_test.dart
+++ b/app/test/app_deep_links_test.dart
@@ -1,0 +1,376 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/app.dart';
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/network/websocket_client.dart';
+import 'package:cantinarr/core/providers/realtime_provider.dart';
+import 'package:cantinarr/features/auth/data/server_status.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/navigation/app_router.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Exercises the cantinarr:// deep-link surface through the
+/// [deepLinkSourceProvider] seam: connect links must reach the auth flow,
+/// passkey links must route only when the link's server matches the connected
+/// one (after normalization), and anything else must be ignored quietly.
+void main() {
+  group('normalizeServer / sameServer', () {
+    test('ignores trailing slashes', () {
+      expect(
+        sameServer('https://media.example.com/', 'https://media.example.com'),
+        isTrue,
+      );
+      expect(
+        sameServer('https://media.example.com///', 'https://media.example.com'),
+        isTrue,
+      );
+    });
+
+    test('ignores a default port', () {
+      expect(
+        sameServer(
+            'https://media.example.com:443', 'https://media.example.com'),
+        isTrue,
+      );
+      expect(
+        sameServer('http://media.example.com:80', 'http://media.example.com'),
+        isTrue,
+      );
+      expect(
+        sameServer(
+            'https://media.example.com:8443', 'https://media.example.com'),
+        isFalse,
+        reason: 'a non-default port is a different server',
+      );
+    });
+
+    test('ignores host casing', () {
+      expect(
+        sameServer('https://MEDIA.Example.COM', 'https://media.example.com'),
+        isTrue,
+      );
+      expect(
+        sameServer('HTTPS://media.example.com', 'https://media.example.com'),
+        isFalse,
+        reason: 'an uppercase scheme defeats the scheme probe and gets '
+            'https:// prepended — pinned so a change here is a conscious one',
+      );
+    });
+
+    test('assumes https for scheme-less input', () {
+      expect(sameServer('media.example.com', 'https://media.example.com'),
+          isTrue);
+      expect(sameServer('media.example.com', 'http://media.example.com'),
+          isFalse,
+          reason: 'a plain host must not match an http:// server');
+    });
+
+    test('treats different hosts and base paths as different servers', () {
+      expect(sameServer('https://a.example.com', 'https://b.example.com'),
+          isFalse);
+      expect(
+        sameServer(
+            'https://media.example.com/base', 'https://media.example.com'),
+        isFalse,
+      );
+    });
+
+    test('never throws on unparseable input', () {
+      expect(() => normalizeServer(''), returnsNormally);
+      expect(() => normalizeServer('http://'), returnsNormally);
+      expect(() => normalizeServer('%%%'), returnsNormally);
+      expect(sameServer('%%%', '%%%'), isTrue);
+    });
+  });
+
+  group('deep link handling', () {
+    testWidgets('an initial connect link is forwarded to the auth flow',
+        (tester) async {
+      final link =
+          Uri.parse('cantinarr://connect?token=abc123&server=$_server');
+      final app = await _pumpApp(tester,
+          authState: const AuthState(), initialLink: link);
+
+      expect(app.auth.connectLinks, [link.toString()]);
+    });
+
+    testWidgets('a connect link arriving while running is forwarded',
+        (tester) async {
+      final app = await _pumpApp(tester, authState: const AuthState());
+      expect(app.auth.connectLinks, isEmpty);
+
+      final link = Uri.parse('cantinarr://connect?token=xyz&server=$_server');
+      app.links.controller.add(link);
+      await _settleLink(tester);
+
+      expect(app.auth.connectLinks, [link.toString()]);
+    });
+
+    testWidgets(
+        'a passkeys link matching the connected server (any normalized '
+        'variant) opens passkey creation', (tester) async {
+      final app = await _pumpApp(tester, authState: _authedState);
+      final router = app.container.read(appRouterProvider);
+
+      const variants = [
+        'https://media.example.com/', // trailing slash
+        'https://MEDIA.EXAMPLE.COM', // case
+        'https://media.example.com:443', // default port
+        'media.example.com', // scheme-less
+      ];
+      for (final server in variants) {
+        app.links.controller.add(
+          Uri.parse('cantinarr://passkeys?server=${Uri.encodeComponent(server)}'),
+        );
+        await _settleLink(tester);
+        expect(
+          router.routeInformationProvider.value.uri.path,
+          '/settings/passkeys/new',
+          reason: '$server should match $_server',
+        );
+
+        router.go('/dashboard/movies');
+        await tester.pumpAndSettle();
+      }
+    });
+
+    testWidgets('a passkeys link without a server parameter routes when '
+        'authenticated', (tester) async {
+      final app = await _pumpApp(tester, authState: _authedState);
+      app.links.controller.add(Uri.parse('cantinarr://passkeys'));
+      await _settleLink(tester);
+
+      expect(
+        app.container
+            .read(appRouterProvider)
+            .routeInformationProvider
+            .value
+            .uri
+            .path,
+        '/settings/passkeys/new',
+      );
+    });
+
+    testWidgets('a passkeys link for a different server does not open '
+        'passkey creation', (tester) async {
+      final app = await _pumpApp(tester, authState: _authedState);
+      app.links.controller.add(
+        Uri.parse('cantinarr://passkeys?server=https://other.example.com'),
+      );
+      await _settleLink(tester);
+
+      expect(
+        app.container
+            .read(appRouterProvider)
+            .routeInformationProvider
+            .value
+            .uri
+            .path,
+        '/dashboard/movies',
+        reason: 'a mismatched server must never reach passkey creation',
+      );
+    });
+
+    testWidgets('a passkeys link while logged out lands on login',
+        (tester) async {
+      final app = await _pumpApp(tester, authState: const AuthState());
+      app.links.controller.add(Uri.parse('cantinarr://passkeys'));
+      await _settleLink(tester);
+
+      expect(
+        app.container
+            .read(appRouterProvider)
+            .routeInformationProvider
+            .value
+            .uri
+            .path,
+        '/login',
+      );
+    });
+
+    testWidgets('wrong-scheme, wrong-host, and malformed links are ignored',
+        (tester) async {
+      final app = await _pumpApp(tester, authState: _authedState);
+
+      for (final uri in [
+        Uri.parse('https://media.example.com/connect?token=abc'), // scheme
+        Uri.parse('cantinarr://something-else?token=abc'), // host
+        Uri.parse('cantinarr:'), // no host at all
+        Uri.parse('mailto:user@example.com'),
+      ]) {
+        app.links.controller.add(uri);
+        await _settleLink(tester);
+      }
+
+      expect(app.auth.connectLinks, isEmpty);
+      expect(
+        app.container
+            .read(appRouterProvider)
+            .routeInformationProvider
+            .value
+            .uri
+            .path,
+        '/dashboard/movies',
+        reason: 'ignored links must not navigate',
+      );
+    });
+
+    testWidgets('a failing initial-link lookup is swallowed and the stream '
+        'still works', (tester) async {
+      final app = await _pumpApp(
+        tester,
+        authState: const AuthState(),
+        initialLinkError: Exception('platform channel unavailable'),
+      );
+
+      final link = Uri.parse('cantinarr://connect?token=abc&server=$_server');
+      app.links.controller.add(link);
+      await _settleLink(tester);
+
+      expect(app.auth.connectLinks, [link.toString()]);
+    });
+  });
+}
+
+const _server = 'https://media.example.com';
+
+const _authedState = AuthState(
+  connection: BackendConnection(
+    serverUrl: _server,
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(),
+  ),
+  user: UserProfile(id: 1, username: 'tester', role: 'user'),
+);
+
+/// Pumps [CantinarrApp] with every platform boundary faked: deep links come
+/// from [_FakeDeepLinks], auth is [_FakeAuthNotifier], the realtime socket is
+/// an empty stream, and HTTP is a canned-JSON Dio adapter.
+Future<
+    ({
+      ProviderContainer container,
+      _FakeAuthNotifier auth,
+      _FakeDeepLinks links,
+    })> _pumpApp(
+  WidgetTester tester, {
+  required AuthState authState,
+  Uri? initialLink,
+  Object? initialLinkError,
+}) async {
+  SharedPreferences.setMockInitialValues({});
+  final links = _FakeDeepLinks(
+    initialLink: initialLink,
+    initialLinkError: initialLinkError,
+  );
+  final auth = _FakeAuthNotifier(authState);
+  final container = ProviderContainer(overrides: [
+    authProvider.overrideWith(() => auth),
+    deepLinkSourceProvider.overrideWithValue(links),
+    realtimeEventsProvider.overrideWithValue(const Stream<WsEvent>.empty()),
+    backendClientProvider.overrideWithValue(_fakeDio()),
+  ]);
+  addTearDown(container.dispose);
+  addTearDown(links.controller.close);
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const CantinarrApp(),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return (container: container, auth: auth, links: links);
+}
+
+/// Lets a just-delivered link work through its async chain: the stream event,
+/// the auth read, the post-frame navigation, and the resulting rebuilds.
+Future<void> _settleLink(WidgetTester tester) async {
+  await tester.pump();
+  await tester.pumpAndSettle();
+}
+
+/// [DeepLinkSource] whose initial link is canned (or throws) and whose stream
+/// is test-driven.
+class _FakeDeepLinks implements DeepLinkSource {
+  _FakeDeepLinks({this.initialLink, this.initialLinkError});
+
+  final Uri? initialLink;
+  final Object? initialLinkError;
+  final StreamController<Uri> controller = StreamController<Uri>.broadcast();
+
+  @override
+  Future<Uri?> getInitialLink() async {
+    final error = initialLinkError;
+    if (error != null) throw error;
+    return initialLink;
+  }
+
+  @override
+  Stream<Uri> get uriLinkStream => controller.stream;
+}
+
+/// [AuthNotifier] fake: fixed state, records connect links, and answers
+/// checkServer without the network (PasskeyCreateScreen probes it on open).
+class _FakeAuthNotifier extends AuthNotifier {
+  _FakeAuthNotifier(this._initial);
+
+  final AuthState _initial;
+  final List<String> connectLinks = [];
+
+  @override
+  Future<AuthState> build() async => _initial;
+
+  @override
+  Future<void> connectWithLink(String link) async {
+    connectLinks.add(link);
+  }
+
+  @override
+  Future<ServerStatus> checkServer(String serverUrl) async =>
+      const ServerStatus(needsSetup: false);
+}
+
+Dio _fakeDio() {
+  final dio = Dio(BaseOptions(baseUrl: _server));
+  dio.httpClientAdapter = _JsonAdapter();
+  return dio;
+}
+
+/// Minimal HTTP fake: every request gets an empty paged-results payload, which
+/// is enough for the dashboard and settings screens the router lands on.
+class _JsonAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final Object body = switch (options.path) {
+      '/api/trakt/anticipated' => <dynamic>[],
+      _ => {
+          'page': 1,
+          'results': <dynamic>[],
+          'total_pages': 0,
+          'total_results': 0,
+        },
+    };
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/app/test/auth/passkey_service_native_test.dart
+++ b/app/test/auth/passkey_service_native_test.dart
@@ -1,0 +1,379 @@
+import 'package:cantinarr/features/auth/data/passkey_service_native.dart'
+    as passkeys;
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:passkeys_platform_interface/passkeys_platform_interface.dart';
+import 'package:passkeys_platform_interface/types/types.dart';
+
+/// Exercises the native passkey glue: the WebAuthn option normalization the
+/// authenticator libraries depend on, the PlatformException code → message
+/// table, and — through a [PasskeysPlatform] fake — that create()/get() hand
+/// the platform a well-formed, normalized typed request.
+void main() {
+  group('normalizeCreationOptions', () {
+    test('defaults excludeCredentials to an empty list when absent', () {
+      final normalized = passkeys.normalizeCreationOptions({
+        'challenge': 'Y2hhbGxlbmdl',
+      });
+      expect(normalized['excludeCredentials'], isEmpty);
+    });
+
+    test('defaults transports on descriptors and preserves base64url ids', () {
+      final normalized = passkeys.normalizeCreationOptions({
+        'excludeCredentials': [
+          {'type': 'public-key', 'id': 'dTlaVy1hYmNfMTIz-_'},
+          {
+            'type': 'public-key',
+            'id': 'b3RoZXI',
+            'transports': ['usb'],
+          },
+        ],
+      });
+      final descriptors = normalized['excludeCredentials'] as List;
+      expect(descriptors, hasLength(2));
+      expect(descriptors[0]['id'], 'dTlaVy1hYmNfMTIz-_',
+          reason: 'base64url ids must pass through untouched');
+      expect(descriptors[0]['transports'], isEmpty);
+      expect(descriptors[1]['transports'], ['usb'],
+          reason: 'existing transports must be preserved');
+    });
+
+    test("residentKey 'required' implies requireResidentKey", () {
+      final normalized = passkeys.normalizeCreationOptions({
+        'authenticatorSelection': {'residentKey': 'required'},
+      });
+      final selection = normalized['authenticatorSelection'] as Map;
+      expect(selection['requireResidentKey'], isTrue);
+      expect(selection['residentKey'], 'required');
+      expect(selection['userVerification'], 'preferred');
+    });
+
+    test("requireResidentKey true implies residentKey 'required'", () {
+      final normalized = passkeys.normalizeCreationOptions({
+        'authenticatorSelection': {'requireResidentKey': true},
+      });
+      final selection = normalized['authenticatorSelection'] as Map;
+      expect(selection['residentKey'], 'required');
+    });
+
+    test('an empty selection gets the preferred defaults', () {
+      final normalized = passkeys.normalizeCreationOptions({
+        'authenticatorSelection': <String, dynamic>{},
+      });
+      final selection = normalized['authenticatorSelection'] as Map;
+      expect(selection['requireResidentKey'], isFalse);
+      expect(selection['residentKey'], 'preferred');
+      expect(selection['userVerification'], 'preferred');
+    });
+
+    test('explicit selection values are never overwritten', () {
+      final normalized = passkeys.normalizeCreationOptions({
+        'authenticatorSelection': {
+          'requireResidentKey': false,
+          'residentKey': 'discouraged',
+          'userVerification': 'required',
+        },
+      });
+      final selection = normalized['authenticatorSelection'] as Map;
+      expect(selection['requireResidentKey'], isFalse);
+      expect(selection['residentKey'], 'discouraged');
+      expect(selection['userVerification'], 'required');
+    });
+
+    test('a missing authenticatorSelection stays missing', () {
+      final normalized = passkeys.normalizeCreationOptions({
+        'challenge': 'Y2hhbGxlbmdl',
+      });
+      expect(normalized.containsKey('authenticatorSelection'), isFalse);
+    });
+
+    test('does not mutate the input map', () {
+      final input = {
+        'excludeCredentials': [
+          {'type': 'public-key', 'id': 'aWQ'},
+        ],
+      };
+      passkeys.normalizeCreationOptions(input);
+      final descriptor = (input['excludeCredentials'] as List).first as Map;
+      expect(descriptor.containsKey('transports'), isFalse);
+    });
+  });
+
+  group('normalizeRequestOptions', () {
+    test('removes an empty or missing allowCredentials list', () {
+      expect(
+        passkeys.normalizeRequestOptions({'allowCredentials': <dynamic>[]}),
+        isNot(contains('allowCredentials')),
+      );
+      expect(
+        passkeys.normalizeRequestOptions({'challenge': 'Y2hhbGxlbmdl'}),
+        isNot(contains('allowCredentials')),
+      );
+      expect(
+        passkeys.normalizeRequestOptions({'allowCredentials': 'garbage'}),
+        isNot(contains('allowCredentials')),
+      );
+    });
+
+    test('keeps entries and defaults their transports', () {
+      final normalized = passkeys.normalizeRequestOptions({
+        'allowCredentials': [
+          {'type': 'public-key', 'id': 'Zmlyc3Q-_'},
+        ],
+      });
+      final credentials = normalized['allowCredentials'] as List;
+      expect(credentials.single['id'], 'Zmlyc3Q-_');
+      expect(credentials.single['transports'], isEmpty);
+    });
+  });
+
+  group('credentialDescriptors', () {
+    test('coerces non-lists to empty and filters non-map entries', () {
+      expect(passkeys.credentialDescriptors(null), isEmpty);
+      expect(passkeys.credentialDescriptors('nope'), isEmpty);
+      expect(
+        passkeys.credentialDescriptors([
+          'junk',
+          42,
+          {'type': 'public-key', 'id': 'aWQ'},
+        ]),
+        hasLength(1),
+      );
+    });
+  });
+
+  group('messageForPlatformException', () {
+    String messageFor(String code, {bool isLogin = false, String? message}) =>
+        passkeys.messageForPlatformException(
+          PlatformException(code: code, message: message),
+          isLogin: isLogin,
+        );
+
+    test('cancelled distinguishes sign-in from creation', () {
+      expect(messageFor('cancelled', isLogin: true),
+          'Passkey sign-in was cancelled.');
+      expect(messageFor('cancelled'), 'Passkey creation was cancelled.');
+    });
+
+    test('maps every known android-*/ios-* code', () {
+      final expected = <String, String>{
+        'domain-not-associated':
+            'This server is not associated with this app for native passkeys.',
+        'deviceNotSupported': 'This device does not support passkeys.',
+        'android-passkey-unsupported':
+            'This device does not support passkeys.',
+        'android-missing-google-sign-in':
+            'Sign in to a Google account before creating Android passkeys.',
+        'android-sync-account-not-available':
+            'The Android passkey sync account is not available. Try again after restarting the device.',
+        'android-no-create-option':
+            'No passkey provider is available. Enable a credential provider such as Bitwarden or Google Password Manager.',
+        'no-credentials-available': 'No passkey was found for this server.',
+        'android-no-credential': 'No passkey was found for this server.',
+        'exclude-credentials-match':
+            'A matching passkey is already registered on this device.',
+        'android-timeout': 'The passkey prompt timed out.',
+        'ios-security-key-timeout': 'The passkey prompt timed out.',
+      };
+      expected.forEach((code, message) {
+        expect(messageFor(code), message, reason: code);
+      });
+    });
+
+    test('unhandled codes surface the platform message when present', () {
+      expect(
+        messageFor('android-unhandled-CreateCredentialUnknownException',
+            message: 'Native detail'),
+        'Native detail',
+      );
+      expect(messageFor('ios-unhandled', message: null),
+          'Passkey authentication failed.');
+    });
+
+    test('unknown codes fall back to the generic message', () {
+      expect(messageFor('surprise-code', message: 'ignored'),
+          'Passkey authentication failed.');
+    });
+  });
+
+  group('create/get through a PasskeysPlatform fake', () {
+    late _FakePasskeysPlatform platform;
+    late PasskeysPlatform original;
+
+    setUp(() {
+      original = PasskeysPlatform.instance;
+      platform = _FakePasskeysPlatform();
+      PasskeysPlatform.instance = platform;
+    });
+
+    tearDown(() {
+      PasskeysPlatform.instance = original;
+    });
+
+    Map<String, dynamic> creationOptions() => {
+          'publicKey': {
+            'challenge': 'Y2hhbGxlbmdlLTEyMw',
+            'rp': {'id': 'media.example.com', 'name': 'Cantinarr'},
+            'user': {
+              'id': 'dXNlci0x',
+              'name': 'tester',
+              'displayName': 'Tester',
+            },
+            'excludeCredentials': [
+              {'type': 'public-key', 'id': 'ZXhpc3Rpbmc-_'},
+            ],
+            'authenticatorSelection': {'residentKey': 'required'},
+          },
+        };
+
+    test('create cancels any pending operation and registers a normalized '
+        'request', () async {
+      final response = await passkeys.create(creationOptions());
+
+      expect(platform.cancelCalls, 1);
+      final request = platform.lastRegister!;
+      expect(request.challenge, 'Y2hhbGxlbmdlLTEyMw');
+      expect(request.relyingParty.id, 'media.example.com');
+      expect(request.user.name, 'tester');
+      expect(request.excludeCredentials.single.id, 'ZXhpc3Rpbmc-_');
+      expect(request.excludeCredentials.single.transports, isEmpty,
+          reason: 'missing transports must be defaulted, or the typed '
+              'deserialization rejects the descriptor');
+      expect(request.authSelectionType?.requireResidentKey, isTrue);
+      expect(response['id'], 'cred-1');
+    });
+
+    test('create accepts options without a publicKey wrapper', () async {
+      final unwrapped =
+          creationOptions()['publicKey']! as Map<String, dynamic>;
+      await passkeys.create(unwrapped);
+      expect(platform.lastRegister, isNotNull);
+    });
+
+    test('create rejects unusable options with a FormatException', () async {
+      await expectLater(
+        passkeys.create({'publicKey': 'garbage'}),
+        throwsFormatException,
+      );
+    });
+
+    test('create maps a PlatformException to its user-facing message',
+        () async {
+      platform.registerError =
+          PlatformException(code: 'exclude-credentials-match');
+      await expectLater(
+        passkeys.create(creationOptions()),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          contains('A matching passkey is already registered on this device.'),
+        )),
+      );
+    });
+
+    test('get authenticates with required mediation and drops empty '
+        'allowCredentials', () async {
+      await passkeys.get({
+        'publicKey': {
+          'challenge': 'bG9naW4tY2hhbGxlbmdl',
+          'rpId': 'media.example.com',
+          'allowCredentials': <dynamic>[],
+        },
+      });
+
+      final request = platform.lastAuthenticate!;
+      expect(request.challenge, 'bG9naW4tY2hhbGxlbmdl');
+      expect(request.relyingPartyId, 'media.example.com');
+      expect(request.allowCredentials, isNull);
+      expect(request.mediation, MediationType.Required);
+      expect(request.preferImmediatelyAvailableCredentials, isFalse);
+    });
+
+    test('get defaults transports on allowed credentials', () async {
+      await passkeys.get({
+        'publicKey': {
+          'challenge': 'bG9naW4tY2hhbGxlbmdl',
+          'rpId': 'media.example.com',
+          'allowCredentials': [
+            {'type': 'public-key', 'id': 'a25vd24'},
+          ],
+        },
+      });
+
+      final credentials = platform.lastAuthenticate!.allowCredentials!;
+      expect(credentials.single.id, 'a25vd24');
+      expect(credentials.single.transports, isEmpty);
+    });
+
+    test('get maps a PlatformException using login wording', () async {
+      platform.authenticateError = PlatformException(code: 'cancelled');
+      await expectLater(
+        passkeys.get({
+          'publicKey': {
+            'challenge': 'bG9naW4',
+            'rpId': 'media.example.com',
+          },
+        }),
+        throwsA(isA<Exception>().having(
+          (e) => e.toString(),
+          'message',
+          contains('Passkey sign-in was cancelled.'),
+        )),
+      );
+    });
+  });
+}
+
+/// [PasskeysPlatform] fake that records the typed requests the service builds
+/// and returns canned WebAuthn responses (or throws a configured error).
+class _FakePasskeysPlatform extends PasskeysPlatform {
+  RegisterRequestType? lastRegister;
+  AuthenticateRequestType? lastAuthenticate;
+  Object? registerError;
+  Object? authenticateError;
+  int cancelCalls = 0;
+
+  @override
+  Future<void> cancelCurrentAuthenticatorOperation() async {
+    cancelCalls++;
+  }
+
+  @override
+  Future<AvailabilityType> getAvailability() async =>
+      AvailabilityTypeIOS(
+        hasPasskeySupport: true,
+        isNative: true,
+        hasBiometrics: true,
+      );
+
+  @override
+  Future<RegisterResponseType> register(RegisterRequestType request) async {
+    final error = registerError;
+    if (error != null) throw error;
+    lastRegister = request;
+    return const RegisterResponseType(
+      id: 'cred-1',
+      rawId: 'cred-1',
+      clientDataJSON: 'e30',
+      attestationObject: 'e30',
+      transports: ['internal'],
+    );
+  }
+
+  @override
+  Future<AuthenticateResponseType> authenticate(
+    AuthenticateRequestType request,
+  ) async {
+    final error = authenticateError;
+    if (error != null) throw error;
+    lastAuthenticate = request;
+    return const AuthenticateResponseType(
+      id: 'cred-1',
+      rawId: 'cred-1',
+      clientDataJSON: 'e30',
+      authenticatorData: 'e30',
+      signature: 'c2ln',
+      userHandle: 'dXNlci0x',
+    );
+  }
+}

--- a/app/test/core/device/device_identity_test.dart
+++ b/app/test/core/device/device_identity_test.dart
@@ -1,0 +1,233 @@
+import 'package:cantinarr/core/device/device_identity.dart';
+import 'package:cantinarr/core/storage/secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Exercises [DeviceIdentityService]: the Apple model-name table, web
+/// browser/OS labeling, and — critically — the persisted-UUID fallback used on
+/// platforms without a native hardware id (web, Android), which must survive
+/// logout so reconnects of the same physical device dedupe.
+void main() {
+  DeviceIdentityService service([Map<String, String?>? data]) =>
+      DeviceIdentityService(_FakeStorage(data ?? {}));
+
+  group('appleModelName', () {
+    test('maps known identifiers to marketing names', () {
+      const expected = <String, String>{
+        'iPhone12,1': 'Apple iPhone 11',
+        'iPhone14,6': 'Apple iPhone SE (3rd gen)',
+        'iPhone16,2': 'Apple iPhone 15 Pro Max',
+        'iPhone17,2': 'Apple iPhone 16 Pro Max',
+        'iPhone17,5': 'Apple iPhone 16e',
+      };
+      final svc = service();
+      expected.forEach((machine, name) {
+        expect(svc.appleModelName(machine), name, reason: machine);
+      });
+    });
+
+    test('falls back to the device class for unmapped models', () {
+      final svc = service();
+      expect(svc.appleModelName('iPhone99,9'), 'Apple iPhone');
+      expect(svc.appleModelName('iPad13,1'), 'Apple iPad');
+      expect(svc.appleModelName('iPod9,1'), 'Apple iPod touch');
+    });
+
+    test('recognizes simulators and passes anything else through raw', () {
+      final svc = service();
+      expect(svc.appleModelName('arm64'), 'iOS Simulator');
+      expect(svc.appleModelName('x86_64'), 'iOS Simulator');
+      expect(svc.appleModelName('i386'), 'iOS Simulator');
+      expect(svc.appleModelName('RealityDevice14,1'),
+          'Apple RealityDevice14,1',
+          reason: 'unknown ids keep the raw identifier as a usable fallback');
+    });
+  });
+
+  group('webDisplayName', () {
+    test('labels browser and OS from a platform hint', () {
+      final svc = service();
+      expect(svc.webDisplayName('chrome', 'MacIntel'), 'Chrome on macOS');
+      expect(svc.webDisplayName('firefox', 'Win32'), 'Firefox on Windows');
+      expect(svc.webDisplayName('edge', 'Linux x86_64'), 'Edge on Linux');
+    });
+
+    test('detects mobile platforms from navigator.platform-style hints', () {
+      final svc = service();
+      expect(svc.webDisplayName('safari', 'iPhone'), 'Safari on iOS');
+      expect(svc.webDisplayName('safari', 'iPad'), 'Safari on iOS');
+      expect(
+        svc.webDisplayName('chrome', 'Mozilla/5.0 (Android 15; Mobile)'),
+        'Chrome on Android',
+      );
+    });
+
+    test('omits the OS when the hint matches nothing', () {
+      expect(service().webDisplayName('chrome', ''), 'Chrome');
+      expect(service().webDisplayName('opera', 'FreeBSD'), 'Opera');
+    });
+  });
+
+  group('persistedId', () {
+    test('mints a UUID once and returns the same value afterwards', () async {
+      final data = <String, String?>{};
+      final svc = service(data);
+
+      final first = await svc.persistedId();
+      expect(first, isNotEmpty);
+      expect(data[StorageKeys.hardwareId], first,
+          reason: 'the generated id must be persisted');
+      expect(await svc.persistedId(), first);
+    });
+
+    test('returns an already-persisted id without overwriting it', () async {
+      final data = <String, String?>{StorageKeys.hardwareId: 'stable-id'};
+      expect(await service(data).persistedId(), 'stable-id');
+      expect(data[StorageKeys.hardwareId], 'stable-id');
+    });
+
+    test('survives a logout purge (which deliberately skips hardware_id)',
+        () async {
+      final data = <String, String?>{};
+      final original = await service(data).persistedId();
+
+      // Mirror AuthNotifier._clearStorage: every auth key is deleted on
+      // logout, but StorageKeys.hardwareId is deliberately not among them.
+      for (final key in [
+        StorageKeys.serverUrl,
+        StorageKeys.jwt,
+        StorageKeys.refreshToken,
+        StorageKeys.refreshTokenBackup,
+        StorageKeys.deviceId,
+        StorageKeys.sessionUser,
+        StorageKeys.sessionConnection,
+      ]) {
+        data.remove(key);
+      }
+
+      // A fresh service (new session after re-login) sees the same id.
+      expect(await service(data).persistedId(), original);
+    });
+  });
+
+  group('resolve', () {
+    test('uses the native hardware id when the platform provides one',
+        () async {
+      final data = <String, String?>{};
+      final svc = _StubbedIdentityService(
+        _FakeStorage(data),
+        identity: const DeviceIdentity(
+          displayName: 'Apple iPhone 16 Pro Max',
+          hardwareId: 'vendor-id-1',
+        ),
+      );
+
+      final identity = await svc.resolve();
+      expect(identity.displayName, 'Apple iPhone 16 Pro Max');
+      expect(identity.hardwareId, 'vendor-id-1');
+      expect(data.containsKey(StorageKeys.hardwareId), isFalse,
+          reason: 'no fallback UUID is minted when a native id exists');
+    });
+
+    test('falls back to the persisted UUID when the platform has no id '
+        '(web/Android) and keeps it across sessions', () async {
+      final data = <String, String?>{};
+      const identity =
+          DeviceIdentity(displayName: 'Google Pixel 8', hardwareId: '');
+
+      final first =
+          await _StubbedIdentityService(_FakeStorage(data), identity: identity)
+              .resolve();
+      expect(first.displayName, 'Google Pixel 8');
+      expect(first.hardwareId, isNotEmpty);
+      expect(first.hardwareId, data[StorageKeys.hardwareId]);
+
+      // Logout: auth keys purged, hardware_id retained.
+      data
+        ..remove(StorageKeys.jwt)
+        ..remove(StorageKeys.refreshToken)
+        ..remove(StorageKeys.deviceId);
+
+      final second =
+          await _StubbedIdentityService(_FakeStorage(data), identity: identity)
+              .resolve();
+      expect(second.hardwareId, first.hardwareId,
+          reason: 'the same physical device must dedupe across sessions');
+    });
+
+    test('degrades to a generic name plus the persisted UUID when the '
+        'platform read fails', () async {
+      final data = <String, String?>{};
+      final svc = _StubbedIdentityService(
+        _FakeStorage(data),
+        error: Exception('platform unavailable'),
+      );
+
+      final identity = await svc.resolve();
+      expect(identity.displayName, isNotEmpty,
+          reason: 'a read failure must never surface an empty name');
+      expect(identity.hardwareId, data[StorageKeys.hardwareId]);
+    });
+
+    test('memoizes the resolved identity per service instance', () async {
+      final storage = _FakeStorage({});
+      final svc = _StubbedIdentityService(
+        storage,
+        identity: const DeviceIdentity(displayName: 'Pixel', hardwareId: ''),
+      );
+
+      final first = await svc.resolve();
+      final readsAfterFirst = storage.reads;
+      final second = await svc.resolve();
+      expect(identical(first, second), isTrue);
+      expect(storage.reads, readsAfterFirst,
+          reason: 'a memoized resolve must not hit storage again');
+    });
+  });
+}
+
+/// [DeviceIdentityService] with the platform read stubbed out: the branch the
+/// real [DeviceIdentityService.readDeviceInfo] takes depends on the host OS,
+/// so tests inject the raw identity (or a failure) at that seam instead.
+class _StubbedIdentityService extends DeviceIdentityService {
+  _StubbedIdentityService(super.storage, {this.identity, this.error});
+
+  final DeviceIdentity? identity;
+  final Object? error;
+
+  @override
+  Future<DeviceIdentity> readDeviceInfo() async {
+    final failure = error;
+    if (failure != null) throw failure;
+    return identity!;
+  }
+}
+
+/// In-memory [StorageService] over a caller-owned map, with a read counter so
+/// memoization can be asserted.
+class _FakeStorage implements StorageService {
+  _FakeStorage(this._data);
+
+  final Map<String, String?> _data;
+  int reads = 0;
+
+  @override
+  Future<String?> read({required String key}) async {
+    reads++;
+    return _data[key];
+  }
+
+  @override
+  Future<void> write({required String key, required String? value}) async {
+    if (value == null) {
+      _data.remove(key);
+    } else {
+      _data[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({required String key}) async => _data.remove(key);
+
+  @override
+  Future<void> hardenAuthKeys() async {}
+}


### PR DESCRIPTION
## Summary

Gives three previously untestable app platform surfaces the smallest seams that make them unit-testable, plus 48 new hermetic tests. Everything is behavior-identical except one fix the new tests forced into the open (details below).

**Deep links (`app/lib/app.dart`)**
- New `deepLinkSourceProvider` (a `DeepLinkSource` with the initial-link `Future` and the running-link `Stream`; default implementation wraps `AppLinks`) so tests inject links without the platform channel.
- `_sameServer`/`_normalizeServer` are now top-level `sameServer`/`normalizeServer` with `@visibleForTesting` — logic unchanged.
- **Forced fix:** the `cantinarr://passkeys` handler navigated with `context.go` from `_CantinarrAppState`, which sits *above* `MaterialApp.router` — `GoRouter.of` walks up the tree and asserts there, and the surrounding `addPostFrameCallback` waits on a frame nothing schedules while the app is idle. The handler now navigates through `ref.read(appRouterProvider)` directly (the file's existing pattern in `_showAutodispatchDisabledSnack`). Without this the new routing tests pin a crash/stall.

**Passkeys (`app/lib/features/auth/data/passkey_service_native.dart`)**
- The pure helpers are public with `@visibleForTesting`: `normalizeCreationOptions`, `normalizeRequestOptions`, `credentialDescriptors`, `messageForPlatformException`. Bodies untouched.
- `create()`/`get()` are additionally proven end-to-end through a `PasskeysPlatform.instance` fake (the interface package is a direct dependency, and the platform class is designed for `extends`-based fakes).

**Device identity (`app/lib/core/device/device_identity.dart`)**
- `appleModelName` and a small `webDisplayName` composition are `@visibleForTesting`; `persistedId` likewise.
- The private `_read()` became `@protected @visibleForTesting readDeviceInfo()` so tests can stub the platform read. Verified `DeviceInfoPlatform.instance` *is* overridable, but chose this seam instead: which plugin branch runs depends on the host OS (`Platform.isMacOS` vs Linux CI), and `device_info_plus_platform_interface` is only a transitive dependency, so an instance-override test would be host-coupled and trip `depend_on_referenced_packages`.

**Not touched:** `push_service.dart` (owned by another PR today), docs/testing, pubspec (no new dependencies).

## New tests (48)

- `app/test/app_deep_links_test.dart` (14): `normalizeServer`/`sameServer` vectors (trailing slash, default port, host case, scheme-less, non-default port, base paths, unparseable input never throws — incl. pinning that an uppercase *scheme* does not match today); widget tests pumping `CantinarrApp` through the seam: connect links (initial + streamed) reach the auth flow verbatim, passkeys links route to `/settings/passkeys/new` for every normalized server variant and without a server param, mismatched servers and logged-out state never reach passkey creation, wrong-scheme/wrong-host/malformed links are ignored without navigating, and a throwing initial-link lookup is swallowed.
- `app/test/auth/passkey_service_native_test.dart` (21): creation/request option normalization vectors (base64url id passthrough, transports defaulting, residentKey/requireResidentKey inference, empty-`allowCredentials` removal, input non-mutation); the full `android-*`/`ios-*` code→message table incl. unhandled-with-message passthrough and unknown-code fallback; `create()`/`get()` through the platform fake asserting the normalized typed request (mediation `Required`, `preferImmediatelyAvailableCredentials` false), `publicKey` unwrapping, `FormatException` on garbage, and `PlatformException` mapping for both flows.
- `app/test/core/device/device_identity_test.dart` (13): Apple model table (known ids → marketing names, unknown → class/raw fallback, simulator ids); web browser/OS labels from platform and UA hints; the persisted-UUID fallback minted once, not overwritten, surviving a simulated logout purge (exactly the `_clearStorage` key set, which skips `hardware_id`), plus `resolve()` using a native id when present, falling back when absent or on a failed platform read, and memoizing.

## Verification

- `cd app && flutter analyze --no-fatal-infos` → No issues found
- `cd app && flutter test` → all 485 tests passed (437 pre-existing + 48 new)
- Reverted the local `generated_plugins.cmake` churn from `flutter pub get` before committing.
- Not run locally: `flutter build web --release` and the store build-only checks — left to CI.

## Docs checklist

- [x] No new routes, tools, env vars, tables, screens, or workflows — README/server/app docs unaffected (test seams + an internal navigation fix only).

Closes #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne