### PR TITLE
fix: sanitize OpenAI tool schema roots

### DIFF
--- a/server/internal/ai/http_providers.go
+++ b/server/internal/ai/http_providers.go
@@ -331,9 +331,16 @@ func openAIMessageToTranscript(message openAIMessage) transcriptMessage {
 func toOpenAITools(tools []mcp.Tool) []openai.ChatCompletionToolUnionParam {
 	out := make([]openai.ChatCompletionToolUnionParam, 0, len(tools))
 	for _, t := range tools {
+		parameters := make(openai.FunctionParameters, len(t.InputSchema))
+		for key, value := range t.InputSchema {
+			parameters[key] = value
+		}
+		for _, key := range []string{"oneOf", "anyOf", "allOf", "enum", "const", "not"} {
+			delete(parameters, key)
+		}
 		fn := openai.FunctionDefinitionParam{
 			Name:       t.Name,
-			Parameters: openai.FunctionParameters(t.InputSchema),
+			Parameters: parameters,
 		}
 		if t.Description != "" {
 			fn.Description = openai.String(t.Description)

--- a/server/internal/ai/provider_contract_test.go
+++ b/server/internal/ai/provider_contract_test.go
@@ -355,6 +355,48 @@ func TestOpenAIInteractiveFinalIterationKeepsToolChoiceWithTools(t *testing.T) {
 	}
 }
 
+func TestOpenAIToolSchemasUseSupportedObjectRoots(t *testing.T) {
+	adminTools := mcp.NewToolServer(nil, nil, nil, nil).GetToolsForRole(auth.RoleAdmin)
+	params := openAIInteractiveParams(
+		"gpt-5.5",
+		[]openai.ChatCompletionMessageParamUnion{openai.UserMessage("hello")},
+		toOpenAITools(adminTools),
+		false,
+	)
+	body, err := json.Marshal(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded struct {
+		Tools []struct {
+			Function struct {
+				Name       string         `json:"name"`
+				Parameters map[string]any `json:"parameters"`
+			} `json:"function"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	seenGrabRelease := false
+	for _, tool := range decoded.Tools {
+		if tool.Function.Name == "grab_release" {
+			seenGrabRelease = true
+		}
+		if tool.Function.Parameters["type"] != "object" {
+			t.Errorf("tool %q parameters must have type object", tool.Function.Name)
+		}
+		for _, keyword := range []string{"oneOf", "anyOf", "allOf", "enum", "const", "not"} {
+			if _, found := tool.Function.Parameters[keyword]; found {
+				t.Errorf("tool %q has unsupported top-level %s", tool.Function.Name, keyword)
+			}
+		}
+	}
+	if !seenGrabRelease {
+		t.Fatal("serialized OpenAI request omitted grab_release")
+	}
+}
+
 func TestOpenAIValidationOmitsUnsupportedReasoningField(t *testing.T) {
 	params := openAINextTurnParams("gpt-4.1", TurnParams{
 		DisableReasoning: true,

--- a/server/internal/ai/provider_contract_test.go
+++ b/server/internal/ai/provider_contract_test.go
@@ -395,6 +395,16 @@ func TestOpenAIToolSchemasUseSupportedObjectRoots(t *testing.T) {
 	if !seenGrabRelease {
 		t.Fatal("serialized OpenAI request omitted grab_release")
 	}
+	// The sanitizer must strip a copy, never the canonical schema: Gemini and
+	// native MCP clients still rely on grab_release's root oneOf.
+	for _, tool := range adminTools {
+		if tool.Name != "grab_release" {
+			continue
+		}
+		if _, found := tool.InputSchema["oneOf"]; !found {
+			t.Error("toOpenAITools mutated the canonical grab_release schema: root oneOf removed")
+		}
+	}
 }
 
 func TestOpenAIValidationOmitsUnsupportedReasoningField(t *testing.T) {


### PR DESCRIPTION
## What

Fix OpenAI chat requests that fail before generation when an enabled tool has unsupported top-level JSON Schema composition keywords.

Cantinarr's canonical MCP schemas remain unchanged for Gemini and native MCP clients. The OpenAI adapter now shallow-copies each tool's parameter root and removes only the top-level keywords OpenAI rejects: `oneOf`, `anyOf`, `allOf`, `enum`, `const`, and `not`.

The production failure was:

```text
Invalid schema for function 'grab_release': schema must have type 'object' and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'const'/'not' at the top level.
param: tools[17].function.parameters
code: invalid_function_parameters
```

Runtime authorization and media-specific `grab_release` validation remain unchanged and continue to fail closed before mutation.

## Verification

- `go vet ./...`
- `go test ./... -count=1`
- Provider-contract regression test serializes the full OpenAI administrator tool catalog, confirms `grab_release` is present, and rejects unsupported root keywords.
- Deployed the patched server and confirmed healthy startup with the OpenAI chat path operating successfully.

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — this only adapts existing canonical tool schemas to OpenAI's documented request constraint.
