### PR TITLE
fix(app): animate the shell top-bar swap between module and pushed routes

### DIFF
--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -567,18 +567,45 @@ class _AppShellState extends ConsumerState<AppShell>
             // Base layer: search bar + module content
             Column(
               children: [
-                // Search bar at top (hidden during AI mode)
-                if (showGlobalSearch) ...[
-                  if (mobile)
-                    SizeTransition(
-                      sizeFactor: _searchBarCurve,
-                      axisAlignment: -1,
-                      child: topBar,
-                    )
-                  else
-                    topBar,
-                ] else if (!desktop)
-                  secondaryTopBar,
+                // Search bar at top (hidden during AI mode). Navigating
+                // between module and pushed routes swaps this slot (search
+                // bar <-> secondary label bar, or nothing on desktop); the
+                // swap cross-fades and height-morphs so the chrome glides
+                // with the page transition below instead of snapping.
+                AnimatedSize(
+                  duration: const Duration(milliseconds: 220),
+                  curve: Curves.easeOutCubic,
+                  alignment: Alignment.topCenter,
+                  child: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 220),
+                    layoutBuilder: (currentChild, previousChildren) => Stack(
+                      alignment: Alignment.topCenter,
+                      children: [
+                        ...previousChildren,
+                        if (currentChild != null) currentChild,
+                      ],
+                    ),
+                    child: showGlobalSearch
+                        ? KeyedSubtree(
+                            key: const ValueKey('module-top-bar'),
+                            child: mobile
+                                ? SizeTransition(
+                                    sizeFactor: _searchBarCurve,
+                                    axisAlignment: -1,
+                                    child: topBar,
+                                  )
+                                : topBar,
+                          )
+                        : !desktop
+                            ? KeyedSubtree(
+                                key: const ValueKey('secondary-top-bar'),
+                                child: secondaryTopBar,
+                              )
+                            : const SizedBox.shrink(
+                                key: ValueKey('no-top-bar'),
+                              ),
+                  ),
+                ),
                 // Module content (includes its own bottom nav)
                 Expanded(
                   child: Stack(


### PR DESCRIPTION
## Problem

Follow-up to #240. On mobile, pushing a secondary route (e.g. media detail) swapped the shell's top bar instantly — search bar out, "MEDIA DETAILS" label bar in — at a different height, so the chrome snapped and the content below jumped while the page transition animated underneath. Desktop had the same hard cut between the search bar and no bar at all.

## Fix

The top-bar slot in `AppShell` is now an `AnimatedSize` + `AnimatedSwitcher` composition (220ms, easeOutCubic): the outgoing and incoming bars cross-fade while the slot's height morphs smoothly, top-anchored. The mobile scroll-collapse `SizeTransition` is preserved inside the module-bar child; keyed subtrees (`module-top-bar` / `secondary-top-bar` / `no-top-bar`) drive the switch.

## Verification

- `flutter analyze` clean; `flutter test` 528/528 — including the shell chrome goldens, which capture the at-rest state and are unaffected by the animation wrappers.
- Runtime browser check via the preview harness: pushing Settings from the Radarr library morphs the bar region instead of snapping; console shows no layout/overflow exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Auepxhn9LGKc1YqjVsUFzM