### PR TITLE
docs(testing): align catalog cases with the 2026-07-17 wave's behavior changes

### DIFF
--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -14,13 +14,13 @@ not machine-enforced claims.
 | Area | Case prefixes | Cases |
 |---|---|---:|
 | [Build, operations, usability, and release](catalog/baseline-operations-release.md) | BASE, OPS, UX, PERF, REL, EXP | 69 |
-| [Authentication, navigation, users, and security](catalog/auth-users-security.md) | AUTH, NAV, USER, SEC | 88 |
-| [Instances, realtime behavior, and push](catalog/instances-realtime-push.md) | INST, RT, PUSH | 65 |
+| [Authentication, navigation, users, and security](catalog/auth-users-security.md) | AUTH, NAV, USER, SEC | 89 |
+| [Instances, realtime behavior, and push](catalog/instances-realtime-push.md) | INST, RT, PUSH | 66 |
 | [Plex linking, libraries, and invitations](catalog/plex.md) | PLEX | 87 |
 | [Discovery and requests](catalog/discovery-requests.md) | DISC, REQ | 69 |
-| [Media services and download clients](catalog/media-services.md) | RAD, SON, BOOK, DOWN, TAUT | 91 |
+| [Media services and download clients](catalog/media-services.md) | RAD, SON, BOOK, DOWN, TAUT | 92 |
 | [Issues, AI, and MCP](catalog/issues-ai-mcp.md) | ISS, AI, MCP | 115 |
-| **Total** | | **584** |
+| **Total** | | **587** |
 
 ## Running the checklist
 

--- a/docs/testing/catalog/auth-users-security.md
+++ b/docs/testing/catalog/auth-users-security.md
@@ -42,6 +42,7 @@ Use the [run template](../run-template.md) to record executions of these cases.
 - [ ] `AUTH-034` · P0 · UI — On native, enter host with no scheme, HTTP/HTTPS, surrounding whitespace, one/many trailing slashes, malformed scheme/host, 404, refusal, TLS failure, and timeout; verify deterministic normalization plus editable, non-secret recovery copy.
 - [ ] `AUTH-035` · P0 · UI/API — Paste connect links with missing/wrong scheme, host, token, duplicate parameters, invalid encoding, whitespace, expired/reused token, and hostile extra parameters; verify safe rejection before unintended connection/session creation.
 - [ ] `AUTH-036` · P0 · UI — Redeem equivalent valid `cantinarr://connect` links by native deep link and paste; verify identical normalized server/account/device outcome, one token consumption, and an already-authenticated app does not switch accounts silently.
+- [ ] `AUTH-037` · P1 · UI — Open a `cantinarr://passkeys` deep link cold-start and while running; verify an authenticated app whose connected server matches the link's `server` parameter (after normalization, or with the parameter absent) lands on the new-passkey settings screen, while a signed-out app or a mismatched server lands on login — never a silent no-op.
 
 ## Navigation, shell, setup checklist, and cross-platform layout
 

--- a/docs/testing/catalog/instances-realtime-push.md
+++ b/docs/testing/catalog/instances-realtime-push.md
@@ -41,9 +41,9 @@ Use the [run template](../run-template.md) to record executions of these cases.
 - [ ] `RT-006` · P0 · LIVE — Send Radarr movie and Sonarr series add/delete/file-delete/grab events; verify only exact instance/media caches/statuses invalidate.
 - [ ] `RT-007` · P0 · LIVE — Import a movie and several episodes; verify availability/events and new-content notification once despite webhook + poll overlap.
 - [ ] `RT-008` · P0 · SEC — Send missing/wrong/query-string credentials, wrong instance type, path traversal/encoding, huge body, and malformed JSON; verify safe rejection and no access-log secret/query leakage.
-- [ ] `RT-009` · P0 · API — Connect WebSocket with valid/invalid/expired/revoked subprotocol auth; verify only the valid current user receives a connection.
+- [ ] `RT-009` · P0 · API — Connect WebSocket with valid/invalid/expired/revoked subprotocol auth; verify only the valid current user receives a connection and the accepted upgrade echoes the static `Bearer` subprotocol — never the token — so browser (web-build) clients can complete the handshake.
 - [ ] `RT-010` · P0 · SEC — Produce events for two users pinned to different instances plus admin-only events; verify each socket receives only authorized/relevant data.
-- [ ] `RT-011` · P0 · CHAOS — Drop network, restart server, rotate tokens, sleep/wake device, and reconnect; verify one subscription and refetch/backfill repairs missed state.
+- [ ] `RT-011` · P0 · CHAOS — Drop network, restart server, rotate tokens, sleep/wake device, and reconnect; verify one subscription and refetch/backfill repairs missed state, and that a client that stops reading is evicted without disrupting delivery to healthy sockets.
 - [ ] `RT-012` · P0 · API — Replay a valid authenticated webhook and deliver duplicate/out-of-order events; verify safe acknowledgement/idempotence, newer state never regresses, and duplicate content notification/action is suppressed.
 - [ ] `RT-013` · P1 · API/UI — Verify REST `partial` and any realtime variant map to one Partially Available state, including older/newer payload compatibility.
 - [ ] `RT-014` · P1 · CHAOS — Send malformed/version-skew/unknown events; verify ignored/generic-safe handling and polling repairs state without a crash.
@@ -65,15 +65,16 @@ Use the [run template](../run-template.md) to record executions of these cases.
 - [ ] `PUSH-009` · P0 · UI/API — Toggle every category independently, restart, and force save failure; verify persistence or optimistic rollback without changing other toggles.
 - [ ] `PUSH-010` · P0 · SEC — Forge admin-category preference as requester; verify SQL recipient selection still limits pending requests/issues/actions/Plex access requests to admins.
 - [ ] `PUSH-011` · P0 · LIVE — Submit a pending request; verify opted-in admins only, queue-depth badge, fixed body, and approval deep link.
-- [ ] `PUSH-012` · P0 · LIVE — Approve/deny a request; verify only its opted-in requester receives correct media identity and detail deep link.
+- [ ] `PUSH-012` · P0 · LIVE — Approve/deny a request; verify only its opted-in requester receives correct media identity and the movie/TV detail deep link (book decisions deep-link to the Books tab instead).
 - [ ] `PUSH-013` · P0 · LIVE — Import movie and multiple episodes; verify opted-in audiences, correct movie/series copy, title collapse keys, and no duplicate from poll/webhook overlap.
 - [ ] `PUSH-014` · P0 · LIVE — Promote an issue to actionable and create an agent action; verify admin pushes/deep links, and verify passive observing/recovering produces neither.
 - [ ] `PUSH-015` · P1 · LIVE — Trigger remediation circuit breaker; verify opted-in admins receive the settings deep link once with no model/user-supplied text.
 - [ ] `PUSH-016` · P0 · LIVE — Execute all Plex notification cases in `PLEX-050`–`PLEX-052` across multiple devices and verify exact preference separation.
-- [ ] `PUSH-017` · P0 · LIVE/UI — Tap every notification type from foreground, background, and terminated app; verify exact detail/approval/issue/action/users/Plex/settings destination and no duplicate navigation.
+- [ ] `PUSH-017` · P0 · LIVE/UI — Tap every notification type from foreground, background, and terminated app; verify exact detail/approval/issue/action/users/Plex/settings/Books-tab destination and no duplicate navigation.
 - [ ] `PUSH-018` · P1 · UI — Tap malformed payloads (missing/bad IDs, unknown type, wrong media type); verify safe no-op/fallback without opening an unrelated record.
 - [ ] `PUSH-019` · P0 · SEC — Put attacker-controlled text in usernames, titles, reports, agent output, and emails; verify lock-screen bodies remain server-authored templates and contain no secrets.
 - [ ] `PUSH-020` · P1 · LIVE — Fail one recipient among many; verify other sends complete and result/dead-token handling is per device.
 - [ ] `PUSH-021` · P1 · API — Verify 10-minute in-process dedupe suppresses duplicate source paths but a genuinely later event after the window sends again.
 - [ ] `PUSH-022` · P1 · CHAOS — Restart during fire-and-forget delivery or gateway timeout; verify app state remains correct, server does not block, and no false durable-delivery claim is shown.
 - [ ] `PUSH-023` · P1 · LIVE — Use self-test from preferences and admin per-user diagnostics; verify delivered/no-token/not-configured/partial/failure results and no test notification changes product badges.
+- [ ] `PUSH-024` · P1 · LIVE/UI — Tap a book request-decision notification (payload carries media_type book and no usable TMDB id); verify it opens the requester-facing Books tab — not a media detail route and not a silent no-op — from foreground, background, and terminated app.

--- a/docs/testing/catalog/media-services.md
+++ b/docs/testing/catalog/media-services.md
@@ -88,8 +88,8 @@ Run client-specific cases once for **each** of SABnzbd, qBittorrent, NZBGet, and
 - [ ] `DOWN-003` · P0 · LIVE — Pause and resume one active item per client; verify exact external item state and UI convergence.
 - [ ] `DOWN-004` · P0 · LIVE — Pause all and resume all per client; verify only the selected instance/client changes and commands are not repeated.
 - [ ] `DOWN-005` · P0 · LIVE — Remove a disposable item with data/files preserved; verify queue removal and data retention using that client's semantics.
