### PR TITLE
fix: ignore Kubernetes service-link port

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Optional server env vars for deployment tuning:
 
 | Variable | Default | Description |
 |---|---|---|
-| `CANTINARR_PORT` | `8585` | HTTP listen port |
+| `CANTINARR_PORT` | `8585` | HTTP listen port. Kubernetes service-link URI values are ignored so a Service named `cantinarr` does not override the application setting |
 | `CANTINARR_SERVER_NAME` | `Cantinarr` | Display name shown in clients |
 | `CANTINARR_PUBLIC_URL` | direct request origin | Trusted public origin (for example `https://cantinarr.example.com`) used when installing authenticated Radarr/Sonarr webhooks; recommended behind a reverse proxy |
 | `CANTINARR_JWT_SECRET` | auto-generated | HMAC secret for signing short-lived access tokens. Device sessions do not depend on it: changing it never signs anyone out |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Optional server env vars for deployment tuning:
 
 | Variable | Default | Description |
 |---|---|---|
-| `CANTINARR_PORT` | `8585` | HTTP listen port. Kubernetes service-link URI values are ignored so a Service named `cantinarr` does not override the application setting |
+| `CANTINARR_PORT` | `8585` | HTTP listen port. Kubernetes service-link values (`tcp://…`) injected by a Service named `cantinarr` are ignored in favor of the default; set a numeric value to override |
 | `CANTINARR_SERVER_NAME` | `Cantinarr` | Display name shown in clients |
 | `CANTINARR_PUBLIC_URL` | direct request origin | Trusted public origin (for example `https://cantinarr.example.com`) used when installing authenticated Radarr/Sonarr webhooks; recommended behind a reverse proxy |
 | `CANTINARR_JWT_SECRET` | auto-generated | HMAC secret for signing short-lived access tokens. Device sessions do not depend on it: changing it never signs anyone out |

--- a/server/README.md
+++ b/server/README.md
@@ -81,7 +81,7 @@ Optional env vars for deployment tuning (a `.env` file next to the binary is aut
 
 | Variable | Default | Description |
 |---|---|---|
-| `CANTINARR_PORT` | `8585` | HTTP listen port. Kubernetes service-link URI values are ignored so a Service named `cantinarr` does not override the application setting |
+| `CANTINARR_PORT` | `8585` | HTTP listen port. Kubernetes service-link values (`tcp://…`) injected by a Service named `cantinarr` are ignored in favor of the default; set a numeric value to override |
 | `CANTINARR_SERVER_NAME` | `Cantinarr` | Display name shown in clients |
 | `CANTINARR_PUBLIC_URL` | direct request origin | Trusted public origin (for example `https://cantinarr.example.com`) used when installing authenticated Radarr/Sonarr webhooks; set this behind a reverse proxy because forwarded host/protocol headers are deliberately ignored |
 | `CANTINARR_JWT_SECRET` | auto-generated | HMAC secret for signing short-lived access tokens (persisted encrypted when auto-generated). Opaque device-session refresh tokens do not depend on it, so changing it never signs devices out |

--- a/server/README.md
+++ b/server/README.md
@@ -81,7 +81,7 @@ Optional env vars for deployment tuning (a `.env` file next to the binary is aut
 
 | Variable | Default | Description |
 |---|---|---|
-| `CANTINARR_PORT` | `8585` | HTTP listen port |
+| `CANTINARR_PORT` | `8585` | HTTP listen port. Kubernetes service-link URI values are ignored so a Service named `cantinarr` does not override the application setting |
 | `CANTINARR_SERVER_NAME` | `Cantinarr` | Display name shown in clients |
 | `CANTINARR_PUBLIC_URL` | direct request origin | Trusted public origin (for example `https://cantinarr.example.com`) used when installing authenticated Radarr/Sonarr webhooks; set this behind a reverse proxy because forwarded host/protocol headers are deliberately ignored |
 | `CANTINARR_JWT_SECRET` | auto-generated | HMAC secret for signing short-lived access tokens (persisted encrypted when auto-generated). Opaque device-session refresh tokens do not depend on it, so changing it never signs devices out |

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -112,12 +112,16 @@ func Load() (*Config, error) {
 	)
 
 	portStr := os.Getenv("CANTINARR_PORT")
-	if portStr == "" || isKubernetesServiceLinkPort(portStr) {
+	switch {
+	case portStr == "":
+		cfg.Port = 8585
+	case isKubernetesServiceLinkPort(portStr):
 		// Kubernetes injects CANTINARR_PORT=tcp://<service-ip>:<port> when a
 		// Service named cantinarr has service links enabled. It is not an app
 		// setting, so retain the default listen port.
+		log.Printf("CANTINARR_PORT=%q is a Kubernetes service link, not a port setting; listening on the default port 8585", portStr)
 		cfg.Port = 8585
-	} else {
+	default:
 		p, err := strconv.Atoi(portStr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid CANTINARR_PORT: %w", err)

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log"
+	"net"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -111,7 +112,10 @@ func Load() (*Config, error) {
 	)
 
 	portStr := os.Getenv("CANTINARR_PORT")
-	if portStr == "" {
+	if portStr == "" || isKubernetesServiceLinkPort(portStr) {
+		// Kubernetes injects CANTINARR_PORT=tcp://<service-ip>:<port> when a
+		// Service named cantinarr has service links enabled. It is not an app
+		// setting, so retain the default listen port.
 		cfg.Port = 8585
 	} else {
 		p, err := strconv.Atoi(portStr)
@@ -122,6 +126,23 @@ func Load() (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func isKubernetesServiceLinkPort(value string) bool {
+	serviceHost := os.Getenv("CANTINARR_SERVICE_HOST")
+	servicePort := os.Getenv("CANTINARR_SERVICE_PORT")
+	if serviceHost == "" || servicePort == "" {
+		return false
+	}
+	u, err := url.Parse(value)
+	if err != nil || u.Scheme != "tcp" || u.User != nil || u.Path != "" || u.RawQuery != "" || u.Fragment != "" {
+		return false
+	}
+	if net.ParseIP(u.Hostname()) == nil || u.Hostname() != serviceHost || u.Port() != servicePort {
+		return false
+	}
+	port, err := strconv.Atoi(u.Port())
+	return err == nil && port > 0 && port <= 65535
 }
 
 func validatePublicURL(value string) error {

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -107,11 +107,13 @@ func TestLoadPort(t *testing.T) {
 		{name: "numeric override", value: "8586", want: 8586},
 		{name: "Kubernetes IPv4 service link", value: "tcp://10.43.161.118:8585", serviceHost: "10.43.161.118", servicePort: "8585", want: 8585},
 		{name: "Kubernetes IPv6 service link", value: "tcp://[fd00::1]:8585", serviceHost: "fd00::1", servicePort: "8585", want: 8585},
+		{name: "numeric override beside service link companions", value: "8586", serviceHost: "10.43.161.118", servicePort: "8585", want: 8586},
 		{name: "invalid value", value: "not-a-port", wantErr: true},
 		{name: "malformed TCP URI", value: "tcp://localhost:not-a-port", wantErr: true},
 		{name: "non-service TCP URI", value: "tcp://example.com:9999", wantErr: true},
 		{name: "manual IP TCP URI", value: "tcp://127.0.0.1:9000", wantErr: true},
-		{name: "mismatched service link", value: "tcp://10.43.161.119:8585", serviceHost: "10.43.161.118", servicePort: "8585", wantErr: true},
+		{name: "mismatched service link host", value: "tcp://10.43.161.119:8585", serviceHost: "10.43.161.118", servicePort: "8585", wantErr: true},
+		{name: "mismatched service link port", value: "tcp://10.43.161.118:8585", serviceHost: "10.43.161.118", servicePort: "9999", wantErr: true},
 	}
 
 	for _, tt := range tests {

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -94,6 +94,48 @@ func TestLoadCodexRuntimeConfig(t *testing.T) {
 	}
 }
 
+func TestLoadPort(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		serviceHost string
+		servicePort string
+		want        int
+		wantErr     bool
+	}{
+		{name: "default", value: "", want: 8585},
+		{name: "numeric override", value: "8586", want: 8586},
+		{name: "Kubernetes IPv4 service link", value: "tcp://10.43.161.118:8585", serviceHost: "10.43.161.118", servicePort: "8585", want: 8585},
+		{name: "Kubernetes IPv6 service link", value: "tcp://[fd00::1]:8585", serviceHost: "fd00::1", servicePort: "8585", want: 8585},
+		{name: "invalid value", value: "not-a-port", wantErr: true},
+		{name: "malformed TCP URI", value: "tcp://localhost:not-a-port", wantErr: true},
+		{name: "non-service TCP URI", value: "tcp://example.com:9999", wantErr: true},
+		{name: "manual IP TCP URI", value: "tcp://127.0.0.1:9000", wantErr: true},
+		{name: "mismatched service link", value: "tcp://10.43.161.119:8585", serviceHost: "10.43.161.118", servicePort: "8585", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CANTINARR_PORT", tt.value)
+			t.Setenv("CANTINARR_SERVICE_HOST", tt.serviceHost)
+			t.Setenv("CANTINARR_SERVICE_PORT", tt.servicePort)
+			cfg, err := Load()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("Load() error = nil, want invalid port error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.Port != tt.want {
+				t.Fatalf("Port = %d, want %d", cfg.Port, tt.want)
+			}
+		})
+	}
+}
+
 func contains(values []string, needle string) bool {
 	for _, value := range values {
 		if value == needle {


### PR DESCRIPTION
## What

Prevent Kubernetes service-link environment variables from overriding Cantinarr's numeric HTTP listen-port setting.

A Kubernetes Service named `cantinarr` injects values including:

```text
CANTINARR_PORT=tcp://10.43.161.118:8585
CANTINARR_SERVICE_HOST=10.43.161.118
CANTINARR_SERVICE_PORT=8585
```

The server currently passes `CANTINARR_PORT` to `strconv.Atoi`, causing a deterministic startup failure:

```text
invalid CANTINARR_PORT: strconv.Atoi: parsing "tcp://10.43.161.118:8585": invalid syntax
```

The loader now recognizes only a strict Kubernetes service-link value whose IP and port match the companion `CANTINARR_SERVICE_HOST` and `CANTINARR_SERVICE_PORT` variables, then retains the default application port. Numeric overrides continue to work, while malformed, unrelated, manually supplied, and mismatched URI values still fail closed.

## Verification

- `go test ./internal/config -run '^TestLoadPort$' -count=1`
- `go vet ./...`
- `go test ./... -count=1`
- Regression coverage includes default and numeric values, IPv4 and IPv6 service links, malformed values, unrelated TCP URIs, manual IP URIs, and mismatched companion variables.
- Dedicated automated code review reported no blocking or important findings and recommended submission.

## Docs

- [x] `README.md` — documents Kubernetes service-link handling for `CANTINARR_PORT`
- [x] `server/README.md` — documents Kubernetes service-link handling for `CANTINARR_PORT`
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact
