### PR TITLE
Fix Sonarr language-profile restore eligibility

### DIFF
--- a/server/internal/mcp/arr_profile_history.go
+++ b/server/internal/mcp/arr_profile_history.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -18,6 +19,24 @@ func profileDependencyHash(snapshot profileSettingsSnapshot) [sha256.Size]byte {
 		material = append(material, 0)
 	}
 	return sha256.Sum256(material)
+}
+
+// profileDependencyMatchesStored preserves the dependency scope captured when
+// the change was applied. Sonarr includes its language catalog only when a
+// changed custom format uses LanguageSpecification, while Radarr always
+// includes it. Trying the base snapshot first keeps non-language Sonarr and
+// Chaptarr history independent from unrelated language-catalog changes.
+func profileDependencyMatchesStored(ctx context.Context, mutator qualityProfileMutator, service string, snapshot *profileSettingsSnapshot, expected string) (bool, error) {
+	if hashString(profileDependencyHash(*snapshot)) == expected {
+		return true, nil
+	}
+	if snapshot.HasLanguages || (service != "radarr" && service != "sonarr") {
+		return false, nil
+	}
+	if err := loadProfileSnapshotLanguages(ctx, mutator, snapshot); err != nil {
+		return false, err
+	}
+	return hashString(profileDependencyHash(*snapshot)) == expected, nil
 }
 
 func profileSettingFieldChanges(beforeRaw, afterRaw json.RawMessage, customFormats []json.RawMessage, plan profileChangePlan) ([]SettingFieldChange, error) {

--- a/server/internal/mcp/arr_profile_tools_test.go
+++ b/server/internal/mcp/arr_profile_tools_test.go
@@ -129,8 +129,13 @@ func profileToolCallContext(turnID, trustedText string) CallContext {
 
 func previewX265ProfileChange(t *testing.T, server *ToolServer, turnID string) string {
 	t.Helper()
+	return previewX265ProfileChangeForService(t, server, "radarr", turnID)
+}
+
+func previewX265ProfileChangeForService(t *testing.T, server *ToolServer, service, turnID string) string {
+	t.Helper()
 	result, err := server.ExecuteTool(context.Background(), "preview_profile_change", json.RawMessage(`{
-		"service":"radarr","profile_id":1,
+		"service":"`+service+`","profile_id":1,
 		"changes":{"custom_format_scores":[{"format_name":"x265","score":25}]}
 	}`), profileToolCallContext(turnID, "Set x265 to 25"))
 	if err != nil {

--- a/server/internal/mcp/settings_change_api.go
+++ b/server/internal/mcp/settings_change_api.go
@@ -129,7 +129,7 @@ func (s *ToolServer) settingChangeDetail(ctx context.Context, id int64) (Externa
 		detail.CurrentError = "This server build cannot read the selected quality profile."
 		return detail, nil
 	}
-	snapshot, err := loadProfileSettingsSnapshot(ctx, mutator, profileID, stored.ServiceType == "radarr")
+	snapshot, err := loadProfileSettingsSnapshot(ctx, mutator, profileID, false)
 	if err != nil {
 		detail.CurrentStatus = "unavailable"
 		detail.CurrentError = "Cantinarr could not read the current profile."
@@ -142,7 +142,17 @@ func (s *ToolServer) settingChangeDetail(ctx context.Context, id int64) (Externa
 		return detail, nil
 	}
 	detail.Changes = withCurrentSettingValues(stored.Changes, values, nil)
-	if hashString(snapshot.ProfileHash) == stored.AfterHash && hashString(profileDependencyHash(snapshot)) == stored.DependencyHash {
+	profileMatches := hashString(snapshot.ProfileHash) == stored.AfterHash
+	dependenciesMatch := false
+	if profileMatches {
+		dependenciesMatch, err = profileDependencyMatchesStored(ctx, mutator, stored.ServiceType, &snapshot, stored.DependencyHash)
+		if err != nil {
+			detail.CurrentStatus = "unavailable"
+			detail.CurrentError = "Cantinarr could not verify the current profile dependencies."
+			return detail, nil
+		}
+	}
+	if profileMatches && dependenciesMatch {
 		detail.CurrentStatus = "matches_applied"
 		detail.CanRevert = stored.Status == settingChangeStatusApplied
 	} else {
@@ -296,11 +306,18 @@ func (s *ToolServer) revertSettingChange(ctx context.Context, id int64, callCtx 
 	if !ok {
 		return ExternalSettingChange{}, errSettingChangeUnavailable
 	}
-	current, err := loadProfileSettingsSnapshot(ctx, mutator, profileID, stored.ServiceType == "radarr")
+	current, err := loadProfileSettingsSnapshot(ctx, mutator, profileID, false)
 	if err != nil {
 		return ExternalSettingChange{}, errSettingChangeUnavailable
 	}
-	if current.ProfileHash != afterHash || hashString(profileDependencyHash(current)) != stored.DependencyHash {
+	if current.ProfileHash != afterHash {
+		return ExternalSettingChange{}, errSettingChangeConflict
+	}
+	dependenciesMatch, err := profileDependencyMatchesStored(ctx, mutator, stored.ServiceType, &current, stored.DependencyHash)
+	if err != nil {
+		return ExternalSettingChange{}, errSettingChangeUnavailable
+	}
+	if !dependenciesMatch {
 		return ExternalSettingChange{}, errSettingChangeConflict
 	}
 	if calculated, hashErr := canonicalProfileJSONHash(stored.BeforeRaw); hashErr != nil || calculated != beforeHash {
@@ -333,11 +350,18 @@ func (s *ToolServer) revertSettingChange(ctx context.Context, id int64, callCtx 
 		if !ok {
 			return errSettingChangeUnavailable
 		}
-		latest, loadErr := loadProfileSettingsSnapshot(ctx, freshMutator, profileID, stored.ServiceType == "radarr")
+		latest, loadErr := loadProfileSettingsSnapshot(ctx, freshMutator, profileID, false)
 		if loadErr != nil {
 			return errSettingChangeUnavailable
 		}
-		if latest.ProfileHash != afterHash || hashString(profileDependencyHash(latest)) != stored.DependencyHash {
+		if latest.ProfileHash != afterHash {
+			return errSettingChangeConflict
+		}
+		dependenciesMatch, loadErr := profileDependencyMatchesStored(ctx, freshMutator, stored.ServiceType, &latest, stored.DependencyHash)
+		if loadErr != nil {
+			return errSettingChangeUnavailable
+		}
+		if !dependenciesMatch {
 			return errSettingChangeConflict
 		}
 		historyChange, guardErr = s.settingsChanges.create(newSettingChange{

--- a/server/internal/mcp/settings_change_history_test.go
+++ b/server/internal/mcp/settings_change_history_test.go
@@ -53,6 +53,27 @@ func testExternalSettingChange(t *testing.T, resourceID string) newSettingChange
 	}
 }
 
+func applyProfileChangeForHistoryTest(t *testing.T, server *ToolServer, reference, turnID, trustedText string) ExternalSettingChange {
+	t.Helper()
+	result, err := server.ExecuteTool(
+		context.Background(),
+		"apply_profile_change",
+		json.RawMessage(`{"change_reference":"`+reference+`"}`),
+		profileToolCallContext(turnID, trustedText),
+	)
+	if err != nil {
+		t.Fatalf("apply profile change: %v", err)
+	}
+	if !strings.Contains(result.Text, "Applied the requested change") {
+		t.Fatalf("apply result = %q", result.Text)
+	}
+	changes, err := server.settingsChanges.list(1, 0)
+	if err != nil || len(changes) != 1 {
+		t.Fatalf("applied history = %#v, %v", changes, err)
+	}
+	return changes[0]
+}
+
 func TestSettingChangeSummaryNeverClaimsAnUnknownRemoteOutcome(t *testing.T) {
 	tests := []struct {
 		resourceType string
@@ -309,6 +330,109 @@ func TestSettingChangeProfileRestoreRefusesDriftThenRestoresExactAppliedImage(t 
 	if restoredHash != before.ProfileHash {
 		t.Fatalf("restored profile differs from before snapshot:\nwant %s\n got %s", before.ProfileRaw, restoredRaw)
 	}
+}
+
+func TestSettingChangeSonarrDependencyScopeControlsRestore(t *testing.T) {
+	t.Run("language score restores while the catalog matches", func(t *testing.T) {
+		fake := newProfileToolFakeArr()
+		server, _, _, _ := newProfileToolIntegrationServerWithStoreForService(t, fake, "sonarr")
+		reference := previewLanguageScoreProfileChange(t, server, "sonarr", "sonarr-language-match")
+		applied := applyProfileChangeForHistoryTest(t, server, reference, "sonarr-language-match", "Set Not English to -9000")
+		if fake.putCount() != 1 {
+			t.Fatalf("apply wrote %d times, want one", fake.putCount())
+		}
+
+		detail, err := server.settingChangeDetail(context.Background(), applied.ID)
+		if err != nil {
+			t.Fatalf("detail at exact applied language state: %v", err)
+		}
+		if detail.CurrentStatus != "matches_applied" || !detail.CanRevert || detail.CurrentError != "" ||
+			len(detail.Changes) != 1 || detail.Changes[0].Key != "custom_format_score:3" ||
+			detail.Changes[0].Current == nil || *detail.Changes[0].Current != "-9000" ||
+			detail.Changes[0].CurrentState != "matches_applied" {
+			t.Fatalf("matching Sonarr language detail = %#v", detail)
+		}
+
+		reverted, err := server.revertSettingChange(context.Background(), applied.ID, profileToolCallContext("restore-sonarr-language", "Restore the previous profile"))
+		if err != nil {
+			t.Fatalf("restore matching Sonarr language profile: %v", err)
+		}
+		if fake.putCount() != 2 || reverted.ParentID == nil || *reverted.ParentID != applied.ID ||
+			reverted.Operation != "revert" || reverted.Status != settingChangeStatusApplied ||
+			reverted.CurrentStatus != "matches_applied" || !reverted.CanRevert {
+			t.Fatalf("Sonarr language restore = %#v puts=%d", reverted, fake.putCount())
+		}
+		fake.mu.Lock()
+		restoredRaw := append(json.RawMessage(nil), fake.profile...)
+		fake.mu.Unlock()
+		restoredHash, err := canonicalProfileJSONHash(restoredRaw)
+		if err != nil {
+			t.Fatalf("hash restored Sonarr profile: %v", err)
+		}
+		beforeHash, err := canonicalProfileJSONHash(json.RawMessage(settingsProfileHD))
+		if err != nil {
+			t.Fatalf("hash original Sonarr profile: %v", err)
+		}
+		if restoredHash != beforeHash {
+			t.Fatalf("restored Sonarr profile differs from original:\nwant %s\n got %s", settingsProfileHD, restoredRaw)
+		}
+		revertedDetail, err := server.settingChangeDetail(context.Background(), reverted.ID)
+		if err != nil {
+			t.Fatalf("detail for Sonarr restore record: %v", err)
+		}
+		if revertedDetail.CurrentStatus != "matches_applied" || !revertedDetail.CanRevert {
+			t.Fatalf("Sonarr restore detail = %#v", revertedDetail)
+		}
+	})
+
+	t.Run("language score refuses real catalog drift", func(t *testing.T) {
+		fake := newProfileToolFakeArr()
+		server, _, _, _ := newProfileToolIntegrationServerWithStoreForService(t, fake, "sonarr")
+		reference := previewLanguageScoreProfileChange(t, server, "sonarr", "sonarr-language-drift")
+		applied := applyProfileChangeForHistoryTest(t, server, reference, "sonarr-language-drift", "Set Not English to -9000")
+		fake.setLanguages(`[{"id":-1,"name":"Any"},{"id":1,"name":"English (changed)"}]`)
+
+		detail, err := server.settingChangeDetail(context.Background(), applied.ID)
+		if err != nil {
+			t.Fatalf("detail after Sonarr language catalog drift: %v", err)
+		}
+		if detail.CurrentStatus != "different" || detail.CanRevert ||
+			detail.CurrentError != "Other settings or dependencies on this profile changed after this entry." ||
+			len(detail.Changes) != 1 || detail.Changes[0].Current == nil ||
+			*detail.Changes[0].Current != "-9000" || detail.Changes[0].CurrentState != "matches_applied" {
+			t.Fatalf("drifted Sonarr language detail = %#v", detail)
+		}
+		if _, err := server.revertSettingChange(context.Background(), applied.ID, profileToolCallContext("restore-sonarr-language-drift", "Restore the previous profile")); !errors.Is(err, errSettingChangeConflict) {
+			t.Fatalf("drifted Sonarr language restore error = %v", err)
+		}
+		if fake.putCount() != 1 {
+			t.Fatalf("drifted Sonarr language restore wrote %d times", fake.putCount()-1)
+		}
+	})
+
+	t.Run("non-language score ignores unrelated catalog drift", func(t *testing.T) {
+		fake := newProfileToolFakeArr()
+		server, _, _, _ := newProfileToolIntegrationServerWithStoreForService(t, fake, "sonarr")
+		reference := previewX265ProfileChangeForService(t, server, "sonarr", "sonarr-non-language")
+		applied := applyProfileChangeForHistoryTest(t, server, reference, "sonarr-non-language", "Set x265 to 25")
+		fake.setLanguages(`[{"id":-1,"name":"Any"},{"id":1,"name":"English (changed)"}]`)
+
+		detail, err := server.settingChangeDetail(context.Background(), applied.ID)
+		if err != nil {
+			t.Fatalf("detail after unrelated Sonarr language catalog drift: %v", err)
+		}
+		if detail.CurrentStatus != "matches_applied" || !detail.CanRevert || detail.CurrentError != "" ||
+			len(detail.Changes) != 1 || detail.Changes[0].Current == nil ||
+			*detail.Changes[0].Current != "+25" || detail.Changes[0].CurrentState != "matches_applied" {
+			t.Fatalf("matching Sonarr non-language detail = %#v", detail)
+		}
+		if _, err := server.revertSettingChange(context.Background(), applied.ID, profileToolCallContext("restore-sonarr-non-language", "Restore the previous profile")); err != nil {
+			t.Fatalf("restore Sonarr non-language profile: %v", err)
+		}
+		if fake.putCount() != 2 {
+			t.Fatalf("Sonarr non-language apply and restore wrote %d times, want two", fake.putCount())
+		}
+	})
 }
 
 func TestSettingChangeCustomFormatDetailComparesLiveStateWithoutOfferingRestore(t *testing.T) {


### PR DESCRIPTION
## What

Fix false restore conflicts for Sonarr quality-profile changes that score language custom formats. History verification now preserves the dependency scope captured at apply time: it checks the base custom-format dependency first and loads the language catalog only when the stored hash requires it.

This repairs existing language-bound history rows while keeping non-language Sonarr rows independent from unrelated language-catalog changes. Regression coverage proves successful restore, genuine language drift refusal, non-language compatibility, and restore-record eligibility.

## Verification

- `go vet ./...`
- `go test ./...`
- `go test -race ./internal/mcp -count=1`
- `CGO_ENABLED=0 go build ./...`

## Docs

- [x] No docs impact — this restores the already-documented guarded-restore behavior; no route, model, setting, workflow, or manual-test surface changed.