### PR TITLE
feat(proxy): remap upstream redirects onto the instance proxy route

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -276,7 +276,8 @@ POST   /api/instances/test                   # admin: dry-run connectivity check
 PUT|DELETE /api/instances/{instanceID}       # admin: update/delete
 GET|PUT /api/instances/{instanceID}/users    # admin: which users are pinned/assigned here
 POST   /api/instances/{instanceID}/webhook   # admin: rotate credentials and upsert a managed arr webhook
-ANY    /api/instances/{instanceID}/*         # proxy to the instance's own API; JSON secrets are redacted
+ANY    /api/instances/{instanceID}/*         # proxy to the instance's own API; JSON secrets are redacted,
+                                             # and upstream redirects are remapped onto this route (off-origin ones become 502)
 ```
 The proxy allows read-only Radarr/Sonarr browsing (library, queue, history, wanted, calendar) for regular users; writes, commands, interactive search, config, and all non-arr services require admin. Requesters are bound to their own effective instance -- their pin, or the deterministic global default/fallback -- exactly as `/api/config` reports it; a sibling instance the admin has hidden cannot be reached by guessing its ID, and instance authorization is classified from stored metadata so an undecryptable secret can never widen access. JSON responses are bounded and recursively scrubbed for credential fields and secret-bearing URL query parameters before they reach any client. An encoded, malformed, streaming, or oversized JSON response fails closed rather than bypassing that scrubber.
 

--- a/server/internal/instance/handler.go
+++ b/server/internal/instance/handler.go
@@ -486,6 +486,11 @@ func validateArrURL(baseURL, apiKey, apiVersion string) error {
 	if resp.StatusCode == 401 {
 		return fmt.Errorf("invalid API key")
 	}
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		// Admin-only surface: naming the Location makes http→https fronting
+		// and URL-base redirects self-diagnosing from the connection test.
+		return fmt.Errorf("server returned redirect status %d to %q (redirects are not followed; use the service's final URL)", resp.StatusCode, resp.Header.Get("Location"))
+	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("server returned status %d", resp.StatusCode)
 	}

--- a/server/internal/proxy/handler.go
+++ b/server/internal/proxy/handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -110,7 +111,10 @@ func (h *Handler) proxyRequest(w http.ResponseWriter, r *http.Request, target *u
 			// bypass the response sanitizer.
 			req.Header.Set("Accept-Encoding", "identity")
 		},
-		ModifyResponse: sanitizeProxyTransportResponse,
+		ModifyResponse: func(resp *http.Response) error {
+			remapUpstreamRedirect(resp, target, stripPrefix)
+			return sanitizeProxyTransportResponse(resp)
+		},
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
 			// ModifyResponse errors are intentionally opaque: an upstream parse
 			// error must never reflect the response body (and any embedded secret)
@@ -129,6 +133,79 @@ func (h *Handler) proxyRequest(w http.ResponseWriter, r *http.Request, target *u
 	// through verbatim.
 	w.Header().Del("Content-Type")
 	proxy.ServeHTTP(w, r)
+}
+
+// remapUpstreamRedirect rewrites a 3xx Location back onto the instance proxy
+// route (/api/instances/{id}/...) so clients follow redirects through
+// Cantinarr — the upstream origin (e.g. http://radarr:7878) may be resolvable
+// only by the server, and a root-relative Location would resolve against the
+// Cantinarr origin without the proxy prefix. A redirect that leaves the
+// instance URL's origin (or escapes its base path) cannot be served through
+// the proxy, so it is replaced with a diagnosable 502 instead of handing
+// clients an address they cannot reach.
+func remapUpstreamRedirect(resp *http.Response, target *url.URL, stripPrefix string) {
+	if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+		return
+	}
+	location := strings.TrimSpace(resp.Header.Get("Location"))
+	if location == "" {
+		return
+	}
+	parsed, err := url.Parse(location)
+	if err != nil {
+		replaceWithOffOriginRedirectError(resp)
+		return
+	}
+	if resp.Request == nil || resp.Request.URL == nil {
+		replaceWithOffOriginRedirectError(resp)
+		return
+	}
+	absolute := resp.Request.URL.ResolveReference(parsed)
+	if !strings.EqualFold(absolute.Scheme, target.Scheme) || !strings.EqualFold(absolute.Host, target.Host) {
+		replaceWithOffOriginRedirectError(resp)
+		return
+	}
+	basePath := strings.TrimRight(target.Path, "/")
+	if basePath != "" && !strings.HasPrefix(absolute.Path, basePath) {
+		replaceWithOffOriginRedirectError(resp)
+		return
+	}
+	mapped := *absolute
+	mapped.Scheme = ""
+	mapped.Host = ""
+	mapped.User = nil
+	mapped.Path = joinURLPath(stripPrefix, strings.TrimPrefix(absolute.Path, basePath))
+	mapped.RawPath = ""
+	resp.Header.Set("Location", mapped.String())
+	// Redirect bodies are decoration (clients act on Location) and typically
+	// embed the upstream origin — the very thing the remap keeps private.
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
+	resp.Body = http.NoBody
+	resp.ContentLength = 0
+	resp.TransferEncoding = nil
+	resp.Header.Del("Content-Type")
+	resp.Header.Set("Content-Length", "0")
+}
+
+// replaceWithOffOriginRedirectError swaps an unfollowable redirect for a 502
+// the client can act on. The message deliberately omits the redirect target:
+// naming another host would hand arr:browse users the very topology detail
+// the proxy exists to contain, and admins can reproduce the redirect with the
+// instance connection test.
+func replaceWithOffOriginRedirectError(resp *http.Response) {
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
+	const body = `{"error":"upstream redirected outside the instance URL origin; check the instance URL, its URL base, and any proxy in front of it"}`
+	resp.StatusCode = http.StatusBadGateway
+	resp.Status = http.StatusText(http.StatusBadGateway)
+	resp.Header = http.Header{"Content-Type": []string{"application/json"}}
+	resp.Header.Set("Content-Length", strconv.Itoa(len(body)))
+	resp.Body = io.NopCloser(strings.NewReader(body))
+	resp.ContentLength = int64(len(body))
+	resp.TransferEncoding = nil
 }
 
 // sanitizeProxyTransportResponse applies the content scrubber and then removes

--- a/server/internal/proxy/handler_test.go
+++ b/server/internal/proxy/handler_test.go
@@ -232,6 +232,115 @@ func TestJoinURLPathPreservesInstanceBasePath(t *testing.T) {
 }
 
 // INST-018: Nested proxy JSON and secret-bearing URLs are recursively scrubbed.
+// noFollowClient returns redirects to the caller instead of chasing them, so
+// tests can assert on the Location the app would actually receive.
+func noFollowClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
+// Upstream redirects must come back on the proxy route: clients cannot
+// resolve the upstream origin (cluster-internal names like radarr:7878), and
+// a root-relative Location would resolve against the Cantinarr origin without
+// the /api/instances/{id} prefix.
+func TestInstanceProxyRemapsSameOriginRedirects(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/absolute":
+			// The proxy sets the upstream Host, so this is the instance URL's
+			// own origin — the shape a Host-derived fronting redirect takes.
+			http.Redirect(w, r, "http://"+r.Host+"/api/v3/system/status?page=2", http.StatusFound)
+		case "/relative":
+			w.Header().Set("Location", "/login")
+			w.WriteHeader(http.StatusMovedPermanently)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+	proxyURL, instanceID := startTestProxy(t, upstream)
+
+	resp, err := noFollowClient().Get(proxyURL + "/api/instances/" + instanceID + "/absolute")
+	if err != nil {
+		t.Fatalf("GET absolute: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("absolute redirect status = %d, want 302", resp.StatusCode)
+	}
+	want := "/api/instances/" + instanceID + "/api/v3/system/status?page=2"
+	if got := resp.Header.Get("Location"); got != want {
+		t.Errorf("absolute Location = %q, want %q", got, want)
+	}
+	// http.Redirect's HTML body names the upstream origin; it must not pass.
+	if len(body) != 0 {
+		t.Errorf("redirect body was not dropped: %q", body)
+	}
+
+	resp, err = noFollowClient().Get(proxyURL + "/api/instances/" + instanceID + "/relative")
+	if err != nil {
+		t.Fatalf("GET relative: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMovedPermanently {
+		t.Fatalf("relative redirect status = %d, want 301", resp.StatusCode)
+	}
+	want = "/api/instances/" + instanceID + "/login"
+	if got := resp.Header.Get("Location"); got != want {
+		t.Errorf("relative Location = %q, want %q", got, want)
+	}
+}
+
+// A redirect that leaves the instance URL's origin cannot be served through
+// the proxy; clients get a diagnosable 502 that does not name the target —
+// that would hand arr:browse users the topology detail the proxy contains.
+func TestInstanceProxyBlocksOffOriginRedirects(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "https://internal-sso.invalid/login", http.StatusFound)
+	})
+	proxyURL, instanceID := startTestProxy(t, upstream)
+
+	resp, err := noFollowClient().Get(proxyURL + "/api/instances/" + instanceID + "/api/v3/queue")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body=%s", resp.StatusCode, body)
+	}
+	if resp.Header.Get("Location") != "" {
+		t.Errorf("Location header survived: %q", resp.Header.Get("Location"))
+	}
+	if bytes.Contains(body, []byte("internal-sso.invalid")) {
+		t.Errorf("502 body names the redirect target: %s", body)
+	}
+	if !bytes.Contains(body, []byte("instance URL")) {
+		t.Errorf("502 body is not diagnosable: %s", body)
+	}
+}
+
+// A same-host redirect that escapes the instance's base path is equally
+// unservable through the proxy (the mapped path would point at a different
+// upstream resource).
+func TestInstanceProxyBlocksRedirectsEscapingBasePath(t *testing.T) {
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", "/login")
+		w.WriteHeader(http.StatusFound)
+	})
+	proxyURL, instanceID := startTestProxyWithBasePath(t, upstream, "/sonarr")
+
+	resp, err := noFollowClient().Get(proxyURL + "/api/instances/" + instanceID + "/api/v3/queue")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+}
+
 func TestInstanceProxyRedactsNestedSecretsAndURLQueries(t *testing.T) {
 	const (
 		objectSecret        = "object-secret-value"


### PR DESCRIPTION
## Summary

Part 3 of the cluster-internal (short-hostname) instance URL e2e work (parts 1–2: #244, #246).

The instance proxy never followed or rewrote upstream 3xx responses — `Location` passed through with only credential scrubbing (a tested, shipped behavior). In a short-hostname deployment that's a structural hole: clients auto-follow redirects, so they either chased an absolute URL on the arr's cluster-internal origin (unresolvable off-cluster → opaque connection error) or a root-relative path that resolved against the Cantinarr origin without the `/api/instances/{id}` prefix (404), losing the proxy-injected API key either way. Registration-time validation rejects redirecting base URLs, but post-registration drift (URL base added in the arr, ingress starts upgrading http→https) is squarely inside this repo's "never trust stored arr state" threat model.

- **Same-origin redirects** are rewritten back onto the proxy route (mirroring nginx `proxy_redirect`): scheme/host must match the instance URL, path-suffixed base URLs are honored, the query is preserved (and still runs through the credential scrubber). The decorative redirect HTML body — which embeds the upstream origin — is dropped.
- **Off-origin redirects** (different host, http→https upgrades, or escaping the instance base path) can't be served through the proxy and become a diagnosable 502 whose message deliberately does not name the redirect target — arr:browse users must not learn topology from it.
- **Admin connection test** (`validateArrURL`) now names the redirect Location, so the drift case is self-diagnosing on the surface where specificity is safe.

Tests cover the absolute and root-relative remaps, the off-origin 502 (including that the body names no host), and the base-path-escape case.

## Verification

- `go vet ./...` and `go test ./...` from `server/` — pass
- No app changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WzwxV4VGEofnT31amcBGoU