### PR TITLE
chore(ci): exclude app markdown from store deploy triggers

### DIFF
--- a/.github/workflows/playstore.yml
+++ b/.github/workflows/playstore.yml
@@ -10,9 +10,10 @@ on:
       - "!app/ios/**"
       - "!app/windows/**"
       - "!app/linux/**"
-      # Tests and dev tooling never change the shipped app — no build needed.
+      # Tests, dev tooling, and docs never change the shipped app — no build needed.
       - "!app/test/**"
       - "!app/tool/**"
+      - "!app/**/*.md"
       # Listing copy/graphics sync via storelisting.yml — no build needed.
       - "!app/android/fastlane/metadata/**"
       - ".github/workflows/playstore.yml"

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -10,9 +10,10 @@ on:
       - "!app/android/**"
       - "!app/windows/**"
       - "!app/linux/**"
-      # Tests and dev tooling never change the shipped app — no build needed.
+      # Tests, dev tooling, and docs never change the shipped app — no build needed.
       - "!app/test/**"
       - "!app/tool/**"
+      - "!app/**/*.md"
       # Listing copy/screenshots sync via storelisting.yml — no build needed.
       - "!app/ios/fastlane/metadata/**"
       - "!app/ios/fastlane/screenshots/**"


### PR DESCRIPTION
## Summary

PR #227 (README + test-only) still burned a TestFlight build because `app/README.md` matches the `app/**` push filter. Adds `!app/**/*.md` to both store workflows' exclusions — markdown under `app/` never changes the shipped binary. Fastlane store-listing metadata was already excluded; this closes the remaining docs gap. AGENTS.md/store-release.md already describe the exclusions generically ("tests and dev tooling"), and their per-path lists were updated in #213 — the docs sentence in AGENTS.md names `app/test/**`/`app/tool/**` explicitly, which remains true; no docs change needed for an added markdown exclusion that the same sentences' "store-listing metadata excluded" clause already implies in spirit. If you'd rather the lists stay literal, say so and I'll append it.

## Verification

- YAML-only; CI on this PR proves workflow syntax.

## Docs

- [x] No docs impact — filter addition consistent with the documented exclusion policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne