### PR TITLE
feat(push): per-book deep links for book request decisions

### DIFF
--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -153,10 +153,12 @@ class PushService {
       case 'new_movie':
       case 'new_episode':
         // Books never carry a TMDB id (the server sends tmdb_id 0; a book is
-        // keyed on its Chaptarr foreignBookId, which isn't in the payload) and
-        // the app has no id-addressable book detail route, so a book decision
-        // lands on the requester-facing Books tab. Movie/TV open media detail;
-        // an unknown media_type keeps the movie fallback.
+        // keyed on its Chaptarr foreignBookId, which newer servers include as
+        // foreign_id on decision payloads). The app has no id-addressable book
+        // detail route yet — the Books tab is a search surface — so a book
+        // decision lands on the requester-facing Books tab regardless of
+        // whether foreign_id is present. Movie/TV open media detail; an
+        // unknown media_type keeps the movie fallback.
         if (data['media_type'] == 'book') {
           router.push('/dashboard/books');
           return;

--- a/app/test/notifications/push_service_test.dart
+++ b/app/test/notifications/push_service_test.dart
@@ -190,11 +190,11 @@ void main() {
       expect(h.router.pushed, ['/detail/movie/9', '/detail/movie/10']);
     });
 
-    // A book decision's custom payload is {type, tmdb_id: 0, media_type} —
-    // the server's passthrough forwards no decision/reason, and a book row
-    // stores tmdb_id 0 (books key on the Chaptarr foreignBookId, which isn't
-    // in the payload). With no id-addressable book detail route, approved and
-    // denied both land on the requester-facing Books tab.
+    // A book decision's custom payload is {type, tmdb_id: 0, media_type} from
+    // old servers, plus foreign_id (the Chaptarr foreignBookId) from newer
+    // ones — the server's passthrough forwards no decision/reason, and a book
+    // row stores tmdb_id 0. With no id-addressable book detail route, approved
+    // and denied both land on the requester-facing Books tab.
     for (final decision in const ['approved', 'denied']) {
       test('book request_decision ($decision) opens the Books tab', () async {
         final h = _Harness();
@@ -208,6 +208,21 @@ void main() {
         expect(h.router.pushed, ['/dashboard/books']);
       });
     }
+
+    test('book request_decision with a foreign_id opens the Books tab',
+        () async {
+      // Newer servers add foreign_id to book decision payloads. There is no
+      // id-addressable book detail route yet, so the additive field must not
+      // change (or break) the Books-tab routing.
+      final h = _Harness();
+      await _emitNativeCall('onNotificationTap', {
+        'type': 'request_decision',
+        'tmdb_id': 0,
+        'media_type': 'book',
+        'foreign_id': '29749107',
+      });
+      expect(h.router.pushed, ['/dashboard/books']);
+    });
 
     test('media_type book wins over a stray positive tmdb_id', () async {
       final h = _Harness();

--- a/server/README.md
+++ b/server/README.md
@@ -407,7 +407,7 @@ Notification categories (per-user preferences; admin-scoped ones are enforced in
 | `plex_access_request` | on | admins | a user shared their Plex email for a server invite (collapse-keyed per user; body says whether auto-invite already handled it) |
 | `plex_invite_sent` | on | requester | their Plex invite email went out (one-tap or auto) |
 
-Bodies are server-authored templates (untrusted text never hits the lock screen), sends are fire-and-forget with a 30s timeout, a 10-minute in-process dedupe window absorbs the overlap between queue polling and webhooks, and tokens the gateway reports dead are pruned automatically. Payloads carry deep-link data (`type`, `tmdb_id`/`issue_id`/`user_id`) the app routes on tap.
+Bodies are server-authored templates (untrusted text never hits the lock screen), sends are fire-and-forget with a 30s timeout, a 10-minute in-process dedupe window absorbs the overlap between queue polling and webhooks, and tokens the gateway reports dead are pruned automatically. Payloads carry deep-link data (`type`, `tmdb_id`/`issue_id`/`user_id`; book request decisions add `foreign_id`, the Chaptarr foreignBookId, since books store `tmdb_id` 0) the app routes on tap.
 
 ### Plex invites
 

--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -371,6 +371,12 @@ func passthrough(eventType string, data map[string]interface{}) map[string]any {
 	if v := str(data["media_type"]); v != "" {
 		out["media_type"] = v
 	}
+	// Books have no TMDB id; their identity is the Chaptarr foreignBookId.
+	// Only book request-decision events carry it, so movie/TV payloads are
+	// unchanged.
+	if v := str(data["foreign_id"]); v != "" {
+		out["foreign_id"] = v
+	}
 	return out
 }
 

--- a/server/internal/push/notifier_test.go
+++ b/server/internal/push/notifier_test.go
@@ -125,6 +125,43 @@ func TestNotifyUserRequestDecision(t *testing.T) {
 	if data["type"] != "request_decision" {
 		t.Errorf("data.type = %v, want request_decision", data["type"])
 	}
+	// Movie/TV rows carry no foreign_id — the field is book-only and must not
+	// appear in their payloads.
+	if v, ok := data["foreign_id"]; ok {
+		t.Errorf("data.foreign_id = %v, want absent for a movie decision", v)
+	}
+}
+
+// A book decision's payload carries the Chaptarr foreignBookId (books store
+// tmdb_id 0), so the app can deep-link the tap to the right book.
+func TestNotifyUserBookRequestDecisionCarriesForeignID(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (42, 'req', '', 'user')")
+	mustExec(t, database, "INSERT INTO notification_prefs (user_id, request_decision) VALUES (42, 1)")
+
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
+
+	n.NotifyUser(42, "request_decision", map[string]interface{}{
+		"decision":   "approved",
+		"tmdb_id":    0,
+		"media_type": "book",
+		"foreign_id": "29749107",
+		"title":      "Ahsoka (Star Wars)",
+		"status":     "requested",
+	})
+
+	body := cap.waitForNotification(t)
+	data, _ := body["data"].(map[string]any)
+	if data["type"] != "request_decision" || data["media_type"] != "book" {
+		t.Errorf("data = %v, want type/media_type request_decision/book", data)
+	}
+	if data["foreign_id"] != "29749107" {
+		t.Errorf("data.foreign_id = %v, want 29749107", data["foreign_id"])
+	}
 }
 
 func TestNotifyUserRequestDecisionSuppressedByDefault(t *testing.T) {

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -1757,13 +1757,20 @@ func (s *Service) ApproveRequest(adminID, requestID int64, override *DecisionOve
 	}
 
 	if s.notifier != nil {
-		s.notifier.NotifyUser(r.userID, "request_decision", map[string]interface{}{
+		data := map[string]interface{}{
 			"decision":   "approved",
 			"tmdb_id":    r.tmdbID,
 			"media_type": r.mediaType,
 			"title":      title,
 			"status":     newStatus,
-		})
+		}
+		// Books have no TMDB id (tmdb_id is 0); the Chaptarr foreignBookId is
+		// the identity a client can deep-link on. Movie/TV rows carry no
+		// foreign_id, so the field is omitted and their payloads are unchanged.
+		if r.foreignID != "" {
+			data["foreign_id"] = r.foreignID
+		}
+		s.notifier.NotifyUser(r.userID, "request_decision", data)
 	}
 	return &CreateResponse{Success: true, Status: newStatus, Title: title}, nil
 }
@@ -1788,14 +1795,20 @@ func (s *Service) DenyRequest(adminID, requestID int64, reason string) error {
 		return nil // already decided by a concurrent action
 	}
 	if s.notifier != nil {
-		s.notifier.NotifyUser(r.userID, "request_decision", map[string]interface{}{
+		data := map[string]interface{}{
 			"decision":   "denied",
 			"tmdb_id":    r.tmdbID,
 			"media_type": r.mediaType,
 			"title":      r.title,
 			"reason":     reason,
 			"status":     StatusDenied,
-		})
+		}
+		// Same as the approval event: book rows carry their foreignBookId for
+		// deep-linking; movie/TV payloads are unchanged.
+		if r.foreignID != "" {
+			data["foreign_id"] = r.foreignID
+		}
+		s.notifier.NotifyUser(r.userID, "request_decision", data)
 	}
 	return nil
 }

--- a/server/internal/request/service_approval_test.go
+++ b/server/internal/request/service_approval_test.go
@@ -394,6 +394,10 @@ func TestDenyRequest(t *testing.T) {
 	if ev.userID != uid || ev.data["decision"] != "denied" || ev.data["reason"] != "library full" {
 		t.Errorf("event = %+v, want denied with the reason", ev)
 	}
+	// foreign_id is book-only: a movie decision payload must not carry it.
+	if v, ok := ev.data["foreign_id"]; ok {
+		t.Errorf("event foreign_id = %v, want absent for a movie decision", v)
+	}
 
 	// The requester's own status now reads denied (nothing landed in any arr).
 	if st, err := s.GetUserStatus(uid, 550, "movie"); err != nil || st.Status != StatusDenied {

--- a/server/internal/request/service_book_test.go
+++ b/server/internal/request/service_book_test.go
@@ -522,6 +522,103 @@ func TestBookRequestMonitorsAndSearchesNewAuthorBook(t *testing.T) {
 	}
 }
 
+// TestApproveBookRequestNotifiesWithForeignID: approving a pending book request
+// notifies the requester with the Chaptarr foreignBookId in the event data —
+// books store tmdb_id 0, so foreign_id is the only identity a client can
+// deep-link the decision tap to.
+func TestApproveBookRequestNotifiesWithForeignID(t *testing.T) {
+	chaptarrServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/book/lookup":
+			_, _ = w.Write([]byte(`[
+				{
+					"title":"Ahsoka (Star Wars)","titleSlug":"ahsoka","foreignBookId":"29749107",
+					"author":{"authorName":"E.K. Johnston","foreignAuthorId":"gr:7418796"},
+					"editions":[{"foreignEditionId":"29749107","title":"Ahsoka (Star Wars)","links":[],"images":[]}]
+				}
+			]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/qualityprofile":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"E-Book"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/metadataprofile":
+			_, _ = w.Write([]byte(`[{"id":1,"name":"Standard"}]`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/rootfolder":
+			_, _ = w.Write([]byte(`[{"id":1,"path":"/books","accessible":true}]`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/book":
+			_, _ = w.Write([]byte(`{"id":42,"title":"Ahsoka (Star Wars)","foreignBookId":"29749107","monitored":true}`))
+		default:
+			http.Error(w, "unexpected route", http.StatusNotFound)
+		}
+	}))
+	defer chaptarrServer.Close()
+
+	svc, uid := newChaptarrBookTestService(t, chaptarrServer.URL)
+	rec := &recordingNotifier{}
+	svc.notifier = rec
+	requireApproval(t, svc)
+	adminID := createTestAdmin(t, svc)
+
+	if _, err := svc.CreateMediaRequest(uid, &CreateRequest{
+		MediaType: "book", ForeignID: "29749107", Title: "Ahsoka (Star Wars)", BookFormat: BookFormatEbook,
+	}); err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	pending, err := svc.ListPending()
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("ListPending = %+v err=%v, want exactly 1", pending, err)
+	}
+
+	if _, err := svc.ApproveRequest(adminID, pending[0].ID, nil); err != nil {
+		t.Fatalf("ApproveRequest: %v", err)
+	}
+	if len(rec.userEvents) != 1 {
+		t.Fatalf("user events = %+v, want exactly one decision", rec.userEvents)
+	}
+	ev := rec.userEvents[0]
+	if ev.userID != uid || ev.eventType != "request_decision" || ev.data["decision"] != "approved" {
+		t.Errorf("event = %+v, want an approved request_decision to the requester", ev)
+	}
+	if ev.data["media_type"] != "book" || ev.data["tmdb_id"] != 0 {
+		t.Errorf("event data = %#v, want media_type book with tmdb_id 0", ev.data)
+	}
+	if ev.data["foreign_id"] != "29749107" {
+		t.Errorf("event foreign_id = %v, want 29749107", ev.data["foreign_id"])
+	}
+}
+
+// TestDenyBookRequestNotifiesWithForeignID: the deny event carries the same
+// book identity (denial touches no arr, so only the DB path is exercised).
+func TestDenyBookRequestNotifiesWithForeignID(t *testing.T) {
+	s, uid := newBookTestService(t)
+	rec := &recordingNotifier{}
+	s.notifier = rec
+	adminID := createTestAdmin(t, s)
+
+	const fid = "goodreads:12345"
+	r := &resolvedRequest{userID: uid, mediaType: "book", foreignID: fid, title: "Some Book"}
+	if _, err := s.createPending(r); err != nil {
+		t.Fatalf("createPending: %v", err)
+	}
+	pending, err := s.ListPending()
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("ListPending = %+v err=%v, want exactly 1", pending, err)
+	}
+
+	if err := s.DenyRequest(adminID, pending[0].ID, "not now"); err != nil {
+		t.Fatalf("DenyRequest: %v", err)
+	}
+	if len(rec.userEvents) != 1 {
+		t.Fatalf("user events = %+v, want exactly one decision", rec.userEvents)
+	}
+	ev := rec.userEvents[0]
+	if ev.data["decision"] != "denied" || ev.data["media_type"] != "book" {
+		t.Errorf("event = %+v, want a denied book decision", ev)
+	}
+	if ev.data["foreign_id"] != fid {
+		t.Errorf("event foreign_id = %v, want %s", ev.data["foreign_id"], fid)
+	}
+}
+
 func TestAdminBookRequestsUseDefaultChaptarrWithoutUserGrant(t *testing.T) {
 	database, err := db.Open(":memory:")
 	if err != nil {


### PR DESCRIPTION
## Summary

Addresses the per-book deep-link bullet of #225.

- **Server:** book request rows store `tmdb_id` 0 — their identity is the Chaptarr foreignBookId — so a `request_decision` push carried nothing a client could deep-link on. Both decision events (`ApproveRequest`/`DenyRequest`) now include `foreign_id` for book rows, and the push `passthrough` forwards it into the APNs custom-data payload. The field is additive and omitted for movie/TV rows (their payloads are unchanged; explicit absence assertions were added), so old clients and existing tests stay valid.
- **App:** book decision taps keep routing to the requester-facing Books tab. No id-addressable book detail surface exists for requesters: the Books tab is a search list with inline request buttons (tiles have no tap target), and the Chaptarr book screens (`ChaptarrBookScreen` / book detail sheet) are admin-only and constructed from pre-loaded library-record lists, not reachable by id. Rather than invent a route with nothing honest behind it, the payload now delivers the identity a future book detail surface needs, the routing comments were updated, and a new test pins that the additive `foreign_id` does not disturb the Books-tab fallback.
- **Docs:** `server/README.md`'s push payload deep-link line now documents `foreign_id` on book decisions.

## Verification

- `cd server && go vet ./... && go test ./...` — all pass (Codex smoke self-skips locally, as normal).
- `cd app && flutter analyze --no-fatal-infos` — no issues; `flutter test` — 493 tests pass.
- Fail-on-old-code proof (server production changes temporarily reverted via `git stash`):
  - `TestApproveBookRequestNotifiesWithForeignID` fails (`event foreign_id = <nil>, want 29749107`)
  - `TestDenyBookRequestNotifiesWithForeignID` fails (`event foreign_id = <nil>, want goodreads:12345`)
  - `TestNotifyUserBookRequestDecisionCarriesForeignID` fails (`data.foreign_id = <nil>, want 29749107`)

  These three tests prove the behavior change. The app-side test (`book request_decision with a foreign_id opens the Books tab`) is a regression pin for the additive payload, not a behavior change — app routing is intentionally unchanged (see Summary).

## Docs checklist

- [x] `server/README.md` — push payload deep-link data updated to include `foreign_id`
- [x] `app/README.md` — no screen/navigation change (Books-tab routing unchanged), no update needed
- [x] `README.md` / `AGENTS.md` / `docs/store-release.md` — not touched by this surface
- [ ] `docs/testing/` — deliberately not touched: a parallel agent owns catalog alignment today

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne