### PR TITLE
feat: add secure media file downloads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,7 @@ CANTINARR_PUSH_ENROLL_TOKEN=
 
 # Only if you self-host your own gateway elsewhere (overrides the compose default).
 # CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
+
+# Optional completed-media downloads. Uncomment the matching read-only volume
+# in docker-compose.yml and list the exact container path reported by the arr.
+# CANTINARR_MEDIA_ROOTS=/data/media

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Discover and request movies, TV shows, and books. Get push notifications. Manage
 - **TMDB + Trakt for discovery** -- The best metadata, images, and trending data, proxied through the server so keys stay off devices. Sonarr's TVDB dependency is invisible.
 - **Automatic ID bridging** -- TMDB-to-TVDB translation with Trakt fallback. The #1 source of failed Sonarr adds, solved.
 - **Books too** -- A Chaptarr (Readarr-API) module with per-format smarts: request the ebook, the audiobook, or both; monitored formats read **Requested** until they download; owned-aware search and plain per-format controls stay pinned to the selected, authorized Chaptarr instance. Access is granted per user.
+- **Take available files with you** -- Optional, resumable downloads let signed-in users save exact ebook, audiobook, movie, and episode files from their authorized library. Cantinarr re-checks the live arr file record before issuing a short-lived, file-scoped link without putting arr credentials in the URL.
 - **Request approvals** -- Optional approval queue, globally or per user. Admins also control per-user season choice, quality choice, and default quality profiles. Approve/deny lands as a push notification for the requester.
 - **AI assistant** -- "What should I watch tonight?" Every user can bring a personal Anthropic, OpenAI, or Gemini API key, or link OpenAI (OAuth) with a one-time ChatGPT browser code—even without included access, and their choice never has to match the server's provider. Admins can configure the same providers as an included server profile and grant that shared access per user. A personal provider is an explicit override; Cantinarr never silently spends the shared account when that override needs attention. The assistant searches your library, checks availability, requests for you, and gives admins conversational queue and release control.
 - **AI remediation agent** -- Users tap "Report a problem" (or Cantinarr detects one in the queue); each report is bound to the exact Radarr/Sonarr instance and begins with a quiet observation window. Cantinarr gives Sonarr/Radarr time to retry or replace a download before it alerts anyone or starts the agent; a persistent quiet problem then enters the supervised workflow. Recovery cancels stale proposals before dispatch. Automatic resolution requires an exact changed file plus a matching post-incident import record—not queue disappearance or a file that was already there. Remediation is server-owned: it always uses the admin's shared API key or shared OpenAI OAuth connection and never a reporter's personal provider or per-user included-access grant. Admins may give remediation its own tested model designation while keeping that global provider and credential.
@@ -95,7 +96,7 @@ cantinarr/
 │   ├── cmd/server/         # Entry point
 │   └── internal/           # ai, api, arr, auth, cache, chaptarr, codexapp,
 │                           # config, credentials, db, discover, downloads, instance,
-│                           # mcp, mcpserver, nzbget, proxy, push, qbittorrent,
+│                           # mcp, mcpserver, mediafiles, nzbget, proxy, push, qbittorrent,
 │                           # radarr, remediation, request, sabnzbd, secrets,
 │                           # sonarr, tautulli, tmdb, trakt, transmission,
 │                           # web, webhooks, websocket
@@ -104,7 +105,7 @@ cantinarr/
 │   ├── lib/
 │   │   ├── core/           # Models, networking, realtime, theme, widgets
 │   │   ├── features/       # auth, discover, request, dashboard, sonarr,
-│   │   │                   # radarr, chaptarr, downloads, tautulli, issues,
+│   │   │                   # radarr, chaptarr, downloads, media_download, tautulli, issues,
 │   │   │                   # ai_assistant, notifications, settings, ...
 │   │   └── navigation/     # GoRouter with auth guard
 │   └── test/
@@ -136,6 +137,8 @@ Included AI is an explicit per-user entitlement for new accounts; the initial ad
 
 **Instance URLs are dialed only by the Cantinarr server** -- phones and browsers never contact them, so cluster-internal names (Docker service names like `http://radarr:7878`, Kubernetes cluster DNS, Tailscale MagicDNS) are the recommended form, and the arrs never need to be exposed outside their network. The in-app **Test Connection** button runs from the server too, so it tells the truth about these URLs. Plain `http` is fully supported on a trusted network; `https` needs a certificate the server's container trusts (mount an internal CA into the image trust store -- a self-signed cert otherwise fails the connection test with an x509 error). Two service-specific notes: SABnzbd's hostname verification rejects service names it doesn't know, so add the name to its `host_whitelist` (Config > Special) or set the container's hostname to match; for Transmission enter just `scheme://host:port` -- Cantinarr appends `/transmission/rpc`. Poster and fanart images load on devices straight from the TMDB/TVDB CDNs, so client devices still need internet egress to those hosts.
 
+Completed-media downloads are deliberately opt-in because Radarr, Sonarr, and Chaptarr report server filesystem paths but do not serve those file bytes through their APIs. Mount each wanted library read-only at the same path inside Cantinarr and allowlist the container path. For example, if Radarr reports `/data/media/movies/...`, add `- /mnt/nas/media:/data/media:ro` under the Cantinarr service's `volumes` and set `CANTINARR_MEDIA_ROOTS=/data/media`. Multiple roots are comma-separated. Cantinarr accepts only live file IDs from a user's effective Radarr/Sonarr instance or granted Chaptarr instance, refuses paths outside those roots, and gives the app a short-lived file-scoped link so large files stream through the browser or operating system without buffering in Flutter.
+
 Optional server env vars for deployment tuning:
 
 | Variable | Default | Description |
@@ -151,6 +154,7 @@ Optional server env vars for deployment tuning:
 | `CANTINARR_AI_MODEL` | provider default | Fallback model for the included server AI profile when none is saved in the admin UI |
 | `CANTINARR_CODEX_BIN` | auto-discovered | Optional path to `codex-app-server` or the full `codex` CLI; container images bundle the tested 0.144.3 app-server at `/usr/local/bin/codex-app-server` |
 | `CANTINARR_CODEX_RUNTIME_DIR` | `/dev/shm/cantinarr-codex` | Absolute Linux tmpfs/ramfs directory used for server-owned, ephemeral per-session Codex state; if it already exists, it must be owned by the server user with mode `0700` |
+| `CANTINARR_MEDIA_ROOTS` | unset | Comma-separated absolute paths from which Cantinarr may serve completed media. Empty disables file downloads. Each library must be mounted read-only into the Cantinarr container at the same absolute path its arr reports; `/` is refused |
 | `CANTINARR_PUSH_GATEWAY_URL` | unset | Push gateway origin -- setting it enables push notifications (auto-enrolls on first start) |
 | `CANTINARR_PUSH_API_KEY` | unset | Optional pinned gateway key (blank = auto-enroll) |
 | `CANTINARR_PUSH_ENROLL_TOKEN` | unset | Only for gateways with gated enrollment |

--- a/app/README.md
+++ b/app/README.md
@@ -62,10 +62,12 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 - **One-tap requesting** with status-aware labels: Request → Pending (awaiting approval) → Requested → Downloading → **Available**; partially-available shows get **Request More**, which jumps to the season picker. The ready state stays provider-neutral rather than assuming a particular playback app.
 - **Season-level choice** -- per-season availability, multi-select, "Request N seasons"; shown only to users the admin has allowed to choose (others inherit the default scope).
 - **Book formats** -- request the eBook, the Audiobook, or both; each format continuously translates live Chaptarr truth into Available / Downloading / Requested / Pending approval / Request denied / Not requested. A monitored format is already Requested, failures stay unknown instead of becoming requestable, and only the still-open format actions are shown.
+- **Available-file downloads** -- when enabled by the server, an exact live movie, eBook, or audiobook file can be downloaded from its requester detail; TV seasons present their available episodes as individual choices so each tap starts only one download.
 - **Live status** -- request state and download progress update in real time over WebSocket, including changes made directly in the arrs (webhooks).
 
 ### Media management (admin)
 - **Drill-down** -- library → movie detail, or series → season → episode, with per-item download progress, quality/size, history, and messages, proxied from Radarr/Sonarr API v3 with credential fields scrubbed server-side.
+- **File delivery parity** -- the Radarr movie, Sonarr episode, and Chaptarr format details expose the same server-enabled download actions as requester details, backed by short-lived same-origin tickets rather than arr URLs or credentials.
 - **Open in Radarr/Sonarr/Chaptarr** -- on a requester detail page, admins get a jump into the exact matching arr item, shown only once the title actually exists there (it appears right after a request adds it). Movies link to Radarr, TV to Sonarr, and books link to their grouped eBook/Audiobook records in Chaptarr.
 - **Explicit safe removal** -- destructive library actions live in each row's labeled overflow menu rather than behind a swipe gesture; confirmation is mandatory and deleting files from disk is always opt-in.
 - **Sonarr episode power tools** -- long-press action menus, episode **multi-select with batch search** (quick-select All / Undownloaded), batch **delete files**, an **All Seasons** view, per-season/series monitor toggles, **Edit Series** (profile, type, path, tags, season folders), and external links (IMDb/TheTVDB/TMDB/Trakt).
@@ -157,6 +159,7 @@ Feature-first structure with data / logic / ui layers per feature. State is Rive
 | Requests & approvals | Backend `/api/requests`, `/api/admin/requests` | ID bridging + policy live server-side |
 | Arr management | Backend `/api/instances/{id}/api/v3` (credential-scrubbed proxy) | API keys never reach devices; reads allowed for users, writes admin-only |
 | Books | Backend proxy to Chaptarr (Readarr API v1) | Per-user grant enforced server-side |
+| Media file downloads | Backend `/api/media-files/tickets` | The short-lived same-origin URL contains no arr host, filesystem path, or credentials |
 | AI chat | Backend `/api/ai/chat` (SSE) | Tool execution stays server-side; chat uses the resolved personal provider or a granted included provider |
 | Connected-app configuration history | Backend `/api/admin/external-settings-changes` | Durable AI/MCP profile/custom-format audit and live comparison; quality-profile restore payloads stay server-owned |
 | AI settings | Backend `/api/ai/settings` + write-only personal credential routes | The app sees provider/model, source, validation errors, and configured booleans, never secret values |
@@ -190,6 +193,7 @@ app/lib/
 │   ├── downloads/                # Unified download-client queue + history
 │   ├── issues/                   # Report-a-problem, threads, agent approvals + audit
 │   ├── media_detail/             # Detail screens, season table, request surface
+│   ├── media_download/           # Short-lived ticket model/service + shared download controls
 │   ├── notifications/            # APNs registration, prefs, deep-link routing
 │   ├── person/                   # Cast/crew detail sheet
 │   ├── radarr/                   # Movie management: library/queue/history/wanted/calendar

--- a/app/lib/core/models/backend_connection.dart
+++ b/app/lib/core/models/backend_connection.dart
@@ -140,6 +140,7 @@ class AvailableServices {
   final bool ai;
   final bool tmdb;
   final bool trakt;
+  final bool mediaDownloads;
 
   const AvailableServices({
     this.radarr = false,
@@ -148,6 +149,7 @@ class AvailableServices {
     this.ai = false,
     this.tmdb = false,
     this.trakt = false,
+    this.mediaDownloads = false,
   });
 
   factory AvailableServices.fromJson(Map<String, dynamic> json) =>
@@ -158,6 +160,7 @@ class AvailableServices {
         ai: json['ai'] as bool? ?? false,
         tmdb: json['tmdb'] as bool? ?? false,
         trakt: json['trakt'] as bool? ?? false,
+        mediaDownloads: json['media_downloads'] as bool? ?? false,
       );
 
   Map<String, dynamic> toJson() => {
@@ -167,5 +170,6 @@ class AvailableServices {
         'ai': ai,
         'tmdb': tmdb,
         'trakt': trakt,
+        'media_downloads': mediaDownloads,
       };
 }

--- a/app/lib/features/chaptarr/ui/chaptarr_book_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_book_screen.dart
@@ -6,6 +6,9 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../../../navigation/ambient_page_route.dart';
+import '../../auth/logic/auth_provider.dart';
+import '../../media_download/data/media_download_models.dart';
+import '../../media_download/ui/media_download_button.dart';
 import '../data/chaptarr_api_service.dart';
 import '../data/chaptarr_models.dart';
 import 'chaptarr_book_detail_sheet.dart';
@@ -189,6 +192,7 @@ class _ChaptarrBookScreenState extends ConsumerState<ChaptarrBookScreen> {
           const Divider(color: AppTheme.border, height: 1),
           for (final r in _records)
             _FormatSection(
+              instanceId: widget.instanceId,
               record: r,
               files: _filesByBook[r.id] ?? const [],
               loading: _isLoading,
@@ -257,13 +261,15 @@ class _BookHeader extends StatelessWidget {
 /// One format (ebook or audiobook) of a title: a format badge, this record's
 /// availability/file line, and a read-only monitor indicator (the toggle lives
 /// on the author screen's card).
-class _FormatSection extends StatelessWidget {
+class _FormatSection extends ConsumerWidget {
+  final String instanceId;
   final ChaptarrBook record;
   final List<ChaptarrBookFile> files;
   final bool loading;
   final VoidCallback onTap;
 
   const _FormatSection({
+    required this.instanceId,
     required this.record,
     required this.files,
     required this.loading,
@@ -271,13 +277,24 @@ class _FormatSection extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final status = bookFileStatusLine(record);
     final file = files.isNotEmpty ? files.first : null;
     final hasFile = file != null;
     final line = hasFile
         ? '${file.qualityName ?? 'Downloaded'} — ${file.sizeFormatted}'
         : (loading ? 'Checking…' : status.text);
+    final connection = ref.watch(authProvider).valueOrNull?.connection;
+    final downloadsEnabled = connection?.services.mediaDownloads ?? false;
+    final choices = [
+      for (var i = 0; i < files.length; i++)
+        if (files[i].id > 0)
+          MediaDownloadChoice(
+            fileId: files[i].id,
+            label: _chaptarrFileLabel(files[i], i),
+            subtitle: _chaptarrFileSubtitle(files[i]),
+          ),
+    ];
     return InkWell(
       onTap: onTap,
       child: Padding(
@@ -313,6 +330,16 @@ class _FormatSection extends StatelessWidget {
                 ],
               ),
             ),
+            if (downloadsEnabled && choices.isNotEmpty)
+              MediaDownloadChoiceButton(
+                instanceId: instanceId,
+                choices: choices,
+                label:
+                    'Download ${chaptarrFormatLabel(record.format)}',
+                sheetTitle:
+                    'Download ${chaptarrFormatLabel(record.format)}',
+                iconOnly: true,
+              ),
             Tooltip(
               message: record.monitored
                   ? 'Tracked ${chaptarrFormatLabel(record.format)}'
@@ -334,6 +361,20 @@ class _FormatSection extends StatelessWidget {
       ),
     );
   }
+}
+
+String _chaptarrFileLabel(ChaptarrBookFile file, int index) {
+  final path = file.path?.replaceAll('\\', '/') ?? '';
+  final parts = path.split('/').where((part) => part.isNotEmpty).toList();
+  return parts.isEmpty ? 'File ${index + 1}' : parts.last;
+}
+
+String? _chaptarrFileSubtitle(ChaptarrBookFile file) {
+  final details = [
+    if (file.qualityName?.isNotEmpty ?? false) file.qualityName!,
+    if (file.size > 0) file.sizeFormatted,
+  ];
+  return details.isEmpty ? null : details.join(' · ');
 }
 
 class _ActionBar extends StatelessWidget {

--- a/app/lib/features/dashboard/ui/requester_book_detail_screen.dart
+++ b/app/lib/features/dashboard/ui/requester_book_detail_screen.dart
@@ -16,6 +16,8 @@ import '../../chaptarr/data/chaptarr_api_service.dart';
 import '../../chaptarr/data/chaptarr_image.dart';
 import '../../chaptarr/data/chaptarr_models.dart';
 import '../../chaptarr/ui/chaptarr_book_screen.dart';
+import '../../media_download/data/media_download_models.dart';
+import '../../media_download/ui/media_download_button.dart';
 import '../../request/data/book_ownership.dart';
 import '../../request/data/request_service.dart';
 import '../../request/ui/book_request_button.dart';
@@ -52,6 +54,7 @@ class _RequesterBookDetailScreenState
   late final RequestService _requestService;
   ChaptarrBook? _metadata;
   List<ChaptarrBook> _chaptarrRecords = const [];
+  Map<int, List<ChaptarrBookFile>> _filesByBook = const {};
   BookRequestStatusDetail? _requestDetail;
   bool _metadataLoading = false;
   int _loadGeneration = 0;
@@ -96,6 +99,7 @@ class _RequesterBookDetailScreenState
         ref.read(instanceProvider).activeChaptarrInstance?.id;
     _metadata = widget.initialBook;
     _chaptarrRecords = const [];
+    _filesByBook = const {};
     _requestDetail = null;
     _metadataLoading = widget.initialBook == null &&
         (widget.titleHint?.trim().isNotEmpty ?? false);
@@ -171,12 +175,15 @@ class _RequesterBookDetailScreenState
     });
   }
 
-  /// Resolve an exact live Chaptarr destination for admins. Lookup records and
-  /// the requester digest intentionally lack trustworthy numeric library ids,
-  /// so only the live library list may back this link.
+  /// Resolve exact live Chaptarr records. Lookup records and the requester
+  /// digest intentionally lack trustworthy numeric library/file ids, so only
+  /// this live list may back admin navigation or requester downloads.
   Future<void> _resolveChaptarrRecords(int generation) async {
-    final isAdmin = ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
-    if (!isAdmin) return;
+    final auth = ref.read(authProvider).valueOrNull;
+    final isAdmin = auth?.user?.isAdmin ?? false;
+    final downloadsEnabled =
+        auth?.connection?.services.mediaDownloads ?? false;
+    if (!isAdmin && !downloadsEnabled) return;
     final service = _chaptarrService();
     if (service == null) return;
     final recordsGeneration = ++_recordsLoadGeneration;
@@ -187,12 +194,30 @@ class _RequesterBookDetailScreenState
               book.id > 0 && book.foreignBookId == widget.foreignId)
           .toList(growable: false)
         ..sort((a, b) => a.format.index.compareTo(b.format.index));
+      final filesByBook = <int, List<ChaptarrBookFile>>{};
+      if (downloadsEnabled) {
+        final results = await Future.wait(matches.map((book) async {
+          try {
+            return await service.getBookFiles(bookId: book.id);
+          } catch (_) {
+            return const <ChaptarrBookFile>[];
+          }
+        }));
+        for (var i = 0; i < matches.length; i++) {
+          filesByBook[matches[i].id] = results[i]
+              .where((file) => file.id > 0)
+              .toList(growable: false);
+        }
+      }
       if (!mounted ||
           generation != _loadGeneration ||
           recordsGeneration != _recordsLoadGeneration) {
         return;
       }
-      setState(() => _chaptarrRecords = matches);
+      setState(() {
+        _chaptarrRecords = matches;
+        _filesByBook = filesByBook;
+      });
     } catch (_) {
       // A transient Chaptarr failure keeps the optional link hidden.
     }
@@ -306,6 +331,11 @@ class _RequesterBookDetailScreenState
           ownership,
           ownershipStatusKnown: owned?.statusKnown ?? true,
         );
+    final auth = ref.watch(authProvider).valueOrNull;
+    final downloadsEnabled = auth?.connection?.services.mediaDownloads ?? false;
+    final ebookFiles = _downloadChoicesFor(BookFormat.ebook);
+    final audiobookFiles = _downloadChoicesFor(BookFormat.audiobook);
+    final isAdmin = auth?.user?.isAdmin ?? false;
 
     final instanceId = _instanceId;
     final requestRefreshTick = ref.watch(libraryRefreshTickProvider);
@@ -387,6 +417,10 @@ class _RequesterBookDetailScreenState
           _FormatStatusPanel(
             detail: detail,
             statusLoaded: _requestDetail != null,
+            instanceId: instanceId,
+            ebookFiles: downloadsEnabled ? ebookFiles : const [],
+            audiobookFiles:
+                downloadsEnabled ? audiobookFiles : const [],
           ),
           const SizedBox(height: 18),
           Wrap(
@@ -407,7 +441,7 @@ class _RequesterBookDetailScreenState
                 onDetailChanged: _onRequestDetailChanged,
                 onRequestCompleted: _onRequestCompleted,
               ),
-              if (_chaptarrRecords.isNotEmpty)
+              if (isAdmin && _chaptarrRecords.isNotEmpty)
                 OutlinedButton.icon(
                   onPressed: _openInChaptarr,
                   icon: const Icon(Icons.open_in_new_rounded, size: 17),
@@ -449,6 +483,27 @@ class _RequesterBookDetailScreenState
     );
   }
 
+  List<MediaDownloadChoice> _downloadChoicesFor(BookFormat format) {
+    final choices = <MediaDownloadChoice>[];
+    for (final record in _chaptarrRecords) {
+      if (record.format != format) continue;
+      final files = _filesByBook[record.id] ?? const [];
+      for (var i = 0; i < files.length; i++) {
+        final file = files[i];
+        final details = [
+          if (file.qualityName?.isNotEmpty ?? false) file.qualityName!,
+          if (file.size > 0) file.sizeFormatted,
+        ].join(' · ');
+        choices.add(MediaDownloadChoice(
+          fileId: file.id,
+          label: _bookFileLabel(file, i),
+          subtitle: details.isEmpty ? null : details,
+        ));
+      }
+    }
+    return choices;
+  }
+
   Widget _notFound() {
     return Center(
       child: Padding(
@@ -480,10 +535,16 @@ class _RequesterBookDetailScreenState
 class _FormatStatusPanel extends StatelessWidget {
   final BookRequestStatusDetail detail;
   final bool statusLoaded;
+  final String? instanceId;
+  final List<MediaDownloadChoice> ebookFiles;
+  final List<MediaDownloadChoice> audiobookFiles;
 
   const _FormatStatusPanel({
     required this.detail,
     required this.statusLoaded,
+    required this.instanceId,
+    required this.ebookFiles,
+    required this.audiobookFiles,
   });
 
   @override
@@ -511,6 +572,15 @@ class _FormatStatusPanel extends StatelessWidget {
               BookRequestFormat.ebook,
               statusLoaded,
             ),
+            download: instanceId == null || ebookFiles.isEmpty
+                ? null
+                : MediaDownloadChoiceButton(
+                    instanceId: instanceId!,
+                    choices: ebookFiles,
+                    label: 'Download eBook',
+                    sheetTitle: 'Download eBook',
+                    iconOnly: true,
+                  ),
           ),
           const Divider(height: 1, indent: 52, color: AppTheme.border),
           _FormatStatusRow(
@@ -521,6 +591,15 @@ class _FormatStatusPanel extends StatelessWidget {
               BookRequestFormat.audiobook,
               statusLoaded,
             ),
+            download: instanceId == null || audiobookFiles.isEmpty
+                ? null
+                : MediaDownloadChoiceButton(
+                    instanceId: instanceId!,
+                    choices: audiobookFiles,
+                    label: 'Download audiobook',
+                    sheetTitle: 'Download audiobook',
+                    iconOnly: true,
+                  ),
           ),
         ],
       ),
@@ -532,11 +611,13 @@ class _FormatStatusRow extends StatelessWidget {
   final IconData icon;
   final String label;
   final ({String label, Color color}) state;
+  final Widget? download;
 
   const _FormatStatusRow({
     required this.icon,
     required this.label,
     required this.state,
+    this.download,
   });
 
   @override
@@ -562,8 +643,24 @@ class _FormatStatusRow extends StatelessWidget {
                 heading,
                 const SizedBox(height: 8),
                 Padding(
-                  padding: const EdgeInsets.only(left: 32),
-                  child: StatusPill(text: state.label, color: state.color),
+                  padding: const EdgeInsets.only(left: 28),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: StatusPill(
+                            text: state.label,
+                            color: state.color,
+                          ),
+                        ),
+                      ),
+                      if (download != null) ...[
+                        const SizedBox(width: 4),
+                        download!,
+                      ],
+                    ],
+                  ),
                 ),
               ],
             )
@@ -571,10 +668,20 @@ class _FormatStatusRow extends StatelessWidget {
               children: [
                 Expanded(child: heading),
                 StatusPill(text: state.label, color: state.color),
+                if (download != null) ...[
+                  const SizedBox(width: 4),
+                  download!,
+                ],
               ],
             ),
     );
   }
+}
+
+String _bookFileLabel(ChaptarrBookFile file, int index) {
+  final path = file.path?.replaceAll('\\', '/') ?? '';
+  final parts = path.split('/').where((part) => part.isNotEmpty).toList();
+  return parts.isEmpty ? 'File ${index + 1}' : parts.last;
 }
 
 ({String label, Color color}) _formatState(

--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -17,7 +17,10 @@ import '../../auth/logic/auth_provider.dart';
 import '../../discover/data/tmdb_models.dart';
 import '../../discover/data/discover_api_service.dart';
 import '../../issues/ui/report_problem_sheet.dart';
+import '../../media_download/data/media_download_models.dart';
+import '../../media_download/ui/media_download_button.dart';
 import '../../radarr/data/radarr_api_service.dart';
+import '../../radarr/data/radarr_models.dart';
 import '../../radarr/ui/radarr_movie_detail_screen.dart';
 import '../../request/data/request_service.dart';
 import '../../request/logic/request_provider.dart';
@@ -25,6 +28,7 @@ import '../../request/ui/request_button.dart';
 import '../../request/ui/request_options_sheet.dart';
 import '../../request/ui/request_status_sheet.dart';
 import '../../sonarr/data/sonarr_api_service.dart';
+import '../../sonarr/data/sonarr_models.dart';
 import '../../sonarr/ui/sonarr_series_detail_screen.dart';
 import '../logic/arr_deep_link.dart';
 import '../logic/media_detail_provider.dart';
@@ -66,6 +70,14 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
   /// for non-admins, or when the title has no destination in the arr yet — the
   /// "Open in …" affordance is shown only when this is non-null.
   ArrDeepLink? _arrLink;
+
+  /// Exact live files exposed as requester downloads. These are resolved from
+  /// the active arr instead of inferred from request status, since admins may
+  /// change or replace files directly in Radarr/Sonarr at any time.
+  RadarrMovieFile? _downloadMovieFile;
+  List<SonarrEpisode> _downloadEpisodes = const [];
+  String? _downloadInstanceId;
+  int _arrResolveGeneration = 0;
 
   @override
   void initState() {
@@ -122,6 +134,14 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
     // Resolve (or re-resolve) the admin link once auth settles — covers auth
     // landing after the initial detail load (e.g. an optimistic reconnect).
     ref.listen(authProvider, (_, __) => _resolveArrLink());
+    ref.listen(
+      instanceProvider.select((s) => s.activeRadarrInstanceId),
+      (_, __) => _resolveArrLink(),
+    );
+    ref.listen(
+      instanceProvider.select((s) => s.activeSonarrInstanceId),
+      (_, __) => _resolveArrLink(),
+    );
     return ListenableBuilder(
       listenable: _detailNotifier,
       builder: (context, _) {
@@ -248,6 +268,17 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                                               label: const Text(
                                                 'Report a problem',
                                               ),
+                                            ),
+                                          if (widget.mediaType ==
+                                                  MediaType.movie &&
+                                              _downloadInstanceId != null &&
+                                              _downloadMovieFile != null)
+                                            MediaDownloadButton(
+                                              instanceId:
+                                                  _downloadInstanceId!,
+                                              fileId:
+                                                  _downloadMovieFile!.id,
+                                              label: 'Download movie',
                                             ),
                                           if (_arrLink != null)
                                             TextButton.icon(
@@ -398,6 +429,9 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                               tvdbId: state.tvDetail?.externalIds?.tvdbId,
                               canRequest: _canChooseSeasons,
                               onRequested: _bumpLibraryRefresh,
+                              downloadInstanceId: _downloadInstanceId,
+                              downloadChoicesBySeason:
+                                  _episodeDownloadChoicesBySeason,
                             ),
                           ],
 
@@ -507,57 +541,127 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
     ref.read(libraryRefreshTickProvider.notifier).state++;
   }
 
-  /// For admins, resolve whether this title already exists in the backing arr
-  /// (Radarr for movies, Sonarr for TV) and, when it does, capture the matched
-  /// library object + instance id so the "Open in …" affordance can push the
-  /// arr detail screen. Runs on load and again after a request (via
-  /// [libraryRefreshTickProvider]). Non-admins never resolve a link, and any
-  /// fetch error leaves the current link untouched (quietly hidden) rather than
-  /// surfacing — the affordance appears only when there's a real destination.
+  /// Resolves this title against the active arr. Admins get a deep link into
+  /// the matched record; any user gets exact live file downloads when the
+  /// server advertises that capability. Runs again after requests, auth
+  /// changes, and instance switches so stale files are never offered.
   Future<void> _resolveArrLink() async {
-    final isAdmin = ref.read(authProvider).valueOrNull?.user?.isAdmin ?? false;
-    if (!isAdmin) return;
-
+    final generation = ++_arrResolveGeneration;
+    final auth = ref.read(authProvider).valueOrNull;
+    final isAdmin = auth?.user?.isAdmin ?? false;
+    final downloadsEnabled = auth?.connection?.services.mediaDownloads ?? false;
     final backendDio = ref.read(backendClientProvider);
     final instances = ref.read(instanceProvider);
-    final connection = ref.read(authProvider).valueOrNull?.connection;
+    final connection = auth?.connection;
+
+    if (mounted) {
+      setState(() {
+        _arrLink = null;
+        _downloadMovieFile = null;
+        _downloadEpisodes = const [];
+        _downloadInstanceId = null;
+      });
+    }
+    if (!isAdmin && !downloadsEnabled) return;
 
     try {
       if (widget.mediaType == MediaType.movie) {
         final instanceId = instances.activeRadarrInstance?.id ??
             connection?.defaultRadarrInstance?.id;
         if (instanceId == null) return;
-        final movies = await RadarrApiService(
+        final service = RadarrApiService(
           backendDio: backendDio,
           instanceId: instanceId,
-        ).getMovies();
-        if (!mounted) return;
-        final match = matchRadarrMovie(movies, widget.id);
-        setState(() => _arrLink = match == null
-            ? null
-            : ArrDeepLink(instanceId: instanceId, movie: match));
+        );
+        final movies = await service.getMovies();
+        var match = matchRadarrMovie(movies, widget.id);
+        if (downloadsEnabled && match != null && match.id > 0) {
+          try {
+            final detail = await service.getMovieById(match.id);
+            if (detail.id == match.id) match = detail;
+          } catch (_) {
+            // The live list may already carry movieFile. Keep that exact
+            // response as a fallback when Radarr's detail endpoint is down.
+          }
+        }
+        if (!mounted || generation != _arrResolveGeneration) return;
+        final file = match?.movieFile;
+        setState(() {
+          _arrLink = isAdmin && match != null
+              ? ArrDeepLink(instanceId: instanceId, movie: match)
+              : null;
+          if (downloadsEnabled && file != null && file.id > 0) {
+            _downloadMovieFile = file;
+            _downloadInstanceId = instanceId;
+          }
+        });
       } else {
         final instanceId = instances.activeSonarrInstance?.id ??
             connection?.defaultSonarrInstance?.id;
         if (instanceId == null) return;
-        final series = await SonarrApiService(
+        final service = SonarrApiService(
           backendDio: backendDio,
           instanceId: instanceId,
-        ).getSeries();
-        if (!mounted) return;
+        );
+        final series = await service.getSeries();
         final match = matchSonarrSeries(
           series,
           tvdbId: _detailNotifier.state.tvDetail?.externalIds?.tvdbId,
           title: _detailNotifier.state.title,
         );
-        setState(() => _arrLink = match == null
-            ? null
-            : ArrDeepLink(instanceId: instanceId, series: match));
+        var episodes = const <SonarrEpisode>[];
+        if (downloadsEnabled && match != null && match.id > 0) {
+          episodes = (await service.getEpisodes(
+            match.id,
+            includeEpisodeFile: true,
+          ))
+              .where((episode) =>
+                  episode.hasFile && episode.episodeFileId > 0)
+              .toList()
+            ..sort((left, right) {
+              final season =
+                  left.seasonNumber.compareTo(right.seasonNumber);
+              return season != 0
+                  ? season
+                  : left.episodeNumber.compareTo(right.episodeNumber);
+            });
+        }
+        if (!mounted || generation != _arrResolveGeneration) return;
+        setState(() {
+          _arrLink = isAdmin && match != null
+              ? ArrDeepLink(instanceId: instanceId, series: match)
+              : null;
+          if (downloadsEnabled && episodes.isNotEmpty) {
+            _downloadEpisodes = episodes;
+            _downloadInstanceId = instanceId;
+          }
+        });
       }
     } catch (_) {
-      // Leave any existing link as-is; a transient fetch failure shouldn't
-      // yank a working affordance.
+      // File/link discovery is an optional affordance. Keep the safely-cleared
+      // state when the active arr is unavailable instead of exposing stale IDs.
     }
+  }
+
+  Map<int, List<MediaDownloadChoice>> get
+      _episodeDownloadChoicesBySeason {
+    final result = <int, List<MediaDownloadChoice>>{};
+    for (final episode in _downloadEpisodes) {
+      final title = episode.title?.trim();
+      final file = episode.episodeFile;
+      final details = <String>[
+        if (file?.quality?.trim().isNotEmpty ?? false) file!.quality!.trim(),
+        if (file != null && file.size > 0) file.sizeFormatted,
+      ];
+      (result[episode.seasonNumber] ??= []).add(MediaDownloadChoice(
+        fileId: episode.episodeFileId,
+        label: title == null || title.isEmpty
+            ? episode.seasonEpisodeLabel
+            : '${episode.seasonEpisodeLabel} · $title',
+        subtitle: details.isEmpty ? null : details.join(' · '),
+      ));
+    }
+    return result;
   }
 
   /// Pushes the matched arr detail screen (movie → Radarr, TV → Sonarr) over

--- a/app/lib/features/media_detail/ui/season_table.dart
+++ b/app/lib/features/media_detail/ui/season_table.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../discover/data/tmdb_models.dart';
+import '../../media_download/data/media_download_models.dart';
+import '../../media_download/ui/media_download_button.dart';
 import '../../request/data/request_service.dart';
 import '../../request/logic/request_provider.dart';
 
@@ -31,6 +33,12 @@ class SeasonTable extends StatefulWidget {
   /// stale-by-design surfaces (the shell's search-chip snapshot).
   final VoidCallback? onRequested;
 
+  /// Exact episode files currently present in Sonarr, grouped per season.
+  /// A season with multiple files opens a picker so one browser gesture starts
+  /// one download instead of attempting a blocked batch launch.
+  final String? downloadInstanceId;
+  final Map<int, List<MediaDownloadChoice>> downloadChoicesBySeason;
+
   const SeasonTable({
     super.key,
     required this.seasons,
@@ -39,6 +47,9 @@ class SeasonTable extends StatefulWidget {
     this.tvdbId,
     this.canRequest = true,
     this.onRequested,
+    this.downloadInstanceId,
+    this.downloadChoicesBySeason =
+        const <int, List<MediaDownloadChoice>>{},
   });
 
   @override
@@ -159,6 +170,10 @@ class _SeasonTableState extends State<SeasonTable> {
                         available: _isAvailable(seasons[i].seasonNumber),
                         selectable: widget.canRequest,
                         onChanged: (v) => _toggle(seasons[i].seasonNumber, v),
+                        downloadInstanceId: widget.downloadInstanceId,
+                        downloadChoices: widget.downloadChoicesBySeason[
+                                seasons[i].seasonNumber] ??
+                            const [],
                       ),
                     ],
                   ],
@@ -215,6 +230,8 @@ class _SeasonRow extends StatelessWidget {
   final bool available;
   final bool selectable;
   final ValueChanged<bool?> onChanged;
+  final String? downloadInstanceId;
+  final List<MediaDownloadChoice> downloadChoices;
 
   const _SeasonRow({
     required this.season,
@@ -223,6 +240,8 @@ class _SeasonRow extends StatelessWidget {
     required this.available,
     required this.selectable,
     required this.onChanged,
+    required this.downloadInstanceId,
+    required this.downloadChoices,
   });
 
   @override
@@ -271,6 +290,16 @@ class _SeasonRow extends StatelessWidget {
               ),
             ),
             _SeasonStatusBadge(status: status?.status),
+            if (downloadInstanceId != null && downloadChoices.isNotEmpty) ...[
+              const SizedBox(width: 4),
+              MediaDownloadChoiceButton(
+                instanceId: downloadInstanceId!,
+                choices: downloadChoices,
+                label: 'Download Season ${season.seasonNumber} episodes',
+                sheetTitle: 'Download Season ${season.seasonNumber}',
+                iconOnly: true,
+              ),
+            ],
           ],
         ),
       ),

--- a/app/lib/features/media_download/data/media_download_models.dart
+++ b/app/lib/features/media_download/data/media_download_models.dart
@@ -1,0 +1,34 @@
+class MediaDownloadTicket {
+  final Uri url;
+  final String filename;
+  final int sizeBytes;
+  final DateTime expiresAt;
+
+  const MediaDownloadTicket({
+    required this.url,
+    required this.filename,
+    required this.sizeBytes,
+    required this.expiresAt,
+  });
+}
+
+class MediaDownloadChoice {
+  final int fileId;
+  final String label;
+  final String? subtitle;
+
+  const MediaDownloadChoice({
+    required this.fileId,
+    required this.label,
+    this.subtitle,
+  });
+}
+
+class MediaDownloadException implements Exception {
+  final String message;
+
+  const MediaDownloadException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/app/lib/features/media_download/data/media_download_service.dart
+++ b/app/lib/features/media_download/data/media_download_service.dart
@@ -1,0 +1,124 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/network/backend_client.dart';
+import 'media_download_models.dart';
+
+class MediaDownloadService {
+  final Dio _dio;
+
+  MediaDownloadService({required Dio backendDio}) : _dio = backendDio;
+
+  Future<MediaDownloadTicket> createTicket({
+    required String instanceId,
+    required int fileId,
+  }) async {
+    if (instanceId.trim().isEmpty || fileId <= 0) {
+      throw const MediaDownloadException(
+        'This file is no longer available.',
+      );
+    }
+
+    try {
+      final response = await _dio.post(
+        '/api/media-files/tickets',
+        data: {
+          'instance_id': instanceId,
+          'file_id': fileId,
+        },
+      );
+      final data = response.data;
+      if (data is! Map<String, dynamic>) {
+        throw const MediaDownloadException(
+          'Could not prepare the download. Try again.',
+        );
+      }
+
+      final filename = (data['filename'] as String? ?? '').trim();
+      final sizeBytes = (data['size_bytes'] as num?)?.toInt();
+      final expiresAt =
+          DateTime.tryParse(data['expires_at'] as String? ?? '');
+      if (filename.isEmpty ||
+          sizeBytes == null ||
+          sizeBytes < 0 ||
+          expiresAt == null) {
+        throw const MediaDownloadException(
+          'Could not prepare the download. Try again.',
+        );
+      }
+
+      return MediaDownloadTicket(
+        url: _resolveDownloadUrl(data['url']),
+        filename: filename,
+        sizeBytes: sizeBytes,
+        expiresAt: expiresAt,
+      );
+    } on MediaDownloadException {
+      rethrow;
+    } on DioException catch (error) {
+      switch (error.response?.statusCode) {
+        case 403:
+          throw const MediaDownloadException(
+            'You do not have access to this file.',
+          );
+        case 404:
+        case 410:
+          throw const MediaDownloadException(
+            'This file is no longer available.',
+          );
+        default:
+          throw const MediaDownloadException(
+            'Could not prepare the download. Try again.',
+          );
+      }
+    } catch (_) {
+      throw const MediaDownloadException(
+        'Could not prepare the download. Try again.',
+      );
+    }
+  }
+
+  Uri _resolveDownloadUrl(dynamic value) {
+    final raw = value is String ? value.trim() : '';
+    final base = Uri.tryParse(_dio.options.baseUrl);
+    final candidate = Uri.tryParse(raw);
+    if (raw.isEmpty ||
+        base == null ||
+        !_isHttpOrigin(base) ||
+        candidate == null ||
+        candidate.userInfo.isNotEmpty ||
+        candidate.fragment.isNotEmpty) {
+      throw const MediaDownloadException(
+        'Could not prepare the download. Try again.',
+      );
+    }
+
+    final resolved = base.resolveUri(candidate);
+    if (!_sameOrigin(base, resolved)) {
+      throw const MediaDownloadException(
+        'Could not prepare the download. Try again.',
+      );
+    }
+    return resolved;
+  }
+
+  bool _isHttpOrigin(Uri uri) =>
+      (uri.scheme == 'http' || uri.scheme == 'https') &&
+      uri.host.isNotEmpty &&
+      uri.userInfo.isEmpty;
+
+  bool _sameOrigin(Uri left, Uri right) =>
+      _isHttpOrigin(right) &&
+      left.scheme.toLowerCase() == right.scheme.toLowerCase() &&
+      left.host.toLowerCase() == right.host.toLowerCase() &&
+      _effectivePort(left) == _effectivePort(right);
+
+  int _effectivePort(Uri uri) {
+    if (uri.hasPort) return uri.port;
+    return uri.scheme.toLowerCase() == 'https' ? 443 : 80;
+  }
+}
+
+final mediaDownloadServiceProvider = Provider<MediaDownloadService>((ref) {
+  return MediaDownloadService(backendDio: ref.watch(backendClientProvider));
+});

--- a/app/lib/features/media_download/ui/media_download_button.dart
+++ b/app/lib/features/media_download/ui/media_download_button.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../data/media_download_models.dart';
+import '../data/media_download_service.dart';
+
+typedef MediaDownloadLauncher = Future<bool> Function(Uri uri);
+
+final mediaDownloadLauncherProvider = Provider<MediaDownloadLauncher>(
+  (_) => (uri) => kIsWeb
+      ? launchUrl(uri, webOnlyWindowName: '_self')
+      : launchUrl(uri, mode: LaunchMode.externalApplication),
+);
+
+class MediaDownloadButton extends ConsumerStatefulWidget {
+  final String instanceId;
+  final int fileId;
+  final String label;
+  final bool iconOnly;
+  final bool outlined;
+
+  const MediaDownloadButton({
+    super.key,
+    required this.instanceId,
+    required this.fileId,
+    required this.label,
+    this.iconOnly = false,
+    this.outlined = false,
+  });
+
+  @override
+  ConsumerState<MediaDownloadButton> createState() =>
+      _MediaDownloadButtonState();
+}
+
+class _MediaDownloadButtonState extends ConsumerState<MediaDownloadButton> {
+  bool _busy = false;
+
+  Future<void> _download() async {
+    if (_busy || widget.fileId <= 0) return;
+    setState(() => _busy = true);
+    try {
+      final service = ref.read(mediaDownloadServiceProvider);
+      final ticket = await service.createTicket(
+        instanceId: widget.instanceId,
+        fileId: widget.fileId,
+      );
+      final launcher = ref.read(mediaDownloadLauncherProvider);
+      final opened = await launcher(ticket.url);
+      if (!opened) {
+        throw const MediaDownloadException(
+          'Could not open the download. Try again.',
+        );
+      }
+    } on MediaDownloadException catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(error.message)));
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+          content: Text('Could not prepare the download. Try again.'),
+        ));
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Widget get _icon => _busy
+      ? const SizedBox(
+          width: 18,
+          height: 18,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        )
+      : const Icon(Icons.download_rounded, size: 19);
+
+  @override
+  Widget build(BuildContext context) {
+    final onPressed = _busy || widget.fileId <= 0 ? null : _download;
+    if (widget.iconOnly) {
+      return IconButton(
+        tooltip: widget.label,
+        onPressed: onPressed,
+        icon: _icon,
+      );
+    }
+    if (widget.outlined) {
+      return OutlinedButton.icon(
+        onPressed: onPressed,
+        icon: _icon,
+        label: Text(widget.label),
+      );
+    }
+    return TextButton.icon(
+      onPressed: onPressed,
+      icon: _icon,
+      label: Text(widget.label),
+    );
+  }
+}
+
+class MediaDownloadChoiceButton extends StatelessWidget {
+  final String instanceId;
+  final List<MediaDownloadChoice> choices;
+  final String label;
+  final String sheetTitle;
+  final bool iconOnly;
+  final bool outlined;
+
+  const MediaDownloadChoiceButton({
+    super.key,
+    required this.instanceId,
+    required this.choices,
+    required this.label,
+    required this.sheetTitle,
+    this.iconOnly = false,
+    this.outlined = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final available =
+        choices.where((choice) => choice.fileId > 0).toList(growable: false);
+    if (available.length == 1) {
+      return MediaDownloadButton(
+        instanceId: instanceId,
+        fileId: available.single.fileId,
+        label: label,
+        iconOnly: iconOnly,
+        outlined: outlined,
+      );
+    }
+
+    final onPressed =
+        available.isEmpty ? null : () => _showChoices(context, available);
+    if (iconOnly) {
+      return IconButton(
+        tooltip: label,
+        onPressed: onPressed,
+        icon: const Icon(Icons.download_rounded, size: 19),
+      );
+    }
+    if (outlined) {
+      return OutlinedButton.icon(
+        onPressed: onPressed,
+        icon: const Icon(Icons.download_rounded, size: 19),
+        label: Text(label),
+      );
+    }
+    return TextButton.icon(
+      onPressed: onPressed,
+      icon: const Icon(Icons.download_rounded, size: 19),
+      label: Text(label),
+    );
+  }
+
+  Future<void> _showChoices(
+    BuildContext context,
+    List<MediaDownloadChoice> available,
+  ) {
+    return showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (_) => Material(
+        color: AppTheme.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+        clipBehavior: Clip.antiAlias,
+        child: SafeArea(
+          top: false,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxHeight: MediaQuery.sizeOf(context).height * 0.75,
+            ),
+            child: ListView(
+              shrinkWrap: true,
+              padding: const EdgeInsets.fromLTRB(16, 18, 16, 16),
+              children: [
+                Text(sheetTitle,
+                    style: Theme.of(context).textTheme.titleLarge),
+                const SizedBox(height: 10),
+                for (final choice in available)
+                  ListTile(
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 4),
+                    title: Text(choice.label),
+                    subtitle: choice.subtitle == null
+                        ? null
+                        : Text(choice.subtitle!),
+                    trailing: MediaDownloadButton(
+                      instanceId: instanceId,
+                      fileId: choice.fileId,
+                      label: 'Download ${choice.label}',
+                      iconOnly: true,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_movie_detail_screen.dart
@@ -10,6 +10,7 @@ import '../../../core/widgets/status_pill.dart';
 import '../../../navigation/ambient_page_route.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../issues/ui/report_problem_sheet.dart';
+import '../../media_download/ui/media_download_button.dart';
 import '../data/radarr_api_service.dart';
 import '../data/radarr_models.dart';
 import 'radarr_import_doctor_sheet.dart';
@@ -178,7 +179,10 @@ class _RadarrMovieDetailScreenState
           ],
           if (_movie.movieFile != null) ...[
             const SizedBox(height: 16),
-            _FileCard(file: _movie.movieFile!),
+            _FileCard(
+              instanceId: widget.instanceId,
+              file: _movie.movieFile!,
+            ),
           ],
           if (_queueItem != null) ...[
             const SizedBox(height: 16),
@@ -329,13 +333,16 @@ class _Header extends StatelessWidget {
 
 /// The downloaded file's quality + size line — Radarr's analogue of the Sonarr
 /// per-episode "WEBDL-1080p — 4.3 GB" status.
-class _FileCard extends StatelessWidget {
+class _FileCard extends ConsumerWidget {
+  final String instanceId;
   final RadarrMovieFile file;
-  const _FileCard({required this.file});
+  const _FileCard({required this.instanceId, required this.file});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final cutoffMet = !file.qualityCutoffNotMet;
+    final connection = ref.watch(authProvider).valueOrNull?.connection;
+    final downloadsEnabled = connection?.services.mediaDownloads ?? false;
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
@@ -390,6 +397,13 @@ class _FileCard extends StatelessWidget {
               ],
             ),
           ),
+          if (downloadsEnabled && file.id > 0)
+            MediaDownloadButton(
+              instanceId: instanceId,
+              fileId: file.id,
+              label: 'Download movie file',
+              iconOnly: true,
+            ),
         ],
       ),
     );

--- a/app/lib/features/sonarr/ui/episode_detail_sheet.dart
+++ b/app/lib/features/sonarr/ui/episode_detail_sheet.dart
@@ -6,6 +6,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/status_pill.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../issues/ui/report_problem_sheet.dart';
+import '../../media_download/ui/media_download_button.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
 import 'import_doctor_sheet.dart';
@@ -109,6 +110,8 @@ class _EpisodeDetailSheetState extends ConsumerState<EpisodeDetailSheet> {
   Widget build(BuildContext context) {
     final e = widget.episode;
     final status = _shortStatus;
+    final connection = ref.watch(authProvider).valueOrNull?.connection;
+    final downloadsEnabled = connection?.services.mediaDownloads ?? false;
     final airDate = e.airDateUtc?.toLocal() ??
         (e.airDate != null ? DateTime.tryParse(e.airDate!) : null);
 
@@ -158,11 +161,25 @@ class _EpisodeDetailSheetState extends ConsumerState<EpisodeDetailSheet> {
               StatusPill(text: status.label, color: status.color),
               if (e.overview != null && e.overview!.isNotEmpty) ...[
                 const SizedBox(height: 14),
-                Text(e.overview!,
-                    style: const TextStyle(
-                        color: AppTheme.textPrimary,
-                        fontSize: 14,
-                        height: 1.4)),
+                Text(
+                  e.overview!,
+                  style: const TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontSize: 14,
+                      height: 1.4),
+                ),
+              ],
+              if (downloadsEnabled && e.hasFile && e.episodeFileId > 0) ...[
+                const SizedBox(height: 14),
+                SizedBox(
+                  width: double.infinity,
+                  child: MediaDownloadButton(
+                    instanceId: widget.instanceId,
+                    fileId: e.episodeFileId,
+                    label: 'Download episode',
+                    outlined: true,
+                  ),
+                ),
               ],
               if (widget.queueItem != null) ...[
                 const SizedBox(height: 16),

--- a/app/test/auth/auth_restore_test.dart
+++ b/app/test/auth/auth_restore_test.dart
@@ -26,8 +26,10 @@ void main() {
     user: user,
     deviceId: 'dev-1',
   );
-  const config =
-      ServerConfig(serverName: 'Home', services: AvailableServices(radarr: true));
+  const config = ServerConfig(
+    serverName: 'Home',
+    services: AvailableServices(radarr: true, mediaDownloads: true),
+  );
 
   final connectionError = DioException(
     requestOptions: RequestOptions(path: '/api/auth/refresh'),
@@ -54,7 +56,10 @@ void main() {
         StorageKeys.sessionUser: jsonEncode(user.toJson()),
         StorageKeys.sessionConnection: jsonEncode({
           'server_name': 'Home',
-          'services': const AvailableServices(radarr: true).toJson(),
+          'services': const AvailableServices(
+            radarr: true,
+            mediaDownloads: true,
+          ).toJson(),
           'instances': const <Map<String, dynamic>>[],
         }),
       };
@@ -86,6 +91,7 @@ void main() {
       expect(optimistic.isReconnecting, isTrue);
       expect(optimistic.user?.username, 'tester');
       expect(optimistic.connection?.services.radarr, isTrue);
+      expect(optimistic.connection?.services.mediaDownloads, isTrue);
 
       // Background validation then refreshes and clears the reconnecting flag.
       await _pumpUntil(() {

--- a/app/test/dashboard/requester_book_detail_screen_test.dart
+++ b/app/test/dashboard/requester_book_detail_screen_test.dart
@@ -147,6 +147,51 @@ void main() {
         orderedEquals(['ebook', 'audiobook']));
   });
 
+  testWidgets('a requester can download each exact available book format',
+      (tester) async {
+    final (:router, container: _) = await _pumpRouter(
+      tester,
+      authState: _downloadBooksState,
+      adapter: _BooksAdapter(bookFiles: true),
+    );
+
+    router.go('/detail/book/29749107?title=Ahsoka');
+    await tester.pumpAndSettle();
+
+    await tester.scrollUntilVisible(
+      find.byTooltip('Download eBook'),
+      250,
+      scrollable: _detailScrollable(),
+    );
+    expect(find.byTooltip('Download eBook'), findsOneWidget);
+    expect(find.byTooltip('Download audiobook'), findsOneWidget);
+    expect(find.textContaining('/library/'), findsNothing);
+    expect(find.textContaining(r'Z:\'), findsNothing);
+  });
+
+  testWidgets('admin Chaptarr detail has the same per-format downloads',
+      (tester) async {
+    final (:router, container: _) = await _pumpRouter(
+      tester,
+      authState: _adminDownloadBooksState,
+      adapter: _BooksAdapter(bookFiles: true),
+    );
+
+    router.go('/detail/book/29749107?title=Ahsoka');
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.text('Manage book'),
+      250,
+      scrollable: _detailScrollable(),
+    );
+    await tester.tap(find.text('Manage book'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ChaptarrBookScreen), findsOneWidget);
+    expect(find.byTooltip('Download eBook'), findsOneWidget);
+    expect(find.byTooltip('Download Audiobook'), findsOneWidget);
+  });
+
   testWidgets('an absolute owned cover origin is never sent to the client',
       (tester) async {
     final (:router, container: _) = await _pumpRouter(
@@ -269,6 +314,42 @@ const _adminBooksState = AuthState(
   user: UserProfile(id: 1, username: 'admin', role: 'admin'),
 );
 
+const _downloadBooksState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(chaptarr: true, mediaDownloads: true),
+    instances: [
+      ServiceInstance(
+        id: 'books',
+        serviceType: 'chaptarr',
+        name: 'Books',
+        isDefault: true,
+      ),
+    ],
+  ),
+  user: UserProfile(id: 1, username: 'tester', role: 'user'),
+);
+
+const _adminDownloadBooksState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(chaptarr: true, mediaDownloads: true),
+    instances: [
+      ServiceInstance(
+        id: 'books',
+        serviceType: 'chaptarr',
+        name: 'Books',
+        isDefault: true,
+      ),
+    ],
+  ),
+  user: UserProfile(id: 1, username: 'admin', role: 'admin'),
+);
+
 Future<({ProviderContainer container, GoRouter router})> _pumpRouter(
   WidgetTester tester, {
   AuthState authState = _booksState,
@@ -329,6 +410,7 @@ class _BooksAdapter implements HttpClientAdapter {
   final bool mismatchedLookupId;
   final bool mismatchedLookupAuthor;
   final bool partiallyUnknownStatus;
+  final bool bookFiles;
   final libraryInstanceIds = <String>[];
   final statusInstanceIds = <String>[];
 
@@ -338,6 +420,7 @@ class _BooksAdapter implements HttpClientAdapter {
     this.mismatchedLookupId = false,
     this.mismatchedLookupAuthor = false,
     this.partiallyUnknownStatus = false,
+    this.bookFiles = false,
   });
 
   @override
@@ -430,13 +513,32 @@ class _BooksAdapter implements HttpClientAdapter {
           },
         },
       ];
+    } else if (options.path.endsWith('/api/v1/book/42')) {
+      body = _liveBook(id: 42, mediaType: 'ebook');
+    } else if (options.path.endsWith('/api/v1/book/43')) {
+      body = _liveBook(id: 43, mediaType: 'audiobook');
     } else if (options.path.endsWith('/api/v1/book')) {
       body = [
         _liveBook(id: 42, mediaType: 'ebook'),
         _liveBook(id: 43, mediaType: 'audiobook'),
       ];
     } else if (options.path.endsWith('/api/v1/bookfile')) {
-      body = <Object>[];
+      final bookId = options.queryParameters['bookId'] as int?;
+      body = bookFiles && (bookId == 42 || bookId == 43)
+          ? [
+              {
+                'id': bookId! + 100,
+                'bookId': bookId,
+                'path': bookId == 42
+                    ? '/library/E. K. Johnston/Ahsoka.epub'
+                    : r'Z:\Audiobooks\E. K. Johnston\Ahsoka.m4b',
+                'size': bookId == 42 ? 4200000 : 420000000,
+                'quality': {
+                  'quality': {'name': bookId == 42 ? 'EPUB' : 'M4B'},
+                },
+              },
+            ]
+          : <Object>[];
     } else if (options.path == '/api/trakt/anticipated') {
       body = <Object>[];
     } else {

--- a/app/test/media_detail/media_detail_arr_link_test.dart
+++ b/app/test/media_detail/media_detail_arr_link_test.dart
@@ -23,6 +23,10 @@ void main() {
     WidgetTester tester, {
     required bool isAdmin,
     required List<Map<String, dynamic>> radarrMovies,
+    bool mediaDownloads = false,
+    MediaType mediaType = MediaType.movie,
+    List<Map<String, dynamic>> sonarrSeries = const [],
+    List<Map<String, dynamic>> sonarrEpisodes = const [],
   }) async {
     tester.view.physicalSize = const Size(390, 844);
     tester.view.devicePixelRatio = 1;
@@ -32,7 +36,7 @@ void main() {
     });
 
     final router = GoRouter(
-      initialLocation: '/detail/movie/$_tmdbId',
+      initialLocation: '/detail/${mediaType.name}/$_tmdbId',
       routes: [
         GoRoute(
           path: '/detail/:type/:id',
@@ -49,8 +53,16 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [
-          authProvider.overrideWith(() => _FakeAuthNotifier(_state(isAdmin))),
-          backendClientProvider.overrideWithValue(_fakeDio(radarrMovies)),
+          authProvider.overrideWith(
+            () => _FakeAuthNotifier(
+              _state(isAdmin, mediaDownloads, mediaType),
+            ),
+          ),
+          backendClientProvider.overrideWithValue(_fakeDio(
+            radarrMovies,
+            sonarrSeries: sonarrSeries,
+            sonarrEpisodes: sonarrEpisodes,
+          )),
           realtimeEventsProvider.overrideWithValue(const Stream<WsEvent>.empty()),
         ],
         child: MaterialApp.router(routerConfig: router),
@@ -98,21 +110,114 @@ void main() {
 
     expect(find.text('Open in Radarr'), findsNothing);
   });
+
+  testWidgets('non-admin can download an exact live movie file when enabled',
+      (tester) async {
+    await pumpDetail(
+      tester,
+      isAdmin: false,
+      mediaDownloads: true,
+      radarrMovies: [
+        {
+          'id': 5,
+          'title': 'The Matrix',
+          'year': 1999,
+          'tmdbId': _tmdbId,
+          'hasFile': true,
+          'movieFile': {
+            'id': 42,
+            'relativePath': 'The Matrix.mkv',
+            'size': 100,
+          },
+        },
+      ],
+    );
+
+    expect(find.text('Download movie'), findsOneWidget);
+    expect(find.text('Open in Radarr'), findsNothing);
+  });
+
+  testWidgets('TV download opens individual exact episode choices',
+      (tester) async {
+    await pumpDetail(
+      tester,
+      isAdmin: false,
+      mediaDownloads: true,
+      mediaType: MediaType.tv,
+      radarrMovies: const [],
+      sonarrSeries: const [
+        {'id': 7, 'title': 'The Show', 'tvdbId': 81189},
+      ],
+      sonarrEpisodes: const [
+        {
+          'id': 71,
+          'seriesId': 7,
+          'seasonNumber': 1,
+          'episodeNumber': 1,
+          'title': 'Pilot',
+          'hasFile': true,
+          'episodeFileId': 101,
+          'episodeFile': {
+            'id': 101,
+            'seriesId': 7,
+            'seasonNumber': 1,
+            'size': 100,
+          },
+        },
+        {
+          'id': 72,
+          'seriesId': 7,
+          'seasonNumber': 1,
+          'episodeNumber': 2,
+          'title': 'Second',
+          'hasFile': true,
+          'episodeFileId': 102,
+          'episodeFile': {
+            'id': 102,
+            'seriesId': 7,
+            'seasonNumber': 1,
+            'size': 200,
+          },
+        },
+      ],
+    );
+
+    expect(find.byTooltip('Download Season 1 episodes'), findsOneWidget);
+    await tester.tap(find.byTooltip('Download Season 1 episodes'));
+    await tester.pumpAndSettle();
+    expect(find.text('S01E01 · Pilot'), findsOneWidget);
+    expect(find.text('S01E02 · Second'), findsOneWidget);
+  });
 }
 
-AuthState _state(bool isAdmin) => AuthState(
-      connection: const BackendConnection(
+AuthState _state(
+  bool isAdmin,
+  bool mediaDownloads,
+  MediaType mediaType,
+) =>
+    AuthState(
+      connection: BackendConnection(
         serverUrl: 'http://localhost',
         accessToken: 'access',
         refreshToken: 'refresh',
-        instances: [
-          ServiceInstance(
-            id: 'radarr-main',
-            serviceType: 'radarr',
-            name: 'Main Radarr',
-            isDefault: true,
-          ),
-        ],
+        services: AvailableServices(mediaDownloads: mediaDownloads),
+        instances: mediaType == MediaType.movie
+            ? const [
+                ServiceInstance(
+                  id: 'radarr-main',
+                  serviceType: 'radarr',
+                  name: 'Main Radarr',
+                  isDefault: true,
+                ),
+              ]
+            : const [
+                ServiceInstance(
+                  id: 'sonarr-main',
+                  serviceType: 'sonarr',
+                  name: 'Main Sonarr',
+                  isDefault: true,
+                ),
+              ],
       ),
       user: UserProfile(
         id: 1,
@@ -130,9 +235,17 @@ class _FakeAuthNotifier extends AuthNotifier {
   Future<AuthState> build() async => authState;
 }
 
-Dio _fakeDio(List<Map<String, dynamic>> radarrMovies) {
+Dio _fakeDio(
+  List<Map<String, dynamic>> radarrMovies, {
+  List<Map<String, dynamic>> sonarrSeries = const [],
+  List<Map<String, dynamic>> sonarrEpisodes = const [],
+}) {
   final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
-  dio.httpClientAdapter = _JsonAdapter(radarrMovies);
+  dio.httpClientAdapter = _JsonAdapter(
+    radarrMovies,
+    sonarrSeries: sonarrSeries,
+    sonarrEpisodes: sonarrEpisodes,
+  );
   return dio;
 }
 
@@ -140,8 +253,14 @@ Dio _fakeDio(List<Map<String, dynamic>> radarrMovies) {
 /// the Radarr library listing the "Open in Radarr" resolution depends on.
 class _JsonAdapter implements HttpClientAdapter {
   final List<Map<String, dynamic>> radarrMovies;
+  final List<Map<String, dynamic>> sonarrSeries;
+  final List<Map<String, dynamic>> sonarrEpisodes;
 
-  _JsonAdapter(this.radarrMovies);
+  _JsonAdapter(
+    this.radarrMovies, {
+    this.sonarrSeries = const [],
+    this.sonarrEpisodes = const [],
+  });
 
   @override
   Future<ResponseBody> fetch(
@@ -151,12 +270,34 @@ class _JsonAdapter implements HttpClientAdapter {
   ) async {
     final path = options.path;
     final Object body;
-    if (path.contains('/api/v3/movie')) {
+    if (path.endsWith('/api/v3/series')) {
+      body = sonarrSeries;
+    } else if (path.endsWith('/api/v3/episode')) {
+      body = sonarrEpisodes;
+    } else if (path.contains('/api/v3/movie/')) {
+      body = radarrMovies.firstWhere(
+        (movie) => path.endsWith('/${movie['id']}'),
+      );
+    } else if (path.contains('/api/v3/movie')) {
       body = radarrMovies; // Radarr library listing.
     } else if (path.endsWith('/recommendations') || path.endsWith('/similar')) {
       body = {'results': <dynamic>[]};
     } else if (path.endsWith('/status')) {
       body = {'status': 'unavailable', 'seasons': <dynamic>[]};
+    } else if (path.contains('/api/media/tv/')) {
+      body = {
+        'id': _tmdbId,
+        'name': 'The Show',
+        'external_ids': {'tvdb_id': 81189},
+        'seasons': [
+          {
+            'id': 7001,
+            'season_number': 1,
+            'name': 'Season 1',
+            'episode_count': 2,
+          },
+        ],
+      };
     } else if (path.contains('/api/media/movie/')) {
       body = {'id': _tmdbId, 'title': 'The Matrix'};
     } else {

--- a/app/test/media_download/media_download_button_test.dart
+++ b/app/test/media_download/media_download_button_test.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+
+import 'package:cantinarr/features/media_download/data/media_download_models.dart';
+import 'package:cantinarr/features/media_download/data/media_download_service.dart';
+import 'package:cantinarr/features/media_download/ui/media_download_button.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('requests one ticket and launches the returned URL',
+      (tester) async {
+    final service = _FakeService();
+    final launched = <Uri>[];
+    await _pumpButton(
+      tester,
+      service: service,
+      launcher: (uri) async {
+        launched.add(uri);
+        return true;
+      },
+    );
+
+    await tester.tap(find.text('Download movie'));
+    await tester.pumpAndSettle();
+
+    expect(service.calls, 1);
+    expect(service.instanceId, 'radarr-main');
+    expect(service.fileId, 42);
+    expect(launched, [Uri.parse('https://cantinarr.example/download/token')]);
+  });
+
+  testWidgets('suppresses a second tap while ticket creation is pending',
+      (tester) async {
+    final completer = Completer<MediaDownloadTicket>();
+    final service = _FakeService(pending: completer.future);
+    await _pumpButton(
+      tester,
+      service: service,
+      launcher: (_) async => true,
+    );
+
+    await tester.tap(find.text('Download movie'));
+    await tester.pump();
+    await tester.tap(find.byType(TextButton));
+    await tester.pump();
+
+    expect(service.calls, 1);
+    completer.complete(_ticket);
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('multiple files require an individual choice', (tester) async {
+    final service = _FakeService();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          mediaDownloadServiceProvider.overrideWithValue(service),
+          mediaDownloadLauncherProvider.overrideWithValue((_) async => true),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: MediaDownloadChoiceButton(
+              instanceId: 'sonarr-main',
+              label: 'Download Season 1 episodes',
+              sheetTitle: 'Download Season 1',
+              choices: [
+                MediaDownloadChoice(fileId: 11, label: 'S01E01 · Pilot'),
+                MediaDownloadChoice(fileId: 12, label: 'S01E02 · Next'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Download Season 1 episodes'));
+    await tester.pumpAndSettle();
+
+    expect(service.calls, 0);
+    expect(find.text('S01E01 · Pilot'), findsOneWidget);
+    expect(find.text('S01E02 · Next'), findsOneWidget);
+    expect(find.byTooltip('Download S01E01 · Pilot'), findsOneWidget);
+    expect(find.byTooltip('Download S01E02 · Next'), findsOneWidget);
+  });
+}
+
+final _ticket = MediaDownloadTicket(
+  url: Uri.parse('https://cantinarr.example/download/token'),
+  filename: 'Movie.mkv',
+  sizeBytes: 100,
+  expiresAt: DateTime.utc(2026, 7, 22, 18),
+);
+
+Future<void> _pumpButton(
+  WidgetTester tester, {
+  required _FakeService service,
+  required MediaDownloadLauncher launcher,
+}) =>
+    tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          mediaDownloadServiceProvider.overrideWithValue(service),
+          mediaDownloadLauncherProvider.overrideWithValue(launcher),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: MediaDownloadButton(
+              instanceId: 'radarr-main',
+              fileId: 42,
+              label: 'Download movie',
+            ),
+          ),
+        ),
+      ),
+    );
+
+class _FakeService extends MediaDownloadService {
+  final Future<MediaDownloadTicket>? pending;
+  int calls = 0;
+  String? instanceId;
+  int? fileId;
+
+  _FakeService({this.pending}) : super(backendDio: Dio());
+
+  @override
+  Future<MediaDownloadTicket> createTicket({
+    required String instanceId,
+    required int fileId,
+  }) {
+    calls++;
+    this.instanceId = instanceId;
+    this.fileId = fileId;
+    return pending ?? Future.value(_ticket);
+  }
+}

--- a/app/test/media_download/media_download_service_test.dart
+++ b/app/test/media_download/media_download_service_test.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/features/media_download/data/media_download_models.dart';
+import 'package:cantinarr/features/media_download/data/media_download_service.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('creates a ticket and resolves its relative same-origin URL', () async {
+    final adapter = _TicketAdapter(response: {
+      'url': '/api/media-files/download/one-time-token',
+      'filename': 'Movie.mkv',
+      'size_bytes': 1234,
+      'expires_at': '2026-07-22T18:00:00Z',
+    });
+    final service = MediaDownloadService(backendDio: _dio(adapter));
+
+    final ticket = await service.createTicket(
+      instanceId: 'radarr-main',
+      fileId: 42,
+    );
+
+    expect(adapter.method, 'POST');
+    expect(adapter.path, '/api/media-files/tickets');
+    expect(adapter.data, {
+      'instance_id': 'radarr-main',
+      'file_id': 42,
+    });
+    expect(
+      ticket.url,
+      Uri.parse(
+        'https://cantinarr.example/api/media-files/download/one-time-token',
+      ),
+    );
+    expect(ticket.filename, 'Movie.mkv');
+    expect(ticket.sizeBytes, 1234);
+    expect(ticket.expiresAt, DateTime.utc(2026, 7, 22, 18));
+  });
+
+  test('accepts an absolute URL only when it has the backend origin', () async {
+    final service = MediaDownloadService(
+      backendDio: _dio(_TicketAdapter(response: {
+        'url': 'https://cantinarr.example:443/download/token',
+        'filename': 'Episode.mkv',
+        'size_bytes': 20,
+        'expires_at': '2026-07-22T18:00:00Z',
+      })),
+    );
+
+    final ticket = await service.createTicket(
+      instanceId: 'sonarr-main',
+      fileId: 9,
+    );
+
+    expect(ticket.url.host, 'cantinarr.example');
+    expect(ticket.url.path, '/download/token');
+  });
+
+  test('rejects a cross-origin ticket URL', () async {
+    final service = MediaDownloadService(
+      backendDio: _dio(_TicketAdapter(response: {
+        'url': 'https://files.example/secret',
+        'filename': 'Book.epub',
+        'size_bytes': 20,
+        'expires_at': '2026-07-22T18:00:00Z',
+      })),
+    );
+
+    expect(
+      () => service.createTicket(instanceId: 'books', fileId: 3),
+      throwsA(
+        isA<MediaDownloadException>().having(
+          (error) => error.message,
+          'message',
+          'Could not prepare the download. Try again.',
+        ),
+      ),
+    );
+  });
+
+  test('maps missing and expired files to a concise safe error', () async {
+    final service = MediaDownloadService(
+      backendDio: _dio(_TicketAdapter(response: const {}, statusCode: 410)),
+    );
+
+    expect(
+      () => service.createTicket(instanceId: 'books', fileId: 3),
+      throwsA(
+        isA<MediaDownloadException>().having(
+          (error) => error.message,
+          'message',
+          'This file is no longer available.',
+        ),
+      ),
+    );
+  });
+}
+
+Dio _dio(HttpClientAdapter adapter) => Dio(
+      BaseOptions(baseUrl: 'https://cantinarr.example'),
+    )..httpClientAdapter = adapter;
+
+class _TicketAdapter implements HttpClientAdapter {
+  final Map<String, dynamic> response;
+  final int statusCode;
+  String? method;
+  String? path;
+  dynamic data;
+
+  _TicketAdapter({required this.response, this.statusCode = 200});
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    method = options.method;
+    path = options.path;
+    data = options.data;
+    return ResponseBody.fromString(
+      jsonEncode(response),
+      statusCode,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
       - "8585:8585"
     volumes:
       - ./config:/config
+      # Optional completed-media downloads. Mount each library read-only at
+      # the same absolute path its arr reports, then list those container paths
+      # in CANTINARR_MEDIA_ROOTS below. Example:
+      # - /mnt/nas/media:/data/media:ro
     environment:
       # Self-hosted push gateway (https://push.julian.codes). Setting the URL
       # ENABLES push: with no API key, the server auto-enrolls on first start and
@@ -17,4 +21,7 @@ services:
       - CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
       - CANTINARR_PUSH_API_KEY=${CANTINARR_PUSH_API_KEY:-}
       - CANTINARR_PUSH_ENROLL_TOKEN=${CANTINARR_PUSH_ENROLL_TOKEN:-}
+      # Comma-separated, absolute container paths. Empty keeps completed-media
+      # downloads disabled.
+      - CANTINARR_MEDIA_ROOTS=${CANTINARR_MEDIA_ROOTS:-}
     restart: unless-stopped

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -29,9 +29,9 @@ such as **AUTO** are informational hints, not machine-enforced claims.
 | [Instances, realtime behavior, and push](catalog/instances-realtime-push.md) | INST, RT, PUSH | 8 |
 | [Plex linking, libraries, and invitations](catalog/plex.md) | PLEX | 18 |
 | [Discovery and requests](catalog/discovery-requests.md) | DISC, REQ | 6 |
-| [Media services and download clients](catalog/media-services.md) | RAD, SON, BOOK, DOWN, TAUT | 10 |
+| [Media services and download clients](catalog/media-services.md) | RAD, SON, BOOK, FILE, DOWN, TAUT | 11 |
 | [Issues, AI, and MCP](catalog/issues-ai-mcp.md) | ISS, AI, MCP | 10 |
-| **Total** | | **91** |
+| **Total** | | **92** |
 
 Case IDs are stable and never renumbered, so deleted cases leave gaps in the
 sequences; a gap means the behavior moved into the automated suites, not that

--- a/docs/testing/catalog/media-services.md
+++ b/docs/testing/catalog/media-services.md
@@ -19,6 +19,10 @@ Use the [run template](../run-template.md) to record executions of these cases.
 - [ ] `BOOK-003` · P0 · UI/LIVE — From the selected Chaptarr instance, request both formats; verify exactly one ebook record and one audiobook record share the foreignBookId/group as one logical title, each moves Requested → Downloading → Available independently, returning from Chaptarr refreshes immediately, and repeating or approving concurrently cannot create a duplicate same-format record in that or another instance.
 - [ ] `BOOK-014` · P0 · LIVE — Run supported Import Doctor classifications/fixes for Chaptarr, including exact queue/manual-import scope; verify no title-level mutation occurs without a durable book ID.
 
+## Completed media files
+
+- [ ] `FILE-001` · P1 · UI/LIVE — With exact-path read-only library mounts and `CANTINARR_MEDIA_ROOTS` configured, download an ebook, one file from a multi-file audiobook, a movie, and an episode from their live detail surfaces. Verify names and bytes match the arr records, a movie/episode transfer can resume with HTTP Range, each requester is limited to their effective or granted instance, and every download action disappears when the roots setting is removed.
+
 ## Download clients and unified downloads
 
 Run client-specific cases once for **each** of SABnzbd, qBittorrent, NZBGet, and Transmission; do not accept one client as proof for the other adapters.

--- a/server/.env.example
+++ b/server/.env.example
@@ -15,3 +15,7 @@ CANTINARR_JWT_SECRET=
 CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
 CANTINARR_PUSH_API_KEY=
 CANTINARR_PUSH_ENROLL_TOKEN=
+
+# Optional completed-media downloads. Every comma-separated root must be an
+# absolute, readable directory matching the paths reported by the arrs.
+CANTINARR_MEDIA_ROOTS=

--- a/server/README.md
+++ b/server/README.md
@@ -27,6 +27,7 @@ A single Go binary that bridges your arr stack, serves the web UI, and keeps API
 
 - **One-tap requests with an approval queue** -- Users browse and tap request; the server handles ID bridging, arr lookups, quality profiles, and root folders. Admins can require approval globally or per user, and per user allow season-level choice, quality choice, and per-service default quality profiles.
 - **Books via Chaptarr** -- A Readarr-API (v1) books module with per-format (ebook/audiobook) monitoring, requesting, and library awareness. Chaptarr access is granted per user by an admin.
+- **Completed-media downloads** -- Opt-in delivery of ebook, audiobook, movie, and episode files from exact read-only library mounts. The server accepts only live arr file IDs, confines every open to explicit roots, and streams through short-lived file-scoped links with HEAD and Range support.
 - **Automatic ID bridging** -- Transparently translates TMDB IDs to TVDB IDs for Sonarr. Falls back to Trakt cross-references, then title+year search. Results cached in SQLite for 30 days.
 - **Availability computed live** -- Request status is derived from the arrs' real episode/file state (never from a stale snapshot or monitored-only stats), refreshed by queue polling and instant arr webhooks.
 - **Connect link auth, passwordless by default** -- Admins generate connect links; redeeming one starts a permanent device session (an opaque refresh token validated against the DB -- never expires, never rotates, independent of the JWT secret) that mints 15-minute access JWTs. Sessions end only by device revocation or user deletion. Passwords and passkeys (WebAuthn, incl. native iOS/Android/Windows) are admin-gated per user.
@@ -92,6 +93,7 @@ Optional env vars for deployment tuning (a `.env` file next to the binary is aut
 | `CANTINARR_AI_MODEL` | provider default | Fallback model for the included server AI profile when none is saved in the admin UI |
 | `CANTINARR_CODEX_BIN` | auto-discovered | Optional path to `codex-app-server` or the full `codex` CLI; official container images bundle the tested 0.144.3 app-server at `/usr/local/bin/codex-app-server` |
 | `CANTINARR_CODEX_RUNTIME_DIR` | `/dev/shm/cantinarr-codex` | Absolute Linux tmpfs/ramfs directory used for server-owned, ephemeral per-session Codex state; if it already exists, it must be owned by the server user with mode `0700` |
+| `CANTINARR_MEDIA_ROOTS` | unset | Comma-separated absolute container paths from which completed arr media may be served. Empty disables downloads. Mount each library read-only at the same absolute path its arr reports; `/` and aliases of `/` are refused |
 | `CANTINARR_PUSH_GATEWAY_URL` | unset | Push gateway origin; setting it **enables** push notifications |
 | `CANTINARR_PUSH_API_KEY` | unset | Optional pinned gateway key -- leave blank and the server auto-enrolls on first start, persisting its issued key encrypted in the DB |
 | `CANTINARR_PUSH_ENROLL_TOKEN` | unset | Shared enroll token, only for gateways with gated enrollment |
@@ -292,6 +294,17 @@ ANY    /api/instances/{instanceID}/*         # proxy to the instance's own API; 
 The proxy allows read-only Radarr/Sonarr browsing (library, queue, history, wanted, calendar) for regular users; writes, commands, interactive search, config, and all non-arr services require admin. Requesters are bound to their own effective instance -- their pin, or the deterministic global default/fallback -- exactly as `/api/config` reports it; a sibling instance the admin has hidden cannot be reached by guessing its ID, and instance authorization is classified from stored metadata so an undecryptable secret can never widen access. JSON responses are bounded and recursively scrubbed for credential fields and secret-bearing URL query parameters before they reach any client. An encoded, malformed, streaming, or oversized JSON response fails closed rather than bypassing that scrubber.
 
 The proxy is also a transport trust boundary. `CONNECT`, `TRACE`, and `TRACK` are rejected before instance resolution or any upstream contact, and an upstream protocol upgrade (`101`) is refused, so the HTTP proxy can never become an opaque tunnel or reflect the injected `X-Api-Key`. Inbound Cantinarr session cookies and every forwarded credential, client-identity assertion (reverse-proxy `X-Auth-*`/`Remote-*`/mTLS headers), routing/method-override, and request-trailer header terminate here; only the instance's own `X-Api-Key` is added outbound. Upstream responses are marked private and non-cacheable, and nginx/lighttpd internal-redirect controls (`X-Accel-*`, `X-Sendfile`, `X-Reproxy-URL`) plus response trailers are stripped so a fronting web server cannot be steered by an upstream header.
+
+### Completed media downloads (user)
+
+```
+POST     /api/media-files/tickets                    # authenticated: { instance_id, file_id }
+GET|HEAD /api/media-files/download/{ticket}          # public bearer capability until expires_at
+```
+
+Ticket issuance requires `media:download`, re-checks the caller's current account role, and limits requesters to their effective Radarr/Sonarr instance or explicitly granted Chaptarr instance. Administrators may select any configured arr instance. The client supplies only an instance ID and live arr file ID; it never supplies a path. Cantinarr re-fetches that exact file record from Radarr (`moviefile`), Sonarr (`episodefile`), or Chaptarr (`bookfile`) both when issuing the ticket and for every transfer.
+
+Bytes are available only when `CANTINARR_MEDIA_ROOTS` contains an exact read-only mount matching the path the arr reports. Files outside those roots, directory entries, and symlink escapes are refused. Tickets are opaque, bounded, reusable for ten minutes so browser HEAD probes and resumed Range requests work, and contain neither JWTs nor server paths. Every GET/HEAD re-checks that the user still exists, uses the user's current role, and re-checks effective-instance access for non-admins. Responses are attachment-only `application/octet-stream` with no-store, no-referrer, nosniff, same-origin resource policy, and sandbox CSP headers; errors never expose arr hosts, filesystem paths, or OS details. `/api/config.services.media_downloads` reports whether roots are configured without returning the roots themselves.
 
 ### Downloads & monitoring (admin)
 ```
@@ -534,6 +547,7 @@ server/
 │   ├── instance/             # Instance registry, defaults invariant, per-user pins, safe webhook rotation
 │   ├── mcp/                  # 33 registered tools, toggles, tool server (31 also exposed through external MCP)
 │   ├── mcpserver/            # MCP Streamable HTTP endpoint, prompts, agent guide (mcp-go)
+│   ├── mediafiles/           # Ticketed, root-confined completed-media streaming
 │   ├── nzbget/               # NZBGet JSON-RPC client
 │   ├── plex/                 # plex.tv PIN link + shared_servers invites (one-tap & auto)
 │   ├── proxy/                # Credential-scrubbing arr reverse proxy (read-only for users)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/downloads"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/mcp"
+	"github.com/windoze95/cantinarr-server/internal/mediafiles"
 	"github.com/windoze95/cantinarr-server/internal/plex"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/push"
@@ -107,6 +108,15 @@ func main() {
 	instanceStore := instance.NewStore(database, cipher)
 	registry := instance.NewRegistry(instanceStore)
 	instanceHandler := instance.NewHandler(instanceStore, registry, cfg.PublicURL)
+	mediaFilesHandler, err := mediafiles.NewHandler(instanceStore, registry, authService, cfg.MediaDownloadRoots)
+	if err != nil {
+		log.Fatalf("Failed to initialize media downloads: %v", err)
+	}
+	defer func() {
+		if err := mediaFilesHandler.Close(); err != nil {
+			log.Printf("Failed to close media download roots: %v", err)
+		}
+	}()
 
 	// Downloads handler (SABnzbd / qBittorrent / NZBGet / Transmission queue management)
 	downloadsHandler := downloads.NewHandler(instanceStore, registry)
@@ -262,7 +272,7 @@ func main() {
 	serverSettings := serversettings.NewService(database)
 
 	// Router
-	router := api.NewRouter(cfg, authHandler, authService, requestHandler, remediationService, remediationHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler, webhookHandler, plexHandler, plexService, updateChecker, serverSettings)
+	router := api.NewRouter(cfg, authHandler, authService, requestHandler, remediationService, remediationHandler, proxyHandler, wsHub, aiHandler, discoverHandler, instanceHandler, instanceStore, downloadsHandler, mediaFilesHandler, tautulliHandler, creds, credHandler, toolServer, pushHandler, webhookHandler, plexHandler, plexService, updateChecker, serverSettings)
 
 	addr := fmt.Sprintf(":%d", cfg.Port)
 	log.Printf("Cantinarr server starting on %s", addr)

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -6,3 +6,11 @@ services:
       - "8585:8585"
     volumes:
       - ./config:/config
+      # Optional completed-media downloads. Mount each library read-only at
+      # the same absolute path its arr reports, then list those container paths
+      # in CANTINARR_MEDIA_ROOTS below. Example:
+      # - /mnt/nas/media:/data/media:ro
+    environment:
+      # Comma-separated, absolute container paths. Empty keeps completed-media
+      # downloads disabled.
+      - CANTINARR_MEDIA_ROOTS=${CANTINARR_MEDIA_ROOTS:-}

--- a/server/internal/api/rbac_integration_test.go
+++ b/server/internal/api/rbac_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/downloads"
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/mcp"
+	"github.com/windoze95/cantinarr-server/internal/mediafiles"
 	"github.com/windoze95/cantinarr-server/internal/plex"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/push"
@@ -110,6 +111,49 @@ func TestRouterRBACMatrixWithAdminAndRequesterTokens(t *testing.T) {
 			if recorder.Code != route.want {
 				t.Errorf("%s %s status = %d, want %d; body=%s", route.method, route.path, recorder.Code, route.want, recorder.Body.String())
 			}
+		}
+	}
+}
+
+func TestMediaFileRouterTicketAuthAndPublicDownloadRoutes(t *testing.T) {
+	harness := newRBACRouterHarness(t, false)
+
+	anonymousIssue := serveRBACRequestWithBody(
+		harness.router,
+		http.MethodPost,
+		"/api/media-files/tickets",
+		"",
+		`{"instance_id":"radarr-main","file_id":1}`,
+	)
+	if anonymousIssue.Code != http.StatusUnauthorized {
+		t.Fatalf("anonymous ticket status = %d, body = %s", anonymousIssue.Code, anonymousIssue.Body.String())
+	}
+
+	// A normal requester owns media:download and passes both middleware layers;
+	// the empty-root handler's 503 proves the request reached the feature rather
+	// than being rejected by role middleware.
+	requesterIssue := serveRBACRequestWithBody(
+		harness.router,
+		http.MethodPost,
+		"/api/media-files/tickets",
+		harness.requesterToken,
+		`{"instance_id":"radarr-main","file_id":1}`,
+	)
+	if requesterIssue.Code != http.StatusServiceUnavailable {
+		t.Fatalf("requester ticket status = %d, body = %s", requesterIssue.Code, requesterIssue.Body.String())
+	}
+
+	invalidCapability := strings.Repeat("A", 43)
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		response := serveRBACRequest(harness.router, method, "/api/media-files/download/"+invalidCapability, "")
+		if response.Code != http.StatusNotFound {
+			t.Errorf("public %s status = %d, body = %s", method, response.Code, response.Body.String())
+		}
+		if method == http.MethodHead && response.Body.Len() != 0 {
+			t.Errorf("public HEAD body = %q", response.Body.String())
+		}
+		if got := response.Header().Get("Cache-Control"); got != "private, no-store" {
+			t.Errorf("public %s Cache-Control = %q", method, got)
 		}
 	}
 }
@@ -406,6 +450,15 @@ func newRBACRouterHarness(t *testing.T, withCodex bool) *rbacRouterHarness {
 	credentialHandler.SetSharedAIValidator(aiHandler.ValidateSharedAISettings, aiHandler.SharedAISettingsValidated)
 	instanceHandler := instance.NewHandler(store, instanceRegistry, "http://cantinarr.test")
 	downloadsHandler := downloads.NewHandler(store, instanceRegistry)
+	mediaFilesHandler, err := mediafiles.NewHandler(store, instanceRegistry, authService, nil)
+	if err != nil {
+		t.Fatalf("create media files handler: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := mediaFilesHandler.Close(); err != nil {
+			t.Errorf("close media files handler: %v", err)
+		}
+	})
 	tautulliHandler := tautulli.NewHandler(store, instanceRegistry)
 	proxyHandler := proxy.NewHandler(store)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -439,6 +492,7 @@ func newRBACRouterHarness(t *testing.T, withCodex bool) *rbacRouterHarness {
 		instanceHandler,
 		store,
 		downloadsHandler,
+		mediaFilesHandler,
 		tautulliHandler,
 		registry,
 		credentialHandler,

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -17,6 +17,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/mcp"
 	"github.com/windoze95/cantinarr-server/internal/mcpserver"
+	"github.com/windoze95/cantinarr-server/internal/mediafiles"
 	"github.com/windoze95/cantinarr-server/internal/plex"
 	"github.com/windoze95/cantinarr-server/internal/proxy"
 	"github.com/windoze95/cantinarr-server/internal/push"
@@ -45,6 +46,7 @@ func NewRouter(
 	instanceHandler *instance.Handler,
 	instanceStore *instance.Store,
 	downloadsHandler *downloads.Handler,
+	mediaFilesHandler *mediafiles.Handler,
 	tautulliHandler *tautulli.Handler,
 	creds *credentials.Registry,
 	credHandler *credentials.Handler,
@@ -98,6 +100,13 @@ func NewRouter(
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 		})
+
+		// Media bytes use a short-lived opaque capability in the path so browser
+		// downloads and Range resumes need not expose the session JWT. Ticket
+		// issuance below is authenticated; an unknown or expired capability is a
+		// generic 404. HEAD is explicit because browsers commonly probe first.
+		r.Get("/media-files/download/{ticket}", mediaFilesHandler.Download)
+		r.Head("/media-files/download/{ticket}", mediaFilesHandler.Download)
 
 		// Arr webhook receiver (Sonarr/Radarr → Connect → Webhook). No session:
 		// the server-only per-instance credential is supplied through Basic Auth;
@@ -241,6 +250,14 @@ func NewRouter(
 			r.Use(authService.AuthMiddleware)
 			r.Get("/config", configHandler(cfg, instanceStore, creds, aiHandler, remediationService))
 		})
+
+		// Completed-media ticket issuance (authenticated requester/admin). The
+		// handler additionally enforces the requester's exact effective instance
+		// and accepts only a live arr file ID, never a client-supplied path.
+		r.With(
+			authService.AuthMiddleware,
+			auth.RequirePermission(auth.PermissionMediaDownload),
+		).Post("/media-files/tickets", mediaFilesHandler.IssueTicket)
 
 		// Device push-token + notification preference routes (authenticated).
 		// Any signed-in user may register/clear the APNs token for one of their
@@ -547,12 +564,13 @@ func configHandler(cfg *config.Config, store configInstanceStore, creds *credent
 			aiAvailable = aiHandler.AvailableForUser(userID)
 		}
 		services := map[string]bool{
-			"radarr":   false,
-			"sonarr":   false,
-			"chaptarr": false,
-			"ai":       aiAvailable,
-			"tmdb":     creds.IsConfigured(credentials.KeyTMDBAccessToken),
-			"trakt":    creds.IsConfigured(credentials.KeyTraktClientID),
+			"radarr":          false,
+			"sonarr":          false,
+			"chaptarr":        false,
+			"media_downloads": len(cfg.MediaDownloadRoots) > 0,
+			"ai":              aiAvailable,
+			"tmdb":            creds.IsConfigured(credentials.KeyTMDBAccessToken),
+			"trakt":           creds.IsConfigured(credentials.KeyTraktClientID),
 		}
 		for _, inst := range instances {
 			switch inst.ServiceType {

--- a/server/internal/api/router_test.go
+++ b/server/internal/api/router_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/windoze95/cantinarr-server/internal/auth"
@@ -220,6 +221,33 @@ func TestConfigHandlerFailsClosedWhenUserDefaultsUnavailable(t *testing.T) {
 	}
 }
 
+func TestConfigHandlerReportsMediaDownloadCapabilityWithoutExposingRoots(t *testing.T) {
+	store, creds, remediationSvc, userID := newConfigHandlerTestState(t)
+	rootSentinel := "/private/library/path-must-not-cross-api"
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{
+		UserID: userID,
+		Role:   auth.RoleUser,
+	}))
+	rec := httptest.NewRecorder()
+
+	configHandler(&config.Config{MediaDownloadRoots: []string{rootSentinel}}, store, creds, nil, remediationSvc)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var response configHandlerResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	if !response.Services["media_downloads"] {
+		t.Fatalf("services = %#v, want media_downloads capability", response.Services)
+	}
+	if strings.Contains(rec.Body.String(), rootSentinel) {
+		t.Fatalf("config exposed media root: %s", rec.Body.String())
+	}
+}
+
 // SEC-018: requester and admin config responses expose only effective, non-secret configuration.
 func TestConfigHandlerResponsesUseLeastPrivilegeSecretFreeShapes(t *testing.T) {
 	store, creds, remediationSvc, userID := newConfigHandlerTestState(t)
@@ -376,11 +404,14 @@ func TestConfigHandlerResponsesUseLeastPrivilegeSecretFreeShapes(t *testing.T) {
 			if err := json.Unmarshal(payload["services"], &services); err != nil {
 				t.Fatalf("decode services: %v", err)
 			}
-			assertExactMapKeys(t, services, "radarr", "sonarr", "chaptarr", "ai", "tmdb", "trakt")
+			assertExactMapKeys(t, services, "radarr", "sonarr", "chaptarr", "media_downloads", "ai", "tmdb", "trakt")
 			for _, serviceType := range []string{"radarr", "sonarr", "chaptarr", "ai", "tmdb", "trakt"} {
 				if !services[serviceType] {
 					t.Errorf("services[%q] = false, want true", serviceType)
 				}
+			}
+			if services["media_downloads"] {
+				t.Error("services[\"media_downloads\"] = true with no configured roots")
 			}
 
 			var gotInstances []map[string]json.RawMessage

--- a/server/internal/auth/permissions.go
+++ b/server/internal/auth/permissions.go
@@ -22,6 +22,7 @@ const (
 	PermissionAdmin             Permission = "admin:*"
 	PermissionMediaDiscover     Permission = "media:discover"
 	PermissionMediaRequest      Permission = "media:request"
+	PermissionMediaDownload     Permission = "media:download"
 	PermissionAIChat            Permission = "ai:chat"
 	PermissionMCPAccess         Permission = "mcp:access"
 	PermissionUsersManage       Permission = "users:manage"
@@ -46,6 +47,7 @@ var rolePermissions = map[string]map[Permission]bool{
 	RoleUser: {
 		PermissionMediaDiscover: true,
 		PermissionMediaRequest:  true,
+		PermissionMediaDownload: true,
 		PermissionAIChat:        true,
 		PermissionMCPAccess:     true,
 		// Read-only Radarr/Sonarr browsing through the app's REST instance
@@ -95,6 +97,7 @@ func allPermissions() map[Permission]bool {
 		PermissionAdmin:             true,
 		PermissionMediaDiscover:     true,
 		PermissionMediaRequest:      true,
+		PermissionMediaDownload:     true,
 		PermissionAIChat:            true,
 		PermissionMCPAccess:         true,
 		PermissionUsersManage:       true,

--- a/server/internal/auth/permissions_test.go
+++ b/server/internal/auth/permissions_test.go
@@ -31,6 +31,7 @@ func TestRolePermissionMatrixIsExact(t *testing.T) {
 		PermissionAdmin,
 		PermissionMediaDiscover,
 		PermissionMediaRequest,
+		PermissionMediaDownload,
 		PermissionAIChat,
 		PermissionMCPAccess,
 		PermissionUsersManage,
@@ -54,6 +55,7 @@ func TestRolePermissionMatrixIsExact(t *testing.T) {
 	userAllowed := map[Permission]bool{
 		PermissionMediaDiscover: true,
 		PermissionMediaRequest:  true,
+		PermissionMediaDownload: true,
 		PermissionAIChat:        true,
 		PermissionMCPAccess:     true,
 		PermissionArrBrowse:     true,

--- a/server/internal/chaptarr/client.go
+++ b/server/internal/chaptarr/client.go
@@ -722,6 +722,16 @@ func (c *Client) GetBookFiles(authorID int) ([]BookFile, error) {
 	return files, nil
 }
 
+// GetBookFile returns live metadata for one completed file in Chaptarr.
+func (c *Client) GetBookFile(id int) (*BookFile, error) {
+	var file BookFile
+	path := fmt.Sprintf("/api/v1/bookfile/%d", id)
+	if err := c.do(http.MethodGet, path, nil, &file); err != nil {
+		return nil, fmt.Errorf("chaptarr book file: %w", err)
+	}
+	return &file, nil
+}
+
 func (c *Client) GetQualityProfiles() ([]QualityProfile, error) {
 	resp, err := c.doRequest("GET", "/api/v1/qualityprofile")
 	if err != nil {

--- a/server/internal/chaptarr/client_test.go
+++ b/server/internal/chaptarr/client_test.go
@@ -16,6 +16,43 @@ type failingTransport struct{ err error }
 
 func (f failingTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, f.err }
 
+func TestGetBookFileUsesExactAuthenticatedEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v1/bookfile/55" || r.URL.RawQuery != "" {
+			t.Errorf("request = %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "book-key" {
+			t.Errorf("X-Api-Key = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"id":55,"authorId":3,"bookId":9,"editionId":12,"path":"/library/Book.epub","size":98765}`))
+	}))
+	t.Cleanup(server.Close)
+
+	file, err := NewClient(server.URL, "book-key").GetBookFile(55)
+	if err != nil {
+		t.Fatalf("GetBookFile() error = %v", err)
+	}
+	if file.ID != 55 || file.AuthorID != 3 || file.BookID != 9 || file.EditionID != 12 || file.Path != "/library/Book.epub" || file.Size != 98765 {
+		t.Fatalf("file = %#v", file)
+	}
+}
+
+func TestGetBookFileOmitsUpstreamErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`secret path /library/private and signed-token`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := NewClient(server.URL, "key").GetBookFile(55)
+	if err == nil {
+		t.Fatal("GetBookFile() error = nil")
+	}
+	if message := err.Error(); strings.Contains(message, "/library/private") || strings.Contains(message, "signed-token") {
+		t.Fatalf("error leaked upstream body: %q", message)
+	}
+}
+
 // TestTransportErrorOmitsHost pins the topology-privacy property: transport
 // failures embed the full request URL (and DNS errors repeat the hostname),
 // and these errors surface to requesters through book-request failures — so

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -63,6 +63,11 @@ type Config struct {
 	// Codex auth state may exist while an app-server process is running. Empty
 	// lets the adapter use /dev/shm/cantinarr-codex when available.
 	CodexRuntimeDir string
+	// MediaDownloadRoots are the explicit read-only filesystem boundaries from
+	// which authenticated users may download completed arr media. Empty keeps
+	// media delivery disabled. Arr-reported paths outside these roots are never
+	// opened, even for administrators.
+	MediaDownloadRoots []string
 }
 
 func Load() (*Config, error) {
@@ -89,6 +94,7 @@ func Load() (*Config, error) {
 		PushEnrollToken:    os.Getenv("CANTINARR_PUSH_ENROLL_TOKEN"),
 		CodexBin:           strings.TrimSpace(os.Getenv("CANTINARR_CODEX_BIN")),
 		CodexRuntimeDir:    strings.TrimSpace(os.Getenv("CANTINARR_CODEX_RUNTIME_DIR")),
+		MediaDownloadRoots: splitEnvList(os.Getenv("CANTINARR_MEDIA_ROOTS")),
 	}
 
 	cfg.DisableUpdateCheck = envBool(os.Getenv("CANTINARR_DISABLE_UPDATE_CHECK"))
@@ -123,12 +129,16 @@ func Load() (*Config, error) {
 	if cfg.CodexRuntimeDir != "" && !filepath.IsAbs(cfg.CodexRuntimeDir) {
 		return nil, fmt.Errorf("invalid CANTINARR_CODEX_RUNTIME_DIR: must be an absolute path")
 	}
+	var err error
+	cfg.MediaDownloadRoots, err = normalizeMediaDownloadRoots(cfg.MediaDownloadRoots)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CANTINARR_MEDIA_ROOTS: %w", err)
+	}
 
 	androidFingerprints := os.Getenv("CANTINARR_ANDROID_CERT_SHA256_FINGERPRINTS")
 	if androidFingerprints == "" {
 		androidFingerprints = os.Getenv("CANTINARR_ANDROID_CERT_SHA256")
 	}
-	var err error
 	cfg.AndroidCertFingerprints, err = normalizeAndroidFingerprints(
 		splitEnvList(androidFingerprints),
 	)
@@ -159,6 +169,48 @@ func Load() (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func normalizeMediaDownloadRoots(values []string) ([]string, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	result := make([]string, 0, len(values))
+	seen := make(map[string]bool, len(values))
+	for _, value := range values {
+		if !filepath.IsAbs(value) {
+			return nil, fmt.Errorf("entry %q must be an absolute path", value)
+		}
+		cleaned := filepath.Clean(value)
+		if filepath.Dir(cleaned) == cleaned {
+			return nil, fmt.Errorf("filesystem root is too broad")
+		}
+		resolved, err := filepath.EvalSymlinks(cleaned)
+		if err != nil {
+			return nil, fmt.Errorf("entry %q is not accessible: %w", value, err)
+		}
+		if filepath.Dir(resolved) == resolved {
+			return nil, fmt.Errorf("entry %q resolves to the filesystem root", value)
+		}
+		info, err := os.Stat(resolved)
+		if err != nil {
+			return nil, fmt.Errorf("entry %q is not accessible: %w", value, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("entry %q is not a directory", value)
+		}
+		// Retain the cleaned lexical path. Arr file records refer to the path
+		// mounted in their container, and resolving aliases here (notably macOS
+		// /var -> /private/var) would make an otherwise exact shared mount stop
+		// matching. The resolved path above is used only to validate the target
+		// and reject aliases of the filesystem root.
+		if seen[cleaned] {
+			continue
+		}
+		seen[cleaned] = true
+		result = append(result, cleaned)
+	}
+	return result, nil
 }
 
 func isKubernetesServiceLinkPort(value string) bool {

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/base64"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -141,6 +143,56 @@ func TestLoadCodexRuntimeConfig(t *testing.T) {
 	t.Setenv("CANTINARR_CODEX_RUNTIME_DIR", "relative/codex")
 	if _, err := Load(); err == nil {
 		t.Fatal("Load() error = nil, want relative Codex runtime dir rejection")
+	}
+}
+
+func TestLoadMediaDownloadRoots(t *testing.T) {
+	first := t.TempDir()
+	second := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "media-link")
+	if err := os.Symlink(first, alias); err != nil {
+		t.Fatalf("Symlink() error = %v", err)
+	}
+	t.Setenv("CANTINARR_MEDIA_ROOTS", first+", "+second+", "+alias)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(cfg.MediaDownloadRoots) != 3 {
+		t.Fatalf("MediaDownloadRoots = %#v, want three lexical roots", cfg.MediaDownloadRoots)
+	}
+	if cfg.MediaDownloadRoots[0] != filepath.Clean(first) ||
+		cfg.MediaDownloadRoots[1] != filepath.Clean(second) ||
+		cfg.MediaDownloadRoots[2] != filepath.Clean(alias) {
+		t.Fatalf("MediaDownloadRoots = %#v, want lexical paths [%q %q %q]", cfg.MediaDownloadRoots, first, second, alias)
+	}
+}
+
+func TestLoadRejectsUnsafeMediaDownloadRoots(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(file, []byte("x"), 0600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	missing := filepath.Join(t.TempDir(), "missing")
+	rootAlias := filepath.Join(t.TempDir(), "root-link")
+	if err := os.Symlink(string(filepath.Separator), rootAlias); err != nil {
+		t.Fatalf("Symlink(root) error = %v", err)
+	}
+
+	for name, value := range map[string]string{
+		"relative":        "media",
+		"filesystem root": string(filepath.Separator),
+		"root symlink":    rootAlias,
+		"regular file":    file,
+		"missing":         missing,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("CANTINARR_MEDIA_ROOTS", value)
+			if _, err := Load(); err == nil {
+				t.Fatal("Load() error = nil, want invalid media root error")
+			}
+		})
 	}
 }
 

--- a/server/internal/mediafiles/handler.go
+++ b/server/internal/mediafiles/handler.go
@@ -1,0 +1,581 @@
+// Package mediafiles serves completed arr media through short-lived,
+// file-scoped capability URLs. The arr supplies only file metadata; bytes are
+// read from explicit local filesystem roots configured by the operator.
+package mediafiles
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+)
+
+const (
+	defaultTicketTTL          = 10 * time.Minute
+	defaultMaxTickets         = 1024
+	defaultMaxTicketsPerUser  = 32
+	maxTicketRequestBodyBytes = 4096
+	ticketRandomBytes         = 32
+	maxDownloadFilenameBytes  = 240
+)
+
+var errMediaFileUnavailable = errors.New("media file unavailable")
+
+type instanceAccessStore interface {
+	Get(id string) (*instance.Instance, error)
+	UserCanAccessInstance(userID int64, instanceID, serviceType string) (bool, error)
+}
+
+type currentUserStore interface {
+	GetUser(userID int64) (*auth.User, error)
+}
+
+type metadataResolver interface {
+	Resolve(instanceID, serviceType string, fileID int) (fileMetadata, error)
+}
+
+type fileMetadata struct {
+	Path string
+}
+
+type registryMetadataResolver struct {
+	registry *instance.Registry
+}
+
+func (r registryMetadataResolver) Resolve(instanceID, serviceType string, fileID int) (fileMetadata, error) {
+	switch serviceType {
+	case "radarr":
+		client, _, err := r.registry.GetFreshRadarrClient(instanceID)
+		if err != nil {
+			return fileMetadata{}, err
+		}
+		file, err := client.GetMovieFile(fileID)
+		if err != nil {
+			return fileMetadata{}, err
+		}
+		return fileMetadata{Path: file.Path}, nil
+	case "sonarr":
+		client, _, err := r.registry.GetFreshSonarrClient(instanceID)
+		if err != nil {
+			return fileMetadata{}, err
+		}
+		file, err := client.GetEpisodeFile(fileID)
+		if err != nil {
+			return fileMetadata{}, err
+		}
+		return fileMetadata{Path: file.Path}, nil
+	case "chaptarr":
+		client, _, err := r.registry.GetFreshChaptarrClient(instanceID)
+		if err != nil {
+			return fileMetadata{}, err
+		}
+		file, err := client.GetBookFile(fileID)
+		if err != nil {
+			return fileMetadata{}, err
+		}
+		return fileMetadata{Path: file.Path}, nil
+	default:
+		return fileMetadata{}, errMediaFileUnavailable
+	}
+}
+
+type mediaRoot struct {
+	path string
+	root *os.Root
+}
+
+type downloadTicket struct {
+	userID      int64
+	instanceID  string
+	serviceType string
+	fileID      int
+	expiresAt   time.Time
+}
+
+// Handler issues and serves bounded, short-lived download capabilities.
+// Tickets retain only identity and authorization state: the arr metadata and
+// local file are re-resolved for every GET or HEAD.
+type Handler struct {
+	store    instanceAccessStore
+	users    currentUserStore
+	resolver metadataResolver
+	roots    []mediaRoot
+
+	mu                sync.Mutex
+	tickets           map[string]downloadTicket
+	now               func() time.Time
+	random            io.Reader
+	ticketTTL         time.Duration
+	maxTickets        int
+	maxTicketsPerUser int
+}
+
+// NewHandler opens each configured root once for the process lifetime. Empty
+// roots are valid and leave media downloads disabled.
+func NewHandler(store *instance.Store, registry *instance.Registry, users *auth.Service, roots []string) (*Handler, error) {
+	return newHandler(store, users, registryMetadataResolver{registry: registry}, roots)
+}
+
+func newHandler(store instanceAccessStore, users currentUserStore, resolver metadataResolver, roots []string) (*Handler, error) {
+	h := &Handler{
+		store:             store,
+		users:             users,
+		resolver:          resolver,
+		tickets:           make(map[string]downloadTicket),
+		now:               time.Now,
+		random:            rand.Reader,
+		ticketTTL:         defaultTicketTTL,
+		maxTickets:        defaultMaxTickets,
+		maxTicketsPerUser: defaultMaxTicketsPerUser,
+	}
+
+	seen := make(map[string]bool, len(roots))
+	for _, configured := range roots {
+		if !filepath.IsAbs(configured) {
+			h.Close()
+			return nil, fmt.Errorf("media root must be absolute")
+		}
+		cleaned := filepath.Clean(configured)
+		if filepath.Dir(cleaned) == cleaned {
+			h.Close()
+			return nil, fmt.Errorf("media root is too broad")
+		}
+		resolved, err := filepath.EvalSymlinks(cleaned)
+		if err != nil {
+			h.Close()
+			return nil, fmt.Errorf("resolve media root: %w", err)
+		}
+		if filepath.Dir(resolved) == resolved {
+			h.Close()
+			return nil, fmt.Errorf("media root resolves to filesystem root")
+		}
+		// Keep the cleaned lexical path because arr file records use the path
+		// visible inside their container. On platforms such as macOS, resolving
+		// /var to /private/var here would make a valid reported path miss its
+		// configured boundary. EvalSymlinks above validates the target and rejects
+		// aliases of the filesystem root; OpenRoot itself holds the safe directory
+		// handle used for all subsequent opens.
+		if seen[cleaned] {
+			continue
+		}
+		root, err := os.OpenRoot(cleaned)
+		if err != nil {
+			h.Close()
+			return nil, fmt.Errorf("open media root: %w", err)
+		}
+		seen[cleaned] = true
+		h.roots = append(h.roots, mediaRoot{path: cleaned, root: root})
+	}
+	return h, nil
+}
+
+// Close releases the directory handles retained by the handler.
+func (h *Handler) Close() error {
+	var joined error
+	for _, root := range h.roots {
+		joined = errors.Join(joined, root.root.Close())
+	}
+	h.roots = nil
+	return joined
+}
+
+type issueTicketRequest struct {
+	InstanceID string `json:"instance_id"`
+	FileID     int    `json:"file_id"`
+}
+
+type issueTicketResponse struct {
+	URL       string    `json:"url"`
+	Filename  string    `json:"filename"`
+	SizeBytes int64     `json:"size_bytes"`
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+// IssueTicket validates the caller's current effective instance access,
+// resolves the live arr file record, verifies the local file boundary, and
+// returns an opaque capability URL. No client-supplied filesystem path is
+// accepted.
+func (h *Handler) IssueTicket(w http.ResponseWriter, r *http.Request) {
+	if len(h.roots) == 0 {
+		writeJSONError(w, http.StatusServiceUnavailable, "media downloads are not configured")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxTicketRequestBodyBytes)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	var request issueTicketRequest
+	if err := decoder.Decode(&request); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request")
+		return
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "invalid request")
+		return
+	}
+	request.InstanceID = strings.TrimSpace(request.InstanceID)
+	if request.InstanceID == "" || len(request.InstanceID) > 128 || request.FileID <= 0 {
+		writeJSONError(w, http.StatusBadRequest, "instance_id and a positive file_id are required")
+		return
+	}
+
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	currentUser, err := h.users.GetUser(claims.UserID)
+	if errors.Is(err, sql.ErrNoRows) {
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "temporarily unavailable, retry shortly")
+		return
+	}
+	if currentUser == nil {
+		writeJSONError(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	if !auth.HasPermission(currentUser.Role, auth.PermissionMediaDownload) {
+		writeJSONError(w, http.StatusForbidden, "permission denied")
+		return
+	}
+	inst, err := h.store.Get(request.InstanceID)
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "temporarily unavailable, retry shortly")
+		return
+	}
+	if inst == nil || !supportedService(inst.ServiceType) {
+		writeJSONError(w, http.StatusNotFound, "media file unavailable")
+		return
+	}
+
+	isAdmin := auth.HasPermission(currentUser.Role, auth.PermissionInstancesManage)
+	if !isAdmin {
+		allowed, err := h.store.UserCanAccessInstance(claims.UserID, inst.ID, inst.ServiceType)
+		if err != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "temporarily unavailable, retry shortly")
+			return
+		}
+		if !allowed {
+			writeJSONError(w, http.StatusForbidden, "permission denied")
+			return
+		}
+	}
+
+	metadata, err := h.resolver.Resolve(inst.ID, inst.ServiceType, request.FileID)
+	if err != nil {
+		writeJSONError(w, http.StatusBadGateway, "media file unavailable")
+		return
+	}
+	opened, err := h.openMediaFile(metadata.Path, request.FileID)
+	if err != nil {
+		writeJSONError(w, http.StatusNotFound, "media file unavailable")
+		return
+	}
+	_ = opened.file.Close()
+
+	ticket := downloadTicket{
+		userID:      claims.UserID,
+		instanceID:  inst.ID,
+		serviceType: inst.ServiceType,
+		fileID:      request.FileID,
+	}
+	token, expiresAt, status, err := h.issue(ticket)
+	if err != nil {
+		writeJSONError(w, status, err.Error())
+		return
+	}
+
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(issueTicketResponse{
+		URL:       "/api/media-files/download/" + token,
+		Filename:  opened.filename,
+		SizeBytes: opened.info.Size(),
+		ExpiresAt: expiresAt,
+	})
+}
+
+// Download serves a previously-issued capability. Tickets are deliberately
+// reusable until expiration so browser HEAD probes and resumed Range requests
+// cannot consume them prematurely.
+func (h *Handler) Download(w http.ResponseWriter, r *http.Request) {
+	w.Header().Del("Content-Type") // The /api router defaults to JSON.
+	setDownloadSecurityHeaders(w.Header())
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
+		writeDownloadError(w, r, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	token := chi.URLParam(r, "ticket")
+	if !validTicketToken(token) {
+		writeDownloadError(w, r, http.StatusNotFound, "download unavailable")
+		return
+	}
+	ticket, ok := h.getTicket(token)
+	if !ok {
+		writeDownloadError(w, r, http.StatusNotFound, "download unavailable")
+		return
+	}
+
+	currentUser, err := h.users.GetUser(ticket.userID)
+	if errors.Is(err, sql.ErrNoRows) {
+		writeDownloadError(w, r, http.StatusNotFound, "download unavailable")
+		return
+	}
+	if err != nil {
+		writeDownloadError(w, r, http.StatusServiceUnavailable, "temporarily unavailable, retry shortly")
+		return
+	}
+	if currentUser == nil {
+		writeDownloadError(w, r, http.StatusNotFound, "download unavailable")
+		return
+	}
+	if !auth.HasPermission(currentUser.Role, auth.PermissionMediaDownload) {
+		writeDownloadError(w, r, http.StatusNotFound, "download unavailable")
+		return
+	}
+	inst, err := h.store.Get(ticket.instanceID)
+	if err != nil {
+		writeDownloadError(w, r, http.StatusServiceUnavailable, "temporarily unavailable, retry shortly")
+		return
+	}
+	if inst == nil || inst.ServiceType != ticket.serviceType || !supportedService(inst.ServiceType) {
+		writeDownloadError(w, r, http.StatusNotFound, "download unavailable")
+		return
+	}
+	if !auth.HasPermission(currentUser.Role, auth.PermissionInstancesManage) {
+		allowed, err := h.store.UserCanAccessInstance(ticket.userID, ticket.instanceID, ticket.serviceType)
+		if err != nil {
+			writeDownloadError(w, r, http.StatusServiceUnavailable, "temporarily unavailable, retry shortly")
+			return
+		}
+		if !allowed {
+			writeDownloadError(w, r, http.StatusNotFound, "download unavailable")
+			return
+		}
+	}
+
+	metadata, err := h.resolver.Resolve(ticket.instanceID, ticket.serviceType, ticket.fileID)
+	if err != nil {
+		writeDownloadError(w, r, http.StatusBadGateway, "download unavailable")
+		return
+	}
+	opened, err := h.openMediaFile(metadata.Path, ticket.fileID)
+	if err != nil {
+		writeDownloadError(w, r, http.StatusNotFound, "download unavailable")
+		return
+	}
+	defer opened.file.Close()
+
+	contentDisposition := mime.FormatMediaType("attachment", map[string]string{"filename": opened.filename})
+	if contentDisposition == "" {
+		contentDisposition = "attachment"
+	}
+	w.Header().Set("Content-Disposition", contentDisposition)
+	// Never let completed media become active same-origin browser content. In
+	// particular, an arr library can contain HTML or SVG; attachment alone is
+	// not a sufficient boundary across every user agent.
+	w.Header().Set("Content-Type", "application/octet-stream")
+
+	secureWriter := downloadResponseWriter{ResponseWriter: w}
+	http.ServeContent(secureWriter, r, opened.filename, opened.info.ModTime(), opened.file)
+}
+
+func (h *Handler) issue(ticket downloadTicket) (string, time.Time, int, error) {
+	now := h.now()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.purgeExpiredLocked(now)
+
+	userTickets := 0
+	for token, existing := range h.tickets {
+		if existing.userID != ticket.userID {
+			continue
+		}
+		userTickets++
+		if existing.instanceID == ticket.instanceID && existing.serviceType == ticket.serviceType && existing.fileID == ticket.fileID {
+			return token, existing.expiresAt, 0, nil
+		}
+	}
+	if userTickets >= h.maxTicketsPerUser {
+		return "", time.Time{}, http.StatusTooManyRequests, errors.New("too many active download tickets")
+	}
+	if len(h.tickets) >= h.maxTickets {
+		return "", time.Time{}, http.StatusServiceUnavailable, errors.New("download service is busy, retry shortly")
+	}
+
+	for range 4 {
+		randomBytes := make([]byte, ticketRandomBytes)
+		if _, err := io.ReadFull(h.random, randomBytes); err != nil {
+			return "", time.Time{}, http.StatusServiceUnavailable, errors.New("temporarily unavailable, retry shortly")
+		}
+		token := base64.RawURLEncoding.EncodeToString(randomBytes)
+		if _, exists := h.tickets[token]; exists {
+			continue
+		}
+		ticket.expiresAt = now.Add(h.ticketTTL).UTC()
+		h.tickets[token] = ticket
+		return token, ticket.expiresAt, 0, nil
+	}
+	return "", time.Time{}, http.StatusServiceUnavailable, errors.New("temporarily unavailable, retry shortly")
+}
+
+func (h *Handler) getTicket(token string) (downloadTicket, bool) {
+	now := h.now()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.purgeExpiredLocked(now)
+	ticket, ok := h.tickets[token]
+	return ticket, ok
+}
+
+func (h *Handler) purgeExpiredLocked(now time.Time) {
+	for token, ticket := range h.tickets {
+		if !now.Before(ticket.expiresAt) {
+			delete(h.tickets, token)
+		}
+	}
+}
+
+type openedMediaFile struct {
+	file     *os.File
+	info     os.FileInfo
+	filename string
+}
+
+func (h *Handler) openMediaFile(reportedPath string, fileID int) (*openedMediaFile, error) {
+	if !filepath.IsAbs(reportedPath) {
+		return nil, errMediaFileUnavailable
+	}
+	cleaned := filepath.Clean(reportedPath)
+	for _, allowedRoot := range h.roots {
+		relative, err := filepath.Rel(allowedRoot.path, cleaned)
+		if err != nil || filepath.IsAbs(relative) || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			continue
+		}
+		file, err := allowedRoot.root.Open(relative)
+		if err != nil {
+			continue
+		}
+		info, err := file.Stat()
+		if err != nil || !info.Mode().IsRegular() {
+			_ = file.Close()
+			continue
+		}
+		return &openedMediaFile{
+			file:     file,
+			info:     info,
+			filename: safeFilename(filepath.Base(cleaned), fileID),
+		}, nil
+	}
+	return nil, errMediaFileUnavailable
+}
+
+func supportedService(serviceType string) bool {
+	return serviceType == "radarr" || serviceType == "sonarr" || serviceType == "chaptarr"
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	var trailing any
+	err := decoder.Decode(&trailing)
+	if errors.Is(err, io.EOF) {
+		return nil
+	}
+	if err == nil {
+		return errors.New("multiple JSON values")
+	}
+	return err
+}
+
+func validTicketToken(token string) bool {
+	if len(token) != base64.RawURLEncoding.EncodedLen(ticketRandomBytes) {
+		return false
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	return err == nil && len(decoded) == ticketRandomBytes
+}
+
+func safeFilename(name string, fileID int) string {
+	name = strings.ReplaceAll(name, "\\", "/")
+	if index := strings.LastIndexByte(name, '/'); index >= 0 {
+		name = name[index+1:]
+	}
+	name = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || r == utf8.RuneError {
+			return -1
+		}
+		return r
+	}, name)
+	name = strings.TrimSpace(name)
+	if name == "" || name == "." || name == ".." {
+		return fmt.Sprintf("media-file-%d", fileID)
+	}
+	for len(name) > maxDownloadFilenameBytes {
+		_, size := utf8.DecodeLastRuneInString(name)
+		name = name[:len(name)-size]
+	}
+	if name == "" {
+		return fmt.Sprintf("media-file-%d", fileID)
+	}
+	return name
+}
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+func writeDownloadError(w http.ResponseWriter, r *http.Request, status int, message string) {
+	setDownloadSecurityHeaders(w.Header())
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if r.Method != http.MethodHead {
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+	}
+}
+
+func setDownloadSecurityHeaders(header http.Header) {
+	header.Set("Cache-Control", "private, no-store")
+	header.Set("Content-Security-Policy", "sandbox; default-src 'none'")
+	header.Set("Pragma", "no-cache")
+	header.Set("Referrer-Policy", "no-referrer")
+	header.Set("X-Content-Type-Options", "nosniff")
+	header.Set("Cross-Origin-Resource-Policy", "same-origin")
+}
+
+// ServeContent removes cache headers on some error paths. Reapply the
+// download security boundary immediately before every status is committed.
+type downloadResponseWriter struct {
+	http.ResponseWriter
+}
+
+func (w downloadResponseWriter) WriteHeader(status int) {
+	setDownloadSecurityHeaders(w.Header())
+	if status >= http.StatusBadRequest {
+		w.Header().Del("Content-Disposition")
+	}
+	w.ResponseWriter.WriteHeader(status)
+}

--- a/server/internal/mediafiles/handler_test.go
+++ b/server/internal/mediafiles/handler_test.go
@@ -1,0 +1,537 @@
+package mediafiles
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+)
+
+type fakeInstanceStore struct {
+	instances   map[string]*instance.Instance
+	allowed     bool
+	getErr      error
+	accessErr   error
+	accessCalls []accessCall
+	roles       map[int64]string
+	deleted     map[int64]bool
+	userErr     error
+}
+
+type accessCall struct {
+	userID      int64
+	instanceID  string
+	serviceType string
+}
+
+func (s *fakeInstanceStore) Get(id string) (*instance.Instance, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	inst := s.instances[id]
+	if inst == nil {
+		return nil, nil
+	}
+	copy := *inst
+	return &copy, nil
+}
+
+func (s *fakeInstanceStore) UserCanAccessInstance(userID int64, instanceID, serviceType string) (bool, error) {
+	s.accessCalls = append(s.accessCalls, accessCall{
+		userID:      userID,
+		instanceID:  instanceID,
+		serviceType: serviceType,
+	})
+	if s.accessErr != nil {
+		return false, s.accessErr
+	}
+	return s.allowed, nil
+}
+
+func (s *fakeInstanceStore) GetUser(userID int64) (*auth.User, error) {
+	if s.userErr != nil {
+		return nil, s.userErr
+	}
+	if s.deleted[userID] {
+		return nil, sql.ErrNoRows
+	}
+	role := s.roles[userID]
+	if role == "" {
+		role = auth.RoleUser
+		if userID == 1 {
+			role = auth.RoleAdmin
+		}
+	}
+	return &auth.User{ID: userID, Role: role}, nil
+}
+
+type fakeMetadataResolver struct {
+	paths map[int]string
+	err   error
+	calls []resolveCall
+}
+
+type resolveCall struct {
+	instanceID  string
+	serviceType string
+	fileID      int
+}
+
+func (r *fakeMetadataResolver) Resolve(instanceID, serviceType string, fileID int) (fileMetadata, error) {
+	r.calls = append(r.calls, resolveCall{instanceID: instanceID, serviceType: serviceType, fileID: fileID})
+	if r.err != nil {
+		return fileMetadata{}, r.err
+	}
+	return fileMetadata{Path: r.paths[fileID]}, nil
+}
+
+func TestHandlerDownloadSupportsReusableHeadAndRange(t *testing.T) {
+	root := t.TempDir()
+	mediaPath := filepath.Join(root, "Movies", "example.mp4")
+	if err := os.MkdirAll(filepath.Dir(mediaPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte("0123456789")
+	if err := os.WriteFile(mediaPath, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &fakeInstanceStore{
+		instances: map[string]*instance.Instance{
+			"radarr-main": {ID: "radarr-main", ServiceType: "radarr"},
+		},
+		allowed: true,
+	}
+	resolver := &fakeMetadataResolver{paths: map[int]string{7: mediaPath}}
+	h := newTestHandler(t, store, resolver, []string{root})
+	fixedNow := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+	h.now = func() time.Time { return fixedNow }
+
+	response, body := issueTicket(t, h, &auth.Claims{UserID: 42, Role: auth.RoleUser}, `{"instance_id":"radarr-main","file_id":7}`)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("issue status = %d, body = %s", response.Code, response.Body.String())
+	}
+	if body.Filename != "example.mp4" || body.SizeBytes != int64(len(content)) {
+		t.Fatalf("ticket metadata = %#v", body)
+	}
+	if !body.ExpiresAt.Equal(fixedNow.Add(defaultTicketTTL)) {
+		t.Fatalf("expires_at = %v", body.ExpiresAt)
+	}
+	if strings.Contains(response.Body.String(), mediaPath) || strings.Contains(response.Body.String(), "radarr-main") {
+		t.Fatalf("ticket response leaked server identity: %s", response.Body.String())
+	}
+	token := strings.TrimPrefix(body.URL, "/api/media-files/download/")
+	decoded, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil || len(decoded) != ticketRandomBytes {
+		t.Fatalf("ticket token = %q, decoded bytes = %d, err = %v", token, len(decoded), err)
+	}
+
+	head := downloadRequest(h, http.MethodHead, body.URL, "")
+	if head.Code != http.StatusOK {
+		t.Fatalf("HEAD status = %d, body = %q", head.Code, head.Body.String())
+	}
+	if head.Body.Len() != 0 {
+		t.Fatalf("HEAD body = %q, want empty", head.Body.String())
+	}
+	if head.Header().Get("Content-Length") != strconv.Itoa(len(content)) {
+		t.Fatalf("HEAD Content-Length = %q", head.Header().Get("Content-Length"))
+	}
+	assertDownloadHeaders(t, head, "example.mp4")
+
+	ranged := downloadRequest(h, http.MethodGet, body.URL, "bytes=2-5")
+	if ranged.Code != http.StatusPartialContent || ranged.Body.String() != "2345" {
+		t.Fatalf("Range response = %d %q", ranged.Code, ranged.Body.String())
+	}
+	if ranged.Header().Get("Content-Range") != "bytes 2-5/10" {
+		t.Fatalf("Content-Range = %q", ranged.Header().Get("Content-Range"))
+	}
+	if ranged.Header().Get("Accept-Ranges") != "bytes" {
+		t.Fatalf("Accept-Ranges = %q", ranged.Header().Get("Accept-Ranges"))
+	}
+	assertDownloadHeaders(t, ranged, "example.mp4")
+
+	full := downloadRequest(h, http.MethodGet, body.URL, "")
+	if full.Code != http.StatusOK || !bytes.Equal(full.Body.Bytes(), content) {
+		t.Fatalf("full response = %d %q", full.Code, full.Body.String())
+	}
+	assertDownloadHeaders(t, full, "example.mp4")
+
+	invalidRange := downloadRequest(h, http.MethodGet, body.URL, "bytes=99-")
+	if invalidRange.Code != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("invalid Range status = %d, body = %q", invalidRange.Code, invalidRange.Body.String())
+	}
+	assertDownloadHeaders(t, invalidRange, "")
+	if got := invalidRange.Header().Get("Content-Disposition"); got != "" {
+		t.Fatalf("error Content-Disposition = %q, want empty", got)
+	}
+
+	if len(resolver.calls) != 5 {
+		t.Fatalf("metadata resolves = %d, want issue plus every HEAD/GET", len(resolver.calls))
+	}
+	if len(store.accessCalls) != 5 {
+		t.Fatalf("access checks = %d, want issue plus every HEAD/GET", len(store.accessCalls))
+	}
+}
+
+func TestIssueTicketEnforcesAccessAndDownloadRechecksGrant(t *testing.T) {
+	root := t.TempDir()
+	mediaPath := filepath.Join(root, "book.epub")
+	if err := os.WriteFile(mediaPath, []byte("book"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := &fakeInstanceStore{
+		instances: map[string]*instance.Instance{
+			"books-1": {ID: "books-1", ServiceType: "chaptarr"},
+		},
+		allowed: false,
+	}
+	resolver := &fakeMetadataResolver{paths: map[int]string{19: mediaPath}}
+	h := newTestHandler(t, store, resolver, []string{root})
+
+	denied, _ := issueTicket(t, h, &auth.Claims{UserID: 8, Role: auth.RoleUser}, `{"instance_id":"books-1","file_id":19}`)
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("denied status = %d, body = %s", denied.Code, denied.Body.String())
+	}
+	if len(resolver.calls) != 0 {
+		t.Fatalf("resolver called before access decision: %#v", resolver.calls)
+	}
+	if got := store.accessCalls[0]; got.userID != 8 || got.instanceID != "books-1" || got.serviceType != "chaptarr" {
+		t.Fatalf("access check = %#v", got)
+	}
+
+	store.userErr = errors.New("database at /private/auth.db failed")
+	unavailable, _ := issueTicket(t, h, &auth.Claims{UserID: 1, Role: auth.RoleAdmin}, `{"instance_id":"books-1","file_id":19}`)
+	if unavailable.Code != http.StatusServiceUnavailable {
+		t.Fatalf("user lookup failure status = %d, body = %s", unavailable.Code, unavailable.Body.String())
+	}
+	if strings.Contains(unavailable.Body.String(), "/private/auth.db") {
+		t.Fatalf("user lookup failure leaked detail: %s", unavailable.Body.String())
+	}
+	store.userErr = nil
+
+	admin, adminBody := issueTicket(t, h, &auth.Claims{UserID: 1, Role: auth.RoleAdmin}, `{"instance_id":"books-1","file_id":19}`)
+	if admin.Code != http.StatusCreated {
+		t.Fatalf("admin status = %d, body = %s", admin.Code, admin.Body.String())
+	}
+	if len(store.accessCalls) != 1 {
+		t.Fatalf("admin unexpectedly used requester grant check")
+	}
+	store.userErr = errors.New("temporary user lookup failure")
+	lookupFailure := downloadRequest(h, http.MethodGet, adminBody.URL, "")
+	if lookupFailure.Code != http.StatusServiceUnavailable {
+		t.Fatalf("download user lookup failure = %d, body = %s", lookupFailure.Code, lookupFailure.Body.String())
+	}
+	store.userErr = nil
+
+	// Ticket authorization uses the current account role, not the role snapshot
+	// in the JWT or at issuance. An admin demotion therefore revokes access to a
+	// non-effective instance immediately.
+	store.roles = map[int64]string{1: auth.RoleUser}
+	demotedResolves := len(resolver.calls)
+	demoted := downloadRequest(h, http.MethodGet, adminBody.URL, "")
+	if demoted.Code != http.StatusNotFound {
+		t.Fatalf("demoted admin download status = %d, body = %s", demoted.Code, demoted.Body.String())
+	}
+	if len(resolver.calls) != demotedResolves {
+		t.Fatal("demoted admin ticket resolved upstream metadata before current-role denial")
+	}
+	staleAdminClaims, _ := issueTicket(t, h, &auth.Claims{UserID: 1, Role: auth.RoleAdmin}, `{"instance_id":"books-1","file_id":19}`)
+	if staleAdminClaims.Code != http.StatusForbidden {
+		t.Fatalf("stale admin claims issue status = %d, body = %s", staleAdminClaims.Code, staleAdminClaims.Body.String())
+	}
+
+	store.allowed = true
+	requester, requesterBody := issueTicket(t, h, &auth.Claims{UserID: 8, Role: auth.RoleUser}, `{"instance_id":"books-1","file_id":19}`)
+	if requester.Code != http.StatusCreated {
+		t.Fatalf("requester status = %d, body = %s", requester.Code, requester.Body.String())
+	}
+	resolvesBeforeRevocation := len(resolver.calls)
+	store.allowed = false
+	download := downloadRequest(h, http.MethodGet, requesterBody.URL, "")
+	if download.Code != http.StatusNotFound {
+		t.Fatalf("revoked download status = %d, body = %s", download.Code, download.Body.String())
+	}
+	if len(resolver.calls) != resolvesBeforeRevocation {
+		t.Fatal("revoked ticket resolved upstream metadata before rejecting access")
+	}
+
+	store.allowed = true
+	store.deleted = map[int64]bool{8: true}
+	deleted := downloadRequest(h, http.MethodHead, requesterBody.URL, "")
+	if deleted.Code != http.StatusNotFound || deleted.Body.Len() != 0 {
+		t.Fatalf("deleted-user HEAD = %d %q", deleted.Code, deleted.Body.String())
+	}
+	if len(resolver.calls) != resolvesBeforeRevocation {
+		t.Fatal("deleted user's ticket resolved upstream metadata")
+	}
+}
+
+func TestIssueTicketRejectsPathsOutsideRootAndDoesNotLeakDetails(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "media")
+	if err := os.Mkdir(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	outsideRoot := t.TempDir()
+	outsidePath := filepath.Join(outsideRoot, "outside-secret.mkv")
+	if err := os.WriteFile(outsidePath, []byte("secret"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	prefixSibling := filepath.Join(parent, "media-other")
+	if err := os.MkdirAll(prefixSibling, 0700); err != nil {
+		t.Fatal(err)
+	}
+	prefixPath := filepath.Join(prefixSibling, "prefix-secret.mkv")
+	if err := os.WriteFile(prefixPath, []byte("secret"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	symlinkPath := filepath.Join(root, "escape.mkv")
+	if err := os.Symlink(outsidePath, symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+	directoryPath := filepath.Join(root, "not-a-file")
+	if err := os.Mkdir(directoryPath, 0700); err != nil {
+		t.Fatal(err)
+	}
+	insideTarget := filepath.Join(root, "inside-target.mkv")
+	if err := os.WriteFile(insideTarget, []byte("inside"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	insideSymlink := filepath.Join(root, "inside-link.mkv")
+	if err := os.Symlink(filepath.Base(insideTarget), insideSymlink); err != nil {
+		t.Fatal(err)
+	}
+
+	store := &fakeInstanceStore{
+		instances: map[string]*instance.Instance{
+			"sonarr-main": {ID: "sonarr-main", ServiceType: "sonarr"},
+		},
+		allowed: true,
+	}
+	resolver := &fakeMetadataResolver{paths: map[int]string{}}
+	h := newTestHandler(t, store, resolver, []string{root})
+	resolver.paths[6] = insideSymlink
+	inside, insideBody := issueTicket(t, h, &auth.Claims{UserID: 11, Role: auth.RoleUser}, `{"instance_id":"sonarr-main","file_id":6}`)
+	if inside.Code != http.StatusCreated {
+		t.Fatalf("in-root symlink status = %d, body = %s", inside.Code, inside.Body.String())
+	}
+	insideDownload := downloadRequest(h, http.MethodGet, insideBody.URL, "")
+	if insideDownload.Code != http.StatusOK || insideDownload.Body.String() != "inside" {
+		t.Fatalf("in-root symlink download = %d %q", insideDownload.Code, insideDownload.Body.String())
+	}
+
+	paths := []string{outsidePath, prefixPath, symlinkPath, directoryPath, "relative/file.mkv"}
+	for index, candidate := range paths {
+		fileID := index + 1
+		resolver.paths[fileID] = candidate
+		response, _ := issueTicket(t, h, &auth.Claims{UserID: 11, Role: auth.RoleUser}, `{"instance_id":"sonarr-main","file_id":`+strconv.Itoa(fileID)+`}`)
+		if response.Code != http.StatusNotFound {
+			t.Errorf("path %q status = %d, body = %s", candidate, response.Code, response.Body.String())
+		}
+		if strings.Contains(response.Body.String(), candidate) || strings.Contains(response.Body.String(), "secret") {
+			t.Errorf("path %q leaked in response %q", candidate, response.Body.String())
+		}
+	}
+
+	resolver.err = errors.New("upstream http://sonarr.internal:8989 exposed /private/library")
+	upstream, _ := issueTicket(t, h, &auth.Claims{UserID: 11, Role: auth.RoleUser}, `{"instance_id":"sonarr-main","file_id":99}`)
+	if upstream.Code != http.StatusBadGateway {
+		t.Fatalf("upstream status = %d, body = %s", upstream.Code, upstream.Body.String())
+	}
+	if strings.Contains(upstream.Body.String(), "sonarr.internal") || strings.Contains(upstream.Body.String(), "/private/library") {
+		t.Fatalf("upstream details leaked: %s", upstream.Body.String())
+	}
+
+	resolver.err = nil
+	callsBeforeClientPath := len(resolver.calls)
+	clientPath, _ := issueTicket(t, h, &auth.Claims{UserID: 11, Role: auth.RoleUser}, `{"instance_id":"sonarr-main","file_id":99,"path":"`+outsidePath+`"}`)
+	if clientPath.Code != http.StatusBadRequest {
+		t.Fatalf("client path status = %d, body = %s", clientPath.Code, clientPath.Body.String())
+	}
+	if len(resolver.calls) != callsBeforeClientPath {
+		t.Fatal("request containing a client-supplied path reached metadata resolver")
+	}
+}
+
+func TestTicketDeduplicationBoundsAndExpiry(t *testing.T) {
+	root := t.TempDir()
+	mediaPath := filepath.Join(root, "file.bin")
+	if err := os.WriteFile(mediaPath, []byte("payload"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := &fakeInstanceStore{
+		instances: map[string]*instance.Instance{
+			"radarr-main": {ID: "radarr-main", ServiceType: "radarr"},
+		},
+		allowed: true,
+	}
+	resolver := &fakeMetadataResolver{paths: map[int]string{7: mediaPath, 8: mediaPath, 9: mediaPath}}
+	h := newTestHandler(t, store, resolver, []string{root})
+	h.maxTickets = 1
+	h.maxTicketsPerUser = 1
+	now := time.Date(2026, time.July, 22, 13, 0, 0, 0, time.UTC)
+	h.now = func() time.Time { return now }
+
+	first, firstBody := issueTicket(t, h, &auth.Claims{UserID: 21, Role: auth.RoleUser}, `{"instance_id":"radarr-main","file_id":7}`)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first status = %d, body = %s", first.Code, first.Body.String())
+	}
+	repeated, repeatedBody := issueTicket(t, h, &auth.Claims{UserID: 21, Role: auth.RoleUser}, `{"instance_id":"radarr-main","file_id":7}`)
+	if repeated.Code != http.StatusCreated || repeatedBody.URL != firstBody.URL || !repeatedBody.ExpiresAt.Equal(firstBody.ExpiresAt) {
+		t.Fatalf("deduplicated ticket = %d %#v, first = %#v", repeated.Code, repeatedBody, firstBody)
+	}
+	if len(h.tickets) != 1 {
+		t.Fatalf("tickets = %d, want one deduplicated capability", len(h.tickets))
+	}
+
+	perUser, _ := issueTicket(t, h, &auth.Claims{UserID: 21, Role: auth.RoleUser}, `{"instance_id":"radarr-main","file_id":8}`)
+	if perUser.Code != http.StatusTooManyRequests {
+		t.Fatalf("per-user bound status = %d, body = %s", perUser.Code, perUser.Body.String())
+	}
+	global, _ := issueTicket(t, h, &auth.Claims{UserID: 22, Role: auth.RoleUser}, `{"instance_id":"radarr-main","file_id":9}`)
+	if global.Code != http.StatusServiceUnavailable {
+		t.Fatalf("global bound status = %d, body = %s", global.Code, global.Body.String())
+	}
+
+	now = firstBody.ExpiresAt
+	expired := downloadRequest(h, http.MethodGet, firstBody.URL, "")
+	if expired.Code != http.StatusNotFound {
+		t.Fatalf("expired ticket status = %d, body = %s", expired.Code, expired.Body.String())
+	}
+	if len(h.tickets) != 0 {
+		t.Fatalf("expired tickets retained: %d", len(h.tickets))
+	}
+	afterExpiry, _ := issueTicket(t, h, &auth.Claims{UserID: 22, Role: auth.RoleUser}, `{"instance_id":"radarr-main","file_id":9}`)
+	if afterExpiry.Code != http.StatusCreated {
+		t.Fatalf("ticket after expiry status = %d, body = %s", afterExpiry.Code, afterExpiry.Body.String())
+	}
+}
+
+func TestLexicalRootAliasAndActiveContentRemainDownloadOnly(t *testing.T) {
+	target := t.TempDir()
+	alias := filepath.Join(t.TempDir(), "library-alias")
+	if err := os.Symlink(target, alias); err != nil {
+		t.Fatal(err)
+	}
+	activePath := filepath.Join(alias, "active.html")
+	if err := os.WriteFile(activePath, []byte(`<script>alert("same origin")</script>`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	store := &fakeInstanceStore{
+		instances: map[string]*instance.Instance{
+			"radarr-main": {ID: "radarr-main", ServiceType: "radarr"},
+		},
+		allowed: true,
+	}
+	resolver := &fakeMetadataResolver{paths: map[int]string{10: activePath}}
+	h := newTestHandler(t, store, resolver, []string{alias})
+
+	issued, body := issueTicket(t, h, &auth.Claims{UserID: 31, Role: auth.RoleUser}, `{"instance_id":"radarr-main","file_id":10}`)
+	if issued.Code != http.StatusCreated {
+		t.Fatalf("lexical alias issue status = %d, body = %s", issued.Code, issued.Body.String())
+	}
+	download := downloadRequest(h, http.MethodGet, body.URL, "")
+	if download.Code != http.StatusOK {
+		t.Fatalf("active-content download status = %d, body = %s", download.Code, download.Body.String())
+	}
+	assertDownloadHeaders(t, download, "active.html")
+	if got := download.Header().Get("Content-Type"); got != "application/octet-stream" {
+		t.Fatalf("active-content Content-Type = %q", got)
+	}
+}
+
+func TestSafeFilenameRemovesHeaderControls(t *testing.T) {
+	got := safeFilename("folder/evil\r\nX-Evil: injected.epub", 5)
+	if got != "evilX-Evil: injected.epub" {
+		t.Fatalf("safeFilename() = %q", got)
+	}
+	disposition := mime.FormatMediaType("attachment", map[string]string{"filename": got})
+	if strings.ContainsAny(disposition, "\r\n") {
+		t.Fatalf("Content-Disposition contains a header control: %q", disposition)
+	}
+}
+
+func newTestHandler(t *testing.T, store *fakeInstanceStore, resolver metadataResolver, roots []string) *Handler {
+	t.Helper()
+	h, err := newHandler(store, store, resolver, roots)
+	if err != nil {
+		t.Fatalf("newHandler() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := h.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+	return h
+}
+
+func issueTicket(t *testing.T, h *Handler, claims *auth.Claims, body string) (*httptest.ResponseRecorder, issueTicketResponse) {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodPost, "/api/media-files/tickets", strings.NewReader(body))
+	if claims != nil {
+		ctx := context.WithValue(request.Context(), auth.ClaimsKey, claims)
+		request = request.WithContext(ctx)
+	}
+	response := httptest.NewRecorder()
+	h.IssueTicket(response, request)
+	var decoded issueTicketResponse
+	if response.Code == http.StatusCreated {
+		if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+			t.Fatalf("decode ticket response: %v; body = %s", err, response.Body.String())
+		}
+	}
+	return response, decoded
+}
+
+func downloadRequest(h *Handler, method, url, byteRange string) *httptest.ResponseRecorder {
+	router := chi.NewRouter()
+	router.Get("/api/media-files/download/{ticket}", h.Download)
+	router.Head("/api/media-files/download/{ticket}", h.Download)
+	request := httptest.NewRequest(method, url, nil)
+	if byteRange != "" {
+		request.Header.Set("Range", byteRange)
+	}
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+	return response
+}
+
+func assertDownloadHeaders(t *testing.T, response *httptest.ResponseRecorder, expectedFilename string) {
+	t.Helper()
+	for name, want := range map[string]string{
+		"Cache-Control":                "private, no-store",
+		"Content-Security-Policy":      "sandbox; default-src 'none'",
+		"Cross-Origin-Resource-Policy": "same-origin",
+		"Pragma":                       "no-cache",
+		"Referrer-Policy":              "no-referrer",
+		"X-Content-Type-Options":       "nosniff",
+	} {
+		if got := response.Header().Get(name); got != want {
+			t.Errorf("%s = %q, want %q", name, got, want)
+		}
+	}
+	if response.Code < http.StatusBadRequest && response.Header().Get("Content-Type") != "application/octet-stream" {
+		t.Errorf("Content-Type = %q", response.Header().Get("Content-Type"))
+	}
+	if expectedFilename != "" {
+		mediaType, params, err := mime.ParseMediaType(response.Header().Get("Content-Disposition"))
+		if err != nil || mediaType != "attachment" || params["filename"] != expectedFilename {
+			t.Errorf("Content-Disposition = %q (type %q params %#v err %v)", response.Header().Get("Content-Disposition"), mediaType, params, err)
+		}
+	}
+}

--- a/server/internal/radarr/client.go
+++ b/server/internal/radarr/client.go
@@ -54,6 +54,15 @@ type Movie struct {
 	RootFolderPath string `json:"rootFolderPath,omitempty"`
 }
 
+// MovieFile is Radarr's metadata for one completed movie file on disk.
+type MovieFile struct {
+	ID           int    `json:"id"`
+	MovieID      int    `json:"movieId"`
+	RelativePath string `json:"relativePath"`
+	Path         string `json:"path"`
+	Size         int64  `json:"size"`
+}
+
 type QualityProfile struct {
 	ID   int    `json:"id"`
 	Name string `json:"name"`
@@ -187,6 +196,16 @@ func (c *Client) GetMovie(id int) (*Movie, error) {
 		return nil, fmt.Errorf("decode radarr movie: %w", err)
 	}
 	return &movie, nil
+}
+
+// GetMovieFile returns live metadata for one completed file in Radarr.
+func (c *Client) GetMovieFile(id int) (*MovieFile, error) {
+	var file MovieFile
+	path := fmt.Sprintf("/api/v3/moviefile/%d", id)
+	if err := c.do(http.MethodGet, path, nil, &file); err != nil {
+		return nil, fmt.Errorf("radarr movie file: %w", err)
+	}
+	return &file, nil
 }
 
 func (c *Client) GetMovieByTMDB(tmdbID int) (*Movie, error) {

--- a/server/internal/radarr/client_test.go
+++ b/server/internal/radarr/client_test.go
@@ -13,6 +13,43 @@ type failingTransport struct{ err error }
 
 func (f failingTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, f.err }
 
+func TestGetMovieFileUsesExactAuthenticatedEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v3/moviefile/73" || r.URL.RawQuery != "" {
+			t.Errorf("request = %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "movie-key" {
+			t.Errorf("X-Api-Key = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"id":73,"movieId":8,"relativePath":"Movie.mkv","path":"/library/Movie.mkv","size":123456}`))
+	}))
+	t.Cleanup(server.Close)
+
+	file, err := NewClient(server.URL, "movie-key").GetMovieFile(73)
+	if err != nil {
+		t.Fatalf("GetMovieFile() error = %v", err)
+	}
+	if file.ID != 73 || file.MovieID != 8 || file.Path != "/library/Movie.mkv" || file.RelativePath != "Movie.mkv" || file.Size != 123456 {
+		t.Fatalf("file = %#v", file)
+	}
+}
+
+func TestGetMovieFileOmitsUpstreamErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`secret path /library/private and signed-token`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := NewClient(server.URL, "key").GetMovieFile(73)
+	if err == nil {
+		t.Fatal("GetMovieFile() error = nil")
+	}
+	if message := err.Error(); strings.Contains(message, "/library/private") || strings.Contains(message, "signed-token") {
+		t.Fatalf("error leaked upstream body: %q", message)
+	}
+}
+
 // TestTransportErrorOmitsHost pins the topology-privacy property: transport
 // failures embed the full request URL (and DNS errors repeat the hostname),
 // and these errors surface to requesters through request failures — so the

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -844,6 +844,26 @@ type Episode struct {
 	Monitored     bool       `json:"monitored"`
 }
 
+// EpisodeFile is Sonarr's metadata for one completed episode file on disk.
+type EpisodeFile struct {
+	ID           int    `json:"id"`
+	SeriesID     int    `json:"seriesId"`
+	SeasonNumber int    `json:"seasonNumber"`
+	RelativePath string `json:"relativePath"`
+	Path         string `json:"path"`
+	Size         int64  `json:"size"`
+}
+
+// GetEpisodeFile returns live metadata for one completed file in Sonarr.
+func (c *Client) GetEpisodeFile(id int) (*EpisodeFile, error) {
+	var file EpisodeFile
+	path := fmt.Sprintf("/api/v3/episodefile/%d", id)
+	if err := c.do(http.MethodGet, path, nil, &file); err != nil {
+		return nil, fmt.Errorf("sonarr episode file: %w", err)
+	}
+	return &file, nil
+}
+
 // GetEpisodes lists the episodes of one season of a series.
 func (c *Client) GetEpisodes(seriesID, seasonNumber int) ([]Episode, error) {
 	var episodes []Episode

--- a/server/internal/sonarr/client_test.go
+++ b/server/internal/sonarr/client_test.go
@@ -16,6 +16,43 @@ type failingTransport struct{ err error }
 
 func (f failingTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, f.err }
 
+func TestGetEpisodeFileUsesExactAuthenticatedEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/api/v3/episodefile/91" || r.URL.RawQuery != "" {
+			t.Errorf("request = %s %s?%s", r.Method, r.URL.Path, r.URL.RawQuery)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "episode-key" {
+			t.Errorf("X-Api-Key = %q", got)
+		}
+		_, _ = w.Write([]byte(`{"id":91,"seriesId":4,"seasonNumber":2,"relativePath":"Season 02/Episode.mkv","path":"/library/Season 02/Episode.mkv","size":654321}`))
+	}))
+	t.Cleanup(server.Close)
+
+	file, err := NewClient(server.URL, "episode-key").GetEpisodeFile(91)
+	if err != nil {
+		t.Fatalf("GetEpisodeFile() error = %v", err)
+	}
+	if file.ID != 91 || file.SeriesID != 4 || file.SeasonNumber != 2 || file.Path != "/library/Season 02/Episode.mkv" || file.RelativePath != "Season 02/Episode.mkv" || file.Size != 654321 {
+		t.Fatalf("file = %#v", file)
+	}
+}
+
+func TestGetEpisodeFileOmitsUpstreamErrorBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`secret path /library/private and signed-token`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := NewClient(server.URL, "key").GetEpisodeFile(91)
+	if err == nil {
+		t.Fatal("GetEpisodeFile() error = nil")
+	}
+	if message := err.Error(); strings.Contains(message, "/library/private") || strings.Contains(message, "signed-token") {
+		t.Fatalf("error leaked upstream body: %q", message)
+	}
+}
+
 // TestTransportErrorOmitsHost pins the topology-privacy property: transport
 // failures embed the full request URL (and DNS errors repeat the hostname),
 // and these errors surface to requesters through request failures — so the


### PR DESCRIPTION
## What

Adds opt-in downloads for completed ebooks, audiobooks, movies, and episodes from requester and admin detail surfaces. Cantinarr resolves each live arr file ID, confines reads to explicitly configured media roots, and streams through short-lived capability links with HEAD and Range support.

The download URL carries no session JWT, arr credential, or filesystem path. Ticket issuance and every transfer re-check the current account role and effective instance access; deleted users, demoted admins, and revoked instance grants fail before metadata or file access.

## Verification

- go vet ./...
- go test ./...
- CGO_ENABLED=0 go build ./cmd/server
- flutter analyze --no-fatal-infos
- flutter test (651 passed)
- flutter build web --release
- make check-test-automation
- git diff --check

## Docs

- [x] README.md — pitch, feature list, configuration/env vars, quick start
- [x] server/README.md — routes, MCP tools, DB tables, env vars, package tree
- [x] app/README.md — screens/features, navigation, project structure
- [ ] AGENTS.md — workflow, verification, or convention changes
- [ ] No docs impact — explained above

Also updates both Compose examples, env templates, and the live/manual media-services test catalog.