### PR TITLE
fix: keep side-scrolling shelves from hiding the search bar

### DIFF
--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -313,6 +313,12 @@ class _AppShellState extends ConsumerState<AppShell>
   }
 
   bool _handleScrollNotification(ScrollNotification notification) {
+    // Side-scrolling shelves (poster rows, chip strips) bubble their
+    // notifications up to this listener too. Only the page's own vertical
+    // scroll may drive the shell chrome: otherwise swiping a row sideways
+    // hides the search bar, and swiping it back to the start pops it open.
+    if (notification.metrics.axis != Axis.vertical) return false;
+
     final atTop =
         notification.metrics.pixels <= notification.metrics.minScrollExtent + 4;
 

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -100,6 +100,92 @@ void main() {
     expect(focusNode.hasFocus, isFalse);
   });
 
+  testWidgets('side-scrolling a shelf leaves the search bar alone',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    const pageScroll = ValueKey('page-scroll');
+    const posterRow = ValueKey('poster-row');
+
+    final router = GoRouter(
+      initialLocation: '/dashboard/movies',
+      routes: [
+        ShellRoute(
+          builder: (context, state, child) =>
+              AppShell(currentPath: state.uri.path, child: child),
+          routes: [
+            GoRoute(
+              path: '/dashboard/movies',
+              builder: (_, __) => Scaffold(
+                body: ListView(
+                  key: pageScroll,
+                  children: [
+                    const SizedBox(height: 400),
+                    SizedBox(
+                      height: 200,
+                      child: ListView.builder(
+                        key: posterRow,
+                        scrollDirection: Axis.horizontal,
+                        itemCount: 20,
+                        itemBuilder: (_, __) => const SizedBox(width: 120),
+                      ),
+                    ),
+                    const SizedBox(height: 1600),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith(
+            () => _FakeAuthNotifier(_authenticatedAiState),
+          ),
+          backendClientProvider.overrideWithValue(_fakeDio()),
+          realtimeEventsProvider
+              .overrideWithValue(const Stream<WsEvent>.empty()),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final topBar = find.byKey(const ValueKey('module-top-bar'));
+    final expanded = tester.getSize(topBar).height;
+    expect(expanded, greaterThan(0));
+
+    await tester.drag(find.byKey(posterRow), const Offset(-200, 0));
+    await tester.pumpAndSettle();
+    expect(
+      tester.getSize(topBar).height,
+      expanded,
+      reason: 'swiping a shelf forward must not hide the search bar',
+    );
+
+    // The page's own vertical scroll still owns the chrome.
+    await tester.drag(find.byKey(pageScroll), const Offset(0, -200));
+    await tester.pumpAndSettle();
+    expect(tester.getSize(topBar).height, lessThan(expanded));
+
+    await tester.drag(find.byKey(posterRow), const Offset(200, 0));
+    await tester.pumpAndSettle();
+    expect(
+      tester.getSize(topBar).height,
+      lessThan(expanded),
+      reason: 'a shelf back at its start must not pop the search bar open',
+    );
+  });
+
   testWidgets(
       'search-bar assistant submit opens route over previous shell content',
       (tester) async {


### PR DESCRIPTION
## Problem

Swiping a horizontal list (poster shelf, chip strip) sideways hid the global search bar, and swiping it back toward the start un-hid it.

## Cause

`AppShell` wraps the entire page subtree in a `NotificationListener<ScrollNotification>`, and scroll notifications bubble up from *every* scrollable underneath — including the horizontal `ListView` inside `HorizontalItemRow`. `_handleScrollNotification` treated them as page scrolls:

- swiping a shelf forward → positive `scrollDelta` → `_searchBarAnim.reverse()` (hide)
- swiping it back to its start → `pixels <= minScrollExtent + 4` → `_searchBarAnim.forward()` (unhide)

## Fix

Ignore notifications whose metrics aren't on the vertical axis, so only the page's own scroll drives the shell chrome. Guarding the whole handler also stops a sideways shelf swipe from dismissing the keyboard — that idiom is about vertical page scrolling too.

One-line guard rather than stopping propagation inside `HorizontalItemRow`, so every horizontal scrollable in the app is covered, not just that one widget.

## Verification

- New widget test in `test/shell/app_shell_test.dart` covers both halves of the report: a forward shelf swipe leaves the bar at full height, a vertical page drag still collapses it, and a shelf swiped back to its start doesn't pop it open. Mutation-checked — without the fix it fails on the first assertion (`Expected: <80.0> Actual: <0.0>`).
- `flutter analyze --no-fatal-infos` → no issues.
- `flutter test` → 740 passing.

No server changes, and no documented surface (route, screen, env var, tool) changed, so no doc updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eoDJQX1fr24CkYVkjLD75