### PR TITLE
Fix full-title Chaptarr search fallback

### DIFF
--- a/app/lib/features/dashboard/logic/book_search_ranking.dart
+++ b/app/lib/features/dashboard/logic/book_search_ranking.dart
@@ -46,10 +46,10 @@ List<RankedBookSearchResult> rankBookSearchResults(
   return ranked;
 }
 
-/// Returns one autocomplete-style fallback by removing the final Unicode code
-/// point from [query]. This is deliberately bounded to one retry: Chaptarr can
-/// cache an empty exact lookup even while the immediately shorter prefix still
-/// returns the intended work.
+/// Returns the next autocomplete-style fallback by removing the final Unicode
+/// code point from [query]. Callers bound how many progressively shorter
+/// prefixes they try: Chaptarr can cache an empty exact lookup while a broader
+/// prefix still returns the intended work.
 String? bookSearchPrefixFallbackTerm(String query) {
   final trimmed = query.trim();
   final codePoints = trimmed.runes.toList(growable: false);

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -35,6 +35,8 @@ class DashboardBooksTab extends ConsumerStatefulWidget {
 
 class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab>
     with WidgetsBindingObserver {
+  static const _maxPrefixFallbacks = 8;
+
   final _controller = TextEditingController();
   Timer? _debounce;
   List<ChaptarrBook> _results = [];
@@ -150,17 +152,22 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab>
       if (!mounted || gen != _searchGen) return;
       var resultLookupTerm = term;
       if (books.isEmpty) {
-        final fallbackTerm = bookSearchPrefixFallbackTerm(term);
-        if (fallbackTerm != null) {
+        var previousTerm = term;
+        for (var attempt = 0;
+            attempt < _maxPrefixFallbacks;
+            attempt++) {
+          final fallbackTerm = bookSearchPrefixFallbackTerm(previousTerm);
+          if (fallbackTerm == null) break;
+          previousTerm = fallbackTerm;
           final fallbackBooks = await service.lookupBook(fallbackTerm);
           if (!mounted || gen != _searchGen) return;
           final matchingBooks = fallbackBooks
               .where((book) => stronglyMatchesBookSearch(term, book))
               .toList();
-          if (matchingBooks.isNotEmpty) {
-            books = matchingBooks;
-            resultLookupTerm = fallbackTerm;
-          }
+          if (matchingBooks.isEmpty) continue;
+          books = matchingBooks;
+          resultLookupTerm = fallbackTerm;
+          break;
         }
       }
       setState(() {

--- a/app/test/dashboard/dashboard_books_tab_test.dart
+++ b/app/test/dashboard/dashboard_books_tab_test.dart
@@ -25,7 +25,7 @@ void main() {
   });
 
   testWidgets(
-      'an empty exact lookup retries one prefix and keeps every strong match',
+      'an empty exact lookup retries bounded prefixes and keeps strong matches',
       (tester) async {
     _usePhoneSize(tester);
     final (:router, container: _, :adapter) = await _pumpRouter(
@@ -33,6 +33,15 @@ void main() {
       lookupHandler: (term) {
         if (term == 'haunting Adeline') return const <Object>[];
         if (term == 'haunting Adelin') {
+          return [
+            _lookupBook(
+              'Adeline: A Haunting Historical Portrait',
+              'Norah Vincent',
+              'unrelated-warmup',
+            ),
+          ];
+        }
+        if (term == 'haunting Ad') {
           return [
             _lookupBook(
               'Haunting Adeline (Cat and Mouse, #1)',
@@ -66,7 +75,14 @@ void main() {
     await tester.pump(const Duration(milliseconds: 450));
     await tester.pumpAndSettle();
 
-    expect(adapter.lookupTerms, ['haunting Adeline', 'haunting Adelin']);
+    expect(adapter.lookupTerms, [
+      'haunting Adeline',
+      'haunting Adelin',
+      'haunting Adeli',
+      'haunting Adel',
+      'haunting Ade',
+      'haunting Ad',
+    ]);
     expect(
       find.text('Haunting Adeline (Cat and Mouse, #1)'),
       findsNWidgets(2),
@@ -90,7 +106,7 @@ void main() {
     expect(adapter.requestBodies, hasLength(1));
     expect(
       adapter.requestBodies.single['book_selection']['lookup_term'],
-      'haunting Adelin',
+      'haunting Ad',
     );
     expect(
       adapter.requestBodies.single['book_selection']


### PR DESCRIPTION
## What changed

- retry progressively broader Chaptarr title prefixes when an exact lookup is empty
- cap fallback traffic at eight attempts and stop at the first strongly matching result
- preserve the exact successful lookup term and catalog ID through the existing request path
- expand the Haunting Adeline regression to reproduce empty and unrelated intermediate responses

## Root cause

The previous fallback removed only one character. The live Chaptarr catalog can keep both the exact lookup and that immediate prefix empty until a broader prefix such as `haunting Ad` warms and returns the intended title.

## User impact

Typing the complete title now reaches the same strongly matched result as the working partial search, without exposing unrelated fallback rows.

## Validation

- `flutter analyze --no-fatal-infos`
- `flutter test` (724 tests)
- `git diff --check`
