### PR TITLE
docs: add a book automation setup guide and link the Chaptarr stack skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Docs are part of the change, not a follow-up. A feature is not merged-complete u
 | `README.md` | Product pitch, feature list, quick start, configuration & env-var tables |
 | `server/README.md` | API route reference, MCP tool table (incl. the tool count), DB tables, WebSocket events, env vars, server package tree |
 | `app/README.md` | App features/screens, navigation map, project structure, key dependencies |
+| `docs/books-setup.md` | End-to-end book automation setup: Chaptarr instance, per-user access grant (no global default), instant updates, download path mappings |
 | `docs/store-release.md` | Store release pipeline: how builds reach TestFlight/Play, signing secrets, one-time store-console setup |
 | `AGENTS.md` | Workflows, verification, conventions (this file) |
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Included AI is an explicit per-user entitlement for new accounts; the initial ad
 |---|---|---|
 | TMDB access token | Admin UI | Required for media discovery and search ([get one here](https://www.themoviedb.org/settings/api)) |
 | Radarr/Sonarr instances | Admin UI | Add via Settings > Add Instance |
-| Chaptarr instance | Admin UI | Books module; grant access per user from the instance editor or user settings |
+| Chaptarr instance | Admin UI | Books module; grant access per user from the instance editor or user settings -- full walkthrough in [`docs/books-setup.md`](docs/books-setup.md) |
 | SABnzbd/qBittorrent/NZBGet/Transmission | Admin UI | Download client modules (queue, history, speeds) |
 | Tautulli instance | Admin UI | Plex activity, watch history, stats |
 | Anthropic/OpenAI/Gemini API key | Admin UI | Enables shared API-key-backed AI chat and autonomous remediation |
@@ -233,6 +233,10 @@ Movies don't need bridging -- Radarr natively supports TMDB IDs. Books are keyed
 ## API Reference
 
 Full API documentation is in [`server/README.md`](server/README.md#api-reference).
+
+## Related Projects
+
+- [**mam-chaptarr-protonvpn-skill**](https://github.com/windoze95/mam-chaptarr-protonvpn-skill) -- an agent skill for building the layer *below* Cantinarr's books module: a VPN-isolated Gluetun/ProtonVPN stack running Chaptarr and qBittorrent in one network namespace, with forwarded-port sync, separated indexer and tracker-host sessions, and end-to-end verification. Useful if you're standing up book automation from scratch and want the container topology right the first time. Independent project; [`docs/books-setup.md`](docs/books-setup.md) shows where it fits.
 
 ## Contributing
 

--- a/docs/books-setup.md
+++ b/docs/books-setup.md
@@ -1,0 +1,60 @@
+# Book automation setup
+
+Books differ from movies and TV in two ways worth knowing before you start:
+
+- **Chaptarr has no global default instance.** The per-user pin *is* the access grant, so a user who hasn't been pinned to a Chaptarr instance doesn't see the Books tab at all.
+- **An ebook can finish downloading between two polls.** Instant updates aren't a nicety here; they're what makes the "ready to read" notification reliable.
+
+This page is the whole path, in order.
+
+## 1. Have a working Chaptarr
+
+Cantinarr manages an existing Chaptarr instance — it doesn't deploy one. What it needs from you:
+
+- A URL the **Cantinarr server** can reach. Clients never dial instance URLs, so cluster-internal names are fine and preferred; see the [instance URL guidance](../README.md#configuration).
+- A Chaptarr API key.
+- Chaptarr itself already working: a root folder, an indexer, a download client, and grabs that actually complete.
+
+That last point is the one that eats a weekend. If you're building the Chaptarr side from scratch — particularly routing Chaptarr and its torrent client through a VPN gateway, where the container topology is easy to get subtly wrong — [`mam-chaptarr-protonvpn-skill`](https://github.com/windoze95/mam-chaptarr-protonvpn-skill) is an agent skill that walks the whole build: one Gluetun/ProtonVPN namespace per environment, qBittorrent and Chaptarr attached to it, forwarded-port sync, indexer and tracker-host sessions kept separate, and verification that refuses to accept "the WebUI loads" as proof it works. It's an independent project, not part of Cantinarr, and it covers the layer *below* this page.
+
+One thing that carries straight over: if Chaptarr shares a gateway's network stack (`network_mode: container:<gateway>`), it has no address of its own, so the instance URL you give Cantinarr must name the gateway that publishes the port.
+
+## 2. Add the instance
+
+**Settings → Add Instance**, service type `chaptarr`, then the URL and API key. Save runs a live connection check from the server — the same host that will dial it in production — so a green result means what it says.
+
+Chaptarr speaks the Readarr `/api/v1` API. Enter just the base URL; Cantinarr appends the API path.
+
+## 3. Grant access per user
+
+This is the step people miss. Unlike Radarr and Sonarr, Chaptarr has no global default — pinning a user to a Chaptarr instance is how you grant that user access to books.
+
+Pin from either side: the instance editor, or **Settings → Users** for one person. Un-pinning revokes access. Admins see Chaptarr without a pin; everyone else needs one, and until they have it `services.chaptarr` stays `false` and the Books tab stays hidden.
+
+Running more than one Chaptarr instance is fine — pin different households or different libraries to different instances.
+
+## 4. Turn on instant updates
+
+Open the instance and tap **Configure instant updates**. The server rotates a per-instance credential and installs its own authenticated webhook in Chaptarr; the secret moves server-to-server and never reaches a device.
+
+Set `CANTINARR_PUBLIC_URL` first if Cantinarr sits behind a reverse proxy. The callback has to be resolvable **from inside the Chaptarr container**, so in Docker or Kubernetes a cluster-internal origin like `http://cantinarr:8585` is usually the right value.
+
+Without this, Cantinarr falls back to polling, and a fast ebook grab can land and be announced late — or, if it imports and finishes between two polls, look like nothing happened.
+
+## 5. Optional — let people download the files
+
+Off by default, and deliberately two-layered. Chaptarr reports file paths but doesn't serve the bytes, so the deployment has to hand Cantinarr the files itself:
+
+1. Mount each library read-only into the container and list the visible boundary in `CANTINARR_MEDIA_ROOTS` (for example `- /mnt/nas/books:/media/books:ro` with `CANTINARR_MEDIA_ROOTS=/media`).
+2. In the instance editor, map each path Chaptarr reports to a folder inside that boundary.
+
+A Chaptarr instance often needs several mappings — `/ebooks`, `/audiobooks`, and any per-library variants. The two sides don't have to match, and folder names never determine the book format; the format comes from the arr's own file record.
+
+An instance offers downloads only once explicit mappings are saved for it.
+
+## 6. Verify
+
+- The Books tab appears for a pinned non-admin user, opening on **Recently Added**.
+- Searching a title returns results, and requesting an eBook or Audiobook row reads **Requested** until it downloads.
+- A grab that completes in Chaptarr flips the row to available within seconds, not on the next poll — that's the webhook working.
+- If downloads are on, a completed book offers a working download from a device.


### PR DESCRIPTION
## What

- **New `docs/books-setup.md`** — the end-to-end book path in order: working Chaptarr → add instance → grant per-user access → instant updates → optional download path mappings → verify.
- **`README.md`** — the Chaptarr configuration row links the guide, and a new **Related Projects** section links [`mam-chaptarr-protonvpn-skill`](https://github.com/windoze95/mam-chaptarr-protonvpn-skill).
- **`AGENTS.md`** — registers the new doc in the ownership table.

## Why a consolidated page

Book setup was spread across four places in `README.md` (feature bullet, config row, path-mapping paragraph, admin step 5) plus one paragraph in `server/README.md`. The step people actually miss — Chaptarr has no global default, so **the per-user pin is the access grant** — was documented only in the API reference. A user with no pin sees `services.chaptarr == false` and no Books tab, which reads as a bug rather than a permission that was never granted.

## Why link the skill

The guide's first step is "have a working Chaptarr," and that's the step that costs people a weekend — especially when Chaptarr and its torrent client route through a VPN gateway, where the container topology is easy to get subtly wrong. The skill covers that layer, below where Cantinarr starts. It's described functionally (Gluetun/ProtonVPN namespace, qBittorrent, forwarded-port sync, session separation, verification) and labeled as an independent project.

It also carries over the namespace-sharing case from #299: a Chaptarr sharing a gateway's network stack has no address of its own, so the instance URL must name the gateway.

## Accuracy

Every behavioral claim was checked against the code, not the existing prose:

- Per-user pin is the grant, no global default — `internal/instance/store.go:586`, `internal/api/router.go:596`
- Non-admin without a pin gets `services.chaptarr == false` — `internal/api/router.go:573`
- Admins bypass the pin requirement — `internal/instance/store.go:743`
- Chaptarr speaks Readarr `/api/v1`, connection check runs from the server — `internal/instance/handler.go:556`
- Webhook rotates a per-instance credential, secret never reaches a device — `server/README.md` instant-updates section

## Docs

- [x] `docs/books-setup.md` — new, registered in the `AGENTS.md` table
- [x] `README.md` — config row + Related Projects
- [x] `AGENTS.md` — ownership table
- No route, tool, env var, DB table, or screen changed; no counts to update.

## Verification

Docs-only — no server or app code touched. Relative links and the `#configuration` anchor verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dgvp9M9EtYg5a9U82ZVP5