### PR TITLE
Stream AI chat incrementally on Flutter Web

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Open `http://your-server:8585` -- the setup wizard walks you through creating an
 cd server
 go run ./cmd/server
 
-# App (requires Flutter stable, Dart SDK 3.3+)
+# App (requires Flutter stable, Dart SDK 3.4+)
 cd app
 flutter pub get
 flutter run

--- a/app/README.md
+++ b/app/README.md
@@ -90,7 +90,7 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 - **Focused attention menu** -- admins can independently keep Approvals, Issues, and Agent fixes pinned or show each only while requests await approval, an issue needs attention or is being tracked, or a fix awaits review. These device-local switches appear on the queue screens and in Settings, so a hidden entry can always be restored; passive tracking keeps the Issues entry available without inflating its actionable badge.
 
 ### AI assistant
-- **Multi-provider chat** with SSE streaming, visible tool activity, and a poster carousel for results. Every user can bring a personal Anthropic, OpenAI, or Gemini API key, or link OpenAI (OAuth) with a ChatGPT browser device code. Admins can configure the same choices as an included server profile and grant it per user. Personal overrides fail closed instead of silently spending shared quota.
+- **Multi-provider chat** with incremental SSE streaming on native and web, visible tool activity, and a poster carousel for results. Every user can bring a personal Anthropic, OpenAI, or Gemini API key, or link OpenAI (OAuth) with a ChatGPT browser device code. Admins can configure the same choices as an included server profile and grant it per user. Personal overrides fail closed instead of silently spending shared quota.
 - **Server-side tools** -- the assistant searches, checks availability, and requests on your behalf; admins can triage queues conversationally.
 - **Configuration receipts** -- explicit admin requests can update supported connected-app settings in one turn, without copying a confirmation command back into chat. Supported profile and custom-format writes return a trusted review receipt; quality-profile receipts also lead to a guarded restore when the live state still matches. Assistant prose never creates controls.
 - **Persistent session** -- the focused `/assistant` workspace keeps one conversation alive across navigation (30-minute idle expiry).
@@ -127,7 +127,7 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 ## Getting Started
 
 ### Prerequisites
-- Flutter (stable channel), Dart SDK 3.3+
+- Flutter (stable channel), Dart SDK 3.4+
 - A running [Cantinarr server](../server/)
 
 ### Run the app
@@ -227,6 +227,7 @@ The router guard redirects unauthenticated users to `/login`, remembers safe int
 | `flutter_riverpod` | State management (hand-written providers) |
 | `go_router` | Shell + stateful tab-shell routing with guards |
 | `dio` | HTTP client with auth/refresh interceptor |
+| `http` | Fetch-backed incremental AI chat streaming on web |
 | `web_socket_channel` | Realtime backend events |
 | `cached_network_image` + `flutter_cache_manager` | Tuned shared image cache |
 | `flutter_secure_storage` / `shared_preferences` | Tokens + device id / lightweight prefs |

--- a/app/lib/core/network/ai_chat_streaming_http_client_adapter.dart
+++ b/app/lib/core/network/ai_chat_streaming_http_client_adapter.dart
@@ -1,0 +1,218 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:http/http.dart' as http;
+
+/// Routes the AI chat SSE request through `package:http` so browser responses
+/// are delivered incrementally by Fetch's `ReadableStream` implementation.
+///
+/// Every other request stays on Dio's normal platform adapter. This keeps the
+/// streaming transport narrowly scoped while preserving the existing client
+/// behavior for the rest of the API.
+class AiChatStreamingHttpClientAdapter implements HttpClientAdapter {
+  final HttpClientAdapter _fallbackAdapter;
+  final http.Client _streamingClient;
+
+  AiChatStreamingHttpClientAdapter({
+    required HttpClientAdapter fallbackAdapter,
+    http.Client? streamingClient,
+  })  : _fallbackAdapter = fallbackAdapter,
+        _streamingClient = streamingClient ?? http.Client();
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    if (!_isAiChatStream(options)) {
+      return _fallbackAdapter.fetch(options, requestStream, cancelFuture);
+    }
+    return _fetchAiChatStream(options, requestStream, cancelFuture);
+  }
+
+  bool _isAiChatStream(RequestOptions options) {
+    final path = Uri.tryParse(options.path)?.path ?? options.path;
+    return path == '/api/ai/chat' &&
+        options.responseType == ResponseType.stream;
+  }
+
+  Future<ResponseBody> _fetchAiChatStream(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    var cancelled = false;
+    var connectTimedOut = false;
+    final abort = Completer<void>();
+
+    cancelFuture?.then(
+      (_) {
+        cancelled = true;
+        if (!abort.isCompleted) abort.complete();
+      },
+      onError: (_, __) {
+        cancelled = true;
+        if (!abort.isCompleted) abort.complete();
+      },
+    );
+
+    final body = await _readRequestBody(
+      requestStream,
+      options,
+      () => cancelled,
+    );
+    if (cancelled) throw _cancelled(options);
+
+    final request = http.AbortableRequest(
+      options.method,
+      options.uri,
+      abortTrigger: abort.future,
+    )
+      ..bodyBytes = body
+      ..headers.addAll(_requestHeaders(options.headers));
+
+    request.followRedirects = options.followRedirects;
+    request.maxRedirects = options.maxRedirects;
+    request.persistentConnection = options.persistentConnection;
+
+    final connectTimeout = options.connectTimeout;
+    Timer? connectTimer;
+    if (connectTimeout != null && connectTimeout > Duration.zero) {
+      connectTimer = Timer(connectTimeout, () {
+        connectTimedOut = true;
+        if (!abort.isCompleted) abort.complete();
+      });
+    }
+
+    final http.StreamedResponse response;
+    try {
+      response = await _streamingClient.send(request);
+    } catch (error, stackTrace) {
+      connectTimer?.cancel();
+      Error.throwWithStackTrace(
+        _transportException(
+          options,
+          cancelled: cancelled,
+          connectTimedOut: connectTimedOut,
+        ),
+        stackTrace,
+      );
+    }
+    connectTimer?.cancel();
+
+    if (cancelled) throw _cancelled(options);
+    if (connectTimedOut) {
+      throw DioException.connectionTimeout(
+        timeout: connectTimeout!,
+        requestOptions: options,
+      );
+    }
+
+    return ResponseBody(
+      _responseStream(
+        response.stream,
+        options,
+        isCancelled: () => cancelled,
+      ),
+      response.statusCode,
+      statusMessage: response.reasonPhrase,
+      isRedirect: response.isRedirect,
+      headers: {
+        for (final header in response.headers.entries)
+          header.key: [header.value],
+      },
+      onClose: () {
+        if (!abort.isCompleted) abort.complete();
+      },
+    );
+  }
+
+  Future<Uint8List> _readRequestBody(
+    Stream<Uint8List>? requestStream,
+    RequestOptions options,
+    bool Function() isCancelled,
+  ) async {
+    if (requestStream == null) return Uint8List(0);
+
+    final bytes = BytesBuilder(copy: false);
+    try {
+      await for (final chunk in requestStream) {
+        if (isCancelled()) throw _cancelled(options);
+        bytes.add(chunk);
+      }
+    } on DioException {
+      rethrow;
+    } catch (_) {
+      throw DioException.connectionError(
+        requestOptions: options,
+        reason: 'The AI chat request body could not be sent.',
+      );
+    }
+    return bytes.takeBytes();
+  }
+
+  Stream<Uint8List> _responseStream(
+    Stream<List<int>> source,
+    RequestOptions options, {
+    required bool Function() isCancelled,
+  }) async* {
+    try {
+      await for (final chunk in source) {
+        yield chunk is Uint8List ? chunk : Uint8List.fromList(chunk);
+      }
+    } catch (error, stackTrace) {
+      Error.throwWithStackTrace(
+        isCancelled()
+            ? _cancelled(options)
+            : DioException.connectionError(
+                requestOptions: options,
+                reason: 'The AI chat response stream was interrupted.',
+              ),
+        stackTrace,
+      );
+    }
+  }
+
+  Map<String, String> _requestHeaders(Map<String, dynamic> headers) => {
+        for (final header in headers.entries)
+          if (header.value != null &&
+              header.key.toLowerCase() != Headers.contentLengthHeader)
+            header.key: header.value is Iterable
+                ? (header.value as Iterable)
+                    .map((value) => value.toString())
+                    .join(', ')
+                : header.value.toString(),
+      };
+
+  DioException _transportException(
+    RequestOptions options, {
+    required bool cancelled,
+    required bool connectTimedOut,
+  }) {
+    if (cancelled) return _cancelled(options);
+    if (connectTimedOut) {
+      return DioException.connectionTimeout(
+        timeout: options.connectTimeout!,
+        requestOptions: options,
+      );
+    }
+    return DioException.connectionError(
+      requestOptions: options,
+      reason: 'The AI chat connection could not be established.',
+    );
+  }
+
+  DioException _cancelled(RequestOptions options) =>
+      DioException.requestCancelled(
+        requestOptions: options,
+        reason: 'The AI chat request was cancelled.',
+      );
+
+  @override
+  void close({bool force = false}) {
+    _streamingClient.close();
+    _fallbackAdapter.close(force: force);
+  }
+}

--- a/app/lib/core/network/backend_auth_interceptor.dart
+++ b/app/lib/core/network/backend_auth_interceptor.dart
@@ -18,6 +18,7 @@ class BackendAuthInterceptor extends Interceptor {
   final Future<void> Function(String accessToken, String refreshToken)
       onTokenRefreshed;
   final VoidCallback onAuthExpired;
+  final HttpClientAdapter Function()? getRetryAdapter;
 
   /// Guards against concurrent refresh attempts.
   Completer<bool>? _refreshCompleter;
@@ -28,6 +29,7 @@ class BackendAuthInterceptor extends Interceptor {
     required this.getServerUrl,
     required this.onTokenRefreshed,
     required this.onAuthExpired,
+    this.getRetryAdapter,
   });
 
   @override
@@ -64,6 +66,10 @@ class BackendAuthInterceptor extends Interceptor {
       final opts = err.requestOptions;
       opts.headers['Authorization'] = 'Bearer ${getAccessToken()}';
       final dio = Dio();
+      final retryAdapter = getRetryAdapter?.call();
+      if (retryAdapter != null) {
+        dio.httpClientAdapter = retryAdapter;
+      }
       final response = await dio.fetch(opts);
       handler.resolve(response);
     } catch (retryErr) {

--- a/app/lib/core/network/backend_client.dart
+++ b/app/lib/core/network/backend_client.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../features/auth/logic/auth_provider.dart';
 import '../config/app_config.dart';
 import 'backend_auth_interceptor.dart';
+import 'backend_http_adapter.dart';
 import 'safe_http_log_interceptor.dart';
 
 /// Provides an authenticated Dio instance configured for the backend.
@@ -32,6 +33,10 @@ final backendClientProvider = Provider<Dio>((ref) {
     receiveTimeout: AppConfig.requestTimeout,
     headers: {'Content-Type': 'application/json'},
   ));
+  final platformAdapter = createBackendHttpClientAdapter();
+  if (platformAdapter != null) {
+    dio.httpClientAdapter = platformAdapter;
+  }
 
   final authNotifier = ref.read(authProvider.notifier);
 
@@ -48,11 +53,15 @@ final backendClientProvider = Provider<Dio>((ref) {
     onAuthExpired: () {
       authNotifier.onAuthExpired();
     },
+    // Retrying through the same adapter preserves incremental Fetch streaming
+    // when a Web chat request first has to refresh an expired access token.
+    getRetryAdapter: () => dio.httpClientAdapter,
   ));
 
   if (kDebugMode) {
     dio.interceptors.add(SafeHttpLogInterceptor(logPrint: debugPrint));
   }
 
+  ref.onDispose(() => dio.close(force: true));
   return dio;
 });

--- a/app/lib/core/network/backend_http_adapter.dart
+++ b/app/lib/core/network/backend_http_adapter.dart
@@ -1,0 +1,8 @@
+import 'package:dio/dio.dart';
+
+import 'backend_http_adapter_stub.dart'
+    if (dart.library.js_interop) 'backend_http_adapter_web.dart' as platform;
+
+/// Returns the platform-specific backend adapter override, when one is needed.
+HttpClientAdapter? createBackendHttpClientAdapter() =>
+    platform.createBackendHttpClientAdapter();

--- a/app/lib/core/network/backend_http_adapter_stub.dart
+++ b/app/lib/core/network/backend_http_adapter_stub.dart
@@ -1,0 +1,3 @@
+import 'package:dio/dio.dart';
+
+HttpClientAdapter? createBackendHttpClientAdapter() => null;

--- a/app/lib/core/network/backend_http_adapter_web.dart
+++ b/app/lib/core/network/backend_http_adapter_web.dart
@@ -1,0 +1,11 @@
+import 'package:dio/browser.dart';
+import 'package:dio/dio.dart';
+import 'package:http/browser_client.dart';
+
+import 'ai_chat_streaming_http_client_adapter.dart';
+
+HttpClientAdapter createBackendHttpClientAdapter() =>
+    AiChatStreamingHttpClientAdapter(
+      fallbackAdapter: BrowserHttpClientAdapter(),
+      streamingClient: BrowserClient(),
+    );

--- a/app/lib/features/ai_assistant/data/ai_chat_service.dart
+++ b/app/lib/features/ai_assistant/data/ai_chat_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 import '../../config_changes/data/config_change_models.dart';
 import 'ai_models.dart';
 
@@ -10,11 +9,8 @@ import 'ai_models.dart';
 /// Uses SSE streaming for real-time response delivery.
 class AiChatService {
   final Dio _backendDio;
-  final bool _isWeb;
 
-  AiChatService({required Dio backendDio, bool? isWeb})
-      : _backendDio = backendDio,
-        _isWeb = isWeb ?? kIsWeb;
+  AiChatService({required Dio backendDio}) : _backendDio = backendDio;
 
   /// Send messages and stream response events via SSE.
   ///
@@ -24,6 +20,7 @@ class AiChatService {
   Stream<ChatStreamEvent> sendMessage({
     required List<ChatMessage> messages,
     String? conversationId,
+    CancelToken? cancelToken,
   }) async* {
     final apiMessages = messages
         .where((m) => m.role != ChatRole.system)
@@ -39,26 +36,25 @@ class AiChatService {
       },
       options: Options(
         responseType: ResponseType.stream,
-        // Agent thinking and slow tools can legitimately run longer than the
-        // normal request timeout. dio_web_adapter implements XMLHttpRequest's
-        // whole-request timeout as connectTimeout + receiveTimeout, so leaving
-        // the inherited 15s connect timeout beside a zero receive timeout
-        // still aborts browser chat after 15s and reports a misleading zero
-        // receive timeout. Disable both browser XHR components; native keeps
-        // its bounded connection setup while the server's SSE keepalives cover
-        // inter-chunk inactivity.
-        connectTimeout:
-            _isWeb ? Duration.zero : _backendDio.options.connectTimeout,
+        // Chat turns can legitimately take minutes. Keep a bounded connection
+        // setup, but never impose an inactivity/whole-response deadline after
+        // headers arrive. Web uses the Fetch-backed streaming adapter while
+        // native Dio receives the server's SSE stream directly.
+        connectTimeout: _backendDio.options.connectTimeout,
         receiveTimeout: Duration.zero,
         headers: {'Accept': 'text/event-stream'},
       ),
+      cancelToken: cancelToken,
     );
 
-    final stream = resp.data.stream as Stream<List<int>>;
+    final byteStream = resp.data.stream as Stream<List<int>>;
     String buffer = '';
 
-    await for (final chunk in stream) {
-      buffer += utf8.decode(chunk);
+    // Browser ReadableStream chunks can split a multi-byte character. Decode
+    // across chunk boundaries instead of treating each network chunk as a
+    // standalone UTF-8 document.
+    await for (final decoded in utf8.decoder.bind(byteStream)) {
+      buffer += decoded;
 
       // Parse SSE events from the buffer
       while (buffer.contains('\n\n')) {

--- a/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
+++ b/app/lib/features/ai_assistant/logic/ai_chat_provider.dart
@@ -130,6 +130,7 @@ class AiChatNotifier extends ChangeNotifier {
   final AiChatService _chatService;
   final _uuid = const Uuid();
   bool _disposed = false;
+  CancelToken? _activeCancelToken;
 
   /// Server-assigned conversation ID; sent on every turn so the server can
   /// keep full tool context. Reset when the chat is cleared.
@@ -183,6 +184,8 @@ class AiChatNotifier extends ChangeNotifier {
     final mediaItems = <MediaResultItem>[];
     final configurationChanges = <ConfigChange>[];
     final toolActivity = <ToolActivity>[];
+    final cancelToken = CancelToken();
+    _activeCancelToken = cancelToken;
     String? errorText;
 
     void upsertResponse({required bool streaming}) {
@@ -218,7 +221,11 @@ class AiChatNotifier extends ChangeNotifier {
       await for (final event in _chatService.sendMessage(
         messages: history,
         conversationId: _conversationId,
+        cancelToken: cancelToken,
       )) {
+        // clearChat (or a future turn) owns every piece of conversation state,
+        // including the server-assigned ID, once the generation changes.
+        if (generation != _generation) break;
         switch (event) {
           case ConversationIdEvent(:final id):
             _conversationId = id;
@@ -279,6 +286,10 @@ class AiChatNotifier extends ChangeNotifier {
       if (generation == _generation) {
         _conversationId = null;
         state = state.copyWith(isLoading: false);
+      }
+    } finally {
+      if (identical(_activeCancelToken, cancelToken)) {
+        _activeCancelToken = null;
       }
     }
   }
@@ -345,6 +356,8 @@ class AiChatNotifier extends ChangeNotifier {
     if (_disposed) return;
     _conversationId = null;
     _generation++; // orphan any in-flight stream
+    _activeCancelToken?.cancel('Chat cleared');
+    _activeCancelToken = null;
     state = const AiChatState();
     _addMessage(ChatMessage(
       id: _uuid.v4(),
@@ -358,6 +371,8 @@ class AiChatNotifier extends ChangeNotifier {
   @override
   void dispose() {
     _generation++;
+    _activeCancelToken?.cancel('Chat disposed');
+    _activeCancelToken = null;
     _disposed = true;
     super.dispose();
   }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 0.1.0+1
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -20,6 +20,7 @@ dependencies:
 
   # Networking
   dio: ^5.7.0
+  http: ^1.6.0
   retrofit: ^4.4.1
 
   # Image loading

--- a/app/test/ai_assistant/ai_chat_provider_test.dart
+++ b/app/test/ai_assistant/ai_chat_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cantinarr/features/ai_assistant/data/ai_chat_service.dart';
 import 'package:cantinarr/features/ai_assistant/data/ai_models.dart';
 import 'package:cantinarr/features/ai_assistant/logic/ai_chat_provider.dart';
@@ -83,18 +85,95 @@ void main() {
       isNot(contains('provider account details')),
     );
   });
+
+  test('publishes tool progress before the assistant stream completes',
+      () async {
+    final service = _ControlledAiChatService();
+    final notifier = AiChatNotifier(chatService: service);
+    addTearDown(notifier.dispose);
+
+    var completed = false;
+    final send = notifier.sendMessage('update my profiles').whenComplete(() {
+      completed = true;
+    });
+    await pumpEventQueue();
+
+    service.events.add(ToolStartEvent(
+      'get_quality_profiles',
+      'Getting quality profiles',
+    ));
+    await pumpEventQueue();
+
+    final streamingMessage = notifier.state.messages.last;
+    expect(completed, isFalse);
+    expect(streamingMessage.isStreaming, isTrue);
+    expect(streamingMessage.toolActivity.single.name, 'get_quality_profiles');
+
+    service.events.add(TextChunkEvent('Working on it.'));
+    await service.events.close();
+    await send;
+
+    expect(notifier.state.messages.last.content, 'Working on it.');
+    expect(notifier.state.messages.last.isStreaming, isFalse);
+  });
+
+  test('clearing chat aborts the active request and ignores late events',
+      () async {
+    final service = _ControlledAiChatService();
+    final notifier = AiChatNotifier(chatService: service);
+    addTearDown(notifier.dispose);
+
+    final send = notifier.sendMessage('change every profile');
+    await pumpEventQueue();
+    expect(service.cancelToken, isNotNull);
+    expect(service.cancelToken!.isCancelled, isFalse);
+
+    notifier.clearChat();
+
+    expect(service.cancelToken!.isCancelled, isTrue);
+    service.events.add(ConversationIdEvent('late-conversation-id'));
+    service.events.add(TextChunkEvent('late response'));
+    await service.events.close();
+    await send;
+
+    expect(notifier.state.messages, hasLength(1));
+    expect(
+      notifier.state.messages.single.content,
+      'Chat cleared! What can I help you find?',
+    );
+    expect(notifier.conversationId, isNull);
+    expect(notifier.state.isLoading, isFalse);
+  });
 }
 
 class _FailingAiChatService extends AiChatService {
   final Object failure;
 
   _FailingAiChatService(this.failure)
-      : super(backendDio: Dio(), isWeb: false);
+      : super(backendDio: Dio());
 
   @override
   Stream<ChatStreamEvent> sendMessage({
     required List<ChatMessage> messages,
     String? conversationId,
+    CancelToken? cancelToken,
   }) =>
       Stream.error(failure);
+}
+
+class _ControlledAiChatService extends AiChatService {
+  final events = StreamController<ChatStreamEvent>();
+  CancelToken? cancelToken;
+
+  _ControlledAiChatService() : super(backendDio: Dio());
+
+  @override
+  Stream<ChatStreamEvent> sendMessage({
+    required List<ChatMessage> messages,
+    String? conversationId,
+    CancelToken? cancelToken,
+  }) async* {
+    this.cancelToken = cancelToken;
+    yield* events.stream;
+  }
 }

--- a/app/test/ai_assistant/ai_chat_service_test.dart
+++ b/app/test/ai_assistant/ai_chat_service_test.dart
@@ -13,7 +13,7 @@ void main() {
     final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
       ..httpClientAdapter = adapter;
 
-    final events = await AiChatService(backendDio: dio, isWeb: false)
+    final events = await AiChatService(backendDio: dio)
         .sendMessage(messages: const [])
         .toList();
 
@@ -24,8 +24,7 @@ void main() {
     expect(receipt.changes.single.after, '+100');
   });
 
-  test('disables the whole-request timeout for browser chat streams',
-      () async {
+  test('keeps a connection timeout without a response deadline', () async {
     final adapter = _SseAdapter();
     final dio = Dio(BaseOptions(
       baseUrl: 'http://localhost',
@@ -33,23 +32,7 @@ void main() {
       receiveTimeout: const Duration(seconds: 15),
     ))..httpClientAdapter = adapter;
 
-    await AiChatService(backendDio: dio, isWeb: true)
-        .sendMessage(messages: const [])
-        .toList();
-
-    expect(adapter.requests.single.connectTimeout, Duration.zero);
-    expect(adapter.requests.single.receiveTimeout, Duration.zero);
-  });
-
-  test('retains the connection timeout for native chat streams', () async {
-    final adapter = _SseAdapter();
-    final dio = Dio(BaseOptions(
-      baseUrl: 'http://localhost',
-      connectTimeout: const Duration(seconds: 15),
-      receiveTimeout: const Duration(seconds: 15),
-    ))..httpClientAdapter = adapter;
-
-    await AiChatService(backendDio: dio, isWeb: false)
+    await AiChatService(backendDio: dio)
         .sendMessage(messages: const [])
         .toList();
 
@@ -57,10 +40,34 @@ void main() {
         const Duration(seconds: 15));
     expect(adapter.requests.single.receiveTimeout, Duration.zero);
   });
+
+  test('preserves multi-byte text split across network chunks', () async {
+    final bytes = utf8.encode(
+      'data: ${jsonEncode({'text': 'Ready 👋'})}\n\n'
+      'data: [DONE]\n\n',
+    );
+    final emojiStart = bytes.indexOf(0xf0);
+    expect(emojiStart, greaterThan(0));
+    final adapter = _SseAdapter(chunks: [
+      Uint8List.fromList(bytes.sublist(0, emojiStart + 2)),
+      Uint8List.fromList(bytes.sublist(emojiStart + 2)),
+    ]);
+    final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+      ..httpClientAdapter = adapter;
+
+    final events = await AiChatService(backendDio: dio)
+        .sendMessage(messages: const [])
+        .toList();
+
+    expect(events.whereType<TextChunkEvent>().single.text, 'Ready 👋');
+  });
 }
 
 class _SseAdapter implements HttpClientAdapter {
+  final List<Uint8List>? chunks;
   final requests = <RequestOptions>[];
+
+  _SseAdapter({this.chunks});
 
   @override
   Future<ResponseBody> fetch(
@@ -69,6 +76,15 @@ class _SseAdapter implements HttpClientAdapter {
     Future<void>? cancelFuture,
   ) async {
     requests.add(options);
+    if (chunks != null) {
+      return ResponseBody(
+        Stream.fromIterable(chunks!),
+        200,
+        headers: {
+          'content-type': ['text/event-stream'],
+        },
+      );
+    }
     final receipt = {
       'id': 42,
       'actor_user_id': 1,

--- a/app/test/core/network/ai_chat_streaming_http_client_adapter_test.dart
+++ b/app/test/core/network/ai_chat_streaming_http_client_adapter_test.dart
@@ -1,0 +1,306 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/network/ai_chat_streaming_http_client_adapter.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+void main() {
+  test('delivers response chunks before the body completes', () async {
+    final body = StreamController<List<int>>();
+    final client = _RecordingClient((_) async => http.StreamedResponse(
+          body.stream,
+          200,
+          headers: {'content-type': 'text/event-stream'},
+        ));
+    final adapter = AiChatStreamingHttpClientAdapter(
+      fallbackAdapter: _FallbackAdapter(),
+      streamingClient: client,
+    );
+    final response = await adapter.fetch(
+      _chatOptions(connectTimeout: const Duration(milliseconds: 1)),
+      null,
+      null,
+    );
+    final chunks = <String>[];
+    final firstChunk = Completer<void>();
+    final complete = Completer<void>();
+    response.stream.listen(
+      (chunk) {
+        chunks.add(utf8.decode(chunk));
+        if (!firstChunk.isCompleted) firstChunk.complete();
+      },
+      onDone: complete.complete,
+    );
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    body.add(utf8.encode('first'));
+    await firstChunk.future;
+
+    expect(chunks, ['first']);
+    expect(complete.isCompleted, isFalse);
+
+    body.add(utf8.encode('second'));
+    await body.close();
+    await complete.future;
+    expect(chunks, ['first', 'second']);
+  });
+
+  test('delegates every request outside the AI chat stream', () async {
+    final fallback = _FallbackAdapter();
+    final client = _RecordingClient((_) async =>
+        http.StreamedResponse(const Stream.empty(), 200));
+    final adapter = AiChatStreamingHttpClientAdapter(
+      fallbackAdapter: fallback,
+      streamingClient: client,
+    );
+    final requestStream = Stream.value(Uint8List.fromList([1]));
+    final cancel = Completer<void>();
+    final otherPath = RequestOptions(
+      path: '/api/other',
+      baseUrl: 'http://localhost',
+      responseType: ResponseType.stream,
+    );
+    final nonStreamingChat = RequestOptions(
+      path: '/api/ai/chat',
+      baseUrl: 'http://localhost',
+      responseType: ResponseType.json,
+    );
+
+    await adapter.fetch(otherPath, requestStream, cancel.future);
+    await adapter.fetch(nonStreamingChat, null, null);
+
+    expect(client.requests, isEmpty);
+    expect(fallback.requests, hasLength(2));
+    expect(identical(fallback.requests.first.options, otherPath), isTrue);
+    expect(identical(fallback.requests.first.requestStream, requestStream),
+        isTrue);
+    expect(identical(fallback.requests.first.cancelFuture, cancel.future),
+        isTrue);
+    expect(identical(fallback.requests.last.options, nonStreamingChat),
+        isTrue);
+  });
+
+  test('forwards URL, method, headers, body, and response metadata', () async {
+    late http.AbortableRequest sent;
+    final client = _RecordingClient((request) async {
+      sent = request as http.AbortableRequest;
+      return http.StreamedResponse(
+        Stream.value(utf8.encode('accepted')),
+        207,
+        headers: {
+          'content-type': 'text/event-stream',
+          'x-response': 'preserved',
+        },
+        isRedirect: true,
+        reasonPhrase: 'Multi-Status',
+      );
+    });
+    final adapter = AiChatStreamingHttpClientAdapter(
+      fallbackAdapter: _FallbackAdapter(),
+      streamingClient: client,
+    );
+    final options = _chatOptions().copyWith(
+      method: 'POST',
+      queryParameters: {'conversation': '42'},
+      headers: {
+        'Authorization': 'Bearer access-token',
+        'Content-Type': 'application/json',
+        'X-Values': ['one', 'two'],
+      },
+      followRedirects: false,
+      maxRedirects: 2,
+      persistentConnection: false,
+    );
+    final response = await adapter.fetch(
+      options,
+      Stream.fromIterable([
+        Uint8List.fromList(utf8.encode('{"message":')),
+        Uint8List.fromList(utf8.encode('"hello"}')),
+      ]),
+      null,
+    );
+
+    expect(sent.method, 'POST');
+    expect(sent.url.toString(),
+        'http://localhost/api/ai/chat?conversation=42');
+    expect(sent.headers['authorization'], 'Bearer access-token');
+    expect(sent.headers['content-type'], 'application/json');
+    expect(sent.headers['x-values'], 'one, two');
+    expect(utf8.decode(sent.bodyBytes), '{"message":"hello"}');
+    expect(sent.followRedirects, isFalse);
+    expect(sent.maxRedirects, 2);
+    expect(sent.persistentConnection, isFalse);
+    expect(response.statusCode, 207);
+    expect(response.statusMessage, 'Multi-Status');
+    expect(response.isRedirect, isTrue);
+    expect(response.headers['content-type'], ['text/event-stream']);
+    expect(response.headers['x-response'], ['preserved']);
+    expect(utf8.decode((await response.stream.toList()).single), 'accepted');
+  });
+
+  test('keeps Dio request interceptors on the Fetch streaming path',
+      () async {
+    late http.AbortableRequest sent;
+    final client = _RecordingClient((request) async {
+      sent = request as http.AbortableRequest;
+      return http.StreamedResponse(
+        Stream.value(utf8.encode('data: [DONE]\n\n')),
+        200,
+        headers: {'content-type': 'text/event-stream'},
+      );
+    });
+    final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+      ..httpClientAdapter = AiChatStreamingHttpClientAdapter(
+        fallbackAdapter: _FallbackAdapter(),
+        streamingClient: client,
+      )
+      ..interceptors.add(InterceptorsWrapper(
+        onRequest: (options, handler) {
+          options.headers['Authorization'] = 'Bearer current-access-token';
+          handler.next(options);
+        },
+      ));
+
+    final response = await dio.post(
+      '/api/ai/chat',
+      data: {'messages': []},
+      options: Options(responseType: ResponseType.stream),
+    );
+    await (response.data.stream as Stream<List<int>>).drain<void>();
+
+    expect(sent.headers['authorization'], 'Bearer current-access-token');
+  });
+
+  test('aborts and reports cancellation while waiting for headers', () async {
+    final requestStarted = Completer<void>();
+    final client = _RecordingClient((request) async {
+      requestStarted.complete();
+      await (request as http.AbortableRequest).abortTrigger;
+      throw http.RequestAbortedException(request.url);
+    });
+    final adapter = AiChatStreamingHttpClientAdapter(
+      fallbackAdapter: _FallbackAdapter(),
+      streamingClient: client,
+    );
+    final cancel = Completer<void>();
+    final response = adapter.fetch(_chatOptions(), null, cancel.future);
+    await requestStarted.future;
+
+    cancel.complete();
+
+    await expectLater(
+      response,
+      throwsA(isA<DioException>().having(
+        (error) => error.type,
+        'type',
+        DioExceptionType.cancel,
+      )),
+    );
+  });
+
+  test('reports a connection timeout only while waiting for headers',
+      () async {
+    final client = _RecordingClient((request) async {
+      await (request as http.AbortableRequest).abortTrigger;
+      throw http.RequestAbortedException(request.url);
+    });
+    final adapter = AiChatStreamingHttpClientAdapter(
+      fallbackAdapter: _FallbackAdapter(),
+      streamingClient: client,
+    );
+
+    await expectLater(
+      adapter.fetch(
+        _chatOptions(connectTimeout: const Duration(milliseconds: 5)),
+        null,
+        null,
+      ),
+      throwsA(isA<DioException>().having(
+        (error) => error.type,
+        'type',
+        DioExceptionType.connectionTimeout,
+      )),
+    );
+  });
+
+  test('closes both transports and preserves the force flag', () {
+    final fallback = _FallbackAdapter();
+    final client = _RecordingClient((_) async =>
+        http.StreamedResponse(const Stream.empty(), 200));
+    final adapter = AiChatStreamingHttpClientAdapter(
+      fallbackAdapter: fallback,
+      streamingClient: client,
+    );
+
+    adapter.close(force: true);
+
+    expect(client.closed, isTrue);
+    expect(fallback.closed, isTrue);
+    expect(fallback.forceClosed, isTrue);
+  });
+}
+
+RequestOptions _chatOptions({Duration? connectTimeout}) => RequestOptions(
+      path: '/api/ai/chat',
+      baseUrl: 'http://localhost',
+      method: 'POST',
+      responseType: ResponseType.stream,
+      connectTimeout: connectTimeout,
+    );
+
+class _RecordingClient extends http.BaseClient {
+  final Future<http.StreamedResponse> Function(http.BaseRequest request)
+      _send;
+  final requests = <http.BaseRequest>[];
+  bool closed = false;
+
+  _RecordingClient(this._send);
+
+  @override
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    requests.add(request);
+    return _send(request);
+  }
+
+  @override
+  void close() {
+    closed = true;
+  }
+}
+
+class _FallbackRequest {
+  final RequestOptions options;
+  final Stream<Uint8List>? requestStream;
+  final Future<void>? cancelFuture;
+
+  const _FallbackRequest(
+    this.options,
+    this.requestStream,
+    this.cancelFuture,
+  );
+}
+
+class _FallbackAdapter implements HttpClientAdapter {
+  final requests = <_FallbackRequest>[];
+  bool closed = false;
+  bool forceClosed = false;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(_FallbackRequest(options, requestStream, cancelFuture));
+    return ResponseBody.fromString('{}', 200);
+  }
+
+  @override
+  void close({bool force = false}) {
+    closed = true;
+    forceClosed = force;
+  }
+}


### PR DESCRIPTION
## What changed

- route only the Flutter Web `POST /api/ai/chat` SSE request through a Fetch/ReadableStream-backed adapter while leaving native and all other Dio traffic unchanged
- preserve the existing Bearer-auth interceptor and the same streaming adapter when a request is replayed after token refresh
- keep the connection setup timeout, remove any whole-response deadline, and add real cancellation when chat is cleared or disposed
- decode UTF-8 across arbitrary network chunks and ignore all stale events from a cancelled chat generation
- document the web streaming behavior and the direct `http` dependency / Dart 3.4 floor

## Why

Dio's browser XHR adapter buffers the response body until the request completes, so Flutter Web could not show SSE text or tool activity incrementally. Long-running turns also surfaced as confusing timeout failures instead of visibly progressing.

Admins now see tool activity and response text as the server sends it, without a copy/paste confirmation detour or a browser-only whole-response timeout.

## Validation

- `flutter analyze --no-fatal-infos`
- `flutter test` — 555 tests passed
- focused streaming/service/provider suite — 15 tests passed
- `flutter build web --release`
- `make check-test-automation` — 20 Python tests; 91 parent cases / 3 Maestro flows
- `git diff --check`

A direct `flutter test --platform chrome` attempt is currently blocked before these tests load by the existing `test/flutter_test_config.dart` use of removed web golden-comparator APIs. The release Web build and VM test suite both pass.
