### PR TITLE
fix(app): harden server-URL entry normalization

### DIFF
--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -959,11 +959,15 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
 
   String _normalizeUrl(String url) {
     var normalized = url.trim();
-    if (!normalized.startsWith('http://') &&
-        !normalized.startsWith('https://')) {
+    final schemeProbe = normalized.toLowerCase();
+    if (schemeProbe.startsWith('http://')) {
+      normalized = 'http://${normalized.substring('http://'.length)}';
+    } else if (schemeProbe.startsWith('https://')) {
+      normalized = 'https://${normalized.substring('https://'.length)}';
+    } else {
       normalized = 'https://$normalized';
     }
-    if (normalized.endsWith('/')) {
+    while (normalized.endsWith('/')) {
       normalized = normalized.substring(0, normalized.length - 1);
     }
     return normalized;

--- a/app/test/auth/server_url_entry_test.dart
+++ b/app/test/auth/server_url_entry_test.dart
@@ -88,23 +88,26 @@ void main() {
     );
   });
 
-  test('PIN: only ONE trailing slash is stripped', () async {
-    // Divergence from app.dart's normalizeServer, which strips them all. The
-    // survivor becomes part of the Dio base URL, so every request goes to
-    // '//api/…'. Pinned so a change here is a conscious one.
+  test('every trailing slash is stripped', () async {
+    // Matches app.dart's normalizeServer: a surviving slash would become part
+    // of the Dio base URL and send every request to '//api/…'.
     expect(
       await normalized('https://media.example.com//'),
-      'https://media.example.com/',
+      'https://media.example.com',
     );
   });
 
-  test('PIN: an uppercase scheme defeats the scheme probe', () async {
-    // Same case-sensitive probe as normalizeServer (pinned in
-    // app_deep_links_test.dart): 'HTTPS://' is not recognized, so https:// is
-    // prepended and the result is not a usable URL.
+  test('an uppercase scheme is recognized and lowercased', () async {
     expect(
       await normalized('HTTPS://media.example.com'),
-      'https://HTTPS://media.example.com',
+      'https://media.example.com',
+    );
+  });
+
+  test('an uppercase http scheme keeps http', () async {
+    expect(
+      await normalized('HTTP://media.example.com:8585'),
+      'http://media.example.com:8585',
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes the two entry-path defects PR #236 pinned: `_normalizeUrl` now strips **every** trailing slash (a survivor became part of the Dio base URL, sending every request to `//api/…`) and recognizes schemes **case-insensitively** (`HTTPS://host` previously became the unusable `https://HTTPS://host`; it now lowercases the scheme and keeps the rest untouched). Entry normalization now matches `app.dart`'s `normalizeServer` on slashes.

Deliberately NOT touched: `normalizeServer`'s own case-sensitive scheme comparison (pinned in `app_deep_links_test.dart`) — it only compares server identities in deep links, both sides of which are machine-generated lowercase; post-fix, stored URLs are always lowercase-scheme, so the comparison is consistent.

The two former `PIN:` vectors are flipped to assert corrected behavior (plus an `HTTP://` case) and fail on the old code.

Addresses the entry-normalization bullet of #231.

## Verification

- `flutter analyze --no-fatal-infos` clean; full `flutter test` 520/520 green from `app/`.
- The flipped vectors fail against the old `_normalizeUrl` by construction (they assert the exact outputs the old code got wrong, per #236's pins).

## Docs

- [x] No docs impact — behavior fix within an undocumented normalization helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZnY4Agn7fo8c5hPihDCne