### PR TITLE
Make book search results actionable

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -56,17 +56,17 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 - **Movies / TV tabs** -- discovery rows plus live library rows from the user's default instances: Downloading Soon, Recently Downloaded, Airing Next.
 - **Cinematic title pages** -- movie/show detail opens under a full-bleed, unblurred backdrop hero: the image parallaxes at half scroll speed (with an iOS overscroll stretch-zoom and a settle-in on load), then hands off to a pinned marquee bar carrying the title and back control. Titles without artwork get a warm ambient-glow stage instead.
 - **Releases tab** -- a unified movie + episode release timeline with list and month-calendar views.
-- **Books tab** -- appears only for users with a Chaptarr grant: owned-aware book search with per-format request buttons (see Books).
+- **Books tab** -- appears only for users with a Chaptarr grant: owned-aware book search with per-format request buttons and tappable results that open a richer book detail (see Books).
 
 ### Requests
 - **One-tap requesting** with status-aware labels: Request → Pending (awaiting approval) → Requested → Downloading → **Available**; partially-available shows get **Request More**, which jumps to the season picker. The ready state stays provider-neutral rather than assuming a particular playback app.
 - **Season-level choice** -- per-season availability, multi-select, "Request N seasons"; shown only to users the admin has allowed to choose (others inherit the default scope).
-- **Book formats** -- request the eBook, the Audiobook, or both; formats already owned or requested are disabled with their status shown.
+- **Book formats** -- request the eBook, the Audiobook, or both; the book detail keeps separate eBook and Audiobook states visible, and formats already owned or requested are disabled with their status shown.
 - **Live status** -- request state and download progress update in real time over WebSocket, including changes made directly in the arrs (webhooks).
 
-### Movies & TV management (admin)
+### Media management (admin)
 - **Drill-down** -- library → movie detail, or series → season → episode, with per-item download progress, quality/size, history, and messages, proxied from Radarr/Sonarr API v3 with credential fields scrubbed server-side.
-- **Open in Radarr/Sonarr** -- on a discovery detail page, admins get a jump into the matching arr item, shown only once the title actually exists there (it appears right after a request adds it). Movies link to Radarr, TV to Sonarr; books are out of scope.
+- **Open in Radarr/Sonarr/Chaptarr** -- on a requester detail page, admins get a jump into the exact matching arr item, shown only once the title actually exists there (it appears right after a request adds it). Movies link to Radarr, TV to Sonarr, and books link to their grouped eBook/Audiobook records in Chaptarr.
 - **Explicit safe removal** -- destructive library actions live in each row's labeled overflow menu rather than behind a swipe gesture; confirmation is mandatory and deleting files from disk is always opt-in.
 - **Sonarr episode power tools** -- long-press action menus, episode **multi-select with batch search** (quick-select All / Undownloaded), batch **delete files**, an **All Seasons** view, per-season/series monitor toggles, **Edit Series** (profile, type, path, tags, season folders), and external links (IMDb/TheTVDB/TMDB/Trakt).
 - **Interactive release search** -- per-episode, per-season, per-movie, and per-book: live indexer results with smart sorting, seeders/leechers, and rejection reasons; tap to grab.
@@ -74,6 +74,7 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 
 ### Books (Chaptarr)
 - **Per-format everything** -- a title's ebook and audiobook are separate records; the author page groups monitored titles first and shows two bookmark toggles per book (tap an empty one to add + search the missing format).
+- **Requester book detail** -- search results stay navigable before and after a request, with author, publication metadata, synopsis, genres, and separate eBook/Audiobook request states; admins can continue into the exact live Chaptarr title.
 - **Owned-aware search** -- library titles are injected into lookup results and floated to the top with Downloaded / In Library chips; distinct records are never merged.
 - **Full module** -- library with author drill-down, queue with Import Doctor, history, and wanted (missing / cutoff unmet).
 

--- a/app/lib/features/chaptarr/data/chaptarr_models.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_models.dart
@@ -22,6 +22,17 @@ List<T> _modelList<T>(
         .map(fromJson)
         .toList();
 
+DateTime? _bookReleaseDate(Map<String, dynamic> json) {
+  final releaseDate =
+      DateTime.tryParse(json['releaseDate'] as String? ?? '');
+  if (releaseDate != null) return releaseDate;
+  final rawYear = json['year'];
+  final year = rawYear is num
+      ? rawYear.toInt()
+      : int.tryParse(rawYear?.toString() ?? '') ?? 0;
+  return year > 0 ? DateTime(year) : null;
+}
+
 List<String> _stringList(dynamic value, {bool splitCommaString = false}) {
   if (value is List) {
     return value
@@ -390,7 +401,10 @@ class ChaptarrBook {
         foreignBookId: json['foreignBookId'] as String?,
         titleSlug: json['titleSlug'] as String?,
         overview: json['overview'] as String?,
-        releaseDate: DateTime.tryParse(json['releaseDate'] as String? ?? ''),
+        // Library records carry releaseDate; metadata lookup rows commonly
+        // carry only year. Normalize both so requester detail can present the
+        // publication year without inventing a second model.
+        releaseDate: _bookReleaseDate(json),
         monitored: json['monitored'] as bool? ?? true,
         mediaType: json['mediaType'] as String?,
         anyEditionOk: json['anyEditionOk'] as bool? ?? true,
@@ -426,6 +440,41 @@ class ChaptarrBook {
       };
 
   String? get coverUrl => _pickCoverUrl(images);
+
+  /// External metadata-provider artwork suitable for a requester client.
+  /// Unlike `url`, `remoteUrl` never points at the private Chaptarr origin.
+  String? get remoteCoverUrl {
+    bool hasRemote(ChaptarrImage image) =>
+        image.remoteUrl != null && image.remoteUrl!.isNotEmpty;
+    for (final type in ['cover', 'poster']) {
+      final matches =
+          images.where((i) => i.coverType == type && hasRemote(i));
+      if (matches.isNotEmpty) return matches.first.remoteUrl;
+    }
+    final matches = images.where(hasRemote);
+    return matches.isNotEmpty ? matches.first.remoteUrl : null;
+  }
+
+  /// Best available synopsis, falling back to edition metadata when the book
+  /// lookup itself leaves `overview` empty.
+  String? get displayOverview {
+    final value = overview?.trim() ?? '';
+    if (value.isNotEmpty) return value;
+    for (final edition in editions) {
+      final editionOverview = edition.overview?.trim() ?? '';
+      if (editionOverview.isNotEmpty) return editionOverview;
+    }
+    return null;
+  }
+
+  /// Best available print length across the book and its editions.
+  int get displayPageCount {
+    if (pageCount > 0) return pageCount;
+    for (final edition in editions) {
+      if (edition.pageCount > 0) return edition.pageCount;
+    }
+    return 0;
+  }
 
   double get percentComplete {
     if (statistics == null || statistics!.bookCount == 0) return 0;

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -3,9 +3,12 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
 import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
+import '../../../core/providers/library_refresh_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/cached_image.dart';
 import '../../chaptarr/data/chaptarr_api_service.dart';
@@ -235,6 +238,7 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
     // backend's /requests endpoint, not the Chaptarr proxy).
     final requestService =
         RequestService(backendDio: ref.read(backendClientProvider));
+    final requestRefreshTick = ref.watch(libraryRefreshTickProvider);
     final instanceId = ref.read(instanceProvider).activeChaptarrInstance?.id;
     // Full-width scroll surface; the result column is capped and centered so
     // rows stay readable on desktop widths.
@@ -255,6 +259,7 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab> {
               ? null
               : chaptarrImageSource(ref, ordered[i].$3, instanceId),
           requestService: requestService,
+          requestRefreshTick: requestRefreshTick,
         ),
       );
     });
@@ -266,12 +271,14 @@ class _BookResultTile extends StatelessWidget {
   final BookOwnership? ownership;
   final ChaptarrImageSource? cover;
   final RequestService requestService;
+  final int requestRefreshTick;
 
   const _BookResultTile({
     required this.book,
     this.ownership,
     this.cover,
     required this.requestService,
+    required this.requestRefreshTick,
   });
 
   @override
@@ -290,8 +297,10 @@ class _BookResultTile extends StatelessWidget {
     final bothDownloaded =
         o != null && o.ebook.downloaded && o.audiobook.downloaded;
     final chip = _ownershipChip(o);
+    final canOpen = fid != null && fid.isNotEmpty;
 
     return ListTile(
+      key: ValueKey('book-result:$fid'),
       contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       leading: ClipRRect(
         borderRadius: BorderRadius.circular(4),
@@ -331,18 +340,33 @@ class _BookResultTile extends StatelessWidget {
                 ],
               ),
             ),
-      // Both files present → just the chip; otherwise offer Request / Request
-      // more for the format(s) without a file (the button gates per format).
-      trailing: bothDownloaded
-          ? null
-          : (fid != null && fid.isNotEmpty)
-              ? BookRequestButton(
-                  foreignId: fid,
-                  title: book.title,
-                  service: requestService,
-                  ownership: o,
-                )
-              : null,
+      // The whole row remains an entry point before and after requesting. The
+      // chevron makes that destination visible even while the trailing request
+      // control is disabled because both formats are already covered.
+      trailing: canOpen
+          ? Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (!bothDownloaded)
+                  BookRequestButton(
+                    key: ValueKey('book-request:$fid:$requestRefreshTick'),
+                    foreignId: fid,
+                    title: book.title,
+                    service: requestService,
+                    ownership: o,
+                  ),
+                const Icon(Icons.chevron_right,
+                    color: AppTheme.textSecondary),
+              ],
+            )
+          : null,
+      onTap: canOpen
+          ? () => context.push(
+                '/detail/book/${Uri.encodeComponent(fid)}'
+                '?title=${Uri.encodeQueryComponent(book.title)}',
+                extra: book,
+              )
+          : null,
     );
   }
 }

--- a/app/lib/features/dashboard/ui/requester_book_detail_screen.dart
+++ b/app/lib/features/dashboard/ui/requester_book_detail_screen.dart
@@ -5,40 +5,185 @@ import 'package:go_router/go_router.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
+import '../../../core/providers/library_refresh_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/cached_image.dart';
 import '../../../core/widgets/status_pill.dart';
+import '../../../navigation/ambient_page_route.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../../chaptarr/data/chaptarr_api_service.dart';
 import '../../chaptarr/data/chaptarr_image.dart';
+import '../../chaptarr/data/chaptarr_models.dart';
+import '../../chaptarr/ui/chaptarr_book_screen.dart';
 import '../../request/data/book_ownership.dart';
 import '../../request/data/request_service.dart';
 import '../../request/ui/book_request_button.dart';
 import '../data/book_library_service.dart';
 
 /// Requester-facing detail for one book, addressed by its Chaptarr/Readarr
-/// foreignBookId — the identity request rows store and request-decision push
-/// payloads carry as `foreign_id`. It reuses the Books tab's presentation
-/// pieces (owned cover, ownership chip, per-format request button); books have
-/// no TMDB-style metadata endpoint, so title/author/cover resolve from the
-/// owned-books digest, with the push payload's title as a fallback for a book
-/// that never landed in the library (e.g. a denied request). When neither
-/// source can name the book, a graceful not-found state points back to the
-/// Books tab instead of presenting an unnamed record.
-class RequesterBookDetailScreen extends ConsumerWidget {
-  /// The Chaptarr/Readarr foreignBookId this screen presents.
+/// foreignBookId. Search navigation supplies [initialBook] for an immediate,
+/// metadata-rich presentation; notification/deep links resolve the same data
+/// from the title hint when possible, and the owned-books digest remains the
+/// live source of per-format ownership.
+class RequesterBookDetailScreen extends ConsumerStatefulWidget {
   final String foreignId;
-
-  /// Display title carried on the deep link (`?title=`), used when the
-  /// owned-books digest can't resolve [foreignId].
   final String? titleHint;
+  final ChaptarrBook? initialBook;
 
   const RequesterBookDetailScreen({
     super.key,
     required this.foreignId,
     this.titleHint,
+    this.initialBook,
   });
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<RequesterBookDetailScreen> createState() =>
+      _RequesterBookDetailScreenState();
+}
+
+class _RequesterBookDetailScreenState
+    extends ConsumerState<RequesterBookDetailScreen> {
+  late final RequestService _requestService;
+  ChaptarrBook? _metadata;
+  List<ChaptarrBook> _chaptarrRecords = const [];
+  BookRequestStatusDetail? _requestDetail;
+  bool _metadataLoading = false;
+  int _loadGeneration = 0;
+  int _recordsLoadGeneration = 0;
+  String? _instanceId;
+
+  @override
+  void initState() {
+    super.initState();
+    _requestService =
+        RequestService(backendDio: ref.read(backendClientProvider));
+    _startLoads();
+  }
+
+  @override
+  void didUpdateWidget(covariant RequesterBookDetailScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.foreignId != widget.foreignId ||
+        oldWidget.initialBook != widget.initialBook ||
+        oldWidget.titleHint != widget.titleHint) {
+      _startLoads();
+    }
+  }
+
+  void _startLoads() {
+    final generation = ++_loadGeneration;
+    _recordsLoadGeneration++;
+    _instanceId = ref.read(instanceProvider).activeChaptarrInstance?.id;
+    _metadata = widget.initialBook;
+    _chaptarrRecords = const [];
+    _requestDetail = null;
+    _metadataLoading = widget.initialBook == null &&
+        (widget.titleHint?.trim().isNotEmpty ?? false);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _resolveMetadata(generation);
+      _resolveChaptarrRecords(generation);
+    });
+  }
+
+  ChaptarrApiService? _chaptarrService() {
+    final instanceId = _instanceId;
+    if (instanceId == null) return null;
+    return ChaptarrApiService(
+      backendDio: ref.read(backendClientProvider),
+      instanceId: instanceId,
+    );
+  }
+
+  /// Notification links carry only a title and foreign id. Resolve their
+  /// metadata with the same read-only lookup as Books search, then require the
+  /// exact foreign id so similarly named books cannot be substituted.
+  Future<void> _resolveMetadata(int generation) async {
+    if (_metadata != null) return;
+    final term = widget.titleHint?.trim() ?? '';
+    final service = _chaptarrService();
+    if (term.isEmpty || service == null) {
+      if (mounted && generation == _loadGeneration) {
+        setState(() => _metadataLoading = false);
+      }
+      return;
+    }
+    ChaptarrBook? match;
+    try {
+      final results = await service.lookupBook(term);
+      for (final book in results) {
+        if (book.foreignBookId == widget.foreignId) {
+          match = book;
+          break;
+        }
+      }
+    } catch (_) {
+      // The title hint still gives the requester a useful fallback.
+    }
+    if (!mounted || generation != _loadGeneration) return;
+    setState(() {
+      _metadata = match;
+      _metadataLoading = false;
+    });
+  }
+
+  /// Resolve an exact live Chaptarr destination for admins. Lookup records and
+  /// the requester digest intentionally lack trustworthy numeric library ids,
+  /// so only the live library list may back this link.
+  Future<void> _resolveChaptarrRecords(int generation) async {
+    final isAdmin = ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
+    if (!isAdmin) return;
+    final service = _chaptarrService();
+    if (service == null) return;
+    final recordsGeneration = ++_recordsLoadGeneration;
+    try {
+      final books = await service.getBooks();
+      final matches = books
+          .where((book) =>
+              book.id > 0 && book.foreignBookId == widget.foreignId)
+          .toList(growable: false)
+        ..sort((a, b) => a.format.index.compareTo(b.format.index));
+      if (!mounted ||
+          generation != _loadGeneration ||
+          recordsGeneration != _recordsLoadGeneration) {
+        return;
+      }
+      setState(() => _chaptarrRecords = matches);
+    } catch (_) {
+      // A transient Chaptarr failure keeps the optional link hidden.
+    }
+  }
+
+  void _onRequestDetailChanged(BookRequestStatusDetail detail) {
+    if (!mounted) return;
+    setState(() => _requestDetail = detail);
+  }
+
+  Future<void> _onRequestCompleted() async {
+    // The request may have created the live Chaptarr records immediately.
+    // Refresh both the ownership digest and the admin destination in place.
+    ref.invalidate(ownedBooksProvider);
+    ref.read(libraryRefreshTickProvider.notifier).state++;
+    await _resolveChaptarrRecords(_loadGeneration);
+  }
+
+  void _openInChaptarr() {
+    if (_chaptarrRecords.isEmpty) return;
+    final instanceId = _instanceId;
+    if (instanceId == null) return;
+    Navigator.of(context, rootNavigator: true).push(
+      AmbientPageRoute(
+        builder: (_) => ChaptarrBookScreen(
+          instanceId: instanceId,
+          records: _chaptarrRecords,
+          bookTitle: _chaptarrRecords.first.title,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final digest = ref.watch(ownedBooksProvider);
     return Scaffold(
       appBar: AppBar(title: const Text('Book details')),
@@ -46,120 +191,204 @@ class RequesterBookDetailScreen extends ConsumerWidget {
         loading: () => const Center(
           child: CircularProgressIndicator(color: AppTheme.accent),
         ),
-        // The digest provider itself degrades to an empty list on failure, so
-        // this branch is defensive: fall through to the hint/not-found flow.
-        error: (_, __) => _resolved(context, ref, const []),
-        data: (titles) => _resolved(context, ref, titles),
+        // The digest normally degrades to an empty list on failure. Keep the
+        // metadata/deep-link path usable if an override surfaces an error.
+        error: (_, __) => _resolved(const []),
+        data: _resolved,
       ),
     );
   }
 
-  Widget _resolved(BuildContext context, WidgetRef ref, List<OwnedTitle> titles) {
+  Widget _resolved(List<OwnedTitle> titles) {
     OwnedTitle? owned;
-    for (final t in titles) {
-      if (t.foreignBookId.isNotEmpty && t.foreignBookId == foreignId) {
-        owned = t;
+    for (final title in titles) {
+      if (title.foreignBookId.isNotEmpty &&
+          title.foreignBookId == widget.foreignId) {
+        owned = title;
         break;
       }
     }
-    final hint = titleHint?.trim() ?? '';
-    final title = owned?.title.isNotEmpty ?? false ? owned!.title : hint;
-    if (title.isEmpty) return _notFound(context);
-    return _detail(context, ref, title, owned);
-  }
 
-  Widget _detail(
-      BuildContext context, WidgetRef ref, String title, OwnedTitle? owned) {
-    final subtitle = <String>[
-      if (owned != null && owned.author.isNotEmpty) owned.author,
-      if (owned != null && owned.year > 0) '${owned.year}',
-    ].join(' · ');
-    final instanceId = ref.read(instanceProvider).activeChaptarrInstance?.id;
-    // Only an owned record carries a loadable cover (its cached /MediaCover);
-    // see the Books tab for why lookup covers aren't attempted.
-    final cover = (owned != null && owned.cover.isNotEmpty && instanceId != null)
-        ? chaptarrImageSource(ref, owned.cover, instanceId)
-        : null;
+    final live = _chaptarrRecords.isEmpty ? null : _chaptarrRecords.first;
+    final hintedTitle = widget.titleHint?.trim() ?? '';
+    final title = _firstText([
+      _metadata?.title,
+      live?.title,
+      owned?.title,
+      hintedTitle,
+    ]);
+    if (title.isEmpty) {
+      return _metadataLoading
+          ? const Center(
+              child: CircularProgressIndicator(color: AppTheme.accent),
+            )
+          : _notFound();
+    }
+
+    final author = _firstText([
+      _metadata?.author?.authorName,
+      live?.author?.authorName,
+      owned?.author,
+    ]);
+    final releaseDate = _metadata?.releaseDate ?? live?.releaseDate;
+    final year = releaseDate?.year ?? owned?.year ?? 0;
+    final overview = _firstText([
+      _metadata?.displayOverview,
+      live?.displayOverview,
+    ]);
+    final metadataPageCount = _metadata?.displayPageCount ?? 0;
+    final pageCount = metadataPageCount > 0
+        ? metadataPageCount
+        : (live?.displayPageCount ?? 0);
+    final genres = _metadata?.genres.isNotEmpty ?? false
+        ? _metadata!.genres
+        : (live?.genres ?? const <String>[]);
     final ownership = owned?.ownership;
-    final bothDownloaded = ownership != null &&
-        ownership.ebook.downloaded &&
-        ownership.audiobook.downloaded;
+    final detail = (_requestDetail ?? const BookRequestStatusDetail())
+        .withOwnership(ownership);
+
+    final instanceId = _instanceId;
+    ChaptarrImageSource? cover;
+    if (instanceId != null) {
+      final rawOwnedCover = owned?.cover.trim() ?? '';
+      final ownedCover = rawOwnedCover.toLowerCase().startsWith('http')
+          ? ''
+          : rawOwnedCover;
+      final remoteCover = _firstText([
+        _metadata?.remoteCoverUrl,
+        live?.remoteCoverUrl,
+      ]);
+      // Live Chaptarr book covers are safe only when relative and routed back
+      // through Cantinarr. An absolute arr-origin URL is never surfaced.
+      final liveCover = live?.coverUrl ?? '';
+      final safeLiveCover = liveCover.toLowerCase().startsWith('http')
+          ? ''
+          : liveCover;
+      cover = chaptarrImageSource(
+        ref,
+        _firstText([ownedCover, remoteCover, safeLiveCover]),
+        instanceId,
+      );
+    }
+
     return CenteredContent(
       child: ListView(
-        padding: const EdgeInsets.all(24),
+        padding: const EdgeInsets.fromLTRB(24, 20, 24, 32),
         children: [
           Center(
             child: ClipRRect(
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: BorderRadius.circular(AppTheme.radiusMedium),
               child: CachedImage(
                 url: cover?.url,
                 headers: cover?.headers,
                 width: 132,
                 height: 198,
                 icon: Icons.menu_book,
+                iconSize: 36,
               ),
             ),
           ),
           const SizedBox(height: 20),
-          Text(
-            title,
-            textAlign: TextAlign.center,
-            style: const TextStyle(
-              color: AppTheme.textPrimary,
-              fontSize: 20,
-              fontWeight: FontWeight.bold,
+          Semantics(
+            header: true,
+            child: Text(
+              title,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
           ),
-          if (subtitle.isNotEmpty) ...[
+          if (author.isNotEmpty) ...[
             const SizedBox(height: 6),
             Text(
-              subtitle,
+              author,
               textAlign: TextAlign.center,
-              style: const TextStyle(color: AppTheme.textSecondary),
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: AppTheme.textSecondary,
+                  ),
             ),
           ],
-          const SizedBox(height: 16),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.center,
+          if (year > 0 || pageCount > 0) ...[
+            const SizedBox(height: 6),
+            Text(
+              [
+                if (year > 0) '$year',
+                if (pageCount > 0) '$pageCount pages',
+              ].join(' · '),
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+          ],
+          const SizedBox(height: 24),
+          _FormatStatusPanel(
+            detail: detail,
+            statusLoaded: _requestDetail != null,
+          ),
+          const SizedBox(height: 18),
+          Wrap(
+            alignment: WrapAlignment.center,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            spacing: 10,
+            runSpacing: 8,
             children: [
-              if (ownership != null && ownership.anyOwned) ...[
-                StatusPill(
-                  text: ownership.anyDownloaded ? 'Downloaded' : 'In Library',
-                  color: ownership.anyDownloaded
-                      ? AppTheme.available
-                      : AppTheme.requested,
-                ),
-                const SizedBox(width: 12),
-              ],
-              // Both files present → the chip says it all; otherwise the same
-              // per-format request affordance as the Books tab (it loads the
-              // user's request state itself and gates each format).
-              if (!bothDownloaded)
-                BookRequestButton(
-                  foreignId: foreignId,
-                  title: title,
-                  service: RequestService(
-                      backendDio: ref.read(backendClientProvider)),
-                  ownership: ownership,
+              BookRequestButton(
+                foreignId: widget.foreignId,
+                title: title,
+                service: _requestService,
+                ownership: ownership,
+                onDetailChanged: _onRequestDetailChanged,
+                onRequestCompleted: _onRequestCompleted,
+              ),
+              if (_chaptarrRecords.isNotEmpty)
+                OutlinedButton.icon(
+                  onPressed: _openInChaptarr,
+                  icon: const Icon(Icons.open_in_new_rounded, size: 17),
+                  label: const Text('Open in Chaptarr'),
                 ),
             ],
           ),
+          if (genres.isNotEmpty) ...[
+            const SizedBox(height: 22),
+            Wrap(
+              alignment: WrapAlignment.center,
+              spacing: 6,
+              runSpacing: 6,
+              children: genres
+                  .map((genre) => Chip(
+                        label: Text(genre),
+                        backgroundColor: AppTheme.surfaceVariant,
+                        side: const BorderSide(color: AppTheme.border),
+                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        visualDensity: VisualDensity.compact,
+                      ))
+                  .toList(),
+            ),
+          ],
+          if (overview.isNotEmpty) ...[
+            const SizedBox(height: 24),
+            Text('About this book',
+                style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Text(
+              overview,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: AppTheme.textPrimary,
+                  ),
+            ),
+          ],
         ],
       ),
     );
   }
 
-  /// Shown when neither the owned-books digest nor the deep link can name the
-  /// book (removed from Chaptarr, or a hand-typed id). Requesting needs a
-  /// title, so the honest affordance is the Books tab's search.
-  Widget _notFound(BuildContext context) {
+  Widget _notFound() {
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(32),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(Icons.menu_book, size: 48, color: AppTheme.textSecondary),
+            const Icon(Icons.menu_book,
+                size: 48, color: AppTheme.textSecondary),
             const SizedBox(height: 12),
             const Text(
               'This book could not be found. It may have been removed from '
@@ -177,4 +406,133 @@ class RequesterBookDetailScreen extends ConsumerWidget {
       ),
     );
   }
+}
+
+class _FormatStatusPanel extends StatelessWidget {
+  final BookRequestStatusDetail detail;
+  final bool statusLoaded;
+
+  const _FormatStatusPanel({
+    required this.detail,
+    required this.statusLoaded,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        color: AppTheme.surface,
+        borderRadius: BorderRadius.circular(AppTheme.radiusMedium),
+        border: Border.all(color: AppTheme.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+            child: Text('Formats',
+                style: Theme.of(context).textTheme.titleSmall),
+          ),
+          const Divider(height: 1, color: AppTheme.border),
+          _FormatStatusRow(
+            icon: Icons.menu_book,
+            label: 'eBook',
+            state: _formatState(
+              detail,
+              BookRequestFormat.ebook,
+              statusLoaded,
+            ),
+          ),
+          const Divider(height: 1, indent: 52, color: AppTheme.border),
+          _FormatStatusRow(
+            icon: Icons.headphones,
+            label: 'Audiobook',
+            state: _formatState(
+              detail,
+              BookRequestFormat.audiobook,
+              statusLoaded,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FormatStatusRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final ({String label, Color color}) state;
+
+  const _FormatStatusRow({
+    required this.icon,
+    required this.label,
+    required this.state,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        children: [
+          Icon(icon, color: AppTheme.accent, size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(label,
+                style: Theme.of(context).textTheme.titleSmall),
+          ),
+          StatusPill(text: state.label, color: state.color),
+        ],
+      ),
+    );
+  }
+}
+
+({String label, Color color}) _formatState(
+  BookRequestStatusDetail detail,
+  BookRequestFormat format,
+  bool statusLoaded,
+) {
+  final ownership = detail.ownership;
+  final owned = switch (format) {
+    BookRequestFormat.ebook => ownership?.ebook,
+    BookRequestFormat.audiobook => ownership?.audiobook,
+    BookRequestFormat.both => null,
+  };
+  if (owned?.downloaded ?? false) {
+    return (label: 'Available', color: AppTheme.available);
+  }
+
+  final status = detail.formats[format];
+  if (status != null) {
+    return switch (status) {
+      RequestStatus.available =>
+        (label: 'Available', color: AppTheme.available),
+      RequestStatus.pending =>
+        (label: 'Pending Approval', color: AppTheme.requested),
+      RequestStatus.requested =>
+        (label: 'Requested', color: AppTheme.requested),
+      RequestStatus.downloading =>
+        (label: 'Downloading', color: AppTheme.downloading),
+      RequestStatus.partial =>
+        (label: 'Requested', color: AppTheme.requested),
+      RequestStatus.denied =>
+        (label: 'Request Denied', color: AppTheme.error),
+      RequestStatus.unavailable =>
+        (label: 'Not requested', color: AppTheme.textSecondary),
+    };
+  }
+  if (!statusLoaded) {
+    return (label: 'Checking…', color: AppTheme.textSecondary);
+  }
+  return (label: 'Not requested', color: AppTheme.textSecondary);
+}
+
+String _firstText(Iterable<String?> values) {
+  for (final value in values) {
+    final text = value?.trim() ?? '';
+    if (text.isNotEmpty) return text;
+  }
+  return '';
 }

--- a/app/lib/features/request/ui/book_request_button.dart
+++ b/app/lib/features/request/ui/book_request_button.dart
@@ -278,31 +278,37 @@ class _FormatChoiceTile extends StatelessWidget {
       BookRequestFormat.audiobook => Icons.headphones,
       BookRequestFormat.both => Icons.library_books,
     };
-    return ListTile(
-      enabled: !covered,
-      contentPadding: const EdgeInsets.symmetric(horizontal: 12),
-      leading:
-          Icon(icon, color: covered ? AppTheme.textSecondary : AppTheme.accent),
-      title: Text(
-        choice.label,
-        style: TextStyle(
-          color: covered ? AppTheme.textSecondary : AppTheme.textPrimary,
-          fontWeight: FontWeight.w600,
+    // Give the tile its own ink surface. The sheet's rounded background is a
+    // DecoratedBox, which otherwise sits between ListTile and the modal's
+    // Material and can hide taps/splashes (and trips Flutter's debug check).
+    return Material(
+      color: Colors.transparent,
+      child: ListTile(
+        enabled: !covered,
+        contentPadding: const EdgeInsets.symmetric(horizontal: 12),
+        leading: Icon(icon,
+            color: covered ? AppTheme.textSecondary : AppTheme.accent),
+        title: Text(
+          choice.label,
+          style: TextStyle(
+            color: covered ? AppTheme.textSecondary : AppTheme.textPrimary,
+            fontWeight: FontWeight.w600,
+          ),
         ),
+        subtitle: covered && statusLabel != null
+            ? Text(statusLabel!,
+                style: const TextStyle(
+                    color: AppTheme.textSecondary, fontSize: 12))
+            : null,
+        trailing: covered
+            ? const Icon(Icons.check, color: AppTheme.available, size: 18)
+            : null,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+          side: const BorderSide(color: AppTheme.border),
+        ),
+        onTap: covered ? null : () => Navigator.of(context).pop(choice),
       ),
-      subtitle: covered && statusLabel != null
-          ? Text(statusLabel!,
-              style:
-                  const TextStyle(color: AppTheme.textSecondary, fontSize: 12))
-          : null,
-      trailing: covered
-          ? const Icon(Icons.check, color: AppTheme.available, size: 18)
-          : null,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(8),
-        side: const BorderSide(color: AppTheme.border),
-      ),
-      onTap: covered ? null : () => Navigator.of(context).pop(choice),
     );
   }
 }

--- a/app/lib/features/request/ui/book_request_button.dart
+++ b/app/lib/features/request/ui/book_request_button.dart
@@ -13,6 +13,8 @@ class BookRequestButton extends StatefulWidget {
   final String title;
   final RequestService service;
   final BookOwnership? ownership;
+  final ValueChanged<BookRequestStatusDetail>? onDetailChanged;
+  final VoidCallback? onRequestCompleted;
 
   const BookRequestButton({
     super.key,
@@ -20,6 +22,8 @@ class BookRequestButton extends StatefulWidget {
     required this.title,
     required this.service,
     this.ownership,
+    this.onDetailChanged,
+    this.onRequestCompleted,
   });
 
   @override
@@ -36,6 +40,7 @@ class _BookRequestButtonState extends State<BookRequestButton> {
   RequestStatus _status = RequestStatus.unavailable;
   bool _loading = true;
   bool _busy = false;
+  int _checkGeneration = 0;
 
   BookRequestStatusDetail get _detail =>
       _serverDetail.withOwnership(widget.ownership);
@@ -51,18 +56,32 @@ class _BookRequestButtonState extends State<BookRequestButton> {
     super.didUpdateWidget(oldWidget);
     // If this row got reused for a different book, re-fetch its request state.
     if (oldWidget.foreignId != widget.foreignId) {
+      _loading = true;
+      _serverDetail = const BookRequestStatusDetail();
+      _status = RequestStatus.unavailable;
       _check();
+    } else if (oldWidget.ownership != widget.ownership) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) widget.onDetailChanged?.call(_detail);
+      });
     }
   }
 
   Future<void> _check() async {
-    final detail = await widget.service.checkBookStatusDetail(widget.foreignId);
-    if (!mounted) return;
+    final foreignId = widget.foreignId;
+    final generation = ++_checkGeneration;
+    final detail = await widget.service.checkBookStatusDetail(foreignId);
+    if (!mounted ||
+        generation != _checkGeneration ||
+        foreignId != widget.foreignId) {
+      return;
+    }
     setState(() {
       _serverDetail = detail;
       _status = detail.status;
       _loading = false;
     });
+    widget.onDetailChanged?.call(_detail);
   }
 
   Future<void> _request() async {
@@ -98,6 +117,7 @@ class _BookRequestButtonState extends State<BookRequestButton> {
     }
     // Re-pull per-format coverage so the button reflects the still-open format.
     await _check();
+    if (mounted) widget.onRequestCompleted?.call();
   }
 
   bool _isCovered(BookRequestFormat f) => _detail.isCovered(f);

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -10,6 +10,7 @@ import '../features/auth/ui/auth_screen.dart';
 import '../features/auth/ui/passkey_create_screen.dart';
 import '../features/auth/ui/passkey_management_screen.dart';
 import '../features/auth/ui/set_password_screen.dart';
+import '../features/chaptarr/data/chaptarr_models.dart';
 import '../features/chaptarr/ui/chaptarr_history_screen.dart';
 import '../features/chaptarr/ui/chaptarr_home_screen.dart';
 import '../features/chaptarr/ui/chaptarr_module_shell.dart';
@@ -712,6 +713,9 @@ Widget _mediaDetailChild(GoRouterState state) {
     return RequesterBookDetailScreen(
       foreignId: foreignId,
       titleHint: state.uri.queryParameters['title'],
+      initialBook: state.extra is ChaptarrBook
+          ? state.extra! as ChaptarrBook
+          : null,
     );
   }
   final id = _positiveIntParameter(state, 'id');

--- a/app/test/dashboard/dashboard_books_tab_test.dart
+++ b/app/test/dashboard/dashboard_books_tab_test.dart
@@ -1,0 +1,222 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/providers/library_refresh_provider.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/dashboard/ui/requester_book_detail_screen.dart';
+import 'package:cantinarr/navigation/app_router.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  testWidgets('a fully requested search row still opens rich book detail',
+      (tester) async {
+    _usePhoneSize(tester);
+    final (:router, :container, :adapter) = await _pumpRouter(tester);
+    router.go('/dashboard/books');
+    await tester.pumpAndSettle();
+
+    final searchField = find.byWidgetPredicate(
+      (widget) =>
+          widget is TextField &&
+          widget.decoration?.hintText == 'Search books or authors…',
+    );
+    expect(searchField, findsOneWidget);
+    await tester.enterText(searchField, 'meditations');
+    await tester.pump(const Duration(milliseconds: 450));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Meditations'), findsOneWidget);
+    expect(find.text('Requested'), findsOneWidget);
+    expect(find.byIcon(Icons.chevron_right), findsWidgets);
+
+    final statusRequestsBeforeRefresh = adapter.statusRequests;
+    container.read(libraryRefreshTickProvider.notifier).state++;
+    await tester.pumpAndSettle();
+    expect(adapter.statusRequests, greaterThan(statusRequestsBeforeRefresh));
+
+    await tester.tap(find.byKey(const ValueKey('book-result:book-1')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RequesterBookDetailScreen), findsOneWidget);
+    expect(find.text('Marcus Aurelius'), findsOneWidget);
+    expect(find.text('2002 · 304 pages'), findsOneWidget);
+    expect(find.text('A practical guide to Stoic philosophy.'), findsOneWidget);
+    expect(find.text('Requested'), findsNWidgets(3));
+  });
+
+  testWidgets('the trailing Request control does not open book detail',
+      (tester) async {
+    _usePhoneSize(tester);
+    final (:router, container: _, adapter: _) = await _pumpRouter(tester);
+    router.go('/dashboard/books');
+    await tester.pumpAndSettle();
+
+    final searchField = find.byWidgetPredicate(
+      (widget) =>
+          widget is TextField &&
+          widget.decoration?.hintText == 'Search books or authors…',
+    );
+    await tester.enterText(searchField, 'meditations');
+    await tester.pump(const Duration(milliseconds: 450));
+    await tester.pumpAndSettle();
+
+    final secondResult = find.byKey(const ValueKey('book-result:book-2'));
+    await tester.tap(
+      find.descendant(of: secondResult, matching: find.text('Request')),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RequesterBookDetailScreen), findsNothing);
+    expect(find.text('Letters from a Stoic'), findsWidgets);
+    expect(find.text('eBook'), findsOneWidget);
+    expect(find.text('Audiobook'), findsOneWidget);
+    expect(find.text('eBook + Audiobook'), findsOneWidget);
+  });
+}
+
+void _usePhoneSize(WidgetTester tester) {
+  tester.view.physicalSize = const Size(390, 844);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
+}
+
+const _booksState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(chaptarr: true),
+    instances: [
+      ServiceInstance(
+        id: 'books',
+        serviceType: 'chaptarr',
+        name: 'Books',
+        isDefault: true,
+      ),
+    ],
+  ),
+  user: UserProfile(id: 1, username: 'tester', role: 'user'),
+);
+
+Future<({
+  ProviderContainer container,
+  GoRouter router,
+  _BooksSearchAdapter adapter,
+})> _pumpRouter(WidgetTester tester) async {
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+  final adapter = _BooksSearchAdapter();
+  dio.httpClientAdapter = adapter;
+  final container = ProviderContainer(
+    overrides: [
+      authProvider.overrideWith(() => _FakeAuthNotifier(_booksState)),
+      backendClientProvider.overrideWithValue(dio),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await container.read(authProvider.future);
+  await container.pump();
+  final router = container.read(appRouterProvider);
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return (container: container, router: router, adapter: adapter);
+}
+
+class _FakeAuthNotifier extends AuthNotifier {
+  _FakeAuthNotifier(this._initial);
+
+  final AuthState _initial;
+
+  @override
+  Future<AuthState> build() async => _initial;
+}
+
+class _BooksSearchAdapter implements HttpClientAdapter {
+  int statusRequests = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final Object body;
+    if (options.path == '/api/requests/book-library') {
+      body = {'titles': <Object>[]};
+    } else if (options.path == '/api/requests/book-status') {
+      statusRequests++;
+      body = options.queryParameters['foreign_id'] == 'book-1'
+          ? {
+              'status': 'requested',
+              'book_formats': {
+                'ebook': 'requested',
+                'audiobook': 'requested',
+              },
+            }
+          : {'status': 'unavailable'};
+    } else if (options.path.endsWith('/api/v1/book/lookup')) {
+      body = [
+        {
+          'title': 'Meditations',
+          'foreignBookId': 'book-1',
+          'year': 2002,
+          'pageCount': 304,
+          'overview': 'A practical guide to Stoic philosophy.',
+          'genres': ['Philosophy'],
+          'author': {
+            'id': 0,
+            'authorName': 'Marcus Aurelius',
+            'foreignAuthorId': 'author-1',
+          },
+        },
+        {
+          'title': 'Letters from a Stoic',
+          'foreignBookId': 'book-2',
+          'year': 1965,
+          'pageCount': 254,
+          'overview': 'Seneca on living with wisdom and courage.',
+          'genres': ['Philosophy'],
+          'author': {
+            'id': 0,
+            'authorName': 'Seneca',
+            'foreignAuthorId': 'author-2',
+          },
+        },
+      ];
+    } else if (options.path == '/api/trakt/anticipated') {
+      body = <Object>[];
+    } else {
+      body = {
+        'page': 1,
+        'results': <Object>[],
+        'total_pages': 0,
+        'total_results': 0,
+      };
+    }
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/app/test/dashboard/requester_book_detail_screen_test.dart
+++ b/app/test/dashboard/requester_book_detail_screen_test.dart
@@ -4,7 +4,10 @@ import 'dart:typed_data';
 import 'package:cantinarr/core/models/backend_connection.dart';
 import 'package:cantinarr/core/models/user_profile.dart';
 import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/providers/instance_provider.dart';
+import 'package:cantinarr/core/widgets/cached_image.dart';
 import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/chaptarr/ui/chaptarr_book_screen.dart';
 import 'package:cantinarr/features/dashboard/ui/requester_book_detail_screen.dart';
 import 'package:cantinarr/navigation/app_router.dart';
 import 'package:dio/dio.dart';
@@ -27,15 +30,23 @@ void main() {
 
     expect(find.byType(RequesterBookDetailScreen), findsOneWidget);
     expect(find.text('Ahsoka'), findsOneWidget);
-    expect(find.text('E. K. Johnston · 2016'), findsOneWidget);
-    // The ebook is monitored (not downloaded) → In Library, and its open
-    // audiobook keeps the requester affordance available: an already-requested
-    // ebook plus an open audiobook reads "Request more".
-    expect(find.text('In Library'), findsOneWidget);
+    expect(find.text('E. K. Johnston'), findsOneWidget);
+    expect(find.text('2016'), findsOneWidget);
+    expect(find.text('eBook'), findsOneWidget);
+    expect(find.text('Audiobook'), findsOneWidget);
+    expect(find.text('Requested'), findsOneWidget);
+    expect(find.text('Not requested'), findsOneWidget);
+    // The requested ebook plus an open audiobook reads "Request more".
+    await tester.scrollUntilVisible(
+      find.text('Request more'),
+      250,
+      scrollable: _detailScrollable(),
+    );
     expect(find.text('Request more'), findsOneWidget);
+    expect(find.text('Open in Chaptarr'), findsNothing);
   });
 
-  testWidgets('the deep-link title names a book the library cannot resolve',
+  testWidgets('a deep link resolves rich metadata and both requested formats',
       (tester) async {
     final (:router, container: _) = await _pumpRouter(tester);
 
@@ -43,8 +54,76 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Dune Messiah'), findsOneWidget);
-    // No request rows and no ownership → a plain Request affordance.
-    expect(find.text('Request'), findsOneWidget);
+    expect(find.text('Frank Herbert'), findsOneWidget);
+    expect(find.text('1969 · 336 pages'), findsOneWidget);
+    expect(find.text('The desert planet has a new emperor.'), findsOneWidget);
+    expect(find.text('Science Fiction'), findsOneWidget);
+    expect(find.text('Requested'), findsNWidgets(3));
+  });
+
+  testWidgets('an admin can open both exact-format records in Chaptarr',
+      (tester) async {
+    final (:router, :container) =
+        await _pumpRouter(tester, authState: _adminBooksState);
+
+    router.go('/detail/book/29749107?title=Ahsoka');
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.text('Open in Chaptarr'),
+      250,
+      scrollable: _detailScrollable(),
+    );
+    expect(find.text('Open in Chaptarr'), findsOneWidget);
+    // The destination stays bound to the instance that supplied the records,
+    // even if the drawer selection changes before the admin taps through.
+    container
+        .read(instanceProvider.notifier)
+        .setActiveChaptarrInstance('books-two');
+    await tester.pump();
+    await tester.tap(find.text('Open in Chaptarr'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ChaptarrBookScreen), findsOneWidget);
+    final screen = tester.widget<ChaptarrBookScreen>(
+      find.byType(ChaptarrBookScreen),
+    );
+    expect(screen.instanceId, 'books');
+    expect(screen.records, hasLength(2));
+    expect(screen.records.map((book) => book.mediaType),
+        orderedEquals(['ebook', 'audiobook']));
+  });
+
+  testWidgets('an absolute owned cover origin is never sent to the client',
+      (tester) async {
+    final (:router, container: _) = await _pumpRouter(
+      tester,
+      ownedCover: 'http://chaptarr:8787/MediaCover/Books/42/cover.jpg',
+    );
+
+    router.go('/detail/book/29749107');
+    await tester.pumpAndSettle();
+
+    final cover = tester.widget<CachedImage>(
+      find.descendant(
+        of: find.byType(RequesterBookDetailScreen),
+        matching: find.byType(CachedImage),
+      ),
+    );
+    expect(cover.url, isNull);
+  });
+
+  testWidgets('an admin link requires an exact live foreign id match',
+      (tester) async {
+    final (:router, container: _) =
+        await _pumpRouter(tester, authState: _adminBooksState);
+
+    router.go('/detail/book/555?title=Dune%20Messiah');
+    await tester.pumpAndSettle();
+
+    // The live list contains Ahsoka, but not this metadata-only Dune result.
+    expect(find.text('Dune Messiah'), findsOneWidget);
+    expect(find.text('Open in Chaptarr'), findsNothing);
   });
 
   testWidgets('an unresolvable id shows a graceful state with a Books tab exit',
@@ -86,12 +165,44 @@ const _booksState = AuthState(
   user: UserProfile(id: 1, username: 'tester', role: 'user'),
 );
 
+const _adminBooksState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(chaptarr: true),
+    instances: [
+      ServiceInstance(
+        id: 'books',
+        serviceType: 'chaptarr',
+        name: 'Books',
+        isDefault: true,
+      ),
+      ServiceInstance(
+        id: 'books-two',
+        serviceType: 'chaptarr',
+        name: 'Other Books',
+      ),
+    ],
+  ),
+  user: UserProfile(id: 1, username: 'admin', role: 'admin'),
+);
+
 Future<({ProviderContainer container, GoRouter router})> _pumpRouter(
-    WidgetTester tester) async {
+  WidgetTester tester, {
+  AuthState authState = _booksState,
+  String ownedCover = '',
+}) async {
+  tester.view.physicalSize = const Size(390, 844);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
   final container = ProviderContainer(
     overrides: [
-      authProvider.overrideWith(() => _FakeAuthNotifier(_booksState)),
-      backendClientProvider.overrideWithValue(_fakeDio()),
+      authProvider.overrideWith(() => _FakeAuthNotifier(authState)),
+      backendClientProvider.overrideWithValue(_fakeDio(ownedCover: ownedCover)),
     ],
   );
   addTearDown(container.dispose);
@@ -118,16 +229,19 @@ class _FakeAuthNotifier extends AuthNotifier {
   Future<AuthState> build() async => _initial;
 }
 
-Dio _fakeDio() {
+Dio _fakeDio({String ownedCover = ''}) {
   final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
-  dio.httpClientAdapter = _BooksAdapter();
+  dio.httpClientAdapter = _BooksAdapter(ownedCover: ownedCover);
   return dio;
 }
 
-/// Serves the two endpoints the detail surface reads — the owned-books digest
-/// and the per-user book request status — plus empty generic payloads for the
-/// dashboard feeds behind the initial route.
+/// Serves requester metadata/status plus the live Chaptarr records an admin
+/// resolves before showing the internal module link.
 class _BooksAdapter implements HttpClientAdapter {
+  final String ownedCover;
+
+  const _BooksAdapter({this.ownedCover = ''});
+
   @override
   Future<ResponseBody> fetch(
     RequestOptions options,
@@ -142,9 +256,8 @@ class _BooksAdapter implements HttpClientAdapter {
             'title': 'Ahsoka',
             'author': 'E. K. Johnston',
             'year': 2016,
-            // Empty on purpose: a non-empty cover would start a real image
-            // fetch inside the test.
-            'cover': '',
+            // Empty by default so most tests never start a real image fetch.
+            'cover': ownedCover,
             'foreign_book_id': '29749107',
             'ebook': {'monitored': true, 'downloaded': false},
             'audiobook': {'monitored': false, 'downloaded': false},
@@ -152,12 +265,43 @@ class _BooksAdapter implements HttpClientAdapter {
         ],
       };
     } else if (options.path == '/api/requests/book-status') {
-      body = options.queryParameters['foreign_id'] == '29749107'
-          ? {
-              'status': 'requested',
-              'book_formats': {'ebook': 'requested'},
-            }
-          : {'status': 'unavailable'};
+      body = switch (options.queryParameters['foreign_id']) {
+        '29749107' => {
+            'status': 'requested',
+            'book_formats': {'ebook': 'requested'},
+          },
+        '555' => {
+            'status': 'requested',
+            'book_formats': {
+              'ebook': 'requested',
+              'audiobook': 'requested',
+            },
+          },
+        _ => {'status': 'unavailable'},
+      };
+    } else if (options.path.endsWith('/api/v1/book/lookup')) {
+      body = [
+        {
+          'title': 'Dune Messiah',
+          'foreignBookId': '555',
+          'year': 1969,
+          'pageCount': 336,
+          'overview': 'The desert planet has a new emperor.',
+          'genres': ['Science Fiction'],
+          'author': {
+            'id': 0,
+            'authorName': 'Frank Herbert',
+            'foreignAuthorId': 'author-2',
+          },
+        },
+      ];
+    } else if (options.path.endsWith('/api/v1/book')) {
+      body = [
+        _liveBook(id: 42, mediaType: 'ebook'),
+        _liveBook(id: 43, mediaType: 'audiobook'),
+      ];
+    } else if (options.path.endsWith('/api/v1/bookfile')) {
+      body = <Object>[];
     } else if (options.path == '/api/trakt/anticipated') {
       body = <Object>[];
     } else {
@@ -180,3 +324,28 @@ class _BooksAdapter implements HttpClientAdapter {
   @override
   void close({bool force = false}) {}
 }
+
+Map<String, dynamic> _liveBook({
+  required int id,
+  required String mediaType,
+}) =>
+    {
+      'id': id,
+      'title': 'Ahsoka',
+      'foreignBookId': '29749107',
+      'mediaType': mediaType,
+      'monitored': true,
+      'releaseDate': '2016-10-11T00:00:00Z',
+      'overview': 'A former Jedi searches for a new path.',
+      'author': {
+        'id': 7,
+        'authorName': 'E. K. Johnston',
+        'foreignAuthorId': 'author-1',
+      },
+      'statistics': {'bookFileCount': 0, 'bookCount': 1},
+    };
+
+Finder _detailScrollable() => find.descendant(
+      of: find.byType(RequesterBookDetailScreen),
+      matching: find.byType(Scrollable),
+    );

--- a/app/test/request/book_status_detail_test.dart
+++ b/app/test/request/book_status_detail_test.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:cantinarr/features/request/data/request_service.dart'
     hide RequestOptions;
+import 'package:cantinarr/features/request/ui/book_request_button.dart';
 import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 /// Minimal GET adapter returning a canned book-status JSON body.
@@ -30,10 +33,57 @@ class _GetAdapter implements HttpClientAdapter {
   void close({bool force = false}) {}
 }
 
+class _DeferredStatusAdapter implements HttpClientAdapter {
+  final responses = <String, Completer<ResponseBody>>{};
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    final foreignId = options.queryParameters['foreign_id'] as String;
+    final completer = Completer<ResponseBody>();
+    responses[foreignId] = completer;
+    return completer.future;
+  }
+
+  void complete(String foreignId, Map<String, dynamic> body) {
+    responses[foreignId]!.complete(
+      ResponseBody.fromString(
+        jsonEncode(body),
+        200,
+        headers: {
+          'content-type': ['application/json'],
+        },
+      ),
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
 RequestService _service(Map<String, dynamic> resp) {
   final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
     ..httpClientAdapter = _GetAdapter(resp);
   return RequestService(backendDio: dio);
+}
+
+Future<void> _waitForRequest(
+  WidgetTester tester,
+  _DeferredStatusAdapter adapter,
+  String foreignId,
+) async {
+  for (var attempt = 0;
+      attempt < 100 && !adapter.responses.containsKey(foreignId);
+      attempt++) {
+    await tester.pump(const Duration(milliseconds: 1));
+    await tester.runAsync(() async {
+      await Future<void>.delayed(const Duration(milliseconds: 1));
+    });
+  }
+  expect(adapter.responses, contains(foreignId));
 }
 
 void main() {
@@ -75,5 +125,50 @@ void main() {
       expect(d.isCovered(BookRequestFormat.ebook), isFalse);
       expect(d.isCovered(BookRequestFormat.audiobook), isFalse);
     });
+  });
+
+  testWidgets('a late status response cannot overwrite a reused book button',
+      (tester) async {
+    final adapter = _DeferredStatusAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+      ..httpClientAdapter = adapter;
+    final service = RequestService(backendDio: dio);
+    var foreignId = 'old-book';
+    late StateSetter rebuild;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (context, setState) {
+              rebuild = setState;
+              return BookRequestButton(
+                foreignId: foreignId,
+                title: foreignId,
+                service: service,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    await _waitForRequest(tester, adapter, 'old-book');
+
+    rebuild(() => foreignId = 'new-book');
+    await _waitForRequest(tester, adapter, 'new-book');
+
+    adapter.complete('new-book', {
+      'status': 'requested',
+      'book_formats': {
+        'ebook': 'requested',
+        'audiobook': 'requested',
+      },
+    });
+    await tester.pumpAndSettle();
+    expect(find.text('Requested'), findsOneWidget);
+
+    adapter.complete('old-book', {'status': 'unavailable'});
+    await tester.pumpAndSettle();
+    expect(find.text('Requested'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## What

- Keep every Chaptarr search result navigable before and after requesting, with a richer requester detail showing author, publication metadata, synopsis, genres, and separate eBook/Audiobook state.
- Give admins an exact, source-instance-bound jump from requester detail into the grouped Chaptarr book records.
- Refresh preserved search-row request state after a detail request and guard reused request buttons against stale status responses.

## Verification

- flutter analyze --no-fatal-infos
- flutter test (568 tests)
- flutter build web --release

Server checks were not run because this PR changes only the Flutter app and its documentation.

## Docs

Docs/testing remains unchanged because this deterministic UI and navigation behavior is covered by Flutter widget tests.

- [ ] README.md — pitch, feature list, configuration/env vars, quick start
- [ ] server/README.md — routes, MCP tools, DB tables, env vars, package tree
- [x] app/README.md — screens/features, navigation, project structure
- [ ] AGENTS.md — workflow, verification, or convention changes
- [ ] No docs impact — explained above