### PR TITLE
fix(app): morph the request dock height when async actions land

### DIFF
--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -193,68 +193,77 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                             padding: const EdgeInsets.symmetric(horizontal: 16),
                             child: AppPanel(
                               accentColor: AppTheme.accent,
-                              child: ListenableBuilder(
-                                listenable: _requestNotifier,
-                                builder: (_, __) => Column(
-                                  mainAxisSize: MainAxisSize.min,
-                                  children: [
-                                    RequestButton(
-                                      status: _requestNotifier.state.status,
-                                      isRequesting:
-                                          _requestNotifier.state.isRequesting,
-                                      error: _requestNotifier.state.error,
-                                      onRequest: () => _onRequest(),
-                                    ),
-                                    const SizedBox(height: 10),
-                                    Wrap(
-                                      alignment: WrapAlignment.center,
-                                      crossAxisAlignment:
-                                          WrapCrossAlignment.center,
-                                      spacing: 6,
-                                      runSpacing: 4,
-                                      children: [
-                                        TextButton.icon(
-                                          onPressed: () => _showStatusSheet(
-                                            context,
-                                            state.title,
-                                            _requestNotifier.state.status,
-                                          ),
-                                          icon: const Icon(
-                                            Icons.info_outline_rounded,
-                                            size: 17,
-                                          ),
-                                          label: Text(
-                                            _requestNotifier.state.status.label,
-                                          ),
-                                        ),
-                                        if (_canReport(
-                                          _requestNotifier.state.status,
-                                        ))
+                              // Secondary actions land async (request status,
+                              // admin arr-link resolution), so the dock height
+                              // morphs instead of snapping when one appears.
+                              child: AnimatedSize(
+                                duration: const Duration(milliseconds: 220),
+                                curve: Curves.easeOutCubic,
+                                alignment: Alignment.topCenter,
+                                child: ListenableBuilder(
+                                  listenable: _requestNotifier,
+                                  builder: (_, __) => Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      RequestButton(
+                                        status: _requestNotifier.state.status,
+                                        isRequesting:
+                                            _requestNotifier.state.isRequesting,
+                                        error: _requestNotifier.state.error,
+                                        onRequest: () => _onRequest(),
+                                      ),
+                                      const SizedBox(height: 10),
+                                      Wrap(
+                                        alignment: WrapAlignment.center,
+                                        crossAxisAlignment:
+                                            WrapCrossAlignment.center,
+                                        spacing: 6,
+                                        runSpacing: 4,
+                                        children: [
                                           TextButton.icon(
-                                            onPressed: () =>
-                                                _onReportProblem(state),
-                                            icon: const Icon(
-                                              Icons.flag_outlined,
-                                              size: 17,
+                                            onPressed: () => _showStatusSheet(
+                                              context,
+                                              state.title,
+                                              _requestNotifier.state.status,
                                             ),
-                                            label: const Text(
-                                              'Report a problem',
-                                            ),
-                                          ),
-                                        if (_arrLink != null)
-                                          TextButton.icon(
-                                            onPressed: _openInArr,
                                             icon: const Icon(
-                                              Icons.open_in_new_rounded,
+                                              Icons.info_outline_rounded,
                                               size: 17,
                                             ),
                                             label: Text(
-                                              'Open in ${_arrLink!.moduleLabel}',
+                                              _requestNotifier
+                                                  .state.status.label,
                                             ),
                                           ),
-                                      ],
-                                    ),
-                                  ],
+                                          if (_canReport(
+                                            _requestNotifier.state.status,
+                                          ))
+                                            TextButton.icon(
+                                              onPressed: () =>
+                                                  _onReportProblem(state),
+                                              icon: const Icon(
+                                                Icons.flag_outlined,
+                                                size: 17,
+                                              ),
+                                              label: const Text(
+                                                'Report a problem',
+                                              ),
+                                            ),
+                                          if (_arrLink != null)
+                                            TextButton.icon(
+                                              onPressed: _openInArr,
+                                              icon: const Icon(
+                                                Icons.open_in_new_rounded,
+                                                size: 17,
+                                              ),
+                                              label: Text(
+                                                'Open in ${_arrLink!.moduleLabel}',
+                                              ),
+                                            ),
+                                        ],
+                                      ),
+                                    ],
+                                  ),
                                 ),
                               ),
                             ),


### PR DESCRIPTION
## Summary
- On media detail, the request dock's secondary actions land asynchronously — "Report a problem" once the request status loads, and the admin "Open in Radarr/Sonarr" link once the arr lookup resolves — so the panel snapped taller mid-view.
- Wrap the dock content in `AnimatedSize` (220ms, easeOutCubic, top-aligned), the same height-morph pattern the shell top bar already uses, so the panel glides open when an action appears instead of popping.

## Why not a greyed placeholder
Whether "Open in …" will ever activate is unknowable at first paint: it appears only when the title actually exists in the backing arr (most Discover titles don't, and non-admins never get it). A disabled placeholder would either sit dead forever or vanish after resolution — worse than animating the reveal. The existing "affordance appears only when there's a real destination" semantics are kept.

## Verification
- `flutter analyze --no-fatal-infos` — no issues
- `flutter test` — 528 passed

## Docs
No documented surface changed (no new route, tool, env var, table, or screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uL6GtWcNker5bU792kYHe