### PR TITLE
test(server): pin CORS posture, WS Origin handling, and the Plex duplicate-share mapping

### DIFF
--- a/server/internal/api/cors_posture_test.go
+++ b/server/internal/api/cors_posture_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// These tests pin the CORS posture the /api router actually ships (#231).
+//
+// The middleware is configured with cors.Handler(AllowedOrigins: []string{})
+// under a "same-origin only" comment, but go-chi/cors v1.2.2 treats an empty
+// origin allowlist as ALLOW ALL ORIGINS (allowedOriginsAll), so cross-origin
+// requests are answered with Access-Control-Allow-Origin: * — the comment and
+// the behavior disagree. What keeps the wildcard from being a session-riding
+// hole is AllowCredentials: false plus Bearer-token auth (no cookies): a
+// cross-origin page can never attach a victim's credentials, so the wildcard
+// only makes non-credentialed responses readable cross-origin. These tests
+// pin exactly that shipped shape; tightening the allowlist to genuinely
+// same-origin is a deliberate change that must flip these assertions.
+// (The separate /mcp mount configures AllowedOrigins: ["*"] explicitly for
+// external MCP clients — that wildcard is intended, not covered here.)
+
+// corsRequest performs one request against the full router and returns the
+// recorder. token and origin are optional ("" omits the header).
+func corsRequest(router http.Handler, method, path, token, origin string, header map[string]string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	for k, v := range header {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	return rec
+}
+
+// assertNoCORSHeaders fails if any Access-Control-* header is present.
+func assertNoCORSHeaders(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	for key := range rec.Header() {
+		if strings.HasPrefix(key, "Access-Control-") {
+			t.Errorf("unexpected CORS header %s: %q", key, rec.Header().Get(key))
+		}
+	}
+}
+
+// TestAPICORSActualRequestPosture pins the headers a cross-origin (and an
+// origin-less) request receives on a representative public route and a
+// representative authenticated route.
+func TestAPICORSActualRequestPosture(t *testing.T) {
+	harness := newRBACRouterHarness(t, false)
+
+	routes := []struct {
+		name  string
+		path  string
+		token string
+	}{
+		{"public health", "/api/health", ""},
+		{"authenticated config", "/api/config", harness.adminToken},
+	}
+	for _, route := range routes {
+		t.Run(route.name+" cross-origin", func(t *testing.T) {
+			rec := corsRequest(harness.router, http.MethodGet, route.path, route.token, "https://attacker.example", nil)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			// Shipped behavior: the empty allowlist is allow-all, so the
+			// wildcard is reflected (see the file comment; #231).
+			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+				t.Fatalf("Access-Control-Allow-Origin = %q, want %q (go-chi/cors treats the empty allowlist as allow-all)", got, "*")
+			}
+			// The compensating control: the wildcard must never come with
+			// permission to send credentials.
+			if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+				t.Fatalf("Access-Control-Allow-Credentials = %q, want unset", got)
+			}
+			if got := rec.Header().Get("Access-Control-Expose-Headers"); got != "Link" {
+				t.Fatalf("Access-Control-Expose-Headers = %q, want %q", got, "Link")
+			}
+		})
+
+		// Native clients and the same-origin web build send no Origin header
+		// (browsers omit it on same-origin GETs): the response must carry no
+		// Access-Control-* headers at all.
+		t.Run(route.name+" without origin", func(t *testing.T) {
+			rec := corsRequest(harness.router, http.MethodGet, route.path, route.token, "", nil)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			assertNoCORSHeaders(t, rec)
+		})
+	}
+}
+
+// TestAPICORSPreflightPosture pins preflight handling: the CORS middleware
+// answers OPTIONS before auth ever runs (a browser preflight carries no
+// credentials, so 200-not-401 on a protected route is the standard shape),
+// reflecting the allow-all wildcard without a credential grant.
+func TestAPICORSPreflightPosture(t *testing.T) {
+	harness := newRBACRouterHarness(t, false)
+
+	for _, path := range []string{"/api/health", "/api/config"} {
+		t.Run(path, func(t *testing.T) {
+			rec := corsRequest(harness.router, http.MethodOptions, path, "", "https://attacker.example", map[string]string{
+				"Access-Control-Request-Method": http.MethodGet,
+			})
+			if rec.Code != http.StatusOK {
+				t.Fatalf("preflight status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+			}
+			if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+				t.Fatalf("Access-Control-Allow-Origin = %q, want %q (go-chi/cors treats the empty allowlist as allow-all)", got, "*")
+			}
+			if got := rec.Header().Get("Access-Control-Allow-Methods"); got != http.MethodGet {
+				t.Fatalf("Access-Control-Allow-Methods = %q, want %q", got, http.MethodGet)
+			}
+			if got := rec.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+				t.Fatalf("Access-Control-Allow-Credentials = %q, want unset", got)
+			}
+			if got := rec.Header().Get("Access-Control-Max-Age"); got != "300" {
+				t.Fatalf("Access-Control-Max-Age = %q, want %q", got, "300")
+			}
+		})
+	}
+}

--- a/server/internal/plex/handler_test.go
+++ b/server/internal/plex/handler_test.go
@@ -1,0 +1,102 @@
+package plex
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// newInviteHandlerEnv wires the real service — linked account (token
+// "secret-token" via link), configured server, seeded user 7 with a shared
+// email — behind the production route pattern, so tests exercise the same chi
+// param extraction InviteUser sees in NewRouter.
+func newInviteHandlerEnv(t *testing.T) (*fakeAPI, http.Handler) {
+	t.Helper()
+	svc, api, _ := newTestService(t)
+	link(t, svc, api)
+	if err := svc.UpdateSettings("machine-1", "Media", []int64{1, 2}, false); err != nil {
+		t.Fatalf("configure invites: %v", err)
+	}
+	seedUser(t, svc, 7, "alice", "alice@example.com")
+	h := NewHandler(svc, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	router := chi.NewRouter()
+	router.Post("/api/admin/users/{userID}/plex-invite", h.InviteUser)
+	return api, router
+}
+
+// TestInviteUserHandlerResponseMapping pins the handler's HTTP translation of
+// invite outcomes. The client maps plex.tv's 422 duplicate-share answer to
+// ErrAlreadyShared (client_test.go); the handler must present that as a 200
+// "already_shared" — an idempotent success, not an error — while a generic
+// upstream failure stays 502 with a fixed body that never echoes upstream
+// detail. No response may contain the linked Plex token.
+func TestInviteUserHandlerResponseMapping(t *testing.T) {
+	upstreamDetail := "plex.tv exploded; token=secret-token request-id=abc123"
+	tests := []struct {
+		name       string
+		inviteErr  error
+		wantStatus int
+		wantBody   map[string]string
+	}{
+		{
+			name:       "fresh invite",
+			inviteErr:  nil,
+			wantStatus: http.StatusOK,
+			wantBody:   map[string]string{"status": "invited", "email": "alice@example.com"},
+		},
+		{
+			name:       "duplicate share is an idempotent success",
+			inviteErr:  ErrAlreadyShared,
+			wantStatus: http.StatusOK,
+			wantBody:   map[string]string{"status": "already_shared", "email": "alice@example.com"},
+		},
+		{
+			name:       "generic upstream failure",
+			inviteErr:  errors.New(upstreamDetail),
+			wantStatus: http.StatusBadGateway,
+			wantBody:   map[string]string{"error": "Plex invite failed"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			api, router := newInviteHandlerEnv(t)
+			api.inviteErr = tt.inviteErr
+
+			req := httptest.NewRequest(http.MethodPost, "/api/admin/users/7/plex-invite", strings.NewReader("{}"))
+			rec := httptest.NewRecorder()
+			router.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if got := rec.Header().Get("Content-Type"); got != "application/json" {
+				t.Fatalf("Content-Type = %q, want application/json", got)
+			}
+			raw := rec.Body.String()
+			for _, sentinel := range []string{"secret-token", "request-id=abc123", "exploded"} {
+				if strings.Contains(raw, sentinel) {
+					t.Fatalf("response leaked %q: %s", sentinel, raw)
+				}
+			}
+			var body map[string]string
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode response %q: %v", raw, err)
+			}
+			if len(body) != len(tt.wantBody) {
+				t.Fatalf("body = %#v, want exactly %#v", body, tt.wantBody)
+			}
+			for key, want := range tt.wantBody {
+				if body[key] != want {
+					t.Fatalf("body[%q] = %q, want %q", key, body[key], want)
+				}
+			}
+		})
+	}
+}

--- a/server/internal/websocket/serve_ws_origin_test.go
+++ b/server/internal/websocket/serve_ws_origin_test.go
@@ -1,0 +1,78 @@
+package websocket
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// dialWithOrigin is dial with an explicit Origin request header ("" sends
+// none, which is what native dart:io clients do).
+func (e *wsTestEnv) dialWithOrigin(t *testing.T, token, origin string) (*websocket.Conn, *http.Response, error) {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(e.server.URL, "http")
+	dialer := websocket.Dialer{Subprotocols: []string{"Bearer", token}, HandshakeTimeout: 5 * time.Second}
+	var header http.Header
+	if origin != "" {
+		header = http.Header{"Origin": []string{origin}}
+	}
+	return dialer.Dial(wsURL, header)
+}
+
+// TestServeWSOriginPolicy pins ServeWS's Origin posture (#231). The hub's
+// upgrader is the zero-value gorilla Upgrader, so gorilla's default
+// CheckOrigin applies: a request with no Origin header (native clients) or
+// whose Origin host equals the request Host (the web build, served
+// same-origin) upgrades; any other Origin is refused with 403 at the upgrade
+// step — even when the caller presents a valid token, so a cross-site page in
+// a victim's browser can never open the socket. Overriding CheckOrigin (or
+// swapping websocket libraries) is a deliberate change that must flip this
+// test.
+func TestServeWSOriginPolicy(t *testing.T) {
+	env := newWSTestEnv(t)
+	token := env.userToken(t, "alice", "hw-alice").AccessToken
+	sameOrigin := "http://" + strings.TrimPrefix(env.server.URL, "http://")
+
+	t.Run("absent origin accepted (native clients)", func(t *testing.T) {
+		conn, resp, err := env.dialWithOrigin(t, token, "")
+		if err != nil {
+			t.Fatalf("dial without Origin: %v", err)
+		}
+		defer conn.Close()
+		if resp.StatusCode != http.StatusSwitchingProtocols {
+			t.Fatalf("status = %d, want 101", resp.StatusCode)
+		}
+		env.waitForClients(t, 1)
+	})
+	env.waitForClients(t, 0)
+
+	t.Run("same-origin accepted (web build)", func(t *testing.T) {
+		conn, resp, err := env.dialWithOrigin(t, token, sameOrigin)
+		if err != nil {
+			t.Fatalf("dial with same-origin %q: %v", sameOrigin, err)
+		}
+		defer conn.Close()
+		if resp.StatusCode != http.StatusSwitchingProtocols {
+			t.Fatalf("status = %d, want 101", resp.StatusCode)
+		}
+		env.waitForClients(t, 1)
+	})
+	env.waitForClients(t, 0)
+
+	t.Run("cross-origin refused even with a valid token", func(t *testing.T) {
+		conn, resp, err := env.dialWithOrigin(t, token, "https://attacker.example")
+		if err == nil {
+			conn.Close()
+			t.Fatal("cross-origin handshake succeeded, want rejection")
+		}
+		if resp == nil || resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("handshake response = %+v, want HTTP 403", resp)
+		}
+		if got := len(env.clientsSnapshot()); got != 0 {
+			t.Fatalf("cross-origin handshake registered %d client(s), want 0", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Test-only PR covering the three server automation-debt pins from the checklist trim. Addresses the server bullets of #231 (app bullets land in a parallel PR — do not close the issue).

- **CORS posture** (`server/internal/api/cors_posture_test.go`): the `/api` router is *not* CORS-less — it mounts `go-chi/cors` with `AllowedOrigins: []string{}` under a "same-origin only" comment, but go-chi/cors v1.2.2 treats an empty allowlist as **allow-all**, so cross-origin requests are answered with `Access-Control-Allow-Origin: *`. The tests pin the shipped posture on a representative public route (`/api/health`) and authenticated route (`/api/config`): the reflected wildcard, `Access-Control-Allow-Credentials` never set (the compensating control — Bearer auth means no ambient credentials to ride), zero `Access-Control-*` headers when no `Origin` is sent (native clients), and the pre-auth preflight shape (200, `Allow-Methods`, `Max-Age: 300`, no credential grant). The comment/behavior mismatch is pinned + flagged, not fixed (see caveats).
- **WebSocket Origin handling** (`server/internal/websocket/serve_ws_origin_test.go`): the hub's upgrader is the zero-value gorilla `Upgrader`, so the default `CheckOrigin` applies. Pinned: absent-Origin (native clients) and same-origin (web build) handshakes upgrade with 101; a cross-origin handshake is refused with 403 at the upgrade step **even with a valid token**, and registers no client. This posture is safe as-is.
- **Plex duplicate-share handler mapping** (`server/internal/plex/handler_test.go`): the client's 422 → `ErrAlreadyShared` mapping was already tested; the handler's translation was not. Pinned through the production chi route pattern: already-shared → 200 `{"status":"already_shared","email":…}` (idempotent success), fresh invite → 200 `{"status":"invited",…}`, generic upstream failure → 502 with the fixed `{"error":"Plex invite failed"}` body — with exact-key body-shape assertions and sentinels proving no response leaks the linked Plex token or upstream error detail.

## Verification

- `cd server && go vet ./...` — clean
- `cd server && go test ./...` — all packages pass (Codex CI smoke self-skips locally — normal)
- `cd server && go test -race ./internal/websocket/ ./internal/api/ ./internal/plex/` — pass

Test-only change: no production code touched, so there is no old-code behavior for these tests to fail against — they pin current behavior so future changes to these surfaces are test-visible.

## Docs checklist

- [x] No documented surface changed (no new route, tool, env var, table, screen, or workflow) — README/server README/app README/AGENTS.md untouched
- [x] `docs/testing/` untouched (no manual-only surface changed)

## Caveats

- **CORS comment vs behavior**: `server/internal/api/router.go` says "CORS: same-origin only" but the empty `AllowedOrigins` list makes go-chi/cors allow **all** origins. Practical exposure is limited — `AllowCredentials: false` plus cookie-less Bearer auth means a cross-origin page can't attach a victim's credentials; the wildcard only makes non-credentialed responses (public endpoints, rate-limited auth endpoints) readable cross-origin. Pinned as shipped per the task; tightening the config to genuinely same-origin (and flipping these assertions) is a follow-up decision. The `/mcp` mount's explicit `AllowedOrigins: ["*"]` is intended for external MCP clients and left uncovered.

Addresses the server bullets of #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne