### PR TITLE
fix: order the TV library rows by time, which is what they promise

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -53,7 +53,7 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 - **Search-to-AI hand-off** -- a query that looks like a question (or returns nothing) lights up an AI affordance; sending it opens the dedicated assistant with the prompt already in flight.
 
 ### Discover
-- **Movies / TV tabs** -- discovery rows plus live library rows from the user's default instances: Downloading Soon, Recently Downloaded (ordered by when the file landed, not when the title was added), Airing Next.
+- **Movies / TV tabs** -- discovery rows plus live library rows from the user's default instances: Downloading Soon, Recently Downloaded (ordered by when the file landed, never when the title was added -- Radarr carries the file date on the movie, Sonarr does not, so series recency comes from its import history), Airing Next (soonest air date first).
 - **Cinematic title pages** -- movie/show detail opens under a full-bleed, unblurred backdrop hero: the image parallaxes at half scroll speed (with an iOS overscroll stretch-zoom and a settle-in on load), then hands off to a pinned marquee bar carrying the title and back control. Titles without artwork get a warm ambient-glow stage instead.
 - **Releases tab** -- a unified movie + episode release timeline with list and month-calendar views.
 - **Books tab** -- appears only for users with a Chaptarr grant: opens on a Recently Added row (newest book-file imports, eBook and Audiobook shown separately since they arrive at different times) above owned-aware book search, whose tappable results open the richer book detail where per-format request controls live (see Books). The row is absent for users with no Chaptarr grant and hides while a search is active.

--- a/app/lib/features/dashboard/logic/library_rows.dart
+++ b/app/lib/features/dashboard/logic/library_rows.dart
@@ -1,4 +1,5 @@
 import '../../radarr/data/radarr_models.dart';
+import '../../sonarr/data/sonarr_models.dart';
 
 /// The dashboard's "Recently Downloaded" movies, newest file first.
 ///
@@ -22,4 +23,81 @@ List<RadarrMovie> recentlyDownloadedMovies(
   final downloaded = movies.where((m) => m.hasFile).toList()
     ..sort((a, b) => landedAt(b).compareTo(landedAt(a)));
   return downloaded.take(limit).toList();
+}
+
+/// The dashboard's "Recently Downloaded" series, newest import first.
+///
+/// Sonarr's series record carries no import timestamp — `statistics` counts the
+/// files but never says when one landed — so recency has to come from
+/// [importHistory], which stamps every completed import with its date. The row
+/// is series cards, so a season pack that imported twelve episodes is one
+/// arrival of one show, dated by its newest file.
+///
+/// This replaces a sort by `percentComplete`, which has no time dimension at
+/// all: it ranked the *most complete* series, so the row was a near-static list
+/// of finished shows that never showed what had actually just downloaded.
+///
+/// Only records naming an import are counted, so a page that also carries
+/// grabs, failures, or deletions cannot pass one off as a download. Series with
+/// no import record are absent rather than appended: without a date there is no
+/// honest place to put them in a list ordered by date. That also means an empty
+/// history — cleared by an admin, or predating the library — yields an empty
+/// row, which is the truthful answer to "what arrived lately".
+List<SonarrSeries> recentlyDownloadedSeries(
+  List<SonarrSeries> series,
+  List<SonarrHistoryRecord> importHistory, {
+  int limit = 10,
+}) {
+  final importedAt = <int, DateTime>{};
+  for (final record in importHistory) {
+    if (record.eventType != SonarrHistoryRecord.importedEventType) continue;
+    final seriesId = record.seriesId;
+    final date = record.date;
+    if (seriesId == null || date == null) continue;
+    final newest = importedAt[seriesId];
+    if (newest == null || date.isAfter(newest)) importedAt[seriesId] = date;
+  }
+
+  DateTime landedAt(SonarrSeries s) => importedAt[s.id] ?? DateTime(0);
+
+  final downloaded = series.where((s) => importedAt.containsKey(s.id)).toList()
+    ..sort((a, b) {
+      final byDate = landedAt(b).compareTo(landedAt(a));
+      // A season pack stamps every episode within the same second; without a
+      // tie-break the row would reshuffle on each fetch.
+      return byDate != 0 ? byDate : b.id.compareTo(a.id);
+    });
+  return downloaded.take(limit).toList();
+}
+
+/// The dashboard's "Airing Next" series, soonest air date first.
+///
+/// [calendar] is Sonarr's raw calendar window. Each series is dated by its
+/// earliest upcoming episode in that window, because that is the date the row
+/// promises. Ordering matters more than it looks: the row shows ten cards, so
+/// leaving it in library order (which is alphabetical) let a series airing in
+/// six days push out one airing tomorrow.
+List<SonarrSeries> airingNextSeries(
+  List<SonarrSeries> series,
+  List<Map<String, dynamic>> calendar, {
+  int limit = 10,
+}) {
+  final airsAt = <int, DateTime>{};
+  for (final entry in calendar) {
+    final seriesId = entry['seriesId'] as int?;
+    // An entry with no air date cannot be placed in a list ordered by air date.
+    final airDate = DateTime.tryParse(entry['airDateUtc'] as String? ?? '');
+    if (seriesId == null || airDate == null) continue;
+    final soonest = airsAt[seriesId];
+    if (soonest == null || airDate.isBefore(soonest)) airsAt[seriesId] = airDate;
+  }
+
+  DateTime airsOn(SonarrSeries s) => airsAt[s.id] ?? DateTime(0);
+
+  final airing = series.where((s) => airsAt.containsKey(s.id)).toList()
+    ..sort((a, b) {
+      final byDate = airsOn(a).compareTo(airsOn(b));
+      return byDate != 0 ? byDate : a.id.compareTo(b.id);
+    });
+  return airing.take(limit).toList();
 }

--- a/app/lib/features/dashboard/ui/dashboard_tv_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_tv_tab.dart
@@ -12,6 +12,13 @@ import '../../discover/ui/category_row.dart';
 import '../../sonarr/data/sonarr_api_service.dart';
 import '../../sonarr/data/sonarr_models.dart';
 import '../../sonarr/logic/tv_discover_provider.dart';
+import '../logic/library_rows.dart';
+
+/// How far back the "Recently Downloaded" row looks. Sonarr writes one import
+/// record per episode, so a season pack spends a dozen of these on one series —
+/// the page has to be deep enough that a single big import does not crowd every
+/// other show out of the row.
+const _importHistoryPageSize = 100;
 
 /// Dashboard TV tab: discovery rows + Sonarr library rows.
 class DashboardTvTab extends ConsumerStatefulWidget {
@@ -64,20 +71,33 @@ class _DashboardTvTabState extends ConsumerState<DashboardTvTab>
     final service =
         SonarrApiService(backendDio: backendDio, instanceId: defaultSonarr.id);
 
-    List<SonarrSeries> series = [];
+    // Both rows are the library joined to a second source, so a failed series
+    // fetch leaves nothing to join and the dependent calls are skipped. The
+    // rows keep what they are already showing rather than blanking the landing
+    // screen over one transient error.
+    final List<SonarrSeries> series;
     try {
       series = await service.getSeries();
+    } catch (_) {
+      if (mounted) setState(() => _isLoadingLibrary = false);
+      return;
+    }
+    if (!mounted) return;
+
+    try {
+      final imports = await service.getHistory(
+        pageSize: _importHistoryPageSize,
+        eventType: SonarrHistoryRecord.importedEventTypeId,
+      );
       if (!mounted) return;
 
-      // "Recently Downloaded" = series with downloaded episodes, sorted by percent complete
-      final downloaded = series.where((s) => s.percentComplete > 0).toList()
-        ..sort((a, b) => b.percentComplete.compareTo(a.percentComplete));
-
       setState(() {
-        _recentlyDownloaded = downloaded.take(10).toList();
+        _recentlyDownloaded = recentlyDownloadedSeries(series, imports.records);
       });
     } catch (_) {
-      // Series fetch failed; leave _recentlyDownloaded empty.
+      // History fetch failed. A series record carries no import date, so there
+      // is no second source to fall back to — leave the row as it is rather
+      // than ordering it by something that is not recency.
     }
 
     try {
@@ -88,19 +108,11 @@ class _DashboardTvTabState extends ConsumerState<DashboardTvTab>
       );
       if (!mounted) return;
 
-      // "Airing Next" = unique series from calendar entries
-      final airingSeriesIds = calendarEntries
-          .map((e) => e['seriesId'] as int?)
-          .whereType<int>()
-          .toSet();
-      final airingNext =
-          series.where((s) => airingSeriesIds.contains(s.id)).toList();
-
       setState(() {
-        _airingNext = airingNext.take(10).toList();
+        _airingNext = airingNextSeries(series, calendarEntries);
       });
     } catch (_) {
-      // Calendar fetch failed; leave _airingNext empty.
+      // Calendar fetch failed; leave _airingNext as it is.
     }
 
     if (mounted) setState(() => _isLoadingLibrary = false);

--- a/app/lib/features/sonarr/data/sonarr_api_service.dart
+++ b/app/lib/features/sonarr/data/sonarr_api_service.dart
@@ -187,16 +187,21 @@ class SonarrApiService {
     });
   }
 
-  /// Fetches a page of history events, newest first.
+  /// Fetches a page of history events, newest first. Pass [eventType] (one of
+  /// the ids on [SonarrHistoryRecord]) to narrow the page to a single kind of
+  /// event, so a caller after imports does not spend the page on grabs and
+  /// failures.
   Future<SonarrHistoryPage> getHistory({
     int page = 1,
     int pageSize = 50,
+    int? eventType,
   }) async {
     final resp = await _dio.get('$_basePath/history', queryParameters: {
       'page': page,
       'pageSize': pageSize,
       'sortKey': 'date',
       'sortDirection': 'descending',
+      if (eventType != null) 'eventType': eventType,
     });
     return SonarrHistoryPage.fromJson(resp.data as Map<String, dynamic>);
   }

--- a/app/lib/features/sonarr/data/sonarr_models.dart
+++ b/app/lib/features/sonarr/data/sonarr_models.dart
@@ -516,6 +516,16 @@ class SonarrQueueItem {
 
 /// A single Sonarr history event.
 class SonarrHistoryRecord {
+  /// Sonarr's `eventType` enum value for a completed import, used to filter the
+  /// history query. Sonarr accepts the integer but answers with the name below,
+  /// so both spellings are needed: one to ask, one to confirm what came back.
+  static const int importedEventTypeId = 3;
+
+  /// The name the same event carries in the response body. Matching on it means
+  /// that if a future Sonarr ever renumbered the enum, the row would come back
+  /// empty rather than quietly presenting deletes or grabs as downloads.
+  static const String importedEventType = 'downloadFolderImported';
+
   final int id;
   final String sourceTitle;
   final String eventType;

--- a/app/test/dashboard/dashboard_tv_tab_test.dart
+++ b/app/test/dashboard/dashboard_tv_tab_test.dart
@@ -1,0 +1,250 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/widgets/horizontal_item_row.dart';
+import 'package:cantinarr/features/auth/logic/auth_provider.dart';
+import 'package:cantinarr/features/dashboard/ui/dashboard_tv_tab.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Covers the wiring the pure row builders in library_rows_test.dart cannot
+/// see: that the tab asks Sonarr for import history at all, and that the row
+/// on screen is the one those builders produced.
+void main() {
+  testWidgets('Recently Downloaded is ordered by import date, not completeness',
+      (tester) async {
+    final adapter = _SonarrAdapter(
+      series: [
+        _series(id: 1, title: 'Finished Show', files: 100, episodes: 100),
+        _series(id: 2, title: 'Just Landed', files: 1, episodes: 20),
+      ],
+      history: [
+        _import(seriesId: 2, date: '2026-07-25T09:00:00Z'),
+        _import(seriesId: 1, date: '2025-01-01T09:00:00Z'),
+      ],
+      calendar: const [],
+    );
+
+    await _pumpTvTab(tester, adapter);
+
+    // Sonarr ranks the finished show at 100% and the new arrival at 5%; only
+    // the import dates put the show that actually just downloaded on top.
+    expect(find.text('Recently Downloaded'), findsOneWidget);
+    expect(
+      _rowItems(tester).map((s) => s.title),
+      ['Just Landed', 'Finished Show'],
+    );
+  });
+
+  testWidgets('asks Sonarr for imports rather than the whole history',
+      (tester) async {
+    final adapter = _SonarrAdapter(
+      series: [_series(id: 1, title: 'Just Landed', files: 1, episodes: 20)],
+      history: [_import(seriesId: 1, date: '2026-07-25T09:00:00Z')],
+      calendar: const [],
+    );
+
+    await _pumpTvTab(tester, adapter);
+
+    // Grabs and failures outnumber imports, so an unfiltered page would spend
+    // itself on events this row cannot use.
+    expect(adapter.historyQuery['eventType'],
+        SonarrHistoryRecord.importedEventTypeId);
+    expect(adapter.historyQuery['pageSize'], greaterThan(50));
+  });
+
+  testWidgets('Airing Next is ordered by air date, not library order',
+      (tester) async {
+    final adapter = _SonarrAdapter(
+      // Sonarr returns the library sorted by title.
+      series: [
+        _series(id: 1, title: 'Alpha Series', files: 4, episodes: 8),
+        _series(id: 2, title: 'Zulu Series', files: 2, episodes: 8),
+      ],
+      history: const [],
+      calendar: [
+        _airing(seriesId: 1, airDateUtc: '2026-07-31T01:00:00Z'),
+        _airing(seriesId: 2, airDateUtc: '2026-07-26T01:00:00Z'),
+      ],
+    );
+
+    await _pumpTvTab(tester, adapter);
+
+    expect(find.text('Airing Next'), findsOneWidget);
+    expect(
+      _rowItems(tester).map((s) => s.title),
+      ['Zulu Series', 'Alpha Series'],
+    );
+  });
+
+  testWidgets('drops the row rather than misordering it when history fails',
+      (tester) async {
+    final adapter = _SonarrAdapter(
+      series: [_series(id: 1, title: 'Finished Show', files: 100, episodes: 100)],
+      history: const [],
+      calendar: const [],
+      failHistory: true,
+    );
+
+    await _pumpTvTab(tester, adapter);
+
+    // A series record carries no import date, so there is nothing to fall back
+    // to. Showing the library under a "Recently Downloaded" heading would be a
+    // claim the app cannot support.
+    expect(find.text('Recently Downloaded'), findsNothing);
+  });
+}
+
+/// The items of the tab's only Sonarr row. Each test leaves exactly one of the
+/// two library rows populated, so this needs no disambiguation.
+List<SonarrSeries> _rowItems(WidgetTester tester) => tester
+    .widget<HorizontalItemRow<SonarrSeries>>(
+        find.byType(HorizontalItemRow<SonarrSeries>))
+    .items;
+
+Future<void> _pumpTvTab(WidgetTester tester, _SonarrAdapter adapter) async {
+  tester.view.physicalSize = const Size(390, 844);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
+
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+  dio.httpClientAdapter = adapter;
+  final container = ProviderContainer(
+    overrides: [
+      authProvider.overrideWith(() => _FakeAuthNotifier(_tvState)),
+      backendClientProvider.overrideWithValue(dio),
+    ],
+  );
+  addTearDown(container.dispose);
+
+  await container.read(authProvider.future);
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: const MaterialApp(home: Scaffold(body: DashboardTvTab())),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+const _tvState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(sonarr: true),
+    instances: [
+      ServiceInstance(
+        id: 'tv',
+        serviceType: 'sonarr',
+        name: 'TV',
+        isDefault: true,
+      ),
+    ],
+  ),
+  user: UserProfile(id: 1, username: 'tester', role: 'user'),
+);
+
+Map<String, dynamic> _series({
+  required int id,
+  required String title,
+  required int files,
+  required int episodes,
+}) =>
+    {
+      'id': id,
+      'title': title,
+      'tmdbId': id,
+      // No images: a null poster keeps the cards off the network.
+      'images': <Object>[],
+      'statistics': {'episodeFileCount': files, 'episodeCount': episodes},
+    };
+
+Map<String, dynamic> _import({required int seriesId, required String date}) => {
+      'id': seriesId,
+      'seriesId': seriesId,
+      'date': date,
+      'eventType': SonarrHistoryRecord.importedEventType,
+    };
+
+Map<String, dynamic> _airing({
+  required int seriesId,
+  required String airDateUtc,
+}) =>
+    {'seriesId': seriesId, 'airDateUtc': airDateUtc};
+
+class _FakeAuthNotifier extends AuthNotifier {
+  _FakeAuthNotifier(this._initial);
+
+  final AuthState _initial;
+
+  @override
+  Future<AuthState> build() async => _initial;
+}
+
+class _SonarrAdapter implements HttpClientAdapter {
+  _SonarrAdapter({
+    required this.series,
+    required this.history,
+    required this.calendar,
+    this.failHistory = false,
+  });
+
+  final List<Map<String, dynamic>> series;
+  final List<Map<String, dynamic>> history;
+  final List<Map<String, dynamic>> calendar;
+  final bool failHistory;
+  Map<String, dynamic> historyQuery = const {};
+
+  static const _base = '/api/instances/tv/api/v3';
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    Object body;
+    if (options.path == '$_base/series') {
+      body = series;
+    } else if (options.path == '$_base/history') {
+      historyQuery = Map<String, dynamic>.from(options.queryParameters);
+      if (failHistory) {
+        return ResponseBody.fromString('{"error":"unavailable"}', 503,
+            headers: {
+              'content-type': ['application/json'],
+            });
+      }
+      body = {'records': history, 'totalRecords': history.length};
+    } else if (options.path == '$_base/calendar') {
+      body = calendar;
+    } else {
+      // Discovery rows: empty is enough, and every fetch there is guarded.
+      body = {
+        'page': 1,
+        'results': <Object>[],
+        'total_pages': 0,
+        'total_results': 0,
+      };
+    }
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/app/test/dashboard/library_rows_test.dart
+++ b/app/test/dashboard/library_rows_test.dart
@@ -1,5 +1,6 @@
 import 'package:cantinarr/features/dashboard/logic/library_rows.dart';
 import 'package:cantinarr/features/radarr/data/radarr_models.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 RadarrMovie _movie({
@@ -21,6 +22,38 @@ RadarrMovie _movie({
           ? RadarrMovieFile(id: id, dateAdded: fileDateAdded)
           : null,
     );
+
+SonarrSeries _series({
+  required int id,
+  int episodeFileCount = 0,
+  int episodeCount = 0,
+}) =>
+    SonarrSeries(
+      id: id,
+      title: 'Series $id',
+      tmdbId: id,
+      statistics: SonarrStatistics(
+        episodeFileCount: episodeFileCount,
+        episodeCount: episodeCount,
+      ),
+    );
+
+SonarrHistoryRecord _event({
+  required int? seriesId,
+  required DateTime? date,
+  String eventType = SonarrHistoryRecord.importedEventType,
+}) =>
+    SonarrHistoryRecord(
+      id: 0,
+      seriesId: seriesId,
+      date: date,
+      eventType: eventType,
+    );
+
+Map<String, dynamic> _airing(int? seriesId, String? airDateUtc) => {
+      'seriesId': seriesId,
+      'airDateUtc': airDateUtc,
+    };
 
 void main() {
   final now = DateTime(2026, 7, 25);
@@ -98,5 +131,195 @@ void main() {
     });
 
     expect(file.dateAdded, DateTime.parse('2026-07-20T10:30:00Z'));
+  });
+
+  group('recentlyDownloadedSeries', () {
+    test('orders by when episodes imported, not by how complete a series is',
+        () {
+      // The bug this replaced: sorting by percentComplete ranked the *most
+      // complete* series, so a finished show whose last episode landed a year
+      // ago sat permanently above the show that downloaded an hour ago.
+      final finishedLongAgo =
+          _series(id: 1, episodeFileCount: 100, episodeCount: 100);
+      final barelyStarted =
+          _series(id: 2, episodeFileCount: 1, episodeCount: 20);
+
+      final row = recentlyDownloadedSeries([finishedLongAgo, barelyStarted], [
+        _event(seriesId: 2, date: now),
+        _event(seriesId: 1, date: DateTime(2025, 7, 25)),
+      ]);
+
+      expect(row.map((s) => s.id), [2, 1]);
+    });
+
+    test('dates a season pack by its newest episode, and shows it once', () {
+      // Sonarr writes one import record per episode, newest first. A twelve
+      // episode pack is one arrival of one show, and it has to take the newest
+      // of those records or the series sorts below its own older episodes.
+      final pack = [
+        for (var i = 0; i < 12; i++)
+          _event(seriesId: 1, date: now.subtract(Duration(minutes: i))),
+      ];
+
+      final row = recentlyDownloadedSeries([
+        _series(id: 1),
+        _series(id: 2),
+      ], [
+        ...pack,
+        _event(seriesId: 2, date: now.subtract(const Duration(minutes: 5))),
+      ]);
+
+      expect(row.map((s) => s.id), [1, 2]);
+    });
+
+    test('counts only imports, not grabs or deletions', () {
+      final row = recentlyDownloadedSeries([
+        _series(id: 1),
+        _series(id: 2),
+      ], [
+        _event(seriesId: 1, date: now, eventType: 'grabbed'),
+        _event(seriesId: 1, date: now, eventType: 'episodeFileDeleted'),
+        _event(seriesId: 2, date: now.subtract(const Duration(days: 1))),
+      ]);
+
+      expect(row.map((s) => s.id), [2]);
+    });
+
+    test('leaves out a series with files but no import on record', () {
+      // A list ordered by date can only hold records that have one. Appending
+      // the undated ones would put "no idea when" in a recency ranking.
+      final row = recentlyDownloadedSeries(
+        [
+          _series(id: 1, episodeFileCount: 50, episodeCount: 50),
+          _series(id: 2),
+        ],
+        [_event(seriesId: 2, date: now)],
+      );
+
+      expect(row.map((s) => s.id), [2]);
+    });
+
+    test('is empty when Sonarr has no import history', () {
+      // Cleared history, or a library older than it: an empty row is the honest
+      // answer to "what arrived lately", where the old sort always showed ten.
+      final row = recentlyDownloadedSeries(
+        [_series(id: 1, episodeFileCount: 9, episodeCount: 9)],
+        [],
+      );
+
+      expect(row, isEmpty);
+    });
+
+    test('ignores history for a series no longer in the library', () {
+      final row = recentlyDownloadedSeries(
+        [_series(id: 1)],
+        [
+          _event(seriesId: 99, date: now),
+          _event(seriesId: 1, date: now.subtract(const Duration(days: 2))),
+        ],
+      );
+
+      expect(row.map((s) => s.id), [1]);
+    });
+
+    test('skips records missing a series or a date', () {
+      final row = recentlyDownloadedSeries(
+        [_series(id: 1)],
+        [
+          _event(seriesId: null, date: now),
+          _event(seriesId: 1, date: null),
+        ],
+      );
+
+      expect(row, isEmpty);
+    });
+
+    test('breaks timestamp ties deterministically and caps the row', () {
+      // A bulk import stamps every record within the same second; without a
+      // tie-break the row would reshuffle between fetches.
+      final series = List.generate(25, (i) => _series(id: i));
+      final history = [
+        for (var i = 0; i < 25; i++) _event(seriesId: i, date: now),
+      ];
+
+      final row = recentlyDownloadedSeries(series, history);
+
+      expect(row.map((s) => s.id), [24, 23, 22, 21, 20, 19, 18, 17, 16, 15]);
+      expect(
+        recentlyDownloadedSeries(series, history, limit: 3).map((s) => s.id),
+        [24, 23, 22],
+      );
+    });
+  });
+
+  group('airingNextSeries', () {
+    test('orders by soonest air date, not by library order', () {
+      // Sonarr returns the library sorted by title, so reusing that order made
+      // "Airing Next" alphabetical — a row that never answered its own title.
+      final row = airingNextSeries(
+        [_series(id: 1), _series(id: 2)],
+        [
+          _airing(1, '2026-08-01T01:00:00Z'),
+          _airing(2, '2026-07-26T01:00:00Z'),
+        ],
+      );
+
+      expect(row.map((s) => s.id), [2, 1]);
+    });
+
+    test('dates a series by its earliest upcoming episode, and shows it once',
+        () {
+      final row = airingNextSeries(
+        [_series(id: 1), _series(id: 2)],
+        [
+          _airing(1, '2026-07-31T01:00:00Z'),
+          _airing(1, '2026-07-26T01:00:00Z'),
+          _airing(1, '2026-07-29T01:00:00Z'),
+          _airing(2, '2026-07-28T01:00:00Z'),
+        ],
+      );
+
+      expect(row.map((s) => s.id), [1, 2]);
+    });
+
+    test('keeps the series airing soonest when the row is capped', () {
+      // The user-visible half of the bug: in library order the cap dropped
+      // whatever sorted last, even when it was the next thing to air.
+      final series = List.generate(5, (i) => _series(id: i));
+      final calendar = [
+        _airing(0, '2026-07-28T01:00:00Z'),
+        _airing(1, '2026-07-29T01:00:00Z'),
+        _airing(2, '2026-07-30T01:00:00Z'),
+        _airing(3, '2026-07-31T01:00:00Z'),
+        _airing(4, '2026-07-26T01:00:00Z'),
+      ];
+
+      expect(
+        airingNextSeries(series, calendar, limit: 2).map((s) => s.id),
+        [4, 0],
+      );
+    });
+
+    test('drops entries with no series or an unusable air date', () {
+      final row = airingNextSeries(
+        [_series(id: 1), _series(id: 2)],
+        [
+          _airing(null, '2026-07-26T01:00:00Z'),
+          _airing(1, 'not a date'),
+          _airing(2, '2026-07-27T01:00:00Z'),
+        ],
+      );
+
+      expect(row.map((s) => s.id), [2]);
+    });
+
+    test('leaves out series with nothing on the calendar', () {
+      final row = airingNextSeries(
+        [_series(id: 1), _series(id: 2)],
+        [_airing(2, '2026-07-27T01:00:00Z')],
+      );
+
+      expect(row.map((s) => s.id), [2]);
+    });
   });
 }


### PR DESCRIPTION
## What

Both Sonarr rows on the TV tab were ordered by something other than time, and both are headed by a promise about time.

**Recently Downloaded** sorted series by `percentComplete` — a ratio with no time dimension in it. It ranked the *most complete* shows, so the row was a near-static list of finished series, and the show that downloaded an hour ago sat below a back catalogue that last gained an episode years ago.

**Airing Next** filtered the library by the calendar and kept library order, which is alphabetical. The ten-card cap then dropped whatever sorted last, so a series airing tomorrow could lose its place to one airing in six days.

Sonarr's series record carries no import timestamp — `statistics` counts files but never dates one — so series recency now comes from history, which stamps every completed import. The row asks for one page of import events, takes the newest per series, and orders by that. A season pack is one arrival of one show, so it is one card, dated by its newest file. Airing Next dates each series by its earliest upcoming episode.

### Why history and not the files

- An `episodefile` read is the complete source, but Sonarr's API demands a `seriesId` filter, so it would be one call per series against libraries that routinely hold hundreds. It is also absent from the requester proxy allowlist. History is one call, and `downloadFolderImported` is literally the event this row is named after.
- The cost: files discovered by a disk rescan write no history record, so they do not appear. That is the same blind spot the Books row avoided by fanning out per author — affordable there, not here.
- Cleared or absent history now yields an empty row where the old sort always produced ten cards. Empty is the truthful answer to "what arrived lately".
- A failed history fetch leaves the row alone rather than falling back to the library. There is no second source for recency, so any fallback would be ordering by something that is not recency.
- The request asks for the import event by id and the response is matched by name. If a future Sonarr renumbered the enum, the row would come back empty rather than presenting deletions as downloads.

## Verification

```
flutter analyze --no-fatal-infos   → No issues found!
flutter test                       → All tests passed! (717)
python3 scripts/check_test_automation.py → catalog valid (100 parent cases)
```

Mutation-verified, 16 mutations, each killed by the one test that names the behaviour it breaks:

| | Mutation | Test that caught it |
|---|---|---|
| A | drop the series date sort | orders by when episodes imported, not by how complete a series is |
| B | newest-wins → last-wins | dates a season pack by its newest episode, and shows it once |
| C | drop the import-event filter | counts only imports, not grabs or deletions |
| D | drop the has-an-import filter | leaves out a series with files but no import on record |
| E | drop the tie-break | breaks timestamp ties deterministically and caps the row |
| F | drop the null-date guard | skips records missing a series or a date |
| G | drop the airing sort | orders by soonest air date, not by library order |
| H | earliest-wins → latest-wins | dates a series by its earliest upcoming episode |
| H2 | earliest-wins → last-wins | dates a series by its earliest upcoming episode |
| I | drop the on-the-calendar filter | leaves out series with nothing on the calendar |
| J | drop the airing null guards | drops entries with no series or an unusable air date |
| W1 | restore the `percentComplete` sort | Recently Downloaded is ordered by import date, not completeness |
| W2 | stop filtering history to imports | asks Sonarr for imports rather than the whole history |
| W3 | restore the unordered Airing Next set | Airing Next is ordered by air date, not library order |
| W4 | fall back to the library when history fails | drops the row rather than misordering it when history fails |
| W5 | shallow history page | asks Sonarr for imports rather than the whole history |

The W set covers the tab wiring, which the pure-function tests cannot see: that the tab asks Sonarr for import history at all, and that the row on screen is the one the builders produced.

Not run: no live Sonarr here, so the wire behaviour of `eventType=3` is proven only against the fixture. `DISC-001` in `docs/testing/` already covers loading these rows against a real instance.

## Docs

- [x] `app/README.md` — screens/features, navigation, project structure

Updated the Discover bullet: the parenthetical added by #287 said Recently Downloaded is ordered by when the file landed, which was only true of Movies. It now says where each side gets that date, and notes Airing Next is air-date ordered.

- [ ] `README.md` — no new config, env vars, or feature surface
- [ ] `server/README.md` — no server change; the Sonarr history read already goes through the existing instance proxy, which allowlists `history` for requesters
- [ ] `AGENTS.md` — no workflow or convention change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFg419sapgyPUx3Y719RPJ
