### PR TITLE
fix(app): surface monitored books first

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -73,7 +73,7 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 - **Import Doctor** -- any stuck queue item explains itself in plain English with the raw arr messages shown for transparency, then offers ordered one-click fixes (manual/force import with candidates preview, remove, blocklist + re-search, category hand-off, rescan). One shared rule engine drives Sonarr, Radarr, and Chaptarr, mirrored from the server's classifier.
 
 ### Books (Chaptarr)
-- **Per-format everything** -- a title's ebook and audiobook are separate records; the author page shows two bookmark toggles per book (tap an empty one to add + search the missing format).
+- **Per-format everything** -- a title's ebook and audiobook are separate records; the author page groups monitored titles first and shows two bookmark toggles per book (tap an empty one to add + search the missing format).
 - **Owned-aware search** -- library titles are injected into lookup results and floated to the top with Downloaded / In Library chips; distinct records are never merged.
 - **Full module** -- library with author drill-down, queue with Import Doctor, history, and wanted (missing / cutoff unmet).
 

--- a/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_author_detail_screen.dart
@@ -5,6 +5,7 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/cached_image.dart';
 import '../../../core/widgets/error_banner.dart';
+import '../../../core/widgets/section_header.dart';
 import '../../../navigation/ambient_page_route.dart';
 import '../data/chaptarr_add_payload.dart';
 import '../data/chaptarr_api_service.dart';
@@ -89,11 +90,27 @@ class _ChaptarrAuthorDetailScreenState
       await _service.setBookMonitored([book.id], target);
       if (!mounted) return;
       // Reflect the change locally without a full reload.
+      var movedSections = false;
       setState(() {
+        final wasMonitored = _books.any((candidate) =>
+            candidate.groupKey == book.groupKey && candidate.monitored);
         _books = _books
             .map((b) => b.id == book.id ? _withMonitored(b, target) : b)
             .toList();
+        final isMonitored = _books.any((candidate) =>
+            candidate.groupKey == book.groupKey && candidate.monitored);
+        movedSections = wasMonitored != isMonitored;
       });
+      final format = chaptarrFormatLabel(book.format);
+      final message = movedSections
+          ? target
+              ? '${book.title} moved to Monitored books'
+              : '${book.title} moved out of Monitored books'
+          : target
+              ? 'Monitoring $format for ${book.title}'
+              : 'Stopped monitoring $format for ${book.title}';
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text(message)));
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -129,6 +146,18 @@ class _ChaptarrAuthorDetailScreenState
     }
     return groups.values.toList();
   }
+
+  Widget _bookCard(List<ChaptarrBook> records) => _BookCard(
+        key: ValueKey('book:${records.first.groupKey}'),
+        records: records,
+        cover: chaptarrImageSource(
+            ref, records.first.coverUrl, widget.instanceId),
+        togglingIds: _togglingBooks,
+        addingKeys: _addingFormats,
+        onTap: () => _openBookGroup(records),
+        onToggleRecord: _toggleBookMonitored,
+        onAddFormat: (format) => _addFormat(records, format),
+      );
 
   String _addKey(List<ChaptarrBook> records, BookFormat format) =>
       '${records.first.groupKey}:${format.index}';
@@ -182,6 +211,18 @@ class _ChaptarrAuthorDetailScreenState
   @override
   Widget build(BuildContext context) {
     final title = _author?.authorName ?? widget.authorName ?? 'Author';
+    final groupedBooks = _groupedBooks();
+    final monitoredBooks = <List<ChaptarrBook>>[];
+    final otherBooks = <List<ChaptarrBook>>[];
+    // A title belongs up top when either of its format records is monitored.
+    // Append into each bucket so the existing newest-first order stays stable.
+    for (final records in groupedBooks) {
+      if (records.any((book) => book.monitored)) {
+        monitoredBooks.add(records);
+      } else {
+        otherBooks.add(records);
+      }
+    }
 
     return Scaffold(
       backgroundColor: AppTheme.background,
@@ -209,17 +250,15 @@ class _ChaptarrAuthorDetailScreenState
                         ErrorBanner(message: _error!, onRetry: _load),
                       if (_author != null) _AuthorSummaryCard(author: _author!),
                       const SizedBox(height: 4),
-                      ..._groupedBooks().map((records) => _BookCard(
-                            records: records,
-                            cover: chaptarrImageSource(
-                                ref, records.first.coverUrl, widget.instanceId),
-                            togglingIds: _togglingBooks,
-                            addingKeys: _addingFormats,
-                            onTap: () => _openBookGroup(records),
-                            onToggleRecord: _toggleBookMonitored,
-                            onAddFormat: (format) =>
-                                _addFormat(records, format),
-                          )),
+                      if (monitoredBooks.isNotEmpty) ...[
+                        const _BookSectionHeading(title: 'Monitored books'),
+                        ...monitoredBooks.map(_bookCard),
+                      ],
+                      if (otherBooks.isNotEmpty) ...[
+                        if (monitoredBooks.isNotEmpty)
+                          const _BookSectionHeading(title: 'Other books'),
+                        ...otherBooks.map(_bookCard),
+                      ],
                       if (_books.isEmpty && !_isLoading)
                         const Padding(
                           padding: EdgeInsets.all(32),
@@ -232,6 +271,23 @@ class _ChaptarrAuthorDetailScreenState
                     ],
                   ),
                 )),
+    );
+  }
+}
+
+class _BookSectionHeading extends StatelessWidget {
+  final String title;
+
+  const _BookSectionHeading({required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      header: true,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+        child: SectionHeader(title: title),
+      ),
     );
   }
 }
@@ -339,6 +395,7 @@ class _BookCard extends StatelessWidget {
   final void Function(BookFormat format) onAddFormat;
 
   const _BookCard({
+    super.key,
     required this.records,
     required this.cover,
     required this.togglingIds,

--- a/app/test/chaptarr/author_detail_monitored_books_test.dart
+++ b/app/test/chaptarr/author_detail_monitored_books_test.dart
@@ -1,0 +1,483 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/features/chaptarr/ui/chaptarr_author_detail_screen.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+typedef _Request = ({
+  String method,
+  String path,
+  Map<String, dynamic> query,
+  dynamic body,
+});
+
+/// Serves an author and its books through the same proxied paths used by the
+/// real detail screen, while recording monitor updates for interaction tests.
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(
+    List<Map<String, dynamic>> books, {
+    this.deferMonitorPuts = false,
+  }) : books = books.map(Map<String, dynamic>.from).toList();
+
+  final List<Map<String, dynamic>> books;
+  final bool deferMonitorPuts;
+  final List<_Request> requests = [];
+  final List<({
+    Map<String, dynamic> body,
+    Completer<ResponseBody> response,
+  })> pendingMonitorPuts = [];
+
+  ResponseBody _response(dynamic body) => ResponseBody.fromString(
+        jsonEncode(body),
+        200,
+        headers: {
+          'content-type': ['application/json'],
+        },
+      );
+
+  void _applyMonitorUpdate(Map<String, dynamic> body) {
+    final ids = (body['bookIds'] as List<dynamic>).cast<int>().toSet();
+    final monitored = body['monitored'] as bool;
+    for (final book in books) {
+      if (ids.contains(book['id'])) book['monitored'] = monitored;
+    }
+  }
+
+  void completeMonitorPut(int index) {
+    final pending = pendingMonitorPuts[index];
+    _applyMonitorUpdate(pending.body);
+    pending.response.complete(_response(<String, dynamic>{}));
+  }
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    dynamic requestBody;
+    if (requestStream != null) {
+      final bytes = await requestStream.expand((chunk) => chunk).toList();
+      if (bytes.isNotEmpty) {
+        requestBody = jsonDecode(utf8.decode(bytes));
+      }
+    }
+
+    final path = options.uri.path;
+    requests.add((
+      method: options.method,
+      path: path,
+      query: Map<String, dynamic>.from(options.uri.queryParameters),
+      body: requestBody,
+    ));
+
+    dynamic response = <String, dynamic>{};
+    if (options.method == 'GET' && path.endsWith('/author/7')) {
+      response = {
+        'id': 7,
+        'authorName': 'Marcus Aurelius',
+        'statistics': {
+          'bookCount': books.length,
+          'bookFileCount': 0,
+        },
+      };
+    } else if (options.method == 'GET' && path.endsWith('/book')) {
+      response = books;
+    } else if (options.method == 'PUT' && path.endsWith('/book/monitor')) {
+      // Mirror the successful server update so this fixture remains correct if
+      // the screen ever chooses to reload after a toggle.
+      final body = requestBody as Map<String, dynamic>;
+      if (deferMonitorPuts) {
+        final completer = Completer<ResponseBody>();
+        pendingMonitorPuts.add((body: body, response: completer));
+        return completer.future;
+      }
+      _applyMonitorUpdate(body);
+    }
+
+    return _response(response);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Map<String, dynamic> _book({
+  required int id,
+  required String title,
+  required String groupKey,
+  required DateTime releaseDate,
+  required bool monitored,
+  String mediaType = 'ebook',
+}) =>
+    {
+      'id': id,
+      'title': title,
+      'authorId': 7,
+      'foreignBookId': groupKey,
+      'releaseDate': releaseDate.toIso8601String(),
+      'monitored': monitored,
+      'mediaType': mediaType,
+      'statistics': {
+        'bookCount': 1,
+        'bookFileCount': 0,
+      },
+    };
+
+Future<_FakeAdapter> _pumpDetail(
+  WidgetTester tester,
+  List<Map<String, dynamic>> books, {
+  bool deferMonitorPuts = false,
+}) async {
+  tester.view.physicalSize = const Size(390, 844);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
+
+  final adapter = _FakeAdapter(books, deferMonitorPuts: deferMonitorPuts);
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+    ..httpClientAdapter = adapter;
+  addTearDown(() => dio.close(force: true));
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [backendClientProvider.overrideWithValue(dio)],
+      child: const MaterialApp(
+        home: ChaptarrAuthorDetailScreen(
+          instanceId: 'inst1',
+          authorId: 7,
+          authorName: 'Marcus Aurelius',
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+
+  expect(
+    adapter.requests.where((request) =>
+        request.method == 'GET' && request.path.endsWith('/author/7')),
+    hasLength(1),
+  );
+  final bookGet = adapter.requests.singleWhere((request) =>
+      request.method == 'GET' && request.path.endsWith('/book'));
+  expect(bookGet.query['authorId'], '7');
+  return adapter;
+}
+
+Finder _card(String groupKey) => find.byKey(ValueKey('book:$groupKey'));
+
+Finder _formatControl(String groupKey, String tooltip) => find.descendant(
+      of: _card(groupKey),
+      matching: find.byTooltip(tooltip),
+    );
+
+Finder _formatControlTapTarget(String groupKey, String tooltip) =>
+    find.descendant(
+      of: _formatControl(groupKey, tooltip),
+      matching: find.byType(InkWell),
+    );
+
+void _invokeFormatControl(
+  WidgetTester tester,
+  String groupKey,
+  String tooltip,
+) {
+  final control = tester.widget<InkWell>(
+      _formatControlTapTarget(groupKey, tooltip));
+  expect(control.onTap, isNotNull);
+  control.onTap!();
+}
+
+void _expectAbove(WidgetTester tester, Finder upper, Finder lower) {
+  expect(
+    tester.getTopLeft(upper).dy,
+    lessThan(tester.getTopLeft(lower).dy),
+  );
+}
+
+Future<void> _waitForPendingMonitorPuts(
+  WidgetTester tester,
+  _FakeAdapter adapter,
+  int count,
+) async {
+  for (var attempt = 0;
+      attempt < 100 && adapter.pendingMonitorPuts.length < count;
+      attempt++) {
+    await tester.pump(const Duration(milliseconds: 1));
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    });
+  }
+  expect(adapter.pendingMonitorPuts, hasLength(count),
+      reason: 'requests received: ${adapter.requests}');
+}
+
+void main() {
+  group('ChaptarrAuthorDetailScreen monitored books', () {
+    testWidgets(
+        'promotes monitored titles and keeps release-date order in both groups',
+        (tester) async {
+      await _pumpDetail(tester, [
+        _book(
+          id: 1,
+          title: 'Oldest other',
+          groupKey: 'other-oldest',
+          releaseDate: DateTime.utc(2001),
+          monitored: false,
+        ),
+        _book(
+          id: 2,
+          title: 'Older monitored',
+          groupKey: 'monitored-older',
+          releaseDate: DateTime.utc(2005),
+          monitored: true,
+        ),
+        _book(
+          id: 3,
+          title: 'Newest other',
+          groupKey: 'other-newest',
+          releaseDate: DateTime.utc(2025),
+          monitored: false,
+        ),
+        _book(
+          id: 4,
+          title: 'Newer monitored',
+          groupKey: 'monitored-newer',
+          releaseDate: DateTime.utc(2020),
+          monitored: true,
+        ),
+      ]);
+
+      final monitoredHeading = find.text('Monitored books');
+      final otherHeading = find.text('Other books');
+      expect(monitoredHeading, findsOneWidget);
+      expect(otherHeading, findsOneWidget);
+      for (final key in [
+        'monitored-newer',
+        'monitored-older',
+        'other-newest',
+        'other-oldest',
+      ]) {
+        expect(_card(key), findsOneWidget);
+      }
+
+      _expectAbove(tester, monitoredHeading, _card('monitored-newer'));
+      _expectAbove(
+          tester, _card('monitored-newer'), _card('monitored-older'));
+      _expectAbove(tester, _card('monitored-older'), otherHeading);
+      _expectAbove(tester, otherHeading, _card('other-newest'));
+      _expectAbove(tester, _card('other-newest'), _card('other-oldest'));
+    });
+
+    testWidgets('one monitored format promotes one combined title card',
+        (tester) async {
+      await _pumpDetail(tester, [
+        _book(
+          id: 10,
+          title: 'Combined title',
+          groupKey: 'combined',
+          releaseDate: DateTime.utc(2010),
+          monitored: false,
+        ),
+        _book(
+          id: 11,
+          title: 'Combined title',
+          groupKey: 'combined',
+          releaseDate: DateTime.utc(2010),
+          monitored: true,
+          mediaType: 'audiobook',
+        ),
+        _book(
+          id: 12,
+          title: 'Newer unmonitored title',
+          groupKey: 'newer-other',
+          releaseDate: DateTime.utc(2025),
+          monitored: false,
+        ),
+      ]);
+
+      expect(find.text('Combined title'), findsOneWidget);
+      expect(_card('combined'), findsOneWidget);
+      expect(
+          _formatControl('combined', 'Monitor eBook'), findsOneWidget);
+      expect(_formatControl('combined', 'Stop monitoring Audiobook'),
+          findsOneWidget);
+      _expectAbove(tester, find.text('Monitored books'), _card('combined'));
+      _expectAbove(tester, _card('combined'), find.text('Other books'));
+      _expectAbove(tester, find.text('Other books'), _card('newer-other'));
+    });
+
+    testWidgets('zero monitored books keeps the plain newest-first catalog',
+        (tester) async {
+      await _pumpDetail(tester, [
+        _book(
+          id: 20,
+          title: 'Old title',
+          groupKey: 'old',
+          releaseDate: DateTime.utc(2000),
+          monitored: false,
+        ),
+        _book(
+          id: 21,
+          title: 'Newest title',
+          groupKey: 'newest',
+          releaseDate: DateTime.utc(2025),
+          monitored: false,
+        ),
+        _book(
+          id: 22,
+          title: 'Middle title',
+          groupKey: 'middle',
+          releaseDate: DateTime.utc(2015),
+          monitored: false,
+        ),
+      ]);
+
+      expect(find.text('Monitored books'), findsNothing);
+      expect(find.text('Other books'), findsNothing);
+      expect(_card('newest'), findsOneWidget);
+      expect(_card('middle'), findsOneWidget);
+      expect(_card('old'), findsOneWidget);
+      _expectAbove(tester, _card('newest'), _card('middle'));
+      _expectAbove(tester, _card('middle'), _card('old'));
+    });
+
+    testWidgets('successful unmonitor relocates the card and records the PUT',
+        (tester) async {
+      final adapter = await _pumpDetail(tester, [
+        _book(
+          id: 30,
+          title: 'Old monitored title',
+          groupKey: 'old-monitored',
+          releaseDate: DateTime.utc(2000),
+          monitored: true,
+        ),
+        _book(
+          id: 31,
+          title: 'New unmonitored title',
+          groupKey: 'new-unmonitored',
+          releaseDate: DateTime.utc(2025),
+          monitored: false,
+        ),
+      ]);
+
+      _expectAbove(
+          tester, _card('old-monitored'), _card('new-unmonitored'));
+      await tester.tap(
+          _formatControl('old-monitored', 'Stop monitoring eBook'));
+      await tester.pumpAndSettle();
+
+      final puts = adapter.requests.where((request) =>
+          request.method == 'PUT' &&
+          request.path.endsWith('/book/monitor'));
+      expect(puts, hasLength(1));
+      expect(puts.single.body, {
+        'bookIds': [30],
+        'monitored': false,
+      });
+      expect(find.text('Monitored books'), findsNothing);
+      expect(find.text('Other books'), findsNothing);
+      expect(_formatControl('old-monitored', 'Monitor eBook'), findsOneWidget);
+      _expectAbove(
+          tester, _card('new-unmonitored'), _card('old-monitored'));
+      expect(find.byType(SnackBar), findsOneWidget);
+    });
+
+    testWidgets(
+        'overlapping format toggles only claim a move on the response that moves',
+        (tester) async {
+      final adapter = await _pumpDetail(
+        tester,
+        [
+          _book(
+            id: 40,
+            title: 'Combined title',
+            groupKey: 'combined-overlap',
+            releaseDate: DateTime.utc(2000),
+            monitored: true,
+          ),
+          _book(
+            id: 41,
+            title: 'Combined title',
+            groupKey: 'combined-overlap',
+            releaseDate: DateTime.utc(2000),
+            monitored: true,
+            mediaType: 'audiobook',
+          ),
+          _book(
+            id: 42,
+            title: 'New unmonitored title',
+            groupKey: 'new-other-overlap',
+            releaseDate: DateTime.utc(2025),
+            monitored: false,
+          ),
+        ],
+        deferMonitorPuts: true,
+      );
+
+      _invokeFormatControl(
+          tester, 'combined-overlap', 'Stop monitoring eBook');
+      await tester.pump();
+      await _waitForPendingMonitorPuts(tester, adapter, 1);
+      _invokeFormatControl(
+          tester, 'combined-overlap', 'Stop monitoring Audiobook');
+      await tester.pump();
+      await _waitForPendingMonitorPuts(tester, adapter, 2);
+
+      // Both decisions were made against the same initial two-format state;
+      // neither response has updated the local model yet.
+      expect(
+        adapter.pendingMonitorPuts.map((pending) => pending.body),
+        [
+          {
+            'bookIds': [40],
+            'monitored': false,
+          },
+          {
+            'bookIds': [41],
+            'monitored': false,
+          },
+        ],
+      );
+
+      adapter.completeMonitorPut(0);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // The audiobook is still monitored, so the first successful response
+      // changes one format without moving the combined title.
+      expect(find.text('Monitored books'), findsOneWidget);
+      expect(find.text('Stopped monitoring eBook for Combined title'),
+          findsOneWidget);
+      expect(find.text('Combined title moved out of Monitored books'),
+          findsNothing);
+      _expectAbove(tester, _card('combined-overlap'),
+          _card('new-other-overlap'));
+
+      tester
+          .state<ScaffoldMessengerState>(find.byType(ScaffoldMessenger))
+          .removeCurrentSnackBar();
+      await tester.pump();
+
+      adapter.completeMonitorPut(1);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 300));
+
+      // This response clears the group's last monitored format, so it is the
+      // only one whose success message may claim a section move.
+      expect(find.text('Combined title moved out of Monitored books'),
+          findsOneWidget);
+      expect(find.text('Monitored books'), findsNothing);
+      expect(find.text('Other books'), findsNothing);
+      _expectAbove(tester, _card('new-other-overlap'),
+          _card('combined-overlap'));
+    });
+  });
+}


### PR DESCRIPTION
## What

- Group author-page title cards with any monitored format under a zero-tap `Monitored books` section, ahead of `Other books`, while preserving newest-first order within each group.
- Keep cards stable as format toggles move them between sections and report accurate success feedback even when ebook and audiobook updates overlap.
- Leave zero-monitored author pages unchanged.

## Verification

- `flutter analyze --no-fatal-infos`
- `flutter test` (562 tests)
- Rendered the real author page at 390x844 with the local screenshot harness; both monitored titles are visible on entry and no app console errors were emitted.

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [x] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above