### PR TITLE
fix(server): host-free transport errors and self-diagnosing connection failures

### DIFF
--- a/server/internal/chaptarr/client.go
+++ b/server/internal/chaptarr/client.go
@@ -13,6 +13,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/transporterr"
 )
 
 type Client struct {
@@ -453,7 +455,11 @@ func (c *Client) doWith(client *http.Client, method, path string, body, out any)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		// Transport errors embed the full request URL (and DNS failures repeat
+		// the hostname). These errors surface beyond admins — e.g. in request
+		// failures — so summarize them host-free like the status branch below.
+		requestPath, _, _ := strings.Cut(path, "?")
+		return fmt.Errorf("chaptarr %s %s: %s", method, requestPath, transporterr.Summarize(err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -474,7 +480,13 @@ func (c *Client) doRequest(method, path string) (*http.Response, error) {
 		return nil, err
 	}
 	req.Header.Set("X-Api-Key", c.apiKey)
-	return c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		// Host-free, like doWith: transport errors embed the full request URL.
+		requestPath, _, _ := strings.Cut(path, "?")
+		return nil, fmt.Errorf("chaptarr %s %s: %s", method, requestPath, transporterr.Summarize(err))
+	}
+	return resp, nil
 }
 
 // LookupAuthor searches Chaptarr's metadata for authors matching term.

--- a/server/internal/chaptarr/client_test.go
+++ b/server/internal/chaptarr/client_test.go
@@ -3,6 +3,7 @@ package chaptarr
 import (
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -10,6 +11,28 @@ import (
 	"sync/atomic"
 	"testing"
 )
+
+type failingTransport struct{ err error }
+
+func (f failingTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, f.err }
+
+// TestTransportErrorOmitsHost pins the topology-privacy property: transport
+// failures embed the full request URL (and DNS errors repeat the hostname),
+// and these errors surface to requesters through book-request failures — so
+// the client must summarize them host-free.
+func TestTransportErrorOmitsHost(t *testing.T) {
+	dnsFailure := &net.OpError{Op: "dial", Err: &net.DNSError{Err: "no such host", Name: "chaptarr-internal"}}
+	c := NewClient("http://chaptarr-internal:8787", "key")
+	c.httpClient = &http.Client{Transport: failingTransport{dnsFailure}}
+
+	if _, err := c.LookupAuthor("le guin"); err == nil {
+		t.Fatal("LookupAuthor succeeded against a failing transport")
+	} else if msg := err.Error(); strings.Contains(msg, "chaptarr-internal") || strings.Contains(msg, "8787") {
+		t.Errorf("LookupAuthor error %q names the host", msg)
+	} else if !strings.Contains(msg, "could not resolve host") {
+		t.Errorf("LookupAuthor error %q lacks the failure summary", msg)
+	}
+}
 
 func TestClientDoesNotFollowRedirects(t *testing.T) {
 	var redirectedRequests atomic.Int32

--- a/server/internal/instance/webhook_config.go
+++ b/server/internal/instance/webhook_config.go
@@ -61,7 +61,14 @@ func (h *Handler) ConfigureWebhook(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// arrConfigurationClient errors contain method/path/status only, never a
 		// response body or the request payload carrying the callback credential.
-		http.Error(w, fmt.Sprintf(`{"error":"failed to configure %s webhook: %s"}`, inst.ServiceType, err), http.StatusBadGateway)
+		// A 400 on the notification save usually means the arr tested the
+		// webhook and could not reach the callback — the one URL that must be
+		// reachable from the arr's own network, not from browsers.
+		hint := ""
+		if strings.Contains(err.Error(), "status 400") {
+			hint = " (the arr tests the webhook when saving; check that the callback URL derived from CANTINARR_PUBLIC_URL is reachable from the arr's own network)"
+		}
+		http.Error(w, fmt.Sprintf(`{"error":"failed to configure %s webhook: %s%s"}`, inst.ServiceType, err, hint), http.StatusBadGateway)
 		return
 	}
 	if err := h.store.PromoteWebhookToken(instanceID, token); err != nil {

--- a/server/internal/nzbget/client.go
+++ b/server/internal/nzbget/client.go
@@ -71,6 +71,9 @@ func (c *Client) call(method string, params []interface{}, out interface{}) erro
 	if resp.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("nzbget: invalid credentials")
 	}
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return fmt.Errorf("nzbget returned redirect status %d to %q (redirects are not followed; use the service's final URL)", resp.StatusCode, resp.Header.Get("Location"))
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("nzbget returned status %d", resp.StatusCode)
 	}

--- a/server/internal/nzbget/client_test.go
+++ b/server/internal/nzbget/client_test.go
@@ -142,6 +142,23 @@ func TestClientDoesNotFollowRedirects(t *testing.T) {
 // TestEditQueueFallsBackToLegacySignature pins the v16+/pre-v16 shim: the
 // modern 3-parameter editqueue is tried first, and on an RPC error the legacy
 // 4-parameter signature (with the Offset param) is used.
+// TestRedirectErrorNamesLocation pins that a refused redirect reports where
+// the service tried to send us, so scheme misconfigurations are self-diagnosing.
+func TestRedirectErrorNamesLocation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://nzbget.internal/jsonrpc", http.StatusMovedPermanently)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, "user", "password").Version()
+	if err == nil || !strings.Contains(err.Error(), "https://nzbget.internal/jsonrpc") {
+		t.Fatalf("redirect error = %v, want the Location named", err)
+	}
+	if strings.Contains(err.Error(), "password") {
+		t.Errorf("error %q echoes credentials", err.Error())
+	}
+}
+
 func TestEditQueueFallsBackToLegacySignature(t *testing.T) {
 	var mu sync.Mutex
 	var calls []rpcRequest

--- a/server/internal/qbittorrent/client.go
+++ b/server/internal/qbittorrent/client.go
@@ -55,10 +55,19 @@ func (c *Client) Login() error {
 	defer resp.Body.Close()
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return fmt.Errorf("qbittorrent login failed: redirect status %d to %q (redirects are not followed; use the WebUI's final URL)", resp.StatusCode, resp.Header.Get("Location"))
+	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("qbittorrent login failed: status %d", resp.StatusCode)
 	}
-	if !strings.HasPrefix(strings.TrimSpace(string(body)), "Ok") {
+	trimmed := strings.TrimSpace(string(body))
+	if !strings.HasPrefix(trimmed, "Ok") {
+		// The login endpoint answers plain "Ok." or "Fails."; an HTML body is
+		// some other page entirely (wrong port or path), not a bad password.
+		if strings.HasPrefix(trimmed, "<") {
+			return fmt.Errorf("qbittorrent login failed: unexpected response (is this the qBittorrent WebUI URL?)")
+		}
 		return fmt.Errorf("qbittorrent login failed: invalid credentials")
 	}
 

--- a/server/internal/qbittorrent/client_test.go
+++ b/server/internal/qbittorrent/client_test.go
@@ -154,6 +154,42 @@ func TestLoginFailuresDoNotEchoCredentials(t *testing.T) {
 	}
 }
 
+// TestLoginDistinguishesWrongPageFromBadPassword pins that an HTML answer —
+// some other WebUI on the entered port, not qBittorrent's plain "Ok."/"Fails."
+// endpoint — is not misreported as invalid credentials.
+func TestLoginDistinguishesWrongPageFromBadPassword(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "<html><title>Some other WebUI</title></html>")
+	}))
+	t.Cleanup(srv.Close)
+
+	err := NewClient(srv.URL, "admin", "password").Login()
+	if err == nil {
+		t.Fatal("Login accepted an HTML response")
+	}
+	if strings.Contains(err.Error(), "invalid credentials") {
+		t.Errorf("error %v misreports a non-qBittorrent page as bad credentials", err)
+	}
+	if !strings.Contains(err.Error(), "unexpected response") {
+		t.Errorf("error %v lacks the wrong-page explanation", err)
+	}
+}
+
+// TestLoginRedirectNamesLocation pins that a refused login redirect reports
+// where the WebUI tried to send us, so scheme misconfigurations are
+// self-diagnosing.
+func TestLoginRedirectNamesLocation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://qbittorrent.internal/", http.StatusMovedPermanently)
+	}))
+	t.Cleanup(srv.Close)
+
+	err := NewClient(srv.URL, "admin", "password").Login()
+	if err == nil || !strings.Contains(err.Error(), "https://qbittorrent.internal/") {
+		t.Fatalf("redirect error = %v, want the Location named", err)
+	}
+}
+
 func TestClientDoesNotFollowRedirects(t *testing.T) {
 	var redirectedRequests atomic.Int32
 	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/radarr/client.go
+++ b/server/internal/radarr/client.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/transporterr"
 )
 
 type Client struct {
@@ -109,7 +111,11 @@ func (c *Client) doWith(client *http.Client, method, path string, body, out any)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		// Transport errors embed the full request URL (and DNS failures repeat
+		// the hostname). These errors surface beyond admins — e.g. in request
+		// failures — so summarize them host-free like the status branch below.
+		requestPath, _, _ := strings.Cut(path, "?")
+		return fmt.Errorf("radarr %s %s: %s", method, requestPath, transporterr.Summarize(err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -130,7 +136,13 @@ func (c *Client) doRequest(method, path string) (*http.Response, error) {
 		return nil, err
 	}
 	req.Header.Set("X-Api-Key", c.apiKey)
-	return c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		// Host-free, like doWith: transport errors embed the full request URL.
+		requestPath, _, _ := strings.Cut(path, "?")
+		return nil, fmt.Errorf("radarr %s %s: %s", method, requestPath, transporterr.Summarize(err))
+	}
+	return resp, nil
 }
 
 func (c *Client) LookupByTMDB(tmdbID int) (*LookupResult, error) {
@@ -224,7 +236,8 @@ func (c *Client) AddMovie(addReq *AddMovieRequest) error {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("radarr add movie: %w", err)
+		// Host-free: this error reaches requesters through request failures.
+		return fmt.Errorf("radarr add movie: %s", transporterr.Summarize(err))
 	}
 	defer resp.Body.Close()
 

--- a/server/internal/radarr/client_test.go
+++ b/server/internal/radarr/client_test.go
@@ -1,12 +1,43 @@
 package radarr
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"sync/atomic"
 	"testing"
 )
+
+type failingTransport struct{ err error }
+
+func (f failingTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, f.err }
+
+// TestTransportErrorOmitsHost pins the topology-privacy property: transport
+// failures embed the full request URL (and DNS errors repeat the hostname),
+// and these errors surface to requesters through request failures — so the
+// client must summarize them host-free.
+func TestTransportErrorOmitsHost(t *testing.T) {
+	dnsFailure := &net.OpError{Op: "dial", Err: &net.DNSError{Err: "no such host", Name: "radarr-internal"}}
+	c := NewClient("http://radarr-internal:7878", "key")
+	c.httpClient = &http.Client{Transport: failingTransport{dnsFailure}}
+
+	if err := c.AddMovie(&AddMovieRequest{}); err == nil {
+		t.Fatal("AddMovie succeeded against a failing transport")
+	} else if msg := err.Error(); strings.Contains(msg, "radarr-internal") || strings.Contains(msg, "7878") {
+		t.Errorf("AddMovie error %q names the host", msg)
+	} else if !strings.Contains(msg, "could not resolve host") {
+		t.Errorf("AddMovie error %q lacks the failure summary", msg)
+	}
+
+	if _, err := c.LookupByTMDB(603); err == nil {
+		t.Fatal("LookupByTMDB succeeded against a failing transport")
+	} else if msg := err.Error(); strings.Contains(msg, "radarr-internal") || strings.Contains(msg, "7878") {
+		t.Errorf("LookupByTMDB error %q names the host", msg)
+	} else if !strings.Contains(msg, "radarr GET /api/v3/movie/lookup") {
+		t.Errorf("LookupByTMDB error %q does not identify the call", msg)
+	}
+}
 
 func TestClientDoesNotFollowRedirects(t *testing.T) {
 	var redirectedRequests atomic.Int32

--- a/server/internal/sabnzbd/client.go
+++ b/server/internal/sabnzbd/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -56,7 +57,17 @@ func (c *Client) call(params url.Values, out interface{}) error {
 	if err != nil {
 		return fmt.Errorf("sabnzbd read response: %w", err)
 	}
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		location := redactSecret(resp.Header.Get("Location"), c.apiKey)
+		return fmt.Errorf("sabnzbd returned redirect status %d to %q (redirects are not followed; use the service's final URL)", resp.StatusCode, location)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Keep the body's explanation: SABnzbd's hostname verification — which
+		// rejects Docker/k8s service names it doesn't know — answers 403 with
+		// the actionable "Access denied - Hostname verification failed" text.
+		if excerpt := c.bodyExcerpt(body); excerpt != "" {
+			return fmt.Errorf("sabnzbd returned status %d: %s", resp.StatusCode, excerpt)
+		}
 		return fmt.Errorf("sabnzbd returned status %d", resp.StatusCode)
 	}
 
@@ -74,10 +85,34 @@ func (c *Client) call(params url.Values, out interface{}) error {
 
 	if out != nil {
 		if err := json.Unmarshal(body, out); err != nil {
+			// A 200 that isn't JSON at all is usually an HTML page (wrong port,
+			// or a denial served with 200); its text beats "invalid character".
+			if excerpt := c.bodyExcerpt(body); excerpt != "" && !json.Valid(body) {
+				return fmt.Errorf("sabnzbd returned an unexpected response: %s", excerpt)
+			}
 			return fmt.Errorf("sabnzbd decode response: %w", err)
 		}
 	}
 	return nil
+}
+
+// htmlTagPattern strips markup from error-page bodies before excerpting.
+var htmlTagPattern = regexp.MustCompile(`<[^>]*>`)
+
+// bodyExcerpt condenses an error-response body into a short, single-line,
+// secret-free excerpt so actionable upstream messages (e.g. SABnzbd's
+// hostname-verification denial) survive into the error.
+func (c *Client) bodyExcerpt(body []byte) string {
+	text := string(body)
+	if strings.Contains(text, "<") {
+		text = htmlTagPattern.ReplaceAllString(text, " ")
+	}
+	text = strings.Join(strings.Fields(text), " ")
+	text = redactSecret(text, c.apiKey)
+	if len(text) > 200 {
+		text = text[:200] + "..."
+	}
+	return text
 }
 
 // Version returns the SABnzbd version; used as the connection test.

--- a/server/internal/sabnzbd/client_test.go
+++ b/server/internal/sabnzbd/client_test.go
@@ -111,6 +111,69 @@ func TestClientDoesNotFollowRedirects(t *testing.T) {
 
 // TestQueueSlotDerivedFields pins the string-typed numeric parsing SABnzbd
 // forces on clients, in particular the "[dd:]hh:mm:ss" timeleft format.
+// TestErrorBodyExcerptSurfaced pins that actionable upstream denials — like
+// SABnzbd's hostname verification, which rejects Docker/k8s service names it
+// doesn't know — reach the admin instead of a bare status number, markup
+// stripped and API key redacted.
+func TestErrorBodyExcerptSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("<html><body>Access denied - Hostname verification failed " +
+			"https://sabnzbd.org/hostname-check key=sab-api-key</body></html>"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, "sab-api-key").Version()
+	if err == nil {
+		t.Fatal("Version succeeded, want a hostname-verification error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "Hostname verification failed") {
+		t.Errorf("error %q does not surface the denial text", msg)
+	}
+	if strings.Contains(msg, "sab-api-key") {
+		t.Errorf("error %q echoes the API key", msg)
+	}
+	if strings.Contains(msg, "<body>") {
+		t.Errorf("error %q contains markup", msg)
+	}
+}
+
+// TestNonJSONResponseExcerptSurfaced pins the wrong-port/HTML-page shape: a
+// 200 that isn't JSON reports the page text, not "invalid character '<'".
+func TestNonJSONResponseExcerptSurfaced(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("<html><title>Some other WebUI</title></html>"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, "sab-api-key").Version()
+	if err == nil || !strings.Contains(err.Error(), "Some other WebUI") {
+		t.Fatalf("non-JSON error = %v, want page text excerpt", err)
+	}
+}
+
+// TestRedirectErrorNamesLocation pins that a refused redirect reports where
+// the service tried to send us (with the API key redacted), so scheme/path
+// misconfigurations are self-diagnosing.
+func TestRedirectErrorNamesLocation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://sabnzbd.internal/api?apikey=sab-api-key", http.StatusMovedPermanently)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, "sab-api-key").Version()
+	if err == nil || !strings.Contains(err.Error(), "redirects are not followed") {
+		t.Fatalf("redirect error = %v, want a redirect explanation", err)
+	}
+	if !strings.Contains(err.Error(), "https://sabnzbd.internal/api") {
+		t.Errorf("error %q does not name the Location", err.Error())
+	}
+	if strings.Contains(err.Error(), "sab-api-key") {
+		t.Errorf("error %q echoes the API key", err.Error())
+	}
+}
+
 func TestQueueSlotDerivedFields(t *testing.T) {
 	etaCases := []struct {
 		timeLeft string

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/transporterr"
 )
 
 type Client struct {
@@ -153,7 +155,11 @@ func (c *Client) doWith(client *http.Client, method, path string, body, out any)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return err
+		// Transport errors embed the full request URL (and DNS failures repeat
+		// the hostname). These errors surface beyond admins — e.g. in request
+		// failures — so summarize them host-free like the status branch below.
+		requestPath, _, _ := strings.Cut(path, "?")
+		return fmt.Errorf("sonarr %s %s: %s", method, requestPath, transporterr.Summarize(err))
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -174,7 +180,13 @@ func (c *Client) doRequest(method, path string) (*http.Response, error) {
 		return nil, err
 	}
 	req.Header.Set("X-Api-Key", c.apiKey)
-	return c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		// Host-free, like doWith: transport errors embed the full request URL.
+		requestPath, _, _ := strings.Cut(path, "?")
+		return nil, fmt.Errorf("sonarr %s %s: %s", method, requestPath, transporterr.Summarize(err))
+	}
+	return resp, nil
 }
 
 func (c *Client) LookupByTVDB(tvdbID int) (*LookupResult, error) {
@@ -285,7 +297,8 @@ func (c *Client) AddSeries(addReq *AddSeriesRequest) error {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("sonarr add series: %w", err)
+		// Host-free: this error reaches requesters through request failures.
+		return fmt.Errorf("sonarr add series: %s", transporterr.Summarize(err))
 	}
 	defer resp.Body.Close()
 

--- a/server/internal/sonarr/client_test.go
+++ b/server/internal/sonarr/client_test.go
@@ -3,6 +3,7 @@ package sonarr
 import (
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -10,6 +11,36 @@ import (
 	"testing"
 	"time"
 )
+
+type failingTransport struct{ err error }
+
+func (f failingTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, f.err }
+
+// TestTransportErrorOmitsHost pins the topology-privacy property: transport
+// failures embed the full request URL (and DNS errors repeat the hostname),
+// and these errors surface to requesters through request failures — so the
+// client must summarize them host-free.
+func TestTransportErrorOmitsHost(t *testing.T) {
+	dnsFailure := &net.OpError{Op: "dial", Err: &net.DNSError{Err: "no such host", Name: "sonarr-internal"}}
+	c := NewClient("http://sonarr-internal:8989", "key")
+	c.httpClient = &http.Client{Transport: failingTransport{dnsFailure}}
+
+	if err := c.AddSeries(&AddSeriesRequest{}); err == nil {
+		t.Fatal("AddSeries succeeded against a failing transport")
+	} else if msg := err.Error(); strings.Contains(msg, "sonarr-internal") || strings.Contains(msg, "8989") {
+		t.Errorf("AddSeries error %q names the host", msg)
+	} else if !strings.Contains(msg, "could not resolve host") {
+		t.Errorf("AddSeries error %q lacks the failure summary", msg)
+	}
+
+	if _, err := c.LookupByTVDB(1234); err == nil {
+		t.Fatal("LookupByTVDB succeeded against a failing transport")
+	} else if msg := err.Error(); strings.Contains(msg, "sonarr-internal") || strings.Contains(msg, "8989") {
+		t.Errorf("LookupByTVDB error %q names the host", msg)
+	} else if !strings.Contains(msg, "sonarr GET /api/v3/series/lookup") {
+		t.Errorf("LookupByTVDB error %q does not identify the call", msg)
+	}
+}
 
 func TestClientDoesNotFollowRedirects(t *testing.T) {
 	var redirectedRequests atomic.Int32

--- a/server/internal/tautulli/client.go
+++ b/server/internal/tautulli/client.go
@@ -59,6 +59,11 @@ func (c *Client) call(cmd string, params url.Values, out interface{}) error {
 	if err != nil {
 		return fmt.Errorf("tautulli read response: %w", err)
 	}
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		// The Location can echo the request query, which carries the apikey.
+		location := redactSecret(resp.Header.Get("Location"), c.apiKey)
+		return fmt.Errorf("tautulli returned redirect status %d to %q (redirects are not followed; use the service's final URL)", resp.StatusCode, location)
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("tautulli returned status %d", resp.StatusCode)
 	}

--- a/server/internal/tautulli/client_test.go
+++ b/server/internal/tautulli/client_test.go
@@ -51,6 +51,27 @@ func TestCallSendsCmdAndAPIKey(t *testing.T) {
 // TestGetActivityToleratesStringNumbers pins the flexInt mapping: Tautulli
 // encodes many numeric fields as strings (sometimes empty or junk), and the
 // client must map every session anyway.
+// TestRedirectErrorNamesLocationRedacted pins that a refused redirect reports
+// where Tautulli tried to send us with the apikey query parameter redacted —
+// Tautulli echoes the request query into the redirect Location.
+func TestRedirectErrorNamesLocationRedacted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://tautulli.internal/api/v2?apikey=tautulli-api-key&cmd=get_server_info", http.StatusMovedPermanently)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, "tautulli-api-key").GetServerInfo()
+	if err == nil || !strings.Contains(err.Error(), "redirects are not followed") {
+		t.Fatalf("redirect error = %v, want a redirect explanation", err)
+	}
+	if !strings.Contains(err.Error(), "https://tautulli.internal/api/v2") {
+		t.Errorf("error %q does not name the Location", err.Error())
+	}
+	if strings.Contains(err.Error(), "tautulli-api-key") {
+		t.Errorf("error %q echoes the API key", err.Error())
+	}
+}
+
 func TestGetActivityToleratesStringNumbers(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.URL.Query().Get("cmd"); got != "get_activity" {

--- a/server/internal/transmission/client.go
+++ b/server/internal/transmission/client.go
@@ -111,6 +111,15 @@ func (c *Client) call(method string, args interface{}, out interface{}) error {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("transmission: invalid credentials")
 	}
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return fmt.Errorf("transmission returned redirect status %d to %q (redirects are not followed; use the service's final URL)", resp.StatusCode, resp.Header.Get("Location"))
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		// The RPC path is appended to the base URL, so a 404 almost always
+		// means the admin pasted the web UI URL (…/transmission or
+		// …/transmission/web) or a custom rpc-url install.
+		return fmt.Errorf("transmission returned status 404 (not the RPC endpoint — enter just scheme://host:port; Cantinarr appends /transmission/rpc)")
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("transmission returned status %d", resp.StatusCode)
 	}

--- a/server/internal/transmission/client_test.go
+++ b/server/internal/transmission/client_test.go
@@ -145,6 +145,33 @@ func TestClientDoesNotFollowRedirects(t *testing.T) {
 // TestRemoveTorrentsGuardsEmptyList pins the destructive-op guard: an empty
 // hash list must be rejected client-side, because a bare torrent-remove would
 // remove every torrent Transmission knows.
+// TestNotFoundExplainsRPCPathShape pins the pasted-web-UI-URL failure: the
+// RPC path is appended to the base URL, so a 404 names the expected shape
+// instead of leaving a bare status number.
+func TestNotFoundExplainsRPCPathShape(t *testing.T) {
+	srv := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL+"/transmission/web", "", "").SessionGet()
+	if err == nil || !strings.Contains(err.Error(), "Cantinarr appends /transmission/rpc") {
+		t.Fatalf("404 error = %v, want the expected-URL-shape explanation", err)
+	}
+}
+
+// TestRedirectErrorNamesLocation pins that a refused redirect reports where
+// the daemon tried to send us, so scheme misconfigurations are self-diagnosing.
+func TestRedirectErrorNamesLocation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://transmission.internal/transmission/rpc", http.StatusMovedPermanently)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := NewClient(srv.URL, "", "").SessionGet()
+	if err == nil || !strings.Contains(err.Error(), "https://transmission.internal/transmission/rpc") {
+		t.Fatalf("redirect error = %v, want the Location named", err)
+	}
+}
+
 func TestRemoveTorrentsGuardsEmptyList(t *testing.T) {
 	var requests atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/transporterr/transporterr.go
+++ b/server/internal/transporterr/transporterr.go
@@ -1,0 +1,38 @@
+// Package transporterr summarizes HTTP transport failures without naming the
+// dialed host. Errors from http.Client.Do embed the full request URL — and
+// DNS failures repeat the hostname — so returning them verbatim from service
+// clients leaks internal topology (e.g. http://radarr:7878) into whatever
+// wraps the error, including requester-facing request failures.
+package transporterr
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"syscall"
+)
+
+// Summarize classifies err into a short, host-free description of why the
+// request never produced a response.
+func Summarize(err error) string {
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return "could not resolve host"
+	}
+	var certErr *tls.CertificateVerificationError
+	if errors.As(err, &certErr) {
+		return "TLS certificate verification failed"
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "request timed out"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "request timed out"
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) {
+		return "connection refused"
+	}
+	return "could not connect"
+}

--- a/server/internal/transporterr/transporterr_test.go
+++ b/server/internal/transporterr/transporterr_test.go
@@ -1,0 +1,46 @@
+package transporterr
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+func TestSummarize(t *testing.T) {
+	dnsErr := &net.DNSError{Err: "no such host", Name: "radarr"}
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"dns failure", &url.Error{Op: "Get", URL: "http://radarr:7878/api", Err: &net.OpError{Op: "dial", Err: dnsErr}}, "could not resolve host"},
+		{"connection refused", &url.Error{Op: "Get", URL: "http://radarr:7878/api", Err: &net.OpError{Op: "dial", Err: syscall.ECONNREFUSED}}, "connection refused"},
+		{"timeout", &url.Error{Op: "Get", URL: "http://radarr:7878/api", Err: timeoutError{}}, "request timed out"},
+		{"context deadline", &url.Error{Op: "Get", URL: "http://radarr:7878/api", Err: context.DeadlineExceeded}, "request timed out"},
+		{"other", errors.New("http: server closed idle connection"), "could not connect"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Summarize(tc.err)
+			if got != tc.want {
+				t.Fatalf("Summarize = %q, want %q", got, tc.want)
+			}
+			// The whole point: no host, port, or URL fragments survive.
+			for _, leak := range []string{"radarr", "7878", "http://"} {
+				if strings.Contains(got, leak) {
+					t.Fatalf("Summarize leaked %q in %q", leak, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Part 2 of the cluster-internal (short-hostname) instance URL e2e work (part 1: #244).

**Topology leak (requester-facing):** arr client transport errors returned Go's raw `*url.Error`, which embeds the full request URL — and DNS failures repeat the hostname — so a requester whose request landed while Radarr was down got a 500 body like `add movie failed: Post "http://radarr:7878/api/v3/movie": dial tcp: lookup radarr: no such host`. That disclosed cluster-internal topology to non-admins and read like a client-side DNS problem. The status branch already deliberately formats method+path+status host-free; the transport branch now matches, via a new `transporterr` package that classifies failures (could not resolve host / connection refused / timed out / TLS verification failed) without naming the host. Applied across radarr, sonarr, and chaptarr clients; tests pin the no-host property on the exact add-movie/add-series/lookup vectors.

**Self-diagnosing connection failures (admin-facing):** with cluster-internal URLs, the admin's browser can't hit the service directly, so the server's error string is the only diagnostic surface — and it collapsed to bare status numbers:

- **SABnzbd**: its hostname verification rejects Docker/k8s service names by default (`http://sabnzbd:8080` deterministically fails until `host_whitelist` is set), and the actionable denial text was discarded into `sabnzbd returned status 403`. Non-2xx errors now carry a redacted, markup-stripped body excerpt; non-JSON 200s report the page text instead of `invalid character '<'`.
- **All five download clients**: refused redirects now name the `Location` (API keys redacted) so http→https fronting and `url_base` prefixes are self-explanatory.
- **Transmission**: 404s explain the expected `scheme://host:port` shape (pasting the web-UI URL is the classic failure).
- **qBittorrent**: an HTML answer (wrong port/page) is no longer misreported as `invalid credentials`.
- **Webhooks**: a 400 on the arr's notification save now hints the arr must be able to reach the `CANTINARR_PUBLIC_URL` callback.

## Verification

- `go vet ./...` and `go test ./...` from `server/` — pass
- No app changes; Flutter suite unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzwxV4VGEofnT31amcBGoU