-- [ ] `DOWN-006` · P0 · LIVE — Remove a disposable item with data/files deletion explicitly selected; verify confirmation and exact external deletion.
-- [ ] `DOWN-007` · P0 · UI — Cancel every remove dialog and verify no external mutation; delete-data must always default off.
+- [ ] `DOWN-006` · P0 · LIVE — Remove a disposable item with data/files deletion explicitly selected on SABnzbd, qBittorrent, and Transmission; verify confirmation and exact external deletion.
+- [ ] `DOWN-007` · P0 · UI — Cancel every remove dialog and verify no external mutation; where offered, delete-data must always default off.
 - [ ] `DOWN-008` · P0 · UI — Switch among multiple download clients while requests are in flight; verify queue/history/actions never target the previously selected instance.
 - [ ] `DOWN-009` · P1 · LIVE — Cover paused, queued, downloading, stalled, checking, seeding/post-processing, completed, warning, and failed statuses per applicable client; verify readable normalized labels.
 - [ ] `DOWN-010` · P1 · UI — Cover zero/unknown size, infinite/unknown ETA, zero speed, Unicode names, duplicate names with distinct IDs, and very large values; verify stable formatting and identity.
@@ -99,6 +99,7 @@ Run client-specific cases once for **each** of SABnzbd, qBittorrent, NZBGet, and
 - [ ] `DOWN-014` · P1 · LIVE — Verify WebSocket queue snapshots update rate/progress/state without duplicates, survive reconnect, and stop after leaving the module or forced auth loss from current-device revocation.
 - [ ] `DOWN-015` · P1 · SEC — Inspect URLs/logs/errors for client usernames, passwords, cookies, API keys, and torrent hashes where sensitive; verify appropriate scrubbing.
 - [ ] `DOWN-016` · P1 · UI — Verify queue/history tab state, pull-to-refresh, empty/error/retry, scroll restoration, and compact/wide layouts for every adapter without expecting nonexistent local filter/search.
+- [ ] `DOWN-017` · P1 · UI — Open the NZBGet remove dialog; verify it offers no delete-data checkbox, shows the hint that NZBGet removes the queue item only while downloaded files stay on disk, and confirming removal never requests file deletion.
 
 ## Tautulli
 


### PR DESCRIPTION
## Summary

Four merged PRs from the 2026-07-17 wave changed observable behavior without updating `docs/testing/` in the same change, as AGENTS.md requires. This PR aligns the master test checklist with shipped reality — edits where a case had drifted, new cases only where genuinely new observable behavior had none.

- **PR #214** — book request-decision push taps now open the Books tab (previously a silent no-op):
  - `PUSH-012` notes book decisions deep-link to the Books tab (movie/TV keep the detail deep link).
  - `PUSH-017`'s exact-destination list gains the Books tab.
  - New `PUSH-024` covers the book decision tap end to end (media_type `book`, no usable TMDB id).
- **PR #216** — websocket handshake and slow-client eviction:
  - `RT-009` now verifies the accepted upgrade echoes the static `Bearer` subprotocol — never the token — so browser (web-build) clients can complete the handshake.
  - `RT-011` now covers eviction of a client that stops reading without disrupting healthy sockets.
- **PR #220** — NZBGet remove dialog no longer offers delete-files:
  - `DOWN-006` scopes explicit delete-files removal to SABnzbd/qBittorrent/Transmission.
  - `DOWN-007` qualifies the default-off rule with "where offered".
  - New `DOWN-017` covers the NZBGet dialog: no checkbox, factual hint, and removal never requests file deletion.
- **PR #224** — `cantinarr://passkeys` deep link now actually navigates:
  - New `AUTH-037` covers matching/absent/mismatched `server` parameter and signed-out routing (new-passkey screen vs login).

Area counts and the total in `docs/testing/README.md` updated: 584 → 587 (AUTH+1, PUSH+1, DOWN+1).

## Verification

- `make check-test-automation` — passed:
  `test catalog valid: 587 parent cases; 3 Maestro flow(s) safety-checked, 3 mapped in suites`

Docs-only change; no server/app code touched, so `go test` / `flutter test` are unaffected (no behavior change to prove with a failing test).

## Docs checklist

- [x] `docs/testing/` catalog cases updated for the behavior changes (this PR's entire purpose)
- [x] `docs/testing/README.md` area table counts and total updated (584 → 587)
- [x] No other documented surface touched (`README.md`, `server/README.md`, `app/README.md`, `docs/store-release.md` unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne