### PR TITLE
fix(ai): preserve Codex turn interleaving in stored transcripts

### DIFF
--- a/server/internal/ai/codex_transcript.go
+++ b/server/internal/ai/codex_transcript.go
@@ -1,0 +1,73 @@
+package ai
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+)
+
+// codexTranscriptBuilder folds the Codex app-server's callback stream into an
+// interleaved provider-neutral transcript. The app-server executes dynamic
+// tools strictly in sequence, so each tool record closes the assistant text
+// that preceded it: [assistant text+tool_use][user tool_result]... followed by
+// any trailing assistant text on Finish. Callbacks may arrive from the
+// app-server notification goroutine while the handler goroutine finishes, so
+// the builder is safe for concurrent use.
+type codexTranscriptBuilder struct {
+	mu       sync.Mutex
+	messages transcript
+	text     strings.Builder
+	// textWritten caps total stored assistant text across the whole run, not
+	// per segment, matching the pre-interleaving bound.
+	textWritten int
+}
+
+func (b *codexTranscriptBuilder) Text(value string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if remaining := maxStoredTextBytes - b.textWritten; remaining > 0 {
+		bounded := boundedString(value, remaining)
+		b.text.WriteString(bounded)
+		b.textWritten += len(bounded)
+	}
+}
+
+func (b *codexTranscriptBuilder) ToolRecord(name string, input json.RawMessage, result string, isError bool) {
+	recordInput := append(json.RawMessage(nil), input...)
+	if len(recordInput) > maxStoredToolInputBytes || !json.Valid(recordInput) {
+		recordInput = json.RawMessage(`{"_cantinarr_truncated":true}`)
+	}
+	id := "codex_" + newConversationID()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	assistant := transcriptMessage{Role: agentRoleAssistant}
+	if text := strings.TrimSpace(b.text.String()); text != "" {
+		assistant.Content = append(assistant.Content, transcriptBlock{Type: blockTypeText, Text: text})
+	}
+	b.text.Reset()
+	assistant.Content = append(assistant.Content, transcriptBlock{
+		Type: blockTypeToolUse, ID: id, Name: name, Input: recordInput,
+	})
+	b.messages = append(b.messages,
+		assistant,
+		transcriptMessage{Role: agentRoleUser, Content: []transcriptBlock{{
+			Type:      blockTypeToolResult,
+			ToolUseID: id,
+			Name:      name,
+			Content:   boundedString(result, maxStoredToolResultBytes),
+			IsError:   isError,
+		}}},
+	)
+}
+
+// Finish flushes any trailing assistant text and returns the accumulated
+// interleaved messages.
+func (b *codexTranscriptBuilder) Finish() transcript {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if text := strings.TrimSpace(b.text.String()); text != "" {
+		b.messages = append(b.messages, textTranscriptMessage(agentRoleAssistant, text))
+		b.text.Reset()
+	}
+	return b.messages
+}

--- a/server/internal/ai/codex_transcript.go
+++ b/server/internal/ai/codex_transcript.go
@@ -10,9 +10,11 @@ import (
 // interleaved provider-neutral transcript. The app-server executes dynamic
 // tools strictly in sequence, so each tool record closes the assistant text
 // that preceded it: [assistant text+tool_use][user tool_result]... followed by
-// any trailing assistant text on Finish. Callbacks may arrive from the
-// app-server notification goroutine while the handler goroutine finishes, so
-// the builder is safe for concurrent use.
+// any trailing assistant text on Finish. ToolRecord runs on per-request
+// tool-call goroutines that can outlive the session's bounded shutdown drain
+// while the handler goroutine calls Finish, so the builder is safe for
+// concurrent use; text-segment attribution around a tool call is best-effort
+// under that concurrency, and the pair structure stays intact regardless.
 type codexTranscriptBuilder struct {
 	mu       sync.Mutex
 	messages transcript

--- a/server/internal/ai/codex_transcript_test.go
+++ b/server/internal/ai/codex_transcript_test.go
@@ -3,6 +3,7 @@ package ai
 import (
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -42,6 +43,18 @@ func TestCodexTranscriptBuilderInterleavesTurns(t *testing.T) {
 	if third := got[4]; len(third.Content) != 1 || third.Content[0].Type != blockTypeToolUse {
 		t.Errorf("no-text tool turn = %+v, want a lone tool_use", third)
 	}
+	seenIDs := map[string]bool{}
+	for _, message := range got {
+		for _, block := range message.Content {
+			if block.Type != blockTypeToolUse {
+				continue
+			}
+			if seenIDs[block.ID] {
+				t.Errorf("tool_use id %q reused across records", block.ID)
+			}
+			seenIDs[block.ID] = true
+		}
+	}
 	if errResult := got[5]; !errResult.Content[0].IsError {
 		t.Error("third tool_result lost its error flag")
 	}
@@ -78,13 +91,54 @@ func TestCodexTranscriptBuilderBoundsInputs(t *testing.T) {
 	got := b.Finish()
 	placeholder := `{"_cantinarr_truncated":true}`
 	if input := string(got[0].Content[len(got[0].Content)-1].Input); input != placeholder {
-		t.Errorf("oversized input stored as %q, want placeholder", input[:64])
+		t.Errorf("oversized input stored as %q, want placeholder", boundedString(input, 64))
 	}
 	if input := string(got[2].Content[len(got[2].Content)-1].Input); input != placeholder {
 		t.Errorf("invalid input stored as %q, want placeholder", input)
 	}
 	if result := got[5].Content[0].Content; len(result) > maxStoredToolResultBytes {
 		t.Errorf("result length = %d, want at most %d", len(result), maxStoredToolResultBytes)
+	}
+}
+
+// The builder promises safety for straggler tool-call goroutines racing the
+// handler's Finish; hammer that window under -race.
+func TestCodexTranscriptBuilderConcurrentUse(t *testing.T) {
+	b := &codexTranscriptBuilder{}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				b.Text("delta ")
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				b.ToolRecord("search_movies", json.RawMessage(`{}`), "ok", false)
+			}
+		}()
+	}
+	done := make(chan transcript)
+	go func() { done <- b.Finish() }()
+	wg.Wait()
+	got := <-done
+
+	for i, message := range got {
+		for _, block := range message.Content {
+			switch block.Type {
+			case blockTypeToolUse:
+				if block.ID == "" {
+					t.Fatalf("message %d: tool_use with empty id", i)
+				}
+			case blockTypeToolResult:
+				if block.ToolUseID == "" {
+					t.Fatalf("message %d: tool_result with no linked id", i)
+				}
+			}
+		}
 	}
 }
 

--- a/server/internal/ai/codex_transcript_test.go
+++ b/server/internal/ai/codex_transcript_test.go
@@ -1,0 +1,113 @@
+package ai
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCodexTranscriptBuilderInterleavesTurns(t *testing.T) {
+	b := &codexTranscriptBuilder{}
+	b.Text("Let me search. ")
+	b.ToolRecord("search_movies", json.RawMessage(`{"query":"dune"}`), "found 2 movies", false)
+	b.Text("Grabbing the 2021 film.")
+	b.ToolRecord("request_media", json.RawMessage(`{"tmdb_id":438631}`), "requested", false)
+	b.ToolRecord("check_request_status", json.RawMessage(`{"tmdb_id":438631}`), "pending approval", true)
+	b.Text("Done - it needs approval.")
+
+	got := b.Finish()
+	if len(got) != 7 {
+		t.Fatalf("messages = %d, want 7 (three tool pairs plus trailing text)", len(got))
+	}
+
+	first := got[0]
+	if first.Role != agentRoleAssistant || len(first.Content) != 2 {
+		t.Fatalf("first message = %+v, want assistant with text+tool_use", first)
+	}
+	if first.Content[0].Type != blockTypeText || first.Content[0].Text != "Let me search." {
+		t.Errorf("first text block = %+v, want the trimmed pre-tool text", first.Content[0])
+	}
+	if first.Content[1].Type != blockTypeToolUse || first.Content[1].Name != "search_movies" {
+		t.Errorf("first tool_use = %+v", first.Content[1])
+	}
+	result := got[1]
+	if result.Role != agentRoleUser || len(result.Content) != 1 || result.Content[0].Type != blockTypeToolResult {
+		t.Fatalf("second message = %+v, want user tool_result", result)
+	}
+	if result.Content[0].ToolUseID != first.Content[1].ID || result.Content[0].ToolUseID == "" {
+		t.Errorf("tool_result id %q does not link to tool_use id %q", result.Content[0].ToolUseID, first.Content[1].ID)
+	}
+
+	// The back-to-back third call carries no interleaved text.
+	if third := got[4]; len(third.Content) != 1 || third.Content[0].Type != blockTypeToolUse {
+		t.Errorf("no-text tool turn = %+v, want a lone tool_use", third)
+	}
+	if errResult := got[5]; !errResult.Content[0].IsError {
+		t.Error("third tool_result lost its error flag")
+	}
+
+	last := got[6]
+	if last.Role != agentRoleAssistant || len(last.Content) != 1 || last.Content[0].Text != "Done - it needs approval." {
+		t.Errorf("trailing message = %+v, want the final assistant text", last)
+	}
+}
+
+func TestCodexTranscriptBuilderTextOnly(t *testing.T) {
+	b := &codexTranscriptBuilder{}
+	b.Text("Just ")
+	b.Text("an answer.")
+	got := b.Finish()
+	if len(got) != 1 || got[0].Role != agentRoleAssistant || got[0].Content[0].Text != "Just an answer." {
+		t.Fatalf("messages = %+v, want one assistant text message", got)
+	}
+}
+
+func TestCodexTranscriptBuilderEmpty(t *testing.T) {
+	if got := (&codexTranscriptBuilder{}).Finish(); len(got) != 0 {
+		t.Fatalf("messages = %+v, want none", got)
+	}
+}
+
+func TestCodexTranscriptBuilderBoundsInputs(t *testing.T) {
+	b := &codexTranscriptBuilder{}
+	oversized := json.RawMessage(`{"blob":"` + strings.Repeat("x", maxStoredToolInputBytes) + `"}`)
+	b.ToolRecord("search_movies", oversized, "ok", false)
+	b.ToolRecord("search_movies", json.RawMessage(`{"broken":`), "ok", false)
+	b.ToolRecord("search_movies", json.RawMessage(`{}`), strings.Repeat("y", maxStoredToolResultBytes+10), false)
+
+	got := b.Finish()
+	placeholder := `{"_cantinarr_truncated":true}`
+	if input := string(got[0].Content[len(got[0].Content)-1].Input); input != placeholder {
+		t.Errorf("oversized input stored as %q, want placeholder", input[:64])
+	}
+	if input := string(got[2].Content[len(got[2].Content)-1].Input); input != placeholder {
+		t.Errorf("invalid input stored as %q, want placeholder", input)
+	}
+	if result := got[5].Content[0].Content; len(result) > maxStoredToolResultBytes {
+		t.Errorf("result length = %d, want at most %d", len(result), maxStoredToolResultBytes)
+	}
+}
+
+func TestCodexTranscriptBuilderCapsTextAcrossSegments(t *testing.T) {
+	b := &codexTranscriptBuilder{}
+	b.Text(strings.Repeat("a", maxStoredTextBytes))
+	b.ToolRecord("search_movies", json.RawMessage(`{}`), "ok", false)
+	// The run-wide cap is already spent; post-tool text must not grow the store.
+	b.Text(strings.Repeat("b", 1024))
+
+	got := b.Finish()
+	total := 0
+	for _, message := range got {
+		for _, block := range message.Content {
+			if block.Type == blockTypeText {
+				total += len(block.Text)
+			}
+		}
+	}
+	if total > maxStoredTextBytes {
+		t.Fatalf("stored text = %d bytes, want at most %d across the whole run", total, maxStoredTextBytes)
+	}
+	if len(got) != 2 {
+		t.Fatalf("messages = %d, want 2 (capped text folds into the tool turn only)", len(got))
+	}
+}

--- a/server/internal/ai/handler.go
+++ b/server/internal/ai/handler.go
@@ -154,22 +154,7 @@ func (h *Handler) Chat(w http.ResponseWriter, r *http.Request) {
 			emit(map[string]any{"media_results": structuredData})
 		},
 	}
-	var assistantText strings.Builder
-	type codexToolRecord struct {
-		name    string
-		input   json.RawMessage
-		result  string
-		isError bool
-	}
-	var codexRecordsMu sync.Mutex
-	var codexRecords []codexToolRecord
-	originalOnText := callbacks.OnText
-	callbacks.OnText = func(value string) {
-		if remaining := maxStoredTextBytes - assistantText.Len(); remaining > 0 {
-			assistantText.WriteString(boundedString(value, remaining))
-		}
-		originalOnText(value)
-	}
+	codexBuilder := &codexTranscriptBuilder{}
 
 	chatCtx := ChatContext{
 		UserID:          claims.UserID,
@@ -239,7 +224,10 @@ func (h *Handler) Chat(w http.ResponseWriter, r *http.Request) {
 			dynamicContext(chatCtx),
 			renderCodexPrompt(history),
 			codexapp.Callbacks{
-				OnText: callbacks.OnText,
+				OnText: func(value string) {
+					codexBuilder.Text(value)
+					callbacks.OnText(value)
+				},
 				OnToolStart: func(name string) {
 					if callbacks.OnToolStart != nil {
 						callbacks.OnToolStart(name, toolLabel(name))
@@ -247,48 +235,11 @@ func (h *Handler) Chat(w http.ResponseWriter, r *http.Request) {
 				},
 				OnToolEnd:    callbacks.OnToolEnd,
 				OnToolResult: callbacks.OnToolResult,
-				OnToolRecord: func(name string, input json.RawMessage, result string, isError bool) {
-					recordInput := append(json.RawMessage(nil), input...)
-					if len(recordInput) > maxStoredToolInputBytes || !json.Valid(recordInput) {
-						recordInput = json.RawMessage(`{"_cantinarr_truncated":true}`)
-					}
-					codexRecordsMu.Lock()
-					codexRecords = append(codexRecords, codexToolRecord{
-						name:    name,
-						input:   recordInput,
-						result:  boundedString(result, maxStoredToolResultBytes),
-						isError: isError,
-					})
-					codexRecordsMu.Unlock()
-				},
+				OnToolRecord: codexBuilder.ToolRecord,
 			},
 		)
 		if err == nil {
-			finalHistory = cloneTranscript(history)
-			codexRecordsMu.Lock()
-			records := append([]codexToolRecord(nil), codexRecords...)
-			codexRecordsMu.Unlock()
-			if len(records) > 0 {
-				toolUses := make([]transcriptBlock, 0, len(records))
-				toolResults := make([]transcriptBlock, 0, len(records))
-				for _, record := range records {
-					id := "codex_" + newConversationID()
-					toolUses = append(toolUses, transcriptBlock{
-						Type: blockTypeToolUse, ID: id, Name: record.name, Input: record.input,
-					})
-					toolResults = append(toolResults, transcriptBlock{
-						Type: blockTypeToolResult, ToolUseID: id, Name: record.name,
-						Content: record.result, IsError: record.isError,
-					})
-				}
-				finalHistory = append(finalHistory,
-					transcriptMessage{Role: agentRoleAssistant, Content: toolUses},
-					transcriptMessage{Role: agentRoleUser, Content: toolResults},
-				)
-			}
-			if text := strings.TrimSpace(assistantText.String()); text != "" {
-				finalHistory = append(finalHistory, textTranscriptMessage(agentRoleAssistant, text))
-			}
+			finalHistory = append(cloneTranscript(history), codexBuilder.Finish()...)
 		}
 	default:
 		err = fmt.Errorf("unsupported AI provider: %s", aiConfig.Provider)


### PR DESCRIPTION
## What

The interactive Codex path stored a degraded transcript: every tool call from a whole run was batched into one synthetic `tool_use` message and one `tool_result` message, with all assistant text appended afterward — so replayed history showed calls, results, and narration out of order relative to what actually happened. Since `renderCodexPrompt` replays that stored history to the model on every following turn, the misordering was model-visible.

This folds the callback stream into an interleaved transcript via a new `codexTranscriptBuilder`: each tool record closes the assistant text that preceded it (`[assistant text+tool_use][user tool_result]… trailing text`), preserving per-turn ordering, the run-wide stored-text cap, and the existing input/result bounding. It is also the prerequisite for any future native-thread projection (`thread/inject_items`) — a faithful reconstruction needs a faithful canonical transcript.

## Verification

- Unit tests cover interleaving/ordering, ID linkage and cross-record uniqueness, text-only and empty runs, oversized/invalid input placeholders, result bounding, the run-wide text cap, and concurrent `Text`/`ToolRecord`/`Finish` under `-race` (straggler tool-call goroutines can outlive the session's bounded shutdown drain).
- `go vet ./...` + `go test -race ./... -count=1` green on this branch merged into current main, and combined with #251.
- Adversarial review: merge-as-is; noted that text-segment attribution around a tool call is best-effort under a narrow SSE-backpressure race (pair structure stays intact either way — documented on the type), plus test polish that has been applied.

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — internal transcript representation; no documented surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxMowuh8xjitM6ySBC6A8S