### PR TITLE
Fix AI chat timeout on web

### DIFF
--- a/app/lib/features/ai_assistant/data/ai_chat_service.dart
+++ b/app/lib/features/ai_assistant/data/ai_chat_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import '../../config_changes/data/config_change_models.dart';
 import 'ai_models.dart';
 
@@ -9,8 +10,11 @@ import 'ai_models.dart';
 /// Uses SSE streaming for real-time response delivery.
 class AiChatService {
   final Dio _backendDio;
+  final bool _isWeb;
 
-  AiChatService({required Dio backendDio}) : _backendDio = backendDio;
+  AiChatService({required Dio backendDio, bool? isWeb})
+      : _backendDio = backendDio,
+        _isWeb = isWeb ?? kIsWeb;
 
   /// Send messages and stream response events via SSE.
   ///
@@ -35,10 +39,16 @@ class AiChatService {
       },
       options: Options(
         responseType: ResponseType.stream,
-        // The base Dio's 15s receiveTimeout acts as an inter-chunk
-        // inactivity timeout on streams, but agent thinking and slow tools
-        // (indexer searches) legitimately go quiet for longer. The server
-        // sends keepalive comments; disable the local inactivity cap.
+        // Agent thinking and slow tools can legitimately run longer than the
+        // normal request timeout. dio_web_adapter implements XMLHttpRequest's
+        // whole-request timeout as connectTimeout + receiveTimeout, so leaving
+        // the inherited 15s connect timeout beside a zero receive timeout
+        // still aborts browser chat after 15s and reports a misleading zero
+        // receive timeout. Disable both browser XHR components; native keeps
+        // its bounded connection setup while the server's SSE keepalives cover
+        // inter-chunk inactivity.
+        connectTimeout:
+            _isWeb ? Duration.zero : _backendDio.options.connectTimeout,
         receiveTimeout: Duration.zero,
         headers: {'Accept': 'text/event-stream'},
       ),

--- a/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
+++ b/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uuid/uuid.dart';
@@ -307,8 +308,31 @@ class AiChatNotifier extends ChangeNotifier {
       .toList();
 
   String _friendlyError(Object e) {
-    final text = e.toString();
-    return 'Failed to get a response: ${text.length > 100 ? '${text.substring(0, 100)}...' : text}';
+    if (e is DioException) {
+      if (e.type == DioExceptionType.receiveTimeout ||
+          e.type == DioExceptionType.sendTimeout) {
+        return 'The assistant did not finish responding in time. If this '
+            'request could change settings, check Configuration History '
+            'before retrying.';
+      }
+      if (e.type == DioExceptionType.connectionError ||
+          e.type == DioExceptionType.connectionTimeout) {
+        return 'Cantinarr could not reach the assistant. Check your '
+            'connection, then try again.';
+      }
+      if (e.type == DioExceptionType.cancel) {
+        return 'The assistant request was cancelled.';
+      }
+
+      final statusCode = e.response?.statusCode;
+      if (statusCode == 429) {
+        return 'The assistant is busy. Wait a moment, then try again.';
+      }
+      if (statusCode != null && statusCode >= 500) {
+        return 'The assistant service had a problem. Try again in a moment.';
+      }
+    }
+    return 'Something went wrong while contacting the assistant. Try again.';
   }
 
   void _addMessage(ChatMessage message) {

--- a/app/test/ai_assistant/ai_chat_provider_test.dart
+++ b/app/test/ai_assistant/ai_chat_provider_test.dart
@@ -1,0 +1,100 @@
+import 'package:cantinarr/features/ai_assistant/data/ai_chat_service.dart';
+import 'package:cantinarr/features/ai_assistant/data/ai_models.dart';
+import 'package:cantinarr/features/ai_assistant/logic/ai_chat_provider.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('shows safe guidance when an assistant response times out', () async {
+    final notifier = AiChatNotifier(
+      chatService: _FailingAiChatService(
+        DioException.receiveTimeout(
+          timeout: Duration.zero,
+          requestOptions: RequestOptions(path: '/api/ai/chat'),
+        ),
+      ),
+    );
+    addTearDown(notifier.dispose);
+
+    await notifier.sendMessage('update every Sonarr profile');
+
+    final errorText = notifier.state.messages.last.errorText;
+    expect(
+      errorText,
+      'The assistant did not finish responding in time. If this request '
+      'could change settings, check Configuration History before retrying.',
+    );
+    expect(errorText, isNot(contains('DioException')));
+    expect(errorText, isNot(contains('0:00:00')));
+    expect(notifier.state.isLoading, isFalse);
+  });
+
+  test('shows safe guidance when Cantinarr cannot reach the assistant',
+      () async {
+    final notifier = AiChatNotifier(
+      chatService: _FailingAiChatService(
+        DioException(
+          requestOptions: RequestOptions(path: '/api/ai/chat'),
+          type: DioExceptionType.connectionError,
+          error: 'private transport details',
+        ),
+      ),
+    );
+    addTearDown(notifier.dispose);
+
+    await notifier.sendMessage('find a movie');
+
+    expect(
+      notifier.state.messages.last.errorText,
+      'Cantinarr could not reach the assistant. Check your connection, '
+      'then try again.',
+    );
+    expect(
+      notifier.state.messages.last.errorText,
+      isNot(contains('private transport details')),
+    );
+  });
+
+  test('shows rate-limit guidance without exposing the response', () async {
+    final request = RequestOptions(path: '/api/ai/chat');
+    final notifier = AiChatNotifier(
+      chatService: _FailingAiChatService(
+        DioException.badResponse(
+          statusCode: 429,
+          requestOptions: request,
+          response: Response(
+            requestOptions: request,
+            statusCode: 429,
+            data: {'error': 'provider account details'},
+          ),
+        ),
+      ),
+    );
+    addTearDown(notifier.dispose);
+
+    await notifier.sendMessage('find a show');
+
+    expect(
+      notifier.state.messages.last.errorText,
+      'The assistant is busy. Wait a moment, then try again.',
+    );
+    expect(
+      notifier.state.messages.last.errorText,
+      isNot(contains('provider account details')),
+    );
+  });
+}
+
+class _FailingAiChatService extends AiChatService {
+  final Object failure;
+
+  _FailingAiChatService(this.failure)
+      : super(backendDio: Dio(), isWeb: false);
+
+  @override
+  Stream<ChatStreamEvent> sendMessage({
+    required List<ChatMessage> messages,
+    String? conversationId,
+  }) =>
+      Stream.error(failure);
+}

--- a/app/test/ai_assistant/ai_chat_service_test.dart
+++ b/app/test/ai_assistant/ai_chat_service_test.dart
@@ -9,10 +9,11 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('parses a structured configuration-change SSE receipt', () async {
+    final adapter = _SseAdapter();
     final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
-      ..httpClientAdapter = _SseAdapter();
+      ..httpClientAdapter = adapter;
 
-    final events = await AiChatService(backendDio: dio)
+    final events = await AiChatService(backendDio: dio, isWeb: false)
         .sendMessage(messages: const [])
         .toList();
 
@@ -22,15 +23,52 @@ void main() {
     expect(receipt.resourceName, 'Very High (4K)');
     expect(receipt.changes.single.after, '+100');
   });
+
+  test('disables the whole-request timeout for browser chat streams',
+      () async {
+    final adapter = _SseAdapter();
+    final dio = Dio(BaseOptions(
+      baseUrl: 'http://localhost',
+      connectTimeout: const Duration(seconds: 15),
+      receiveTimeout: const Duration(seconds: 15),
+    ))..httpClientAdapter = adapter;
+
+    await AiChatService(backendDio: dio, isWeb: true)
+        .sendMessage(messages: const [])
+        .toList();
+
+    expect(adapter.requests.single.connectTimeout, Duration.zero);
+    expect(adapter.requests.single.receiveTimeout, Duration.zero);
+  });
+
+  test('retains the connection timeout for native chat streams', () async {
+    final adapter = _SseAdapter();
+    final dio = Dio(BaseOptions(
+      baseUrl: 'http://localhost',
+      connectTimeout: const Duration(seconds: 15),
+      receiveTimeout: const Duration(seconds: 15),
+    ))..httpClientAdapter = adapter;
+
+    await AiChatService(backendDio: dio, isWeb: false)
+        .sendMessage(messages: const [])
+        .toList();
+
+    expect(adapter.requests.single.connectTimeout,
+        const Duration(seconds: 15));
+    expect(adapter.requests.single.receiveTimeout, Duration.zero);
+  });
 }
 
 class _SseAdapter implements HttpClientAdapter {
+  final requests = <RequestOptions>[];
+
   @override
   Future<ResponseBody> fetch(
     RequestOptions options,
     Stream<Uint8List>? requestStream,
     Future<void>? cancelFuture,
   ) async {
+    requests.add(options);
     final receipt = {
       'id': 42,
       'actor_user_id': 1,


### PR DESCRIPTION
## What

- Remove the unintended 15-second whole-request cutoff from Web AI chat while retaining the bounded native connection timeout.
- Replace raw Dio exception text with safe, actionable messages, including a Configuration History reminder when a timed-out request may have changed settings.
- Add regression coverage for browser/native timeout composition and user-facing transport failures.

The root cause was `dio_web_adapter` adding `connectTimeout` and `receiveTimeout` into one XHR timeout. Chat had disabled only the receive component, so the inherited 15-second connect timeout still aborted long-running profile operations and was then mislabeled as a zero-duration receive timeout.

## Verification

- `flutter test test/ai_assistant/ai_chat_service_test.dart test/ai_assistant/ai_chat_provider_test.dart`
- `flutter analyze --no-fatal-infos`
- `flutter test` (546 tests)
- `flutter build web --release`
- `make check-test-automation`
- `git diff --check`

## Docs

- [x] No docs impact — this restores the existing long-running chat behavior and changes no documented screen, route, configuration, or workflow.
