### PR TITLE
fix(app): opaque per-page backdrops end route-transition double exposure

### DIFF
--- a/app/.claude/skills/verify/SKILL.md
+++ b/app/.claude/skills/verify/SKILL.md
@@ -27,9 +27,11 @@ flutter run -d web-server -t test/preview/preview_main.dart \
 Drive with the claude-in-chrome tools. Gotchas learned the hard way:
 
 - **Debug-web page transitions are slow (2–4s)** — a screenshot right after a
-  click captures a mid-transition frame that looks like two screens layered
-  (e.g. login ghosting behind the shell on first load). Always `wait` 3–4s and
-  re-screenshot before judging layout.
+  click captures a mid-transition frame. Routed pages paint an opaque ambient
+  backdrop, so a mid-transition frame is a clean dissolve (lateral surfaces)
+  or slide (pushes) — two screens showing *through* each other is a
+  regression, not debug-web noise. Still `wait` 3–4s and re-screenshot before
+  judging final layout.
 - **`resize_window` may not change the CSS viewport** (window managers /
   non-100% zoom). Confirm with `javascript_tool`:
   `window.innerWidth` — the app's breakpoints key off CSS px (desktop ≥ 900).

--- a/app/lib/core/widgets/app_ambient_background.dart
+++ b/app/lib/core/widgets/app_ambient_background.dart
@@ -7,6 +7,15 @@ import '../theme/app_theme.dart';
 /// The effect is intentionally static and pointer-transparent: it gives bare
 /// and translucent surfaces a shared cinematic depth without adding perpetual
 /// animation, hit-test cost, or accessibility noise.
+///
+/// Routed pages paint their own copy so transitions occlude the page beneath
+/// (scaffolds are transparent by theme). Copies must be pixel-identical to the
+/// app-level canvas even when painted in a box smaller than the screen (the
+/// shell's content area sits below the top bar / right of the sidebar), so the
+/// gradient layers are laid out at full-screen size anchored bottom-right —
+/// the one corner every such box shares with the screen — and clipped to the
+/// box. Anchoring by alignment alone would re-center the glows per box and
+/// leave a brightness seam at the chrome boundary.
 class AppAmbientBackground extends StatelessWidget {
   const AppAmbientBackground({super.key, required this.child});
 
@@ -14,61 +23,22 @@ class AppAmbientBackground extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final screen = MediaQuery.sizeOf(context);
     return ColoredBox(
       color: AppTheme.background,
       child: Stack(
         fit: StackFit.expand,
         children: [
-          const ExcludeSemantics(
+          ExcludeSemantics(
             child: IgnorePointer(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      Color(0xFF1D130C),
-                      AppTheme.background,
-                      Color(0xFF120B07),
-                    ],
-                    stops: [0, 0.52, 1],
-                  ),
-                ),
-              ),
-            ),
-          ),
-          const ExcludeSemantics(
-            child: IgnorePointer(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: RadialGradient(
-                    center: Alignment(1.05, -1.05),
-                    radius: 1.2,
-                    colors: [
-                      Color(0x24F47A2E),
-                      Color(0x0BF47A2E),
-                      Colors.transparent,
-                    ],
-                    stops: [0, 0.36, 1],
-                  ),
-                ),
-              ),
-            ),
-          ),
-          const ExcludeSemantics(
-            child: IgnorePointer(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: RadialGradient(
-                    center: Alignment(-1.1, 1.15),
-                    radius: 1.15,
-                    colors: [
-                      Color(0x1FF2AC2D),
-                      Color(0x08F2AC2D),
-                      Colors.transparent,
-                    ],
-                    stops: [0, 0.38, 1],
-                  ),
+              child: ClipRect(
+                child: OverflowBox(
+                  alignment: Alignment.bottomRight,
+                  minWidth: screen.width,
+                  maxWidth: screen.width,
+                  minHeight: screen.height,
+                  maxHeight: screen.height,
+                  child: const _AmbientGradients(),
                 ),
               ),
             ),
@@ -76,6 +46,61 @@ class AppAmbientBackground extends StatelessWidget {
           child,
         ],
       ),
+    );
+  }
+}
+
+class _AmbientGradients extends StatelessWidget {
+  const _AmbientGradients();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Stack(
+      fit: StackFit.expand,
+      children: [
+        DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                Color(0xFF1D130C),
+                AppTheme.background,
+                Color(0xFF120B07),
+              ],
+              stops: [0, 0.52, 1],
+            ),
+          ),
+        ),
+        DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: RadialGradient(
+              center: Alignment(1.05, -1.05),
+              radius: 1.2,
+              colors: [
+                Color(0x24F47A2E),
+                Color(0x0BF47A2E),
+                Colors.transparent,
+              ],
+              stops: [0, 0.36, 1],
+            ),
+          ),
+        ),
+        DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: RadialGradient(
+              center: Alignment(-1.1, 1.15),
+              radius: 1.15,
+              colors: [
+                Color(0x1FF2AC2D),
+                Color(0x08F2AC2D),
+                Colors.transparent,
+              ],
+              stops: [0, 0.38, 1],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
@@ -5,6 +5,7 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/cached_image.dart';
 import '../../../core/widgets/error_banner.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/chaptarr_add_payload.dart';
 import '../data/chaptarr_api_service.dart';
 import '../data/chaptarr_image.dart';
@@ -104,7 +105,7 @@ class _ChaptarrAuthorDetailScreenState
 
   void _openBookGroup(List<ChaptarrBook> records) {
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => ChaptarrBookScreen(
           instanceId: widget.instanceId,
           records: records,

--- a/app/lib/features/chaptarr/ui/chaptarr_book_detail_sheet.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_book_detail_sheet.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/status_pill.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/chaptarr_api_service.dart';
 import '../data/chaptarr_models.dart';
 import 'chaptarr_releases_screen.dart';
@@ -109,7 +110,7 @@ class _ChaptarrBookDetailSheetState
     final nav = Navigator.of(context, rootNavigator: true);
     Navigator.of(context).pop(true);
     nav.push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => ChaptarrReleasesScreen(
           instanceId: widget.instanceId,
           bookId: chosen.id,

--- a/app/lib/features/chaptarr/ui/chaptarr_book_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_book_screen.dart
@@ -5,6 +5,7 @@ import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/chaptarr_api_service.dart';
 import '../data/chaptarr_models.dart';
 import 'chaptarr_book_detail_sheet.dart';
@@ -98,7 +99,7 @@ class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
     final chosen = await pickFormatRecord(context, _records);
     if (chosen == null || !mounted) return;
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => ChaptarrReleasesScreen(
           instanceId: widget.instanceId,
           bookId: chosen.id,

--- a/app/lib/features/chaptarr/ui/chaptarr_home_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_home_screen.dart
@@ -5,6 +5,7 @@ import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../../../core/widgets/library_command_header.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/chaptarr_api_service.dart';
 import '../data/chaptarr_models.dart';
 import '../logic/chaptarr_library_provider.dart';
@@ -68,7 +69,7 @@ class _ChaptarrHomeScreenState extends ConsumerState<ChaptarrHomeScreen> {
     final instanceId = ref.read(instanceProvider).activeChaptarrInstance?.id;
     if (instanceId == null) return;
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => ChaptarrAuthorDetailScreen(
           instanceId: instanceId,
           authorId: author.id,

--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -12,6 +12,7 @@ import '../../../core/widgets/app_panel.dart';
 import '../../../core/widgets/horizontal_item_row.dart';
 import '../../../core/widgets/media_card.dart';
 import '../../../core/widgets/section_header.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../discover/data/tmdb_models.dart';
 import '../../discover/data/discover_api_service.dart';
@@ -568,7 +569,7 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
       return;
     }
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(builder: (_) => screen),
+      AmbientPageRoute(builder: (_) => screen),
     );
   }
 

--- a/app/lib/features/notifications/push_service.dart
+++ b/app/lib/features/notifications/push_service.dart
@@ -161,7 +161,10 @@ class PushService {
         if (data['media_type'] == 'book') {
           final foreignId = _asTrimmedString(data['foreign_id']);
           if (foreignId == null) {
-            router.push('/dashboard/books');
+            // go(), not push(): a module surface must replace the stack — a
+            // pushed module shell has no back affordance (no app-bar back
+            // button, and its fade page has no iOS swipe-back gesture).
+            router.go('/dashboard/books');
             return;
           }
           // The payload's title rides along so the detail screen can still

--- a/app/lib/features/radarr/ui/radarr_home_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_home_screen.dart
@@ -5,6 +5,7 @@ import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../../../core/widgets/library_command_header.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/radarr_api_service.dart';
 import '../data/radarr_models.dart';
 import '../logic/radarr_movies_provider.dart';
@@ -69,7 +70,7 @@ class _RadarrHomeScreenState extends ConsumerState<RadarrHomeScreen> {
     final instanceId = ref.read(instanceProvider).activeRadarrInstance?.id;
     if (instanceId == null) return;
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => RadarrReleasesScreen(
           instanceId: instanceId,
           movieId: movie.id,
@@ -83,7 +84,7 @@ class _RadarrHomeScreenState extends ConsumerState<RadarrHomeScreen> {
     final instanceId = ref.read(instanceProvider).activeRadarrInstance?.id;
     if (instanceId == null) return;
     await Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => RadarrMovieDetailScreen(
           instanceId: instanceId,
           movie: movie,

--- a/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
@@ -7,6 +7,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/cached_image.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../../../core/widgets/status_pill.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../issues/ui/report_problem_sheet.dart';
 import '../data/radarr_api_service.dart';
@@ -99,7 +100,7 @@ class _RadarrMovieDetailScreenState
 
   void _interactiveSearch() {
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => RadarrReleasesScreen(
           instanceId: widget.instanceId,
           movieId: _movie.id,

--- a/app/lib/features/radarr/ui/radarr_wanted_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_wanted_screen.dart
@@ -5,6 +5,7 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/radarr_api_service.dart';
 import '../data/radarr_models.dart';
 import 'radarr_releases_screen.dart';
@@ -159,7 +160,7 @@ class _RadarrWantedScreenState extends ConsumerState<RadarrWantedScreen> {
     final instanceId = ref.read(instanceProvider).activeRadarrInstance?.id;
     if (instanceId == null) return;
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => RadarrReleasesScreen(
           instanceId: instanceId,
           movieId: movie.id,

--- a/app/lib/features/sonarr/ui/series_actions.dart
+++ b/app/lib/features/sonarr/ui/series_actions.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/action_sheet.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
 import 'edit_series_screen.dart';
@@ -51,7 +52,7 @@ Future<void> showSeriesActions(
         toast('Searching for monitored episodes of ${series.title}…');
       case SeriesAction.edit:
         final saved = await Navigator.of(context, rootNavigator: true)
-            .push<bool>(MaterialPageRoute(
+            .push<bool>(AmbientPageRoute(
           builder: (_) =>
               EditSeriesScreen(instanceId: instanceId, series: series),
         ));

--- a/app/lib/features/sonarr/ui/sonarr_home_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_home_screen.dart
@@ -5,6 +5,7 @@ import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../../../core/widgets/library_command_header.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
 import '../logic/sonarr_series_provider.dart';
@@ -70,7 +71,7 @@ class _SonarrHomeScreenState extends ConsumerState<SonarrHomeScreen> {
     final instanceId = ref.read(instanceProvider).activeSonarrInstance?.id;
     if (instanceId == null) return;
     await Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => SonarrSeriesDetailScreen(
           instanceId: instanceId,
           series: show,
@@ -137,7 +138,7 @@ class _SonarrHomeScreenState extends ConsumerState<SonarrHomeScreen> {
     if (seasonNumber == null || !mounted) return;
 
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => SonarrReleasesScreen(
           instanceId: instanceId,
           seriesId: show.id,

--- a/app/lib/features/sonarr/ui/sonarr_season_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_season_screen.dart
@@ -5,6 +5,7 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/action_sheet.dart';
 import '../../../core/widgets/error_banner.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
 import '../logic/episode_selection.dart';
@@ -158,7 +159,7 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
       if (seasonNumber == null || !mounted) return;
     }
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => SonarrReleasesScreen(
           instanceId: widget.instanceId,
           seriesId: widget.series.id,
@@ -180,7 +181,7 @@ class _SonarrSeasonScreenState extends ConsumerState<SonarrSeasonScreen> {
 
   void _interactiveEpisodeSearch(SonarrEpisode episode) {
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => SonarrReleasesScreen(
           instanceId: widget.instanceId,
           seriesId: widget.series.id,

--- a/app/lib/features/sonarr/ui/sonarr_series_detail_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_series_detail_screen.dart
@@ -6,6 +6,7 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/action_sheet.dart';
 import '../../../core/widgets/error_banner.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
 import 'edit_series_screen.dart';
@@ -121,7 +122,7 @@ class _SonarrSeriesDetailScreenState
 
   void _openSeason(SonarrSeason season) {
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => SonarrSeasonScreen(
           instanceId: widget.instanceId,
           series: _series,
@@ -134,7 +135,7 @@ class _SonarrSeriesDetailScreenState
   /// Every episode across all seasons, grouped by season headers.
   void _openAllSeasons() {
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => SonarrSeasonScreen(
           instanceId: widget.instanceId,
           series: _series,
@@ -170,7 +171,7 @@ class _SonarrSeriesDetailScreenState
         }
       case 'interactive':
         Navigator.of(context, rootNavigator: true).push(
-          MaterialPageRoute(
+          AmbientPageRoute(
             builder: (_) => SonarrReleasesScreen(
               instanceId: widget.instanceId,
               seriesId: _series.id,
@@ -184,7 +185,7 @@ class _SonarrSeriesDetailScreenState
 
   Future<void> _openEdit() async {
     final saved = await Navigator.of(context, rootNavigator: true).push<bool>(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => EditSeriesScreen(
           instanceId: widget.instanceId,
           series: _series,

--- a/app/lib/features/sonarr/ui/sonarr_wanted_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_wanted_screen.dart
@@ -5,6 +5,7 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
 import 'sonarr_releases_screen.dart';
@@ -164,7 +165,7 @@ class _SonarrWantedScreenState extends ConsumerState<SonarrWantedScreen> {
     if (instanceId == null) return;
     // The interactive search is season-scoped; pass the episode's season.
     Navigator.of(context, rootNavigator: true).push(
-      MaterialPageRoute(
+      AmbientPageRoute(
         builder: (_) => SonarrReleasesScreen(
           instanceId: instanceId,
           seriesId: record.seriesId,

--- a/app/lib/navigation/ambient_page_route.dart
+++ b/app/lib/navigation/ambient_page_route.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+import '../core/widgets/app_ambient_background.dart';
+
+/// A [MaterialPageRoute] whose page paints the shared ambient backdrop.
+///
+/// Cantinarr scaffolds are transparent by theme, so a route that doesn't paint
+/// its own backdrop lets the screen beneath it show through while a transition
+/// (or iOS swipe-back) is in flight — both screens render at once as a jarring
+/// double exposure. Use this for every imperative full-screen push instead of
+/// a bare [MaterialPageRoute]; the backdrop is pixel-identical to the app-level
+/// ambient canvas, so the page looks unchanged at rest.
+class AmbientPageRoute<T> extends MaterialPageRoute<T> {
+  AmbientPageRoute({required WidgetBuilder builder})
+      : super(
+          builder: (context) => AppAmbientBackground(child: builder(context)),
+        );
+}

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -61,8 +61,36 @@ import '../features/tautulli/ui/tautulli_activity_screen.dart';
 import '../features/tautulli/ui/tautulli_history_screen.dart';
 import '../features/tautulli/ui/tautulli_module_shell.dart';
 import '../features/tautulli/ui/tautulli_stats_screen.dart';
+import '../core/widgets/app_ambient_background.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
+
+/// Lateral page for top-level surfaces: login, the app shell, and the module
+/// shells. The incoming page dissolves in over whatever it replaces.
+///
+/// Scaffolds are transparent by theme, so every routed page must paint its own
+/// opaque backdrop (AppAmbientBackground) — otherwise the previous route shows
+/// through during transitions and both screens render at once as a jarring
+/// double exposure. Lateral surfaces fade because they're peer navigation with
+/// no back stack; pushed routes keep MaterialPage's platform slide (and iOS
+/// swipe-back), made correct by the same opaque backdrop on their children.
+CustomTransitionPage<void> _fadeSurfacePage({
+  required LocalKey key,
+  required Widget child,
+}) {
+  return CustomTransitionPage<void>(
+    key: key,
+    transitionDuration: const Duration(milliseconds: 280),
+    reverseTransitionDuration: const Duration(milliseconds: 220),
+    transitionsBuilder: (context, animation, secondaryAnimation, child) {
+      return FadeTransition(
+        opacity: CurvedAnimation(parent: animation, curve: Curves.easeOutCubic),
+        child: child,
+      );
+    },
+    child: AppAmbientBackground(child: child),
+  );
+}
 
 /// Central router configuration using GoRouter with module-based navigation.
 /// Outer ShellRoute provides the drawer + search bar.
@@ -129,24 +157,29 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: '/login',
         parentNavigatorKey: _rootNavigatorKey,
-        builder: (_, __) => const AuthScreen(),
+        pageBuilder: (context, state) => _fadeSurfacePage(
+          key: state.pageKey,
+          child: const AuthScreen(),
+        ),
       ),
 
       // Module shell (provides drawer/sidebar + search bar, no bottom nav)
       ShellRoute(
-        builder: (context, state, child) {
-          return AppShell(currentPath: state.uri.path, child: child);
-        },
+        pageBuilder: (context, state, child) => _fadeSurfacePage(
+          key: state.pageKey,
+          child: AppShell(currentPath: state.uri.path, child: child),
+        ),
         routes: [
           // Dashboard module (Movies/TV tabs)
           StatefulShellRoute.indexedStack(
-            builder: (context, state, navigationShell) {
-              return DashboardShell(
+            pageBuilder: (context, state, navigationShell) => _fadeSurfacePage(
+              key: state.pageKey,
+              child: DashboardShell(
                 currentIndex: navigationShell.currentIndex,
                 onTabChanged: (index) => navigationShell.goBranch(index),
                 child: navigationShell,
-              );
-            },
+              ),
+            ),
             branches: [
               StatefulShellBranch(
                 routes: [
@@ -189,13 +222,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
 
           // Radarr module (Library/Queue/History/Wanted/Calendar tabs)
           StatefulShellRoute.indexedStack(
-            builder: (context, state, navigationShell) {
-              return RadarrModuleShell(
+            pageBuilder: (context, state, navigationShell) => _fadeSurfacePage(
+              key: state.pageKey,
+              child: RadarrModuleShell(
                 currentIndex: navigationShell.currentIndex,
                 onTabChanged: (index) => navigationShell.goBranch(index),
                 child: navigationShell,
-              );
-            },
+              ),
+            ),
             branches: [
               StatefulShellBranch(
                 routes: [
@@ -242,13 +276,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
 
           // Sonarr module (Library/Queue/History/Wanted/Calendar tabs)
           StatefulShellRoute.indexedStack(
-            builder: (context, state, navigationShell) {
-              return SonarrModuleShell(
+            pageBuilder: (context, state, navigationShell) => _fadeSurfacePage(
+              key: state.pageKey,
+              child: SonarrModuleShell(
                 currentIndex: navigationShell.currentIndex,
                 onTabChanged: (index) => navigationShell.goBranch(index),
                 child: navigationShell,
-              );
-            },
+              ),
+            ),
             branches: [
               StatefulShellBranch(
                 routes: [
@@ -295,13 +330,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
 
           // Chaptarr module (Library/Queue/History/Wanted tabs)
           StatefulShellRoute.indexedStack(
-            builder: (context, state, navigationShell) {
-              return ChaptarrModuleShell(
+            pageBuilder: (context, state, navigationShell) => _fadeSurfacePage(
+              key: state.pageKey,
+              child: ChaptarrModuleShell(
                 currentIndex: navigationShell.currentIndex,
                 onTabChanged: (index) => navigationShell.goBranch(index),
                 child: navigationShell,
-              );
-            },
+              ),
+            ),
             branches: [
               StatefulShellBranch(
                 routes: [
@@ -340,13 +376,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
 
           // Downloads module (Queue/History tabs, admin only)
           StatefulShellRoute.indexedStack(
-            builder: (context, state, navigationShell) {
-              return DownloadsModuleShell(
+            pageBuilder: (context, state, navigationShell) => _fadeSurfacePage(
+              key: state.pageKey,
+              child: DownloadsModuleShell(
                 currentIndex: navigationShell.currentIndex,
                 onTabChanged: (index) => navigationShell.goBranch(index),
                 child: navigationShell,
-              );
-            },
+              ),
+            ),
             branches: [
               StatefulShellBranch(
                 routes: [
@@ -369,13 +406,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
 
           // Tautulli module (Activity/History/Stats tabs, admin only)
           StatefulShellRoute.indexedStack(
-            builder: (context, state, navigationShell) {
-              return TautulliModuleShell(
+            pageBuilder: (context, state, navigationShell) => _fadeSurfacePage(
+              key: state.pageKey,
+              child: TautulliModuleShell(
                 currentIndex: navigationShell.currentIndex,
                 onTabChanged: (index) => navigationShell.goBranch(index),
                 child: navigationShell,
-              );
-            },
+              ),
+            ),
             branches: [
               StatefulShellBranch(
                 routes: [
@@ -409,70 +447,52 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           // each screen's own back affordance.
           GoRoute(
             path: '/assistant',
-            builder: (_, __) => const AiChatScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: AiChatScreen()),
           ),
           GoRoute(
             path: '/detail/:type/:id',
             redirect: (_, state) => _mediaDetailRedirect(state),
-            builder: (context, state) {
-              final type = state.pathParameters['type']!;
-              // Books are addressed by their (string) Chaptarr foreignBookId —
-              // the identity request rows store and decision push payloads
-              // carry — not a TMDB id.
-              if (type == 'book') {
-                final foreignId = state.pathParameters['id']?.trim() ?? '';
-                if (foreignId.isEmpty) {
-                  return const _InvalidRouteScreen(
-                    message: 'This book link is invalid.',
-                  );
-                }
-                return RequesterBookDetailScreen(
-                  foreignId: foreignId,
-                  titleHint: state.uri.queryParameters['title'],
-                );
-              }
-              final id = _positiveIntParameter(state, 'id');
-              if (id == null) {
-                return const _InvalidRouteScreen(
-                  message: 'This media link is invalid.',
-                );
-              }
-              final mediaType = type == 'tv' ? MediaType.tv : MediaType.movie;
-              return MediaDetailScreen(
-                id: id,
-                mediaType: mediaType,
-              );
-            },
+            builder: (context, state) =>
+                AppAmbientBackground(child: _mediaDetailChild(state)),
           ),
           GoRoute(
             path: '/settings',
-            builder: (_, __) => const SettingsScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: SettingsScreen()),
           ),
           GoRoute(
             path: '/settings/ai',
-            builder: (_, __) => const AiAccessScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: AiAccessScreen()),
           ),
           GoRoute(
             path: '/settings/chatgpt',
-            builder: (_, __) => const CodexConnectionScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: CodexConnectionScreen()),
           ),
           GoRoute(
             path: '/settings/credentials/chatgpt',
-            builder: (_, __) => const CodexConnectionScreen(
-              scope: CodexOAuthScope.adminShared,
+            builder: (_, __) => const AppAmbientBackground(
+              child: CodexConnectionScreen(
+                scope: CodexOAuthScope.adminShared,
+              ),
             ),
           ),
           GoRoute(
             path: '/settings/credentials',
-            builder: (_, __) => const CredentialsScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: CredentialsScreen()),
           ),
           GoRoute(
             path: '/settings/ai-tools',
-            builder: (_, __) => const AiToolsScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: AiToolsScreen()),
           ),
           GoRoute(
             path: '/settings/users',
-            builder: (_, __) => const UsersScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: UsersScreen()),
           ),
           GoRoute(
             path: '/settings/users/:userId/request-settings',
@@ -483,99 +503,120 @@ final appRouterProvider = Provider<GoRouter>((ref) {
             builder: (context, state) {
               final userId = _positiveIntParameter(state, 'userId');
               if (userId == null) {
-                return const _InvalidRouteScreen(
-                  message: 'This user settings link is invalid.',
+                return const AppAmbientBackground(
+                  child: _InvalidRouteScreen(
+                    message: 'This user settings link is invalid.',
+                  ),
                 );
               }
               final username = state.extra as String? ?? '';
-              return UserRequestSettingsScreen(
-                  userId: userId, username: username);
+              return AppAmbientBackground(
+                child: UserRequestSettingsScreen(
+                    userId: userId, username: username),
+              );
             },
           ),
           GoRoute(
             path: '/approvals',
-            builder: (_, __) => const PendingRequestsScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: PendingRequestsScreen()),
           ),
           GoRoute(
             path: '/issues',
-            builder: (_, __) => const IssuesListScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: IssuesListScreen()),
           ),
           GoRoute(
             path: '/issues/:id',
             builder: (context, state) {
               final id = int.tryParse(state.pathParameters['id'] ?? '') ?? 0;
-              return IssueThreadScreen(issueId: id);
+              return AppAmbientBackground(
+                  child: IssueThreadScreen(issueId: id));
             },
           ),
           GoRoute(
             path: '/agent-actions',
-            builder: (_, __) => const PendingAgentActionsScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: PendingAgentActionsScreen()),
           ),
           GoRoute(
             path: '/agent-runs/:id',
             builder: (context, state) {
               final id = int.tryParse(state.pathParameters['id'] ?? '') ?? 0;
-              return AgentRunScreen(runId: id);
+              return AppAmbientBackground(child: AgentRunScreen(runId: id));
             },
           ),
           GoRoute(
             path: '/settings/ai-remediation',
-            builder: (_, __) => const AiRemediationSettingsScreen(),
+            builder: (_, __) => const AppAmbientBackground(
+                child: AiRemediationSettingsScreen()),
           ),
           GoRoute(
             path: '/settings/request-settings',
-            builder: (_, __) => const RequestSettingsScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: RequestSettingsScreen()),
           ),
           GoRoute(
             path: '/settings/devices',
-            builder: (_, __) => const DevicesScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: DevicesScreen()),
           ),
           GoRoute(
             path: '/settings/plex',
-            builder: (_, __) => const PlexSettingsScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: PlexSettingsScreen()),
           ),
           GoRoute(
             path: '/settings/notifications',
-            builder: (_, __) => const NotificationPreferencesScreen(),
+            builder: (_, __) => const AppAmbientBackground(
+                child: NotificationPreferencesScreen()),
           ),
           GoRoute(
             path: '/settings/passkeys',
-            builder: (_, __) => const PasskeyManagementScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: PasskeyManagementScreen()),
           ),
           GoRoute(
             path: '/settings/passkeys/new',
-            builder: (_, __) => const PasskeyCreateScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: PasskeyCreateScreen()),
           ),
           GoRoute(
             path: '/settings/password',
-            builder: (_, __) => const SetPasswordScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: SetPasswordScreen()),
           ),
           GoRoute(
             path: '/settings/instance/new',
-            builder: (_, __) => const InstanceEditScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: InstanceEditScreen()),
           ),
           GoRoute(
             path: '/settings/instance/:id',
             builder: (context, state) {
               final extra = state.extra as Map<String, dynamic>?;
-              return InstanceEditScreen(
-                instanceId: state.pathParameters['id'],
-                initialServiceType: extra?['service_type'] as String?,
-                initialName: extra?['name'] as String?,
-                initialUrl: extra?['url'] as String?,
-                initialApiKey: extra?['api_key'] as String?,
-                initialUsername: extra?['username'] as String?,
-                initialIsDefault: extra?['is_default'] as bool? ?? false,
+              return AppAmbientBackground(
+                child: InstanceEditScreen(
+                  instanceId: state.pathParameters['id'],
+                  initialServiceType: extra?['service_type'] as String?,
+                  initialName: extra?['name'] as String?,
+                  initialUrl: extra?['url'] as String?,
+                  initialApiKey: extra?['api_key'] as String?,
+                  initialUsername: extra?['username'] as String?,
+                  initialIsDefault: extra?['is_default'] as bool? ?? false,
+                ),
               );
             },
           ),
           GoRoute(
             path: '/setup',
-            builder: (_, __) => const SetupWizardScreen(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: SetupWizardScreen()),
           ),
           GoRoute(
             path: '/plex-guide',
-            builder: (_, __) => const PlexWatchGuide(),
+            builder: (_, __) =>
+                const AppAmbientBackground(child: PlexWatchGuide()),
           ),
         ],
       ),
@@ -625,6 +666,36 @@ bool _isAdminOnlyRoute(String path) {
 int? _positiveIntParameter(GoRouterState state, String name) {
   final value = int.tryParse(state.pathParameters[name] ?? '');
   return value != null && value > 0 ? value : null;
+}
+
+/// The `/detail/:type/:id` route body. Books are addressed by their (string)
+/// Chaptarr foreignBookId — the identity request rows store and decision push
+/// payloads carry — not a TMDB id.
+Widget _mediaDetailChild(GoRouterState state) {
+  final type = state.pathParameters['type']!;
+  if (type == 'book') {
+    final foreignId = state.pathParameters['id']?.trim() ?? '';
+    if (foreignId.isEmpty) {
+      return const _InvalidRouteScreen(
+        message: 'This book link is invalid.',
+      );
+    }
+    return RequesterBookDetailScreen(
+      foreignId: foreignId,
+      titleHint: state.uri.queryParameters['title'],
+    );
+  }
+  final id = _positiveIntParameter(state, 'id');
+  if (id == null) {
+    return const _InvalidRouteScreen(
+      message: 'This media link is invalid.',
+    );
+  }
+  final mediaType = type == 'tv' ? MediaType.tv : MediaType.movie;
+  return MediaDetailScreen(
+    id: id,
+    mediaType: mediaType,
+  );
 }
 
 bool _hasValidMediaDetailParameters(GoRouterState state) {

--- a/app/test/navigation/app_router_test.dart
+++ b/app/test/navigation/app_router_test.dart
@@ -3,13 +3,17 @@ import 'dart:typed_data';
 
 import 'package:cantinarr/core/models/backend_connection.dart';
 import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/widgets/app_ambient_background.dart';
 import 'package:cantinarr/core/widgets/search_bar.dart';
 import 'package:cantinarr/core/models/user_profile.dart';
 import 'package:cantinarr/features/ai_assistant/ui/codex_connection_screen.dart';
 import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/auth/ui/auth_screen.dart';
 import 'package:cantinarr/features/auth/ui/set_password_screen.dart';
+import 'package:cantinarr/features/dashboard/ui/dashboard_shell.dart';
 import 'package:cantinarr/features/dashboard/ui/requester_book_detail_screen.dart';
 import 'package:cantinarr/features/shell/ui/app_shell.dart';
+import 'package:cantinarr/features/sonarr/ui/sonarr_module_shell.dart';
 import 'package:cantinarr/navigation/app_router.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
@@ -226,6 +230,80 @@ void main() {
     router.go('/settings/users/not-a-number/request-settings');
     await tester.pumpAndSettle();
     expect(router.routeInformationProvider.value.uri.path, '/settings/users');
+  });
+
+  // Scaffolds are transparent by theme, so every routed page must paint its
+  // own ambient backdrop — a page without one lets the previous route show
+  // through mid-transition as a double exposure.
+  testWidgets('routed pages paint their own opaque ambient backdrop',
+      (tester) async {
+    final (:router, container: _) = await _pumpRouter(tester, _authedState);
+
+    // Module page: backdrop on the shell page AND the module shell page.
+    expect(
+      find.ancestor(
+        of: find.byType(DashboardShell),
+        matching: find.byType(AppAmbientBackground),
+      ),
+      findsNWidgets(2),
+    );
+
+    // Pushed secondary route: its own backdrop plus the shell page's.
+    router.push('/settings/password');
+    await tester.pumpAndSettle();
+    expect(
+      find.ancestor(
+        of: find.byType(SetPasswordScreen),
+        matching: find.byType(AppAmbientBackground),
+      ),
+      findsNWidgets(2),
+    );
+  });
+
+  testWidgets('the login page paints its own opaque ambient backdrop',
+      (tester) async {
+    await _pumpRouter(tester, const AuthState());
+
+    expect(
+      find.ancestor(
+        of: find.byType(AuthScreen),
+        matching: find.byType(AppAmbientBackground),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('module switches dissolve the incoming shell over the old one',
+      (tester) async {
+    final (:router, container: _) = await _pumpRouter(tester, _adminState);
+
+    router.go('/sonarr/library');
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 140));
+
+    // Mid-dissolve: both module pages are mounted and the incoming page is
+    // fading in (over its opaque backdrop) rather than double-exposing.
+    expect(find.byType(DashboardShell), findsOneWidget);
+    expect(find.byType(SonarrModuleShell), findsOneWidget);
+    final fades = tester.widgetList<FadeTransition>(
+      find.ancestor(
+        of: find.byType(SonarrModuleShell),
+        matching: find.byType(FadeTransition),
+      ),
+    );
+    expect(
+      fades.any((f) => f.opacity.value > 0 && f.opacity.value < 1),
+      isTrue,
+      reason: 'incoming module page should be mid-fade',
+    );
+
+    // Bounded pumps (not pumpAndSettle): the stubbed Sonarr library shows an
+    // indeterminate spinner, which never settles. 140+200+100ms covers the
+    // 280ms dissolve plus a frame for the outgoing route's removal.
+    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(find.byType(DashboardShell), findsNothing);
+    expect(find.byType(SonarrModuleShell), findsOneWidget);
   });
 }
 

--- a/app/test/notifications/push_service_test.dart
+++ b/app/test/notifications/push_service_test.dart
@@ -38,11 +38,17 @@ class _RecordingRouter extends GoRouter {
         );
 
   final pushed = <String>[];
+  final went = <String>[];
 
   @override
   Future<T?> push<T extends Object?>(String location, {Object? extra}) {
     pushed.add(location);
     return Future<T?>.value();
+  }
+
+  @override
+  void go(String location, {Object? extra}) {
+    went.add(location);
   }
 }
 
@@ -208,7 +214,8 @@ void main() {
           // Not part of the real push payload; routing must not depend on it.
           'decision': decision,
         });
-        expect(h.router.pushed, ['/dashboard/books']);
+        expect(h.router.went, ['/dashboard/books']);
+        expect(h.router.pushed, isEmpty);
       });
     }
 
@@ -256,7 +263,8 @@ void main() {
         'media_type': 'book',
         'foreign_id': 29749107,
       });
-      expect(h.router.pushed, ['/dashboard/books', '/dashboard/books']);
+      expect(h.router.went, ['/dashboard/books', '/dashboard/books']);
+      expect(h.router.pushed, isEmpty);
     });
 
     test('media_type book wins over a stray positive tmdb_id', () async {
@@ -266,7 +274,8 @@ void main() {
         'tmdb_id': 10,
         'media_type': 'book',
       });
-      expect(h.router.pushed, ['/dashboard/books']);
+      expect(h.router.went, ['/dashboard/books']);
+      expect(h.router.pushed, isEmpty);
     });
 
     test('tmdb_id survives string and double payload encodings', () async {

--- a/app/test/preview/preview_main.dart
+++ b/app/test/preview/preview_main.dart
@@ -16,6 +16,7 @@ import 'package:cantinarr/core/network/backend_client.dart';
 import 'package:cantinarr/core/network/websocket_client.dart';
 import 'package:cantinarr/core/providers/realtime_provider.dart';
 import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/core/widgets/app_ambient_background.dart';
 import 'package:cantinarr/features/auth/logic/auth_provider.dart';
 import 'package:cantinarr/navigation/app_router.dart';
 import 'package:dio/dio.dart';
@@ -47,6 +48,8 @@ class _PreviewApp extends ConsumerWidget {
       theme: AppTheme.dark,
       debugShowCheckedModeBanner: false,
       routerConfig: ref.watch(appRouterProvider),
+      builder: (context, child) =>
+          AppAmbientBackground(child: child ?? const SizedBox.shrink()),
     );
   }
 }

--- a/app/test/preview/screenshot_main.dart
+++ b/app/test/preview/screenshot_main.dart
@@ -18,6 +18,7 @@ import 'package:cantinarr/core/network/backend_client.dart';
 import 'package:cantinarr/core/network/websocket_client.dart';
 import 'package:cantinarr/core/providers/realtime_provider.dart';
 import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/core/widgets/app_ambient_background.dart';
 import 'package:cantinarr/features/auth/logic/auth_provider.dart';
 import 'package:cantinarr/navigation/app_router.dart';
 import 'package:dio/dio.dart';
@@ -49,6 +50,8 @@ class _ScreenshotApp extends ConsumerWidget {
       theme: AppTheme.dark,
       debugShowCheckedModeBanner: false,
       routerConfig: ref.watch(appRouterProvider),
+      builder: (context, child) =>
+          AppAmbientBackground(child: child ?? const SizedBox.shrink()),
     );
   }
 }


### PR DESCRIPTION
## Problem

Route transitions looked clumsy/jarring: mid-transition, two screens rendered through each other (overlapping titles, doubled headers, list text bleeding through the incoming page), and the media-detail loading state showed the previous screen behind a lone spinner.

Root cause: `scaffoldBackgroundColor` is transparent by theme and the ambient canvas is painted once behind the root navigator — so no routed page was opaque, and every transition (default Cupertino slide on iOS) animated two see-through screens over one static background.

## Fix

- **Lateral surfaces dissolve.** `/login`, the outer `ShellRoute` (AppShell), and all six module `StatefulShellRoute`s move to `pageBuilder` returning a fade page: the incoming page (wrapped in its own `AppAmbientBackground`, so it's opaque) dissolves in over the static outgoing page (280ms in / 220ms out). Branch (bottom-tab) switches remain instant `IndexedStack` swaps.
- **Pushed routes keep the native slide + iOS swipe-back.** All secondary `GoRoute` children are wrapped in `AppAmbientBackground` so the `MaterialPage` slide occludes correctly; this also makes media detail's loading/error states opaque.
- **Raw `rootNavigator` pushes** (Sonarr/Radarr/Chaptarr drill-down screens, 19 sites) move to a new `AmbientPageRoute` (`MaterialPageRoute` + backdrop).
- **Screen-anchored ambient copies.** `AppAmbientBackground` now lays out its gradient layers at full-screen size anchored bottom-right, so copies painted in the shell's content box are pixel-identical to the app-level canvas (no glow seam at the top-bar boundary, no glow motion during the mobile search-bar collapse). Verified geometry: every in-shell box shares its bottom-right corner with the screen.
- **Notification fallback.** Book notifications without a `foreign_id` now `go()` to the Books tab instead of `push()`ing a module surface (a pushed module shell has no back affordance and its fade page has no swipe-back gesture).
- Preview/screenshot harnesses gain production's ambient `builder:` wrapper (they previously rendered without it); `app:verify` skill gotcha updated to reflect that double-exposure is now a regression, not debug-web noise.

## Verification

- `flutter analyze` clean; `flutter test` 528/528 (new: backdrop-ancestor guards for module/pushed/login pages, plus a mid-dissolve frame test — the suite's first real transition coverage).
- Runtime browser check via the preview harness: module switch is a clean opaque dissolve, pushes slide with a crisp occlusion edge (native parallax beneath), pop reveals the intact library, detail error/loading states sit on an opaque canvas, and the ambient glow is continuous across the chrome boundary.
- Adversarial multi-agent review over the diff: 2 confirmed minors (both fixed in this PR: pushed-module swipe-back trigger path, gradient re-anchoring seam), 2 claims rejected as pre-existing/false-positive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Auepxhn9LGKc1YqjVsUFzM