### PR TITLE
Fix formatless Chaptarr audiobook lookup

### DIFF
--- a/server/internal/request/book_selection.go
+++ b/server/internal/request/book_selection.go
@@ -384,6 +384,25 @@ func lookupResultMatchesPublication(result chaptarr.LookupResult, format string,
 			matches++
 		}
 	}
+	// This Chaptarr fork can return an authoritative top-level medium and
+	// edition identity together with one otherwise format-less child edition.
+	// Accept that exact parent-child relationship just as the later local-row
+	// verifier does. An isEbook hint alone is not authoritative, and an
+	// explicitly conflicting or duplicate child still fails closed.
+	if matches == 0 && len(editions) == 1 &&
+		strictChaptarrFormat(result.MediaType) == format &&
+		selection.ForeignEditionID != "" &&
+		strings.TrimSpace(result.ForeignEditionID) == selection.ForeignEditionID {
+		edition := editions[0]
+		if strings.TrimSpace(edition.Format) == "" &&
+			strings.TrimSpace(edition.ForeignEditionID) == strings.TrimSpace(result.ForeignEditionID) {
+			candidateSelection := *selection
+			candidateSelection.Year = 0
+			if bookPublicationMatchesEdition(&candidateSelection, edition, lookupBook) {
+				matches++
+			}
+		}
+	}
 	if len(editions) == 0 && strictChaptarrFormat(result.MediaType) == format {
 		candidateSelection := *selection
 		candidateSelection.Year = 0

--- a/server/internal/request/book_selection_test.go
+++ b/server/internal/request/book_selection_test.go
@@ -823,6 +823,79 @@ func TestLookupPublicationCanUseStableTopLevelEditionIdentity(t *testing.T) {
 	}
 }
 
+func TestLookupPublicationAcceptsExactFormatlessChildFromAuthoritativeParent(t *testing.T) {
+	formatlessChild, err := json.Marshal(map[string]any{
+		"foreignEditionId": "58763686",
+		"title":            "Haunting Adeline (Cat and Mouse, #1)",
+		"format":           nil,
+		"isEbook":          false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := chaptarr.LookupResult{
+		Title:            "Haunting Adeline (Cat and Mouse, #1)",
+		ForeignBookID:    "gr:91913524",
+		ForeignEditionID: "58763686",
+		MediaType:        BookFormatAudiobook,
+		PageCount:        629,
+		Editions:         []json.RawMessage{formatlessChild},
+	}
+	selection := &BookPublicationSelection{
+		ForeignEditionID: "58763686",
+		PageCount:        629,
+	}
+
+	matched, err := lookupResultMatchesPublication(
+		result,
+		BookFormatAudiobook,
+		selection,
+	)
+	if err != nil || !matched {
+		t.Fatalf("authoritative format-less child = %v, %v; want exact audiobook match", matched, err)
+	}
+
+	wrongMedium := result
+	wrongMedium.MediaType = BookFormatEbook
+	matched, err = lookupResultMatchesPublication(
+		wrongMedium,
+		BookFormatAudiobook,
+		selection,
+	)
+	if err != nil || matched {
+		t.Fatalf("wrong parent medium = %v, %v; want false", matched, err)
+	}
+
+	explicitConflict, err := json.Marshal(map[string]any{
+		"foreignEditionId": "58763686",
+		"format":           BookFormatEbook,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conflictingChild := result
+	conflictingChild.Editions = []json.RawMessage{explicitConflict}
+	matched, err = lookupResultMatchesPublication(
+		conflictingChild,
+		BookFormatAudiobook,
+		selection,
+	)
+	if err != nil || matched {
+		t.Fatalf("conflicting child medium = %v, %v; want false", matched, err)
+	}
+
+	duplicateChild := result
+	duplicateChild.Editions = []json.RawMessage{formatlessChild, formatlessChild}
+	matched, err = lookupResultMatchesPublication(
+		duplicateChild,
+		BookFormatAudiobook,
+		selection,
+	)
+	if err != nil || matched {
+		t.Fatalf("duplicate child identity = %v, %v; want false", matched, err)
+	}
+}
+
 func TestPendingBookSelectionsForSameWorkRemainDistinct(t *testing.T) {
 	service, userID := newBookTestService(t)
 	first, err := normalizeBookSelection(&BookSelection{


### PR DESCRIPTION
## What changed
- Accept Chaptarr’s authoritative top-level audiobook identity when its sole child edition has the same foreign edition ID but a blank format.
- Continue failing closed for wrong media types, conflicting child formats, mismatched IDs, and duplicate children.
- Add a regression using the exact Haunting Adeline response shape returned by the live Chaptarr instance.

## Root cause
Chaptarr returned the correct catalog row, but Cantinarr ignored the valid parent `mediaType` and `foreignEditionId` whenever any child edition existed. The real audiobook row contains one child with a blank format, so replay rejected the selected publication before any Chaptarr mutation and returned `book_match_not_found`.

## User impact
Retrying the selected Haunting Adeline audiobook can resolve the exact edition and proceed to the normal add/search flow instead of immediately flip-flopping back to “Couldn’t add.”

## Validation
- `go vet ./...`
- `go test ./...`
- Focused publication regression test
- `git diff --check`

## Documentation
- No documented API or UI surface changed.