### PR TITLE
feat(instances): test connections from the server, not the device

### DIFF
--- a/app/lib/features/settings/data/instance_api_service.dart
+++ b/app/lib/features/settings/data/instance_api_service.dart
@@ -97,20 +97,27 @@ class InstanceApiService {
     await _dio.put('/api/instances/$id/users', data: {'user_ids': userIds});
   }
 
-  /// Test connection to a service URL.
-  Future<bool> testConnection(String url, String apiKey) async {
-    try {
-      final testDio = Dio(BaseOptions(
-        connectTimeout: const Duration(seconds: 10),
-        receiveTimeout: const Duration(seconds: 10),
-      ));
-      final resp = await testDio.get(
-        '$url/api/v3/system/status',
-        options: Options(headers: {'X-Api-Key': apiKey}),
-      );
-      return resp.statusCode == 200;
-    } catch (_) {
-      return false;
-    }
+  /// Ask the server to test a candidate instance configuration. The server is
+  /// what dials instance URLs in production, so cluster-internal names this
+  /// device cannot resolve (e.g. http://radarr:7878) still test truthfully —
+  /// and credentials never leave the backend boundary. When [id] is set,
+  /// blank credentials fall back to the stored write-only ones, matching
+  /// save's semantics. Throws on failure with the server's reason.
+  Future<void> testConnection({
+    String? id,
+    required String serviceType,
+    required String url,
+    String apiKey = '',
+    String username = '',
+    String password = '',
+  }) async {
+    await _dio.post('/api/instances/test', data: {
+      if (id != null) 'id': id,
+      'service_type': serviceType,
+      'url': url,
+      'api_key': apiKey,
+      'username': username,
+      'password': password,
+    });
   }
 }

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -50,6 +50,7 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
   bool _isSaving = false;
   bool _isTesting = false;
   String? _testResult;
+  bool _testSucceeded = false;
   bool _isConfiguringWebhook = false;
   bool? _webhookConfigured;
   String? _webhookResult;
@@ -94,12 +95,6 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
       _serviceType == 'qbittorrent' ||
       _serviceType == 'nzbget' ||
       _serviceType == 'transmission';
-
-  /// Only the v3 arr services support a device-direct connection test (it hits
-  /// `/api/v3/system/status`); the rest — including Chaptarr, which is `/api/v1`
-  /// — are validated by the backend when saving.
-  bool get _supportsDirectTest =>
-      _serviceType == 'radarr' || _serviceType == 'sonarr';
 
   bool get _supportsWebhook =>
       _serviceType == 'radarr' || _serviceType == 'sonarr';
@@ -267,17 +262,34 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
       _testResult = null;
     });
 
-    final backendDio = ref.read(backendClientProvider);
-    final service = InstanceApiService(backendDio: backendDio);
-    final success = await service.testConnection(
-      _urlController.text.trim(),
-      _apiKeyController.text.trim(),
-    );
-
-    setState(() {
-      _isTesting = false;
-      _testResult = success ? 'Connection successful!' : 'Connection failed';
-    });
+    // The server performs the check: it is what dials instance URLs in
+    // production, so cluster-internal names this device cannot resolve still
+    // test truthfully, and blank credentials fall back to the stored ones.
+    try {
+      final backendDio = ref.read(backendClientProvider);
+      final service = InstanceApiService(backendDio: backendDio);
+      await service.testConnection(
+        id: widget.instanceId,
+        serviceType: _serviceType,
+        url: _urlController.text.trim(),
+        apiKey: _apiKeyController.text.trim(),
+        username: _usernameController.text.trim(),
+        password: _passwordController.text,
+      );
+      if (!mounted) return;
+      setState(() {
+        _isTesting = false;
+        _testSucceeded = true;
+        _testResult = 'Connection successful!';
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _isTesting = false;
+        _testSucceeded = false;
+        _testResult = _errorMessage(e);
+      });
+    }
   }
 
   String? _validate() {
@@ -721,24 +733,27 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
     }
   }
 
+  /// Service-name examples: the Cantinarr server is what dials this URL, so
+  /// the container/cluster DNS name is the canonical form for the primary
+  /// (compose/k8s) distribution. LAN IPs and FQDNs work just as well.
   String get _urlHint {
     switch (_serviceType) {
       case 'sonarr':
-        return 'http://192.168.1.100:8989';
+        return 'http://sonarr:8989';
       case 'chaptarr':
-        return 'http://192.168.1.100:8787';
+        return 'http://chaptarr:8787';
       case 'sabnzbd':
-        return 'http://192.168.1.100:8080';
+        return 'http://sabnzbd:8080';
       case 'qbittorrent':
-        return 'http://192.168.1.100:8081';
+        return 'http://qbittorrent:8081';
       case 'nzbget':
-        return 'http://192.168.1.100:6789';
+        return 'http://nzbget:6789';
       case 'transmission':
-        return 'http://192.168.1.100:9091';
+        return 'http://transmission:9091';
       case 'tautulli':
-        return 'http://192.168.1.100:8181';
+        return 'http://tautulli:8181';
       default:
-        return 'http://192.168.1.100:7878';
+        return 'http://radarr:7878';
     }
   }
 
@@ -813,6 +828,8 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
             decoration: InputDecoration(
               labelText: 'URL',
               hintText: _urlHint,
+              helperText:
+                  'Reached from the Cantinarr server, not from this device.',
             ),
             keyboardType: TextInputType.url,
           ),
@@ -892,41 +909,31 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
 
           const SizedBox(height: 24),
 
-          // Test connection button (Radarr/Sonarr only — the device calls
-          // the arr server directly). Download clients and Tautulli are
-          // validated by the backend when saving.
-          if (_supportsDirectTest) ...[
-            OutlinedButton.icon(
-              onPressed: _isTesting ? null : _testConnection,
-              icon: _isTesting
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(
-                          strokeWidth: 2, color: AppTheme.accent),
-                    )
-                  : const Icon(Icons.wifi_tethering),
-              label: const Text('Test Connection'),
-            ),
-            if (_testResult != null) ...[
-              const SizedBox(height: 8),
-              Text(
-                _testResult!,
-                style: TextStyle(
-                  color: _testResult!.contains('successful')
-                      ? AppTheme.available
-                      : AppTheme.error,
-                  fontSize: 13,
-                ),
-                textAlign: TextAlign.center,
+          // Test connection button — the server performs the check for every
+          // service type, so it works for URLs only the server can resolve.
+          OutlinedButton.icon(
+            onPressed: _isTesting ? null : _testConnection,
+            icon: _isTesting
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(
+                        strokeWidth: 2, color: AppTheme.accent),
+                  )
+                : const Icon(Icons.wifi_tethering),
+            label: const Text('Test Connection'),
+          ),
+          if (_testResult != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              _testResult!,
+              style: TextStyle(
+                color: _testSucceeded ? AppTheme.available : AppTheme.error,
+                fontSize: 13,
               ),
-            ],
-          ] else
-            const Text(
-              'The connection is verified by the server when you save.',
-              style: TextStyle(color: AppTheme.textSecondary, fontSize: 12),
               textAlign: TextAlign.center,
             ),
+          ],
 
           const SizedBox(height: 32),
 

--- a/app/test/settings/instance_edit_screen_test.dart
+++ b/app/test/settings/instance_edit_screen_test.dart
@@ -20,11 +20,13 @@ class _FakeAdapter implements HttpClientAdapter {
     this.instances = const [],
     this.pins = const [],
     this.webhookError,
+    this.testError,
   });
 
   final List<Map<String, dynamic>> instances;
   final List<Map<String, dynamic>> pins;
   final String? webhookError;
+  final String? testError;
   final List<({String method, String path, dynamic body})> requests = [];
 
   @override
@@ -46,6 +48,19 @@ class _FakeAdapter implements HttpClientAdapter {
       response = instances;
     } else if (options.method == 'GET' && path.endsWith('/users')) {
       response = pins;
+    } else if (options.method == 'POST' && path == '/api/instances/test') {
+      final error = testError;
+      if (error != null) {
+        // Mirrors Go's http.Error: JSON-shaped body, text/plain content type.
+        return ResponseBody.fromString(
+          '${jsonEncode({'error': error})}\n',
+          400,
+          headers: {
+            'content-type': ['text/plain; charset=utf-8'],
+          },
+        );
+      }
+      return ResponseBody.fromString('', 204, headers: {});
     } else if (options.method == 'POST' && path == '/api/instances') {
       final map = body as Map<String, dynamic>;
       response = {...map, 'id': '${map['service_type']}-new'};
@@ -403,6 +418,82 @@ void main() {
     expect(putUsers.body, {
       'user_ids': [1]
     });
+  });
+
+  testWidgets('Test Connection asks the server to dial the URL', (tester) async {
+    final adapter = _FakeAdapter();
+    await _pumpEdit(tester, adapter: adapter, users: const []);
+
+    // Only the URL and key are filled in: the test must not require a name.
+    await tester.enterText(
+        find.widgetWithText(TextField, 'URL'), 'http://radarr:7878');
+    await tester.enterText(find.widgetWithText(TextField, 'API Key'), 'key');
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Test Connection'));
+    await tester.pumpAndSettle();
+
+    // The check runs on the server — the host that can resolve
+    // cluster-internal names — never as a device-direct arr call.
+    final test = adapter.requests
+        .singleWhere((r) => r.path == '/api/instances/test');
+    expect(test.method, 'POST');
+    expect(test.body['service_type'], 'radarr');
+    expect(test.body['url'], 'http://radarr:7878');
+    expect(test.body['api_key'], 'key');
+    expect(test.body.containsKey('id'), isFalse);
+    expect(find.text('Connection successful!'), findsOneWidget);
+  });
+
+  testWidgets(
+      'Test Connection on edit sends the id so stored credentials are used',
+      (tester) async {
+    final adapter = _FakeAdapter(instances: [Map.of(_radarrB)]);
+    await _pumpEdit(
+      tester,
+      adapter: adapter,
+      users: const [],
+      screen: const InstanceEditScreen(
+        instanceId: 'radarr-b',
+        initialServiceType: 'radarr',
+        initialName: 'Radarr B',
+        initialUrl: 'http://radarr-b',
+      ),
+    );
+
+    // The key field is blank (write-only credentials); the id lets the
+    // server fall back to the stored key instead of failing with a 401.
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Test Connection'));
+    await tester.pumpAndSettle();
+
+    final test = adapter.requests
+        .singleWhere((r) => r.path == '/api/instances/test');
+    expect(test.body['id'], 'radarr-b');
+    expect(test.body['api_key'], '');
+    expect(find.text('Connection successful!'), findsOneWidget);
+  });
+
+  testWidgets('Test Connection failure surfaces the server reason',
+      (tester) async {
+    const reason =
+        'connection test failed: could not reach server: dial tcp: connection refused';
+    final adapter = _FakeAdapter(testError: reason);
+    await _pumpEdit(tester, adapter: adapter, users: const []);
+
+    // Download clients get the same server-side test as the arrs.
+    await tester.tap(find.text('Radarr'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('SABnzbd').last);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(
+        find.widgetWithText(TextField, 'URL'), 'http://sabnzbd:8080');
+    await tester.enterText(find.widgetWithText(TextField, 'API Key'), 'key');
+    await tester.tap(find.widgetWithText(OutlinedButton, 'Test Connection'));
+    await tester.pumpAndSettle();
+
+    final test = adapter.requests
+        .singleWhere((r) => r.path == '/api/instances/test');
+    expect(test.body['service_type'], 'sabnzbd');
+    expect(find.text(reason), findsOneWidget);
   });
 
   testWidgets('configures instant updates without displaying a webhook token',

--- a/server/README.md
+++ b/server/README.md
@@ -272,6 +272,7 @@ Tool debug mode records names, timing, status, and payload sizes only; tool inpu
 ### Instances & arr proxy
 ```
 GET|POST /api/instances                      # admin: list/create
+POST   /api/instances/test                   # admin: dry-run connectivity check, dialed from the server
 PUT|DELETE /api/instances/{instanceID}       # admin: update/delete
 GET|PUT /api/instances/{instanceID}/users    # admin: which users are pinned/assigned here
 POST   /api/instances/{instanceID}/webhook   # admin: rotate credentials and upsert a managed arr webhook

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -345,6 +345,10 @@ func NewRouter(
 				r.Use(auth.RequirePermission(auth.PermissionInstancesManage))
 				r.Get("/instances", instanceHandler.List)
 				r.Post("/instances", instanceHandler.Create)
+				// Dry-run connectivity check from the server — the host that
+				// actually dials instance URLs — so cluster-internal names the
+				// admin's device cannot resolve still test truthfully.
+				r.Post("/instances/test", instanceHandler.TestConnection)
 				r.Put("/instances/{instanceID}", instanceHandler.Update)
 				r.Delete("/instances/{instanceID}", instanceHandler.Delete)
 				// Instance-centric view of user_default_instances (the static

--- a/server/internal/instance/handler.go
+++ b/server/internal/instance/handler.go
@@ -193,6 +193,65 @@ func (h *Handler) Update(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(toResponse(&inst))
 }
 
+// TestConnection validates a candidate configuration's reachability and
+// credentials from the server — the host that actually dials instance URLs,
+// so cluster-internal names the admin's device cannot resolve still test
+// truthfully — without persisting anything. For an existing instance (id set
+// in the body), blank credentials fall back to the stored ones, mirroring
+// Update's write-only semantics.
+func (h *Handler) TestConnection(w http.ResponseWriter, r *http.Request) {
+	var inst Instance
+	if err := json.NewDecoder(r.Body).Decode(&inst); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	if inst.ID != "" {
+		existing, err := h.store.Get(inst.ID)
+		if err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusInternalServerError)
+			return
+		}
+		if existing == nil {
+			http.Error(w, `{"error":"instance not found"}`, http.StatusNotFound)
+			return
+		}
+		inst.ServiceType = existing.ServiceType
+		if inst.APIKey == "" {
+			inst.APIKey = existing.APIKey
+		}
+		if inst.Username == "" {
+			inst.Username = existing.Username
+		}
+		if inst.Password == "" {
+			inst.Password = existing.Password
+		}
+	}
+
+	if !allowedServiceTypes[inst.ServiceType] {
+		http.Error(w, `{"error":"service_type must be one of 'radarr', 'sonarr', 'chaptarr', 'sabnzbd', 'qbittorrent', 'nzbget', 'transmission', 'tautulli'"}`, http.StatusBadRequest)
+		return
+	}
+	// The test doesn't need a name; default it so the shared validation only
+	// enforces the URL and credentials.
+	if inst.Name == "" {
+		inst.Name = inst.ServiceType
+	}
+	if err := validateRequiredFields(&inst); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err), http.StatusBadRequest)
+		return
+	}
+
+	inst.URL = strings.TrimRight(inst.URL, "/")
+
+	if err := validateConnection(&inst); err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"connection test failed: %s"}`, err), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // Delete removes a service instance.
 func (h *Handler) Delete(w http.ResponseWriter, r *http.Request) {
 	instanceID := chi.URLParam(r, "instanceID")

--- a/server/internal/instance/handler_test.go
+++ b/server/internal/instance/handler_test.go
@@ -108,6 +108,91 @@ func TestInstanceURLRejectsEmbeddedSecrets(t *testing.T) {
 	}
 }
 
+// Instance URLs are dialed only by the server, so cluster-internal names
+// (Docker service names, k8s cluster DNS, Tailscale MagicDNS) are a supported
+// production configuration — lock in that the URL contract accepts them.
+func TestInstanceURLAcceptsClusterInternalHostnames(t *testing.T) {
+	for _, rawURL := range []string{
+		"http://radarr:7878",
+		"http://sonarr",
+		"https://radarr.media.svc.cluster.local:7878",
+		"http://chaptarr:8787/books",
+	} {
+		inst := &Instance{ServiceType: "sonarr", Name: "TV", URL: rawURL, APIKey: "write-only"}
+		if err := validateRequiredFields(inst); err != nil {
+			t.Fatalf("validateRequiredFields(%q) = %v, want accepted", rawURL, err)
+		}
+	}
+	// A schemeless host:port parses as an opaque URL, not an absolute one.
+	inst := &Instance{ServiceType: "sonarr", Name: "TV", URL: "radarr:7878", APIKey: "write-only"}
+	if err := validateRequiredFields(inst); err == nil {
+		t.Fatal("validateRequiredFields accepted a schemeless URL")
+	}
+}
+
+func TestTestConnectionEndpoint(t *testing.T) {
+	const storedKey = "stored-api-secret"
+	arr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v3/system/status" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("X-Api-Key") != storedKey {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(arr.Close)
+
+	s := newTestStore(t)
+	stored := &Instance{ServiceType: "radarr", Name: "Movies", URL: arr.URL, APIKey: storedKey}
+	if err := s.Create(stored); err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+
+	h := NewHandler(s, nil)
+	router := chi.NewRouter()
+	router.Post("/instances/test", h.TestConnection)
+	do := func(body string) *httptest.ResponseRecorder {
+		t.Helper()
+		req := httptest.NewRequest("POST", "/instances/test", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// A candidate config tests without persisting anything; name is optional
+	// because the Test button is usable before the form is complete.
+	rec := do(`{"service_type":"radarr","url":"` + arr.URL + `","api_key":"` + storedKey + `"}`)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("test candidate = %d %s, want 204", rec.Code, rec.Body.String())
+	}
+
+	// Editing an existing instance: blank credentials fall back to the stored
+	// write-only ones, so re-testing an unmodified form passes.
+	rec = do(`{"id":"` + stored.ID + `","url":"` + arr.URL + `","api_key":""}`)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("test with stored credentials = %d %s, want 204", rec.Code, rec.Body.String())
+	}
+
+	// A wrong key still fails even when an id is supplied.
+	rec = do(`{"id":"` + stored.ID + `","url":"` + arr.URL + `","api_key":"wrong"}`)
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "connection test failed") {
+		t.Fatalf("test with wrong key = %d %s, want 400 connection test failed", rec.Code, rec.Body.String())
+	}
+
+	if rec := do(`{"id":"radarr-missing","url":"` + arr.URL + `"}`); rec.Code != http.StatusNotFound {
+		t.Fatalf("test unknown id = %d, want 404", rec.Code)
+	}
+	if rec := do(`{"service_type":"floppy","url":"` + arr.URL + `"}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("test unknown service type = %d, want 400", rec.Code)
+	}
+	if rec := do(`not json`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("test invalid body = %d, want 400", rec.Code)
+	}
+}
+
 func TestValidateArrURLDoesNotFollowRedirects(t *testing.T) {
 	var redirectedRequests atomic.Int32
 	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Part 1 of the cluster-internal (short-hostname) instance URL e2e work. Instance URLs are dialed only by the Cantinarr server, so `http://radarr:7878`-style Docker/k8s/MagicDNS names are a fully supported configuration — but the Test Connection button dialed the arr **from the user's device**, so those URLs always reported "Connection failed" despite being correct (and on edit, write-only credentials meant the device sent an empty API key, so even FQDN instances failed their re-test). It was also the only code path where an instance API key ever left the server.

- **Server:** new admin-gated `POST /api/instances/test` — a dry-run of the same `validateRequiredFields` + `validateConnection` used on save; blank credentials fall back to the stored write-only ones when an `id` is supplied; name optional so the button works before the form is complete.
- **App:** the Test button now goes through the backend, works for all eight service types (previously Radarr/Sonarr only), and shows the server's failure reason instead of a bare "Connection failed".
- **App:** URL hints teach the service-name form (`http://radarr:7878`) and the URL field notes it is reached from the server, not the device.
- **Tests:** Go — cluster-internal URL contract locked in, endpoint success/stored-credential/wrong-key/404/400 paths; Flutter — button posts to the server, sends the id on edit, surfaces the server reason.
- **Docs:** route table row in `server/README.md`.

## Verification

- `go vet ./...` and `go test ./...` from `server/` — pass
- `flutter analyze --no-fatal-infos` and `flutter test` from `app/` — pass (531 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzwxV4VGEofnT31amcBGoU