### PR TITLE
chore(app): drive the real logout purge in the device-identity test; NZBGet README qualifier

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -77,7 +77,7 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 - **Full module** -- library with author drill-down, queue with Import Doctor, history, and wanted (missing / cutoff unmet).
 
 ### Downloads & Tautulli (admin)
-- **Unified download queue** across SABnzbd, qBittorrent, NZBGet, and Transmission: pause/resume all or per item, remove (optionally with data), speeds, ETAs -- live via WebSocket snapshots.
+- **Unified download queue** across SABnzbd, qBittorrent, NZBGet, and Transmission: pause/resume all or per item, remove (optionally with data; NZBGet removes the queue item only, files stay on disk), speeds, ETAs -- live via WebSocket snapshots.
 - **Tautulli** -- current Plex streams with quality/transcode badges, watch history, and top-stats.
 
 ### Issues & AI remediation

--- a/app/test/core/device/device_identity_test.dart
+++ b/app/test/core/device/device_identity_test.dart
@@ -1,5 +1,8 @@
 import 'package:cantinarr/core/device/device_identity.dart';
 import 'package:cantinarr/core/storage/secure_storage.dart';
+import 'package:cantinarr/features/auth/data/auth_service.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Exercises [DeviceIdentityService]: the Apple model-name table, web
@@ -85,24 +88,38 @@ void main() {
       expect(data[StorageKeys.hardwareId], 'stable-id');
     });
 
-    test('survives a logout purge (which deliberately skips hardware_id)',
-        () async {
+    test('survives the real logout purge (which deliberately skips '
+        'hardware_id)', () async {
       final data = <String, String?>{};
       final original = await service(data).persistedId();
 
-      // Mirror AuthNotifier._clearStorage: every auth key is deleted on
-      // logout, but StorageKeys.hardwareId is deliberately not among them.
-      for (final key in [
-        StorageKeys.serverUrl,
-        StorageKeys.jwt,
-        StorageKeys.refreshToken,
-        StorageKeys.refreshTokenBackup,
-        StorageKeys.deviceId,
-        StorageKeys.sessionUser,
-        StorageKeys.sessionConnection,
-      ]) {
-        data.remove(key);
-      }
+      // Build the REAL AuthNotifier over the same fake storage so the purge
+      // below runs its actual _clearStorage routine, not a mirrored key list.
+      // Storage holds no auth keys yet, so restore settles without touching
+      // the network.
+      final container = ProviderContainer(overrides: [
+        storageServiceProvider.overrideWithValue(_FakeStorage(data)),
+        authServiceProvider.overrideWithValue(_NoNetworkAuthService()),
+      ]);
+      addTearDown(container.dispose);
+      await container.read(authProvider.future);
+
+      // A full session now sits in storage alongside the persisted id.
+      data.addAll({
+        StorageKeys.serverUrl: 'http://localhost',
+        StorageKeys.jwt: 'access',
+        StorageKeys.refreshToken: 'refresh',
+        StorageKeys.refreshTokenBackup: 'refresh',
+        StorageKeys.deviceId: 'dev-1',
+        StorageKeys.sessionUser: '{}',
+        StorageKeys.sessionConnection: '{}',
+      });
+
+      // The production purge path (session expiry / logout).
+      await container.read(authProvider.notifier).onAuthExpired();
+
+      expect(data.keys.toSet(), {StorageKeys.hardwareId},
+          reason: 'the purge must delete every auth key — and nothing else');
 
       // A fresh service (new session after re-login) sees the same id.
       expect(await service(data).persistedId(), original);
@@ -200,6 +217,18 @@ class _StubbedIdentityService extends DeviceIdentityService {
     if (failure != null) throw failure;
     return identity!;
   }
+}
+
+/// [AuthService] that fails loudly if the notifier ever reaches for the
+/// network — the logout-purge test must exercise storage only.
+class _NoNetworkAuthService extends AuthService {
+  @override
+  Future<AuthResponse> refreshToken(String serverUrl, String refreshToken) =>
+      throw StateError('unexpected network call: refreshToken');
+
+  @override
+  Future<ServerConfig> fetchConfig(String serverUrl, String accessToken) =>
+      throw StateError('unexpected network call: fetchConfig');
 }
 
 /// In-memory [StorageService] over a caller-owned map, with a read counter so


### PR DESCRIPTION
## Summary

Addresses the device-identity-test and README bullets of #225.

- **`app/test/core/device/device_identity_test.dart`** — the `survives a logout purge` test hand-mirrored `AuthNotifier._clearStorage`'s key list, so it could never catch the purge starting to delete `StorageKeys.hardwareId`. It now constructs the **real `AuthNotifier`** (via a `ProviderContainer` with the fake storage and a fail-loud no-network `AuthService`, the same pattern as `auth_restore_test.dart`) and drives the production purge path (`onAuthExpired`). It asserts the purge deletes every seeded auth key — and nothing else — and that a fresh `DeviceIdentityService` still resolves the original persisted id. No production code changed.
- **`app/README.md`** — the downloads line's "remove (optionally with data)" now carries the NZBGet qualifier: the queue item only, files stay on disk, matching the behavior shipped in #220.

## Verification

- `flutter analyze --no-fatal-infos` — No issues found.
- `flutter test` — all 492 tests passed.
- **Fails-on-old-code proof**: temporarily added `await _storage.delete(key: StorageKeys.hardwareId);` to `_clearStorage`, and the reworked `persistedId survives the real logout purge` test failed (the old hand-mirrored version could not detect this); reverted the mutation and the suite is green again. That test is the proof for this PR's behavior claim.

## Docs

- [x] `app/README.md` updated (NZBGet remove qualifier) — no other documented surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne