### PR TITLE
fix(ai): pass full tool schemas to Anthropic

### DIFF
--- a/server/internal/ai/provider_contract_test.go
+++ b/server/internal/ai/provider_contract_test.go
@@ -407,6 +407,43 @@ func TestOpenAIToolSchemasUseSupportedObjectRoots(t *testing.T) {
 	}
 }
 
+func TestAnthropicToolSchemasCarryFullRoots(t *testing.T) {
+	adminTools := mcp.NewToolServer(nil, nil, nil, nil).GetToolsForRole(auth.RoleAdmin)
+	body, err := json.Marshal(toSDKTools(adminTools))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded []struct {
+		Name        string         `json:"name"`
+		InputSchema map[string]any `json:"input_schema"`
+	}
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	seenGrabRelease := false
+	for _, tool := range decoded {
+		if tool.InputSchema["type"] != "object" {
+			t.Errorf("tool %q input_schema must have type object", tool.Name)
+		}
+		if tool.Name != "grab_release" {
+			continue
+		}
+		seenGrabRelease = true
+		if oneOf, ok := tool.InputSchema["oneOf"].([]any); !ok || len(oneOf) != 3 {
+			t.Errorf("grab_release input_schema oneOf = %#v, want the three media_type branches", tool.InputSchema["oneOf"])
+		}
+		if props, ok := tool.InputSchema["properties"].(map[string]any); !ok || len(props) == 0 {
+			t.Error("grab_release input_schema lost its properties")
+		}
+		if req, ok := tool.InputSchema["required"].([]any); !ok || len(req) == 0 {
+			t.Error("grab_release input_schema lost its required list")
+		}
+	}
+	if !seenGrabRelease {
+		t.Fatal("serialized Anthropic tools omitted grab_release")
+	}
+}
+
 func TestOpenAIValidationOmitsUnsupportedReasoningField(t *testing.T) {
 	params := openAINextTurnParams("gpt-4.1", TurnParams{
 		DisableReasoning: true,

--- a/server/internal/ai/service.go
+++ b/server/internal/ai/service.go
@@ -433,6 +433,19 @@ func toSDKTools(tools []mcp.Tool) []anthropic.ToolUnionParam {
 				}
 			}
 		}
+		// The API takes full JSON Schema; carry root keywords beyond the
+		// typed fields (grab_release's oneOf) so the model sees the same
+		// constraints Gemini and Codex get.
+		for key, value := range t.InputSchema {
+			switch key {
+			case "type", "properties", "required":
+			default:
+				if schema.ExtraFields == nil {
+					schema.ExtraFields = map[string]any{}
+				}
+				schema.ExtraFields[key] = value
+			}
+		}
 		tp := anthropic.ToolParam{
 			Name:        t.Name,
 			Description: anthropic.String(t.Description),


### PR DESCRIPTION
## What

`toSDKTools` copied only `properties` and `required` into the Anthropic tool params, silently dropping `grab_release`'s root `oneOf` — making Anthropic the one provider whose model never saw the per-media required branches (Gemini and Codex receive the full schema; OpenAI strips root composition keywords only because that API rejects them, per #245). The Messages API accepts full JSON Schema in `input_schema` with no root-keyword restrictions in non-strict tool use, so this carries every remaining root key through the SDK's `ExtraFields` (marshaled via `MarshalWithExtras`).

The constraint was never load-bearing — `release_capability.go` enforces it server-side — so this is a model-visible fidelity improvement, not a behavior fix.

## Verification

- New contract test `TestAnthropicToolSchemasCarryFullRoots` serializes the real admin catalog and asserts `grab_release`'s wire `input_schema` carries the three-branch `oneOf` plus intact `properties`/`required`; it fails against the previous converter (mutation-checked).
- `go vet ./...` + `go test -race ./... -count=1` green on this branch merged into current main, and on this branch combined with #252.
- Adversarial review: merge-as-is; sole note is that `ExtraFields` marshal order is map-iteration order, deterministic today with a single extra key.

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — provider adapter internals; the documented tool surface is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxMowuh8xjitM6ySBC6A8S