### PR TITLE
fix: reconcile the search bar with the page it sits over

### DIFF
--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -71,6 +71,11 @@ class _AppShellState extends ConsumerState<AppShell>
   late final AnimationController _searchBarAnim;
   late final Animation<double> _searchBarCurve;
 
+  /// Last module route the search bar was shown over. Its collapse state
+  /// belongs to that page, so it survives a pushed route and resets when a
+  /// different module page takes over.
+  String? _searchBarPath;
+
   // Shimmer sweep rotation for aiReady state
   late final AnimationController _shimmerRotationAnim;
 
@@ -95,8 +100,26 @@ class _AppShellState extends ConsumerState<AppShell>
     );
     WidgetsBinding.instance.addObserver(this);
     _searchFocusNode.addListener(_onSearchFocusChanged);
+    _searchBarPath = _searchBarPathFor(widget.currentPath);
     WidgetsBinding.instance.addPostFrameCallback((_) => _initLibraries());
   }
+
+  @override
+  void didUpdateWidget(covariant AppShell oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A different module page means a fresh scroll view sitting at the top, so
+    // the search bar comes back with it. Pushed routes (detail pages, forms)
+    // aren't module pages, so popping back leaves the bar as its page had it.
+    final path = _searchBarPathFor(widget.currentPath);
+    if (path != null && path != _searchBarPath) {
+      _searchBarPath = path;
+      _searchBarAnim.forward();
+    }
+  }
+
+  /// [path] when it owns the search bar, else null (pushed routes don't).
+  static String? _searchBarPathFor(String path) =>
+      _moduleTypeForPath(path) == null ? null : path;
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
@@ -335,6 +358,11 @@ class _AppShellState extends ConsumerState<AppShell>
     if (isUserDrag) {
       _dismissKeyboard();
     }
+
+    // Pushed routes show the secondary bar, not the search bar. Scrolling one
+    // must not decide what the module page underneath looks like once the user
+    // pops back to it.
+    if (_searchBarPathFor(widget.currentPath) == null) return false;
 
     if (atTop) {
       _searchBarAnim.forward();

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -186,6 +186,48 @@ void main() {
     );
   });
 
+  testWidgets('scrolling a pushed route leaves the module search bar alone',
+      (tester) async {
+    final router = await _pumpScrollShell(tester);
+    final topBar = find.byKey(const ValueKey('module-top-bar'));
+    final expanded = tester.getSize(topBar).height;
+    expect(expanded, greaterThan(0));
+
+    router.push('/movie/1');
+    await tester.pumpAndSettle();
+    await tester.drag(find.byKey(const ValueKey('detail-scroll')),
+        const Offset(0, -300));
+    await tester.pumpAndSettle();
+
+    router.pop();
+    await tester.pumpAndSettle();
+    expect(
+      tester.getSize(topBar).height,
+      expanded,
+      reason: 'the dashboard is still at the top, so its search bar is too',
+    );
+  });
+
+  testWidgets('opening another module page brings the search bar back',
+      (tester) async {
+    final router = await _pumpScrollShell(tester);
+    final topBar = find.byKey(const ValueKey('module-top-bar'));
+    final expanded = tester.getSize(topBar).height;
+
+    await tester.drag(
+        find.byKey(const ValueKey('dash-scroll')), const Offset(0, -300));
+    await tester.pumpAndSettle();
+    expect(tester.getSize(topBar).height, lessThan(expanded));
+
+    router.go('/radarr/library');
+    await tester.pumpAndSettle();
+    expect(
+      tester.getSize(topBar).height,
+      expanded,
+      reason: 'a fresh module page starts at the top with its search bar shown',
+    );
+  });
+
   testWidgets(
       'search-bar assistant submit opens route over previous shell content',
       (tester) async {
@@ -507,6 +549,59 @@ Future<void> _pumpAdminDrawer(
 
   await tester.tap(find.byIcon(Icons.menu));
   await tester.pumpAndSettle();
+}
+
+/// Shell over long scrollable pages: two module routes and one pushed route.
+Future<GoRouter> _pumpScrollShell(WidgetTester tester) async {
+  tester.view.physicalSize = const Size(390, 844);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
+
+  Widget page(String key) => Scaffold(
+        body: ListView(
+          key: ValueKey(key),
+          children: const [SizedBox(height: 3000)],
+        ),
+      );
+
+  final router = GoRouter(
+    initialLocation: '/dashboard/movies',
+    routes: [
+      ShellRoute(
+        builder: (context, state, child) =>
+            AppShell(currentPath: state.uri.path, child: child),
+        routes: [
+          GoRoute(
+            path: '/dashboard/movies',
+            builder: (_, __) => page('dash-scroll'),
+          ),
+          GoRoute(
+            path: '/radarr/library',
+            builder: (_, __) => page('radarr-scroll'),
+          ),
+          GoRoute(path: '/movie/1', builder: (_, __) => page('detail-scroll')),
+        ],
+      ),
+    ],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        authProvider.overrideWith(
+          () => _FakeAuthNotifier(_authenticatedAiState),
+        ),
+        backendClientProvider.overrideWithValue(_fakeDio()),
+        realtimeEventsProvider.overrideWithValue(const Stream<WsEvent>.empty()),
+      ],
+      child: MaterialApp.router(routerConfig: router),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return router;
 }
 
 const _authenticatedAiState = AuthState(


### PR DESCRIPTION
Follow-up to #297, same handler. The search bar's collapse state was a pure function of scroll events and was never reconciled when the page underneath changed, so two routes left it stuck hidden over a page sitting at the top:

1. **Pushed routes drove it.** Detail pages and forms show the secondary bar, but their scrolling still ran `_searchBarAnim`. Scroll a movie detail page, pop back to a dashboard that never moved, and the search bar was gone until you scrolled it.
2. **Module switches didn't reset it.** Scroll the dashboard down (bar hidden), open Radarr library — a fresh page at the top — and the bar stayed hidden.

## Fix

Track the module route the bar is shown over:

- Scroll notifications from a non-module route no longer touch the bar, so popping back restores exactly what that page had (hidden if it was scrolled down, shown if it wasn't). Keyboard dismissal is left alone — it still fires on pushed forms, which is what #297's existing test covers.
- `didUpdateWidget` re-shows the bar when a *different* module page takes over. A pop back to the same module path isn't a change, so it doesn't clobber that page's state.

## Verification

- Two tests in `test/shell/app_shell_test.dart`, one per case. Both mutation-checked: without the fix each fails `Expected: <80.0> Actual: <0.0>`.
- `flutter analyze --no-fatal-infos` → no issues.
- `flutter test` → 742 passing.

No server changes, and no documented surface changed, so no doc updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eoDJQX1fr24CkYVkjLD75