### PR TITLE
ci: skip the GHCR push for fork PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -131,6 +131,9 @@ jobs:
           '
 
       - name: Build and push
+        # Fork PRs run with a read-only GITHUB_TOKEN, so pushing the pr-N tag
+        # is denied; the smoke-test builds above still prove both Dockerfiles.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
## What

The Docker workflow's final **Build and push** step runs `push: true` on every `pull_request` event to publish a `pr-N` tag. Fork PRs run with a read-only `GITHUB_TOKEN`, so that push is always denied (`installation not allowed to Write organization package`) and the job fails after every smoke test has already passed — observed on #245 and #249, where the failure was pure noise next to green required checks.

This adds an `if:` to that one step: same-repo PRs keep publishing their `pr-N` tag; fork PRs skip the push. All smoke-test builds (root and server-only images, Codex runtime and license-notice verification) still run for every PR.

## Verification

- The docker workflow runs on this PR itself (it touches `.github/workflows/docker.yml`) from a same-repo branch, exercising the kept-push path.
- The skipped path is exactly the observed fork-PR failure mode from #245/#249.

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — the documented behavior (build + smoke-test both Dockerfiles on PRs, publish from main/tags) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxMowuh8xjitM6ySBC6A8S