### PR TITLE
test(app): cross-server state isolation, WS reconnect repair, host normalization vectors

### DIFF
--- a/app/lib/core/network/websocket_client.dart
+++ b/app/lib/core/network/websocket_client.dart
@@ -31,6 +31,14 @@ class WebSocketClient extends ChangeNotifier {
   final String? Function() _getServerUrl;
   final String? Function() _getAccessToken;
 
+  /// Creates the underlying channel. Production always uses
+  /// [WebSocketChannel.connect]; tests inject a factory so the
+  /// connect → drop → reconnect lifecycle can be driven with fake streams
+  /// instead of real sockets.
+  @visibleForTesting
+  final WebSocketChannel Function(Uri uri, {Iterable<String>? protocols})
+      connectChannel;
+
   WebSocketChannel? _channel;
   StreamSubscription? _subscription;
   Timer? _reconnectTimer;
@@ -46,8 +54,11 @@ class WebSocketClient extends ChangeNotifier {
   WebSocketClient({
     required String? Function() getServerUrl,
     required String? Function() getAccessToken,
+    WebSocketChannel Function(Uri uri, {Iterable<String>? protocols})?
+        connectChannel,
   })  : _getServerUrl = getServerUrl,
-        _getAccessToken = getAccessToken;
+        _getAccessToken = getAccessToken,
+        connectChannel = connectChannel ?? WebSocketChannel.connect;
 
   /// Starts the connection on first call; subsequent calls are no-ops.
   /// Reconnection after that is handled internally with backoff.
@@ -77,7 +88,7 @@ class WebSocketClient extends ChangeNotifier {
           .replaceFirst('https://', 'wss://')
           .replaceFirst('http://', 'ws://');
 
-      final channel = WebSocketChannel.connect(
+      final channel = connectChannel(
         Uri.parse('$wsUrl/api/ws'),
         protocols: ['Bearer', accessToken],
       );

--- a/app/test/auth/server_switch_isolation_test.dart
+++ b/app/test/auth/server_switch_isolation_test.dart
@@ -1,0 +1,381 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/device/device_identity.dart';
+import 'package:cantinarr/core/models/app_module.dart';
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/network/websocket_client.dart';
+import 'package:cantinarr/core/providers/instance_provider.dart';
+import 'package:cantinarr/core/providers/module_provider.dart';
+import 'package:cantinarr/core/providers/realtime_provider.dart';
+import 'package:cantinarr/core/storage/secure_storage.dart';
+import 'package:cantinarr/features/auth/data/auth_service.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/notifications/push_service.dart';
+import 'package:cantinarr/features/request/logic/pending_approvals_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _serverA = 'https://server-a.example.com';
+const _serverB = 'https://server-b.example.com';
+
+/// Cross-server cached-state isolation: when the auth flow connects to a
+/// DIFFERENT server, nothing user-visible from the old server may bleed
+/// through. The app's isolation mechanism is that every per-server provider
+/// keys off [authProvider] (directly, or via [backendClientProvider]'s
+/// serverUrl select) — these tests pin that contract end to end through the
+/// real [AuthNotifier], and pin that secure storage (single-slot, not keyed
+/// per server) is fully overwritten by the switch so a later cold-start
+/// restore cannot resurrect old-server state.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('connecting to a different server drops all old-server state',
+      () async {
+    final storage = _MemoryStorage();
+    final container = ProviderContainer(overrides: [
+      authServiceProvider.overrideWithValue(_FakeAuthService()),
+      storageServiceProvider.overrideWithValue(storage),
+      deviceIdentityProvider
+          .overrideWithValue(_FakeDeviceIdentityService(storage)),
+      pushServiceProvider.overrideWith(_NoopPushService.new),
+      // Keep the realtime stream inert; the socket lifecycle itself is
+      // asserted via provider identity below.
+      realtimeEventsProvider.overrideWithValue(const Stream<WsEvent>.empty()),
+    ]);
+    addTearDown(container.dispose);
+
+    // Keep the per-server providers alive across the switch, like the
+    // widgets that watch them at runtime.
+    for (final listen in [
+      () => container.listen(instanceProvider, (_, __) {}),
+      () => container.listen(moduleProvider, (_, __) {}),
+      () => container.listen(backendClientProvider, (_, __) {}),
+      () => container.listen(webSocketClientProvider, (_, __) {}),
+    ]) {
+      addTearDown(listen().close);
+    }
+
+    expect((await container.read(authProvider.future)).isAuthenticated, isFalse,
+        reason: 'clean install: nothing to restore');
+
+    // ── Connect to server A and take non-default, user-visible state. ──
+    final notifier = container.read(authProvider.notifier);
+    await notifier.connectWithToken(_serverA, 'token-a');
+
+    final stateA = container.read(authProvider).valueOrNull!;
+    expect(stateA.isAuthenticated, isTrue);
+    expect(stateA.connection!.serverUrl, _serverA);
+    expect(stateA.user!.username, 'admin-a');
+
+    var instances = container.read(instanceProvider);
+    expect(instances.radarrInstances.map((i) => i.id),
+        ['a-radarr-main', 'a-radarr-4k']);
+    expect(instances.sonarrInstances.map((i) => i.id), ['a-sonarr-main']);
+    container.read(instanceProvider.notifier)
+        .setActiveRadarrInstance('a-radarr-4k');
+    expect(container.read(instanceProvider).activeRadarrInstance!.id,
+        'a-radarr-4k');
+
+    expect(_labels(container.read(moduleProvider).modules),
+        ['Discover', 'Radarr', 'Sonarr']);
+    container.read(moduleProvider.notifier)
+        .setActiveModule(ModuleType.radarr);
+    expect(container.read(moduleProvider).activeModuleType, ModuleType.radarr);
+
+    expect(container.read(backendClientProvider).options.baseUrl, _serverA);
+    final socketA = container.read(webSocketClientProvider);
+
+    // ── Switch: the auth flow connects to server B. ──
+    await notifier.connectWithToken(_serverB, 'token-b');
+
+    final stateB = container.read(authProvider).valueOrNull!;
+    expect(stateB.connection!.serverUrl, _serverB);
+    expect(stateB.user!.username, 'admin-b');
+
+    // Instance config is server B's; the server-A selection is gone.
+    instances = container.read(instanceProvider);
+    expect(instances.radarrInstances.map((i) => i.id), ['b-radarr-main']);
+    expect(instances.sonarrInstances, isEmpty);
+    expect(instances.activeRadarrInstance!.id, 'b-radarr-main',
+        reason: "server A's '4K' selection must not survive the switch");
+
+    // Module state rebuilds from server B and lands back on Discover.
+    final modules = container.read(moduleProvider);
+    expect(_labels(modules.modules), ['Discover', 'Radarr', 'AI Assistant']);
+    expect(modules.activeModuleType, ModuleType.dashboard,
+        reason: 'the active module must reset, not stay on a server-A screen');
+
+    // The HTTP client and the websocket client are rebuilt for server B.
+    expect(container.read(backendClientProvider).options.baseUrl, _serverB);
+    expect(identical(container.read(webSocketClientProvider), socketA), isFalse,
+        reason: 'a server switch must tear down the old socket client');
+
+    // Storage holds ONLY server B: tokens, and the cold-start session
+    // snapshot a later launch would restore optimistically from.
+    expect(storage.values[StorageKeys.serverUrl], _serverB);
+    expect(storage.values[StorageKeys.jwt], 'b-access');
+    expect(storage.values[StorageKeys.refreshToken], 'b-refresh');
+    expect(storage.values[StorageKeys.refreshTokenBackup], 'b-refresh');
+    expect(storage.values[StorageKeys.deviceId], 'b-device');
+    final snapshot = jsonDecode(storage.values[StorageKeys.sessionConnection]!)
+        as Map<String, dynamic>;
+    expect(snapshot['server_name'], 'Server B');
+    expect(
+      (snapshot['instances'] as List<dynamic>)
+          .map((i) => (i as Map<String, dynamic>)['id'])
+          .toList(),
+      ['b-radarr-main'],
+      reason: 'no server-A instance may linger in the restore snapshot',
+    );
+    final user = jsonDecode(storage.values[StorageKeys.sessionUser]!)
+        as Map<String, dynamic>;
+    expect(user['username'], 'admin-b');
+  });
+
+  test(
+      'a stale in-flight approvals fetch from the old server cannot '
+      "overwrite the new server's requests badge", () async {
+    final auth = _MutableAuthNotifier(_adminStateFor(_serverA));
+    final adapter = _PerHostApprovalsAdapter();
+    final container = ProviderContainer(overrides: [
+      authProvider.overrideWith(() => auth),
+      // Mirrors the real backendClientProvider contract: a new Dio keyed on
+      // the connection's serverUrl, so the fetch target follows the switch.
+      backendClientProvider.overrideWith((ref) {
+        final serverUrl = ref.watch(
+          authProvider.select((s) => s.valueOrNull?.connection?.serverUrl),
+        );
+        return Dio(BaseOptions(baseUrl: serverUrl ?? 'http://localhost'))
+          ..httpClientAdapter = adapter;
+      }),
+      realtimeEventsProvider.overrideWithValue(const Stream<WsEvent>.empty()),
+      pushServiceProvider.overrideWith(_NoopPushService.new),
+    ]);
+    addTearDown(container.dispose);
+
+    await container.read(authProvider.future);
+    final subscription = container.listen<int>(
+      pendingApprovalsProvider,
+      (_, __) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+
+    // Server A's approvals fetch is in flight (slow server) …
+    await _waitFor(() => adapter.serverACalls == 1);
+
+    // … when the user switches to server B, whose queue holds ONE request.
+    auth.setAuth(_adminStateFor(_serverB));
+    await _waitFor(() => container.read(pendingApprovalsLoadedProvider));
+    expect(container.read(pendingApprovalsProvider), 1);
+
+    // Server A finally answers with its three pending requests. The stale
+    // response must be discarded, not shown as server B's queue.
+    adapter.completeServerA([
+      {'id': 11, 'title': 'Stale A'},
+      {'id': 12, 'title': 'Stale B'},
+      {'id': 13, 'title': 'Stale C'},
+    ]);
+    await pumpEventQueue();
+
+    expect(container.read(pendingApprovalsProvider), 1,
+        reason: "server A's queue depth must never appear on server B");
+    expect(container.read(pendingApprovalsLoadedProvider), isTrue);
+  });
+}
+
+List<String> _labels(List<AppModule> modules) =>
+    modules.map((m) => m.label).toList();
+
+AuthState _adminStateFor(String serverUrl) => AuthState(
+      connection: BackendConnection(
+        serverUrl: serverUrl,
+        accessToken: 'access',
+        refreshToken: 'refresh',
+      ),
+      user: const UserProfile(id: 1, username: 'admin', role: 'admin'),
+    );
+
+Future<void> _waitFor(bool Function() condition) async {
+  final deadline = DateTime.now().add(const Duration(seconds: 2));
+  while (!condition() && DateTime.now().isBefore(deadline)) {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+  }
+  expect(condition(), isTrue);
+}
+
+/// Canned two-server backend: connect tokens and configs are answered per
+/// server URL, so the real [AuthNotifier] can run its full connect flow
+/// against both servers without a network.
+class _FakeAuthService extends AuthService {
+  static const _configs = {
+    _serverA: ServerConfig(
+      serverName: 'Server A',
+      serverVersion: '1.0.0',
+      services: AvailableServices(radarr: true, sonarr: true),
+      instances: [
+        ServiceInstance(
+          id: 'a-radarr-main',
+          serviceType: 'radarr',
+          name: 'Main Radarr',
+          isDefault: true,
+        ),
+        ServiceInstance(
+          id: 'a-radarr-4k',
+          serviceType: 'radarr',
+          name: '4K Radarr',
+        ),
+        ServiceInstance(
+          id: 'a-sonarr-main',
+          serviceType: 'sonarr',
+          name: 'Main Sonarr',
+          isDefault: true,
+        ),
+      ],
+    ),
+    _serverB: ServerConfig(
+      serverName: 'Server B',
+      serverVersion: '1.1.0',
+      services: AvailableServices(radarr: true, ai: true),
+      instances: [
+        ServiceInstance(
+          id: 'b-radarr-main',
+          serviceType: 'radarr',
+          name: 'Radarr',
+          isDefault: true,
+        ),
+      ],
+    ),
+  };
+
+  static const _users = {
+    _serverA: UserProfile(id: 1, username: 'admin-a', role: 'admin'),
+    _serverB: UserProfile(id: 7, username: 'admin-b', role: 'admin'),
+  };
+
+  String _slot(String serverUrl) => serverUrl == _serverA ? 'a' : 'b';
+
+  @override
+  Future<AuthResponse> redeemConnectToken(
+    String serverUrl,
+    String token,
+    String deviceName,
+    String hardwareId,
+  ) async {
+    final slot = _slot(serverUrl);
+    return AuthResponse(
+      accessToken: '$slot-access',
+      refreshToken: '$slot-refresh',
+      user: _users[serverUrl]!,
+      deviceId: '$slot-device',
+    );
+  }
+
+  @override
+  Future<ServerConfig> fetchConfig(String serverUrl, String accessToken) async {
+    expect(accessToken, '${_slot(serverUrl)}-access',
+        reason: "config must be fetched with the target server's own token");
+    return _configs[serverUrl]!;
+  }
+}
+
+/// In-memory [StorageService]; exposes [values] so tests can assert exactly
+/// what a later cold start would restore from.
+class _MemoryStorage implements StorageService {
+  final Map<String, String> values = {};
+
+  @override
+  Future<String?> read({required String key}) async => values[key];
+
+  @override
+  Future<void> write({required String key, required String? value}) async {
+    if (value == null) {
+      values.remove(key);
+    } else {
+      values[key] = value;
+    }
+  }
+
+  @override
+  Future<void> delete({required String key}) async {
+    values.remove(key);
+  }
+
+  @override
+  Future<void> hardenAuthKeys() async {}
+}
+
+class _FakeDeviceIdentityService extends DeviceIdentityService {
+  _FakeDeviceIdentityService(super.storage);
+
+  @override
+  Future<DeviceIdentity> resolve() async =>
+      const DeviceIdentity(displayName: 'Test Device', hardwareId: 'hw-test');
+}
+
+/// Push is platform-channel territory; auth flows only need it to be inert.
+class _NoopPushService extends PushService {
+  _NoopPushService(super.ref);
+
+  @override
+  Future<void> registerForPush() async {}
+
+  @override
+  Future<void> setBadgeCount(int count) async {}
+}
+
+class _MutableAuthNotifier extends AuthNotifier {
+  _MutableAuthNotifier(this._initial);
+
+  final AuthState _initial;
+
+  @override
+  Future<AuthState> build() async => _initial;
+
+  void setAuth(AuthState value) => state = AsyncData(value);
+}
+
+/// Admin-approvals endpoint fake that answers per server: server A's
+/// response is deferred until the test releases it; server B answers
+/// immediately with a single pending request.
+class _PerHostApprovalsAdapter implements HttpClientAdapter {
+  final _serverAResponse = Completer<ResponseBody>();
+  int serverACalls = 0;
+  int serverBCalls = 0;
+
+  void completeServerA(List<Map<String, dynamic>> requests) {
+    _serverAResponse.complete(_json(requests));
+  }
+
+  static ResponseBody _json(Object body) => ResponseBody.fromString(
+        jsonEncode(body),
+        200,
+        headers: {
+          'content-type': ['application/json'],
+        },
+      );
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    if (options.uri.host == 'server-a.example.com') {
+      serverACalls++;
+      return _serverAResponse.future;
+    }
+    serverBCalls++;
+    return Future.value(_json([
+      {'id': 21, 'title': 'Server B request'},
+    ]));
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/app/test/auth/server_url_entry_test.dart
+++ b/app/test/auth/server_url_entry_test.dart
@@ -1,0 +1,172 @@
+import 'package:cantinarr/core/device/device_identity.dart';
+import 'package:cantinarr/core/storage/secure_storage.dart';
+import 'package:cantinarr/features/auth/data/auth_service.dart';
+import 'package:cantinarr/features/auth/data/server_status.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Normalization of the server URL a user TYPES on the connect screen.
+///
+/// This is `AuthNotifier._normalizeUrl`, observed through the URLs the
+/// notifier hands to its [AuthService] — it is NOT `normalizeServer` in
+/// app.dart, which only canonicalizes URLs for same-server comparison and is
+/// already covered by test/app_deep_links_test.dart (PR #224). The entry
+/// path differs: it never lowercases (the URL is used verbatim as the base
+/// URL) and it strips at most ONE trailing slash.
+void main() {
+  Future<_Harness> harness() async {
+    final service = _RecordingAuthService();
+    final storage = _EmptyStorage();
+    final container = ProviderContainer(overrides: [
+      authServiceProvider.overrideWithValue(service),
+      storageServiceProvider.overrideWithValue(storage),
+      deviceIdentityProvider
+          .overrideWithValue(_FakeDeviceIdentityService(storage)),
+    ]);
+    addTearDown(container.dispose);
+    await container.read(authProvider.future);
+    return (container: container, service: service);
+  }
+
+  /// Runs the entry-path normalization on [input] via [AuthNotifier.checkServer]
+  /// and returns the URL the server-status probe was sent to.
+  Future<String> normalized(String input) async {
+    final h = await harness();
+    await h.container.read(authProvider.notifier).checkServer(input);
+    return h.service.statusUrls.single;
+  }
+
+  test('infers https:// for a bare hostname', () async {
+    expect(await normalized('media.example.com'), 'https://media.example.com');
+  });
+
+  test('trims surrounding whitespace before inferring the scheme', () async {
+    expect(
+      await normalized('  media.example.com \n'),
+      'https://media.example.com',
+      reason: 'pasted URLs often carry spaces/newlines; they must not end up '
+          'inside the URL or defeat the scheme probe',
+    );
+  });
+
+  test('keeps an explicit http:// (LAN servers without TLS)', () async {
+    expect(
+      await normalized('http://192.168.1.20:8585'),
+      'http://192.168.1.20:8585',
+    );
+  });
+
+  test('strips a trailing slash', () async {
+    expect(
+      await normalized('https://media.example.com/'),
+      'https://media.example.com',
+    );
+  });
+
+  test('keeps a non-default port when inferring the scheme', () async {
+    expect(
+      await normalized('cantinarr.local:8585'),
+      'https://cantinarr.local:8585',
+    );
+  });
+
+  test('accepts bare IPv4 and IPv6 literals', () async {
+    expect(await normalized('192.168.1.20'), 'https://192.168.1.20');
+    expect(await normalized('[::1]:8585'), 'https://[::1]:8585');
+  });
+
+  test('accepts a .local (mDNS) hostname', () async {
+    expect(await normalized('cantinarr.local'), 'https://cantinarr.local');
+  });
+
+  test('keeps a base path, stripping its trailing slash', () async {
+    expect(
+      await normalized('https://media.example.com/cantinarr/'),
+      'https://media.example.com/cantinarr',
+    );
+  });
+
+  test('PIN: only ONE trailing slash is stripped', () async {
+    // Divergence from app.dart's normalizeServer, which strips them all. The
+    // survivor becomes part of the Dio base URL, so every request goes to
+    // '//api/…'. Pinned so a change here is a conscious one.
+    expect(
+      await normalized('https://media.example.com//'),
+      'https://media.example.com/',
+    );
+  });
+
+  test('PIN: an uppercase scheme defeats the scheme probe', () async {
+    // Same case-sensitive probe as normalizeServer (pinned in
+    // app_deep_links_test.dart): 'HTTPS://' is not recognized, so https:// is
+    // prepended and the result is not a usable URL.
+    expect(
+      await normalized('HTTPS://media.example.com'),
+      'https://HTTPS://media.example.com',
+    );
+  });
+
+  test('the connect-token flow normalizes its entered URL the same way',
+      () async {
+    final h = await harness();
+    await h.container
+        .read(authProvider.notifier)
+        .connectWithToken('media.example.com/', 'tok');
+    expect(h.service.redeemUrls, ['https://media.example.com'],
+        reason: 'checkServer and the credential flows share _normalizeUrl');
+  });
+}
+
+typedef _Harness = ({ProviderContainer container, _RecordingAuthService service});
+
+/// Records every server URL the notifier targets. The connect-token call
+/// fails with a transport error after recording, ending the flow before it
+/// needs config/storage.
+class _RecordingAuthService extends AuthService {
+  final List<String> statusUrls = [];
+  final List<String> redeemUrls = [];
+
+  @override
+  Future<ServerStatus> getServerStatus(String serverUrl) async {
+    statusUrls.add(serverUrl);
+    return const ServerStatus(needsSetup: false);
+  }
+
+  @override
+  Future<AuthResponse> redeemConnectToken(
+    String serverUrl,
+    String token,
+    String deviceName,
+    String hardwareId,
+  ) async {
+    redeemUrls.add(serverUrl);
+    throw DioException(
+      requestOptions: RequestOptions(path: '/api/auth/connect'),
+      type: DioExceptionType.connectionError,
+    );
+  }
+}
+
+class _FakeDeviceIdentityService extends DeviceIdentityService {
+  _FakeDeviceIdentityService(super.storage);
+
+  @override
+  Future<DeviceIdentity> resolve() async =>
+      const DeviceIdentity(displayName: 'Test Device', hardwareId: 'hw-test');
+}
+
+class _EmptyStorage implements StorageService {
+  @override
+  Future<String?> read({required String key}) async => null;
+
+  @override
+  Future<void> write({required String key, required String? value}) async {}
+
+  @override
+  Future<void> delete({required String key}) async {}
+
+  @override
+  Future<void> hardenAuthKeys() async {}
+}

--- a/app/test/core/network/websocket_client_reconnect_test.dart
+++ b/app/test/core/network/websocket_client_reconnect_test.dart
@@ -1,0 +1,272 @@
+import 'dart:async';
+
+import 'package:cantinarr/core/network/websocket_client.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+/// Reconnect/backoff behavior of [WebSocketClient], driven entirely through
+/// the injected channel factory and the widget test binding's fake clock —
+/// no real sockets, no wall-clock timing.
+///
+/// What the client does on reconnect (and what these tests pin): it redials
+/// with the freshest credentials from its getters, re-pipes the new channel
+/// into the same broadcast [WebSocketClient.events] stream (so consumer
+/// subscriptions survive the drop), and flips [WebSocketClient.isConnected].
+/// It performs NO data backfill of its own — consumers are documented as
+/// best-effort listeners that keep a REST polling / foreground-refresh
+/// fallback for anything missed while the socket was down.
+void main() {
+  testWidgets(
+      'connects lazily, marks connected only after the handshake, and '
+      'keeps the event stream alive through malformed frames', (tester) async {
+    final harness = _Harness();
+    addTearDown(harness.dispose);
+
+    // Dormant until ensureConnected.
+    expect(harness.factory.channels, isEmpty);
+
+    harness.client.ensureConnected();
+    expect(harness.factory.channels, hasLength(1));
+    expect(
+      harness.factory.uris.single.toString(),
+      'wss://media.example.com/api/ws',
+      reason: 'https:// must be dialed as wss://',
+    );
+    expect(harness.factory.protocols.single, ['Bearer', 'token-1']);
+    expect(harness.client.isConnected, isFalse,
+        reason: 'not connected until the upgrade handshake completes');
+
+    // A second call must not dial a second connection.
+    harness.client.ensureConnected();
+    expect(harness.factory.channels, hasLength(1));
+
+    harness.factory.current.readyCompleter.complete();
+    await tester.pump();
+    expect(harness.client.isConnected, isTrue);
+
+    // A malformed frame is swallowed; a valid one still comes through after.
+    harness.factory.current.controller.add('{not json');
+    harness.factory.current.controller
+        .add('{"type":"request_decision","data":{"decision":"approved"}}');
+    await tester.pump();
+    expect(harness.events, hasLength(1));
+    expect(harness.events.single.type, 'request_decision');
+    expect(harness.events.single.data['decision'], 'approved');
+  });
+
+  testWidgets(
+      'a dropped connection reconnects after 1s with fresh credentials and '
+      'feeds the same event stream', (tester) async {
+    final harness = _Harness();
+    addTearDown(harness.dispose);
+
+    harness.client.ensureConnected();
+    harness.factory.current.readyCompleter.complete();
+    await tester.pump();
+    expect(harness.client.isConnected, isTrue);
+
+    // A token refresh lands while connected; the reconnect must pick it up
+    // through the getter (the live connection is not torn down for it).
+    harness.accessToken = 'token-2';
+    expect(harness.factory.channels, hasLength(1));
+
+    // Server drops the connection.
+    await harness.factory.current.controller.close();
+    await tester.pump();
+    expect(harness.client.isConnected, isFalse);
+    expect(harness.factory.channels, hasLength(1),
+        reason: 'reconnect waits for the backoff delay');
+
+    await tester.pump(const Duration(milliseconds: 999));
+    expect(harness.factory.channels, hasLength(1));
+    await tester.pump(const Duration(milliseconds: 1));
+    expect(harness.factory.channels, hasLength(2),
+        reason: 'first reconnect fires after 1s');
+    expect(harness.factory.protocols.last, ['Bearer', 'token-2'],
+        reason: 'reconnects must use the freshest access token');
+
+    harness.factory.current.readyCompleter.complete();
+    await tester.pump();
+    expect(harness.client.isConnected, isTrue);
+
+    // Consumers' existing subscription keeps receiving events from the NEW
+    // channel — reconnection re-pipes into the same broadcast stream.
+    harness.factory.current.controller
+        .add('{"type":"arr_queue_changed","data":{"instance_id":"r1"}}');
+    await tester.pump();
+    expect(harness.events.map((e) => e.type), ['arr_queue_changed']);
+
+    // A successful handshake reset the backoff: the next drop redials
+    // after 1s again, not after a grown delay.
+    await harness.factory.current.controller.close();
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 1));
+    expect(harness.factory.channels, hasLength(3));
+  });
+
+  testWidgets(
+      'failed attempts back off exponentially (1,2,4,8,16s) and clamp at 30s',
+      (tester) async {
+    final harness = _Harness();
+    addTearDown(harness.dispose);
+
+    harness.client.ensureConnected();
+    expect(harness.factory.channels, hasLength(1));
+    await harness.failCurrent(tester);
+
+    // After the k-th consecutive failure the next dial happens after
+    // min(2^k, 30) seconds. A failed dial reports both onError and onDone;
+    // if that ever double-incremented the backoff this sequence would read
+    // 2,8,32… instead.
+    const delays = [1, 2, 4, 8, 16, 30, 30];
+    var dials = 1;
+    for (final seconds in delays) {
+      await tester.pump(Duration(seconds: seconds) -
+          const Duration(milliseconds: 1));
+      expect(harness.factory.channels, hasLength(dials),
+          reason: 'no redial before the full ${seconds}s backoff');
+      await tester.pump(const Duration(milliseconds: 1));
+      dials++;
+      expect(harness.factory.channels, hasLength(dials),
+          reason: 'redial after ${seconds}s');
+      await harness.failCurrent(tester);
+    }
+
+    expect(harness.client.isConnected, isFalse);
+
+    // The next (pending) retry timer would trip the binding's timer
+    // invariant; disposing here cancels it (also proving cancel-on-dispose).
+    harness.dispose();
+  });
+
+  testWidgets('never dials without credentials; dials once they appear',
+      (tester) async {
+    final harness = _Harness(serverUrl: null, accessToken: null);
+    addTearDown(harness.dispose);
+
+    harness.client.ensureConnected();
+    expect(harness.factory.channels, isEmpty,
+        reason: 'no handshake with credentials known to be absent');
+
+    // Retries on the same backoff schedule, still without dialing.
+    await tester.pump(const Duration(seconds: 1));
+    expect(harness.factory.channels, isEmpty);
+
+    // Credentials appear (login); the next retry dials with them.
+    harness.serverUrl = 'http://10.0.0.5:8585';
+    harness.accessToken = 'fresh';
+    await tester.pump(const Duration(seconds: 2));
+    expect(harness.factory.channels, hasLength(1));
+    expect(
+      harness.factory.uris.single.toString(),
+      'ws://10.0.0.5:8585/api/ws',
+      reason: 'http:// must be dialed as ws://',
+    );
+    expect(harness.factory.protocols.single, ['Bearer', 'fresh']);
+  });
+
+  testWidgets('dispose stops the reconnect chain and closes the channel',
+      (tester) async {
+    final harness = _Harness();
+
+    harness.client.ensureConnected();
+    harness.factory.current.readyCompleter.complete();
+    await tester.pump();
+    await harness.factory.current.controller.close();
+    await tester.pump();
+
+    final sink = harness.factory.current.channelSink;
+    harness.client.dispose();
+    expect(sink.closed, isTrue);
+
+    await tester.pump(const Duration(minutes: 5));
+    expect(harness.factory.channels, hasLength(1),
+        reason: 'a disposed client must never redial');
+  });
+}
+
+/// A [WebSocketClient] wired to a recording channel factory and mutable
+/// credential getters, with a listener collecting every emitted [WsEvent].
+class _Harness {
+  _Harness({
+    this.serverUrl = 'https://media.example.com',
+    this.accessToken = 'token-1',
+  }) {
+    client = WebSocketClient(
+      getServerUrl: () => serverUrl,
+      getAccessToken: () => accessToken,
+      connectChannel: factory.call,
+    );
+    _sub = client.events.listen(events.add);
+  }
+
+  final factory = _ChannelFactory();
+  final events = <WsEvent>[];
+  String? serverUrl;
+  String? accessToken;
+  late final WebSocketClient client;
+  late final StreamSubscription<WsEvent> _sub;
+  bool _disposed = false;
+
+  /// Fails the newest channel the way a refused/killed socket does: an error
+  /// followed by done.
+  Future<void> failCurrent(WidgetTester tester) async {
+    factory.current.controller.addError(const SocketFault());
+    await factory.current.controller.close();
+    await tester.pump();
+  }
+
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    _sub.cancel();
+    client.dispose();
+  }
+}
+
+/// Marker error used to fail fake connections.
+class SocketFault implements Exception {
+  const SocketFault();
+}
+
+class _ChannelFactory {
+  final List<_FakeChannel> channels = [];
+  final List<Uri> uris = [];
+  final List<List<String>> protocols = [];
+
+  _FakeChannel get current => channels.last;
+
+  WebSocketChannel call(Uri uri, {Iterable<String>? protocols}) {
+    uris.add(uri);
+    this.protocols.add(protocols?.toList() ?? const []);
+    final channel = _FakeChannel();
+    channels.add(channel);
+    return channel;
+  }
+}
+
+/// Only the members [WebSocketClient] touches are real: [stream], [ready],
+/// and [sink].close(). Everything else throws via [Fake].
+class _FakeChannel extends Fake implements WebSocketChannel {
+  final StreamController<dynamic> controller = StreamController<dynamic>();
+  final Completer<void> readyCompleter = Completer<void>();
+  final _FakeSink channelSink = _FakeSink();
+
+  @override
+  Stream<dynamic> get stream => controller.stream;
+
+  @override
+  Future<void> get ready => readyCompleter.future;
+
+  @override
+  WebSocketSink get sink => channelSink;
+}
+
+class _FakeSink extends Fake implements WebSocketSink {
+  bool closed = false;
+
+  @override
+  Future<dynamic> close([int? closeCode, String? closeReason]) async {
+    closed = true;
+  }
+}


### PR DESCRIPTION
## Summary

Test-only PR pinning the three app items from the checklist trim's automation-debt list. Addresses the app bullets of #231 (server bullets land in a parallel PR — do not close the issue here).

- **Cross-server cached-state isolation** (former USER-012) — `app/test/auth/server_switch_isolation_test.dart`: drives the real `AuthNotifier` through connect → server A, takes non-default user-visible state (active 4K Radarr instance, active Radarr module), then connects to server B and asserts nothing from A bleeds through: instance config, module state (back on Discover), the backend Dio base URL, the websocket client identity, and the single-slot secure-storage restore snapshot (tokens + session user/connection) all track B only. A second test proves a stale in-flight approvals fetch from the old server is discarded by the refresh epoch instead of overwriting the new server's requests badge.
- **WS reconnect repair** (former RT-011) — `app/test/core/network/websocket_client_reconnect_test.dart`: `WebSocketClient` gains a `@visibleForTesting` `connectChannel` factory (defaults to `WebSocketChannel.connect`; production behavior unchanged) so the connect → drop → reconnect lifecycle runs on fake channels under the widget-test fake clock — no real sockets, no wall-clock timing. Covered: lazy single dial, connected only after the handshake, drop → redial after 1s with the freshest token feeding the same broadcast stream, exponential backoff 1/2/4/8/16s clamped at 30s (error+done cannot double-increment), reset on success, no dial without credentials, wss/ws scheme mapping, malformed-frame tolerance, and dispose ending the chain. The client performs no data backfill on reconnect by design (consumers keep REST polling / foreground-refresh fallbacks); the tests document that.
- **Native host-entry normalization vectors** (former AUTH-034) — `app/test/auth/server_url_entry_test.dart`: the entry path is `AuthNotifier._normalizeUrl`, which is NOT `normalizeServer` in app.dart (comparison-only; covered by PR #224's tests — not duplicated). Vectors observe the URLs the notifier hands its `AuthService`: https inference, whitespace trim, explicit http kept (LAN), ports, base paths, IPv4/IPv6/.local hosts, and the connect-token flow sharing the same helper. Two current behaviors are pinned rather than fixed: only ONE trailing slash is stripped (a `//` entry survives into the Dio base URL as `/`) and an uppercase scheme defeats the case-sensitive scheme probe.

The only production touch is the authorized test seam (channel factory injection); no behavior change.

## Verification

- `cd app && flutter analyze --no-fatal-infos` → No issues found
- `cd app && flutter test` → All 511 tests passed (18 new)
- Mutation checks (temporarily applied, then reverted) prove the tests bite:
  - backoff changed to a fixed 5s → 3 reconnect tests fail
  - `InstanceNotifier` switched from `ref.watch(authProvider)` to `ref.read` → isolation test fails
- Server suite untouched (no `server/` changes)

## Docs checklist

- [x] No documented surface changed (no new route, tool, env var, table, screen, or workflow); `docs/testing/` is manual-only and none of its surfaces changed — left alone.

Addresses the app bullets of #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne