### PR TITLE
fix: stop book search rows going dead once the book is requested

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -78,7 +78,7 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 ### Books (Chaptarr)
 - **Per-format everything** -- a title's ebook and audiobook are separate records; the author page groups tracked titles first and gives each format its own accessible tracking control (an empty control adds and searches that format).
 - **Requester book detail** -- search results stay navigable before and after a request, with author, publication metadata, synopsis, genres, and separate eBook/Audiobook request states; admins can continue into the exact live Chaptarr title.
-- **Owned-aware search** -- library titles are injected into lookup results and floated to the top with format-specific Available / Requested summaries; distinct records are never merged.
+- **Owned-aware search** -- library titles are injected into lookup results and floated to the top with format-specific Available / Requested summaries; distinct records are never merged. A lookup row that can't be tied to exactly one library record claims no ownership and targets no library id -- it says which record to act on instead, and every record it could be is listed above it.
 - **Full module** -- library with author drill-down, queue with Import Doctor, history, and wanted (missing / cutoff unmet).
 
 ### Downloads & Tautulli (admin)

--- a/app/lib/features/dashboard/logic/book_ownership_matcher.dart
+++ b/app/lib/features/dashboard/logic/book_ownership_matcher.dart
@@ -202,19 +202,28 @@ OwnedTitle? ownedMatchFor(ChaptarrBook result, List<OwnedTitle> digest) {
 }
 
 /// One-to-one lookup-to-library mappings. A mapping is safe only when a lookup
-/// row has exactly one digest candidate and that digest row belongs to exactly
-/// one lookup row. This rejects ambiguity in either direction.
+/// row has exactly one digest candidate and no other lookup row makes an
+/// equally strong claim on that digest row. This rejects ambiguity in either
+/// direction.
+///
+/// Exact and fuzzy claims are counted apart, because they are not the same kind
+/// of statement: an id the library itself files a record under identifies it,
+/// while a same-title sibling only resembles it. A resemblance therefore cannot
+/// cancel an identity — otherwise requesting a book leaves the very row that
+/// created the library record unable to recognise it.
 Map<ChaptarrBook, OwnedTitle> unambiguousOwnedMatches(
   List<ChaptarrBook> lookupResults,
   List<OwnedTitle> digest,
 ) {
   final candidates = <ChaptarrBook, List<OwnedTitle>>{};
-  final lookupCounts = <OwnedTitle, int>{};
+  final exactClaims = <OwnedTitle, int>{};
+  final fuzzyClaims = <OwnedTitle, int>{};
   for (final result in lookupResults) {
     final matches = ownedIdentityCandidatesFor(result, digest);
     candidates[result] = matches;
     for (final match in matches) {
-      lookupCounts[match] = (lookupCounts[match] ?? 0) + 1;
+      final claims = _sameForeignId(result, match) ? exactClaims : fuzzyClaims;
+      claims[match] = (claims[match] ?? 0) + 1;
     }
   }
 
@@ -222,13 +231,88 @@ Map<ChaptarrBook, OwnedTitle> unambiguousOwnedMatches(
   for (final entry in candidates.entries) {
     if (entry.value.length != 1) continue;
     final match = entry.value.single;
-    if (lookupCounts[match] == 1 &&
-        (_sameForeignId(entry.key, match) ||
-            _strongIdentityMatch(entry.key, match))) {
+    if (_sameForeignId(entry.key, match)) {
+      // Two lookup rows carrying the same library id are still ambiguous —
+      // only a fuzzy contender is outranked.
+      if ((exactClaims[match] ?? 0) == 1) resolved[entry.key] = match;
+      continue;
+    }
+    if ((exactClaims[match] ?? 0) == 0 &&
+        (fuzzyClaims[match] ?? 0) == 1 &&
+        _strongIdentityMatch(entry.key, match)) {
       resolved[entry.key] = match;
     }
   }
   return resolved;
+}
+
+/// How a book search's lookup rows line up with the requester's library,
+/// resolved once so every part of the results list agrees.
+class BookSearchIdentity {
+  /// Safe one-to-one lookup-to-library bindings (see [unambiguousOwnedMatches]).
+  final Map<ChaptarrBook, OwnedTitle> matches;
+
+  /// Lookup rows that plausibly are a library record but could not be tied to
+  /// one, valued by the records each might be. These rows must not claim owned
+  /// state or target a library id — but they still address a real metadata
+  /// record, so they stay openable.
+  final Map<ChaptarrBook, List<OwnedTitle>> contested;
+
+  /// Library records to surface as their own result rows.
+  final List<OwnedTitle> libraryRows;
+
+  const BookSearchIdentity({
+    required this.matches,
+    required this.contested,
+    required this.libraryRows,
+  });
+}
+
+/// Resolves [lookupResults] against [digest] for the search [query].
+BookSearchIdentity resolveBookSearchIdentity({
+  required String query,
+  required List<ChaptarrBook> lookupResults,
+  required List<OwnedTitle> digest,
+}) {
+  final matches = unambiguousOwnedMatches(lookupResults, digest);
+  final bound = matches.values.toSet();
+
+  final contested = <ChaptarrBook, List<OwnedTitle>>{};
+  for (final result in lookupResults) {
+    if (matches.containsKey(result)) continue;
+    final candidates = ownedIdentityCandidatesFor(result, digest)
+        .where((owned) => !bound.contains(owned))
+        .toList(growable: false);
+    if (candidates.isNotEmpty) contested[result] = candidates;
+  }
+  final needsChoosing = <OwnedTitle>{
+    for (final candidates in contested.values) ...candidates,
+  };
+
+  // Concrete library records not already represented by a safe one-to-one
+  // lookup mapping: the ones the query names, plus every record an unresolved
+  // row might be. That second group is what makes "choose a matching library
+  // record" a real instruction — an author search never names a title, so the
+  // record the row means would otherwise not be on screen at all.
+  final libraryRows = <OwnedTitle>[];
+  for (final owned in digest) {
+    if (bound.contains(owned)) continue;
+    if (needsChoosing.contains(owned)) {
+      libraryRows.add(owned);
+      continue;
+    }
+    // Only surface books the user actually has or is monitoring — not empty
+    // library shells (all-missing, unmonitored duplicate records).
+    if (!owned.ownership.anyOwned && owned.statusKnown) continue;
+    if (!titleMatchesQuery(query, owned.title)) continue;
+    libraryRows.add(owned);
+  }
+
+  return BookSearchIdentity(
+    matches: matches,
+    contested: contested,
+    libraryRows: libraryRows,
+  );
 }
 
 /// Decides whether the user already owns [result], by matching it against the
@@ -237,33 +321,62 @@ Map<ChaptarrBook, OwnedTitle> unambiguousOwnedMatches(
 BookOwnership? ownershipFor(ChaptarrBook result, List<OwnedTitle> digest) =>
     ownedMatchFor(result, digest)?.ownership;
 
-/// Owned digest titles matching the search [query] (every query token appears in
-/// the title), each kept as its own entry so the user sees and picks among their
-/// distinct records — nothing is merged or deduplicated by title. Only titles
-/// the user actually has/monitors (plus unresolved fail-closed rows) qualify.
-/// A record is omitted only when a strong one-to-one lookup mapping already
-/// represents that exact digest row.
+/// Whether [title] answers the search [query]: every query word appears in the
+/// title, the last one as a prefix.
+///
+/// The trailing word is matched as a prefix because search runs on every
+/// keystroke — the word being typed right now must not disqualify a requester's
+/// own library from their own search.
+///
+/// Both sides are compared under both tokenizations. The series-stripped form
+/// drops everything before the first ": ", which is right for "Series: Title"
+/// but would otherwise throw away the headline of "Headline: Subtitle" — the
+/// very words a requester types first.
+bool titleMatchesQuery(String query, String title) {
+  final queries = _tokenizations(query);
+  final titles = _tokenizations(title);
+  for (final queryTokens in queries) {
+    if (queryTokens.isEmpty) continue;
+    for (final titleTokens in titles) {
+      if (_tokensContain(titleTokens, queryTokens)) return true;
+    }
+  }
+  return false;
+}
+
+/// A string's series-kept and series-stripped token lists (identical, and so
+/// collapsed to one, when the string has no "Prefix: " to strip).
+List<List<String>> _tokenizations(String text) {
+  final kept = normalizeTitleTokens(text, stripSeries: false);
+  final stripped = normalizeTitleTokens(text);
+  if (kept.length == stripped.length) return [kept];
+  return [kept, stripped];
+}
+
+bool _tokensContain(List<String> titleTokens, List<String> queryTokens) {
+  if (titleTokens.isEmpty) return false;
+  for (var i = 0; i < queryTokens.length; i++) {
+    final token = queryTokens[i];
+    final partial = i == queryTokens.length - 1;
+    final present = titleTokens.any(
+      (candidate) => partial ? candidate.startsWith(token) : candidate == token,
+    );
+    if (!present) return false;
+  }
+  return true;
+}
+
+/// Owned digest titles to surface as their own search rows, each kept as its own
+/// entry so the user sees and picks among their distinct records — nothing is
+/// merged or deduplicated by title. See [resolveBookSearchIdentity], which owns
+/// the rule.
 List<OwnedTitle> ownedTitlesForQuery(
   String query,
   List<OwnedTitle> digest,
   List<ChaptarrBook> lookupResults,
-) {
-  final queryTokens = normalizeTitleTokens(query).toSet();
-  if (queryTokens.isEmpty) return const [];
-
-  final alreadyRepresented =
-      unambiguousOwnedMatches(lookupResults, digest).values.toSet();
-  final out = <OwnedTitle>[];
-  for (final owned in digest) {
-    // Only surface books the user actually has or is monitoring — not empty
-    // library shells (all-missing, unmonitored duplicate records).
-    if (!owned.ownership.anyOwned && owned.statusKnown) continue;
-    final titleTokens = normalizeTitleTokens(owned.title).toSet();
-    if (titleTokens.isEmpty) continue;
-    // The query must be contained in the title (a partial-name match).
-    if (!queryTokens.every(titleTokens.contains)) continue;
-    if (alreadyRepresented.contains(owned)) continue;
-    out.add(owned);
-  }
-  return out;
-}
+) =>
+    resolveBookSearchIdentity(
+      query: query,
+      lookupResults: lookupResults,
+      digest: digest,
+    ).libraryRows;

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -226,31 +226,29 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab>
     // requests, and surface owned/monitored books the metadata search missed.
     final digest =
         ref.watch(ownedBooksProvider).valueOrNull ?? const <OwnedTitle>[];
+    final identity = resolveBookSearchIdentity(
+      query: _searchedTerm,
+      lookupResults: _results,
+      digest: digest,
+    );
     // Concrete library records not already represented by a safe one-to-one
     // lookup mapping. Ambiguous candidates are shown separately here so the
     // requester can choose a real record rather than targeting a fuzzy guess.
-    final injected = digest.isEmpty
-        ? const <OwnedTitle>[]
-        : ownedTitlesForQuery(_searchedTerm, digest, _results);
+    final injected = identity.libraryRows;
     // Mark each lookup result with its ownership and float owned titles to the
     // top, preserving Chaptarr's relevance order within each bucket (don't
     // collapse versions — the user wants to see ones they don't own). Only owned
     // results carry a cover: the owned record's cached /MediaCover, which loads
     // with the API key. Lookup (/MediaCoverProxy) covers are broken server-side
     // in this fork, so we don't attempt them — not-yet-owned rows stay iconic.
-    final safeMatches = unambiguousOwnedMatches(_results, digest);
     final owned = <_ResolvedBookResult>[];
     final rest = <_ResolvedBookResult>[];
     for (var lookupIndex = 0;
         lookupIndex < _results.length;
         lookupIndex++) {
       final book = _results[lookupIndex];
-      final candidates =
-          digest.isEmpty
-              ? const <OwnedTitle>[]
-              : ownedIdentityCandidatesFor(book, digest);
-      final match = safeMatches[book];
-      final identityAmbiguous = candidates.isNotEmpty && match == null;
+      final match = identity.matches[book];
+      final identityAmbiguous = identity.contested.containsKey(book);
       final cover =
           (match != null && match.cover.isNotEmpty) ? match.cover : null;
       final libraryId = match?.foreignBookId.trim() ?? '';
@@ -409,9 +407,14 @@ class _BookResultTile extends StatelessWidget {
     final lookupId = book.foreignBookId?.trim() ?? '';
     final o = ownership;
     final chip = _ownershipChip(o);
-    final canOpen = fid.isNotEmpty && !identityAmbiguous;
+    // Ambiguity is about which library record this row is, not about whether the
+    // requester may read it: the row still addresses a real metadata record, and
+    // closing the tap left a just-requested book with no way to be opened at
+    // all. The row states which record to act on instead; the library rows it
+    // points at are listed above it.
+    final canOpen = fid.isNotEmpty;
     final identityGuidance = identityAmbiguous
-        ? 'Choose a matching library record'
+        ? 'Choose the library record above'
         : fid.isEmpty
             ? 'Ask an admin to check this book’s library record'
             : null;

--- a/app/test/dashboard/book_ownership_matcher_test.dart
+++ b/app/test/dashboard/book_ownership_matcher_test.dart
@@ -207,6 +207,122 @@ void main() {
     });
   });
 
+  group('titleMatchesQuery', () {
+    const subtitled = '10 Algorithms Every Forward Deployed Engineer Should '
+        'Know: Shortest Paths and Minimum Spanning Trees';
+
+    test('matches the headline of a title whose colon adds a subtitle', () {
+      expect(titleMatchesQuery('10 algorithms every forward', subtitled),
+          isTrue);
+      // The subtitle is still the requester's to search by.
+      expect(titleMatchesQuery('shortest paths', subtitled), isTrue);
+    });
+
+    test('matches the word still being typed as a prefix', () {
+      expect(titleMatchesQuery('10 algorithms every fo', subtitled), isTrue);
+      expect(titleMatchesQuery('10 algorithms every fx', subtitled), isFalse);
+    });
+
+    test('still requires the completed words in full', () {
+      expect(titleMatchesQuery('algo forward', subtitled), isFalse);
+    });
+
+    test('drops a series prefix on either side', () {
+      expect(
+        titleMatchesQuery('Star Wars: Heir to the Empire', 'Heir to the Empire'),
+        isTrue,
+      );
+      expect(
+        titleMatchesQuery('heir', 'Star Wars: Heir to the Empire'),
+        isTrue,
+      );
+    });
+
+    test('a query naming nothing in the title does not match', () {
+      expect(titleMatchesQuery('foundation', subtitled), isFalse);
+      expect(titleMatchesQuery('', subtitled), isFalse);
+    });
+  });
+
+  group('resolveBookSearchIdentity', () {
+    OwnedTitle libraryFlock() => _owned(
+          'Flock',
+          'Kate Stewart',
+          audiobookMonitored: true,
+          foreignBookId: 'library-flock',
+        );
+
+    test('an exact library id outranks a same-title sibling claim', () {
+      final digest = [libraryFlock()];
+      final exact = _result('Flock',
+          author: 'Kate Stewart', foreignBookId: 'library-flock');
+      final sibling =
+          _result('Flock', author: 'Kate Stewart', foreignBookId: 'other-id');
+
+      final identity = resolveBookSearchIdentity(
+        query: 'flock',
+        lookupResults: [exact, sibling],
+        digest: digest,
+      );
+
+      expect(identity.matches[exact], same(digest.single));
+      // The record is spoken for, so the sibling is not left half-claiming it.
+      expect(identity.contested, isEmpty);
+      expect(identity.libraryRows, isEmpty);
+    });
+
+    test('two rows carrying the same library id stay unresolved', () {
+      final digest = [libraryFlock()];
+      final first = _result('Flock',
+          author: 'Kate Stewart', foreignBookId: 'library-flock');
+      final second = _result('Flock',
+          author: 'Kate Stewart', foreignBookId: 'library-flock');
+
+      final identity = resolveBookSearchIdentity(
+        query: 'flock',
+        lookupResults: [first, second],
+        digest: digest,
+      );
+
+      expect(identity.matches, isEmpty);
+      expect(identity.contested.keys, hasLength(2));
+      expect(identity.libraryRows, [same(digest.single)]);
+    });
+
+    test('an author search still surfaces the record a row might be', () {
+      final digest = [libraryFlock()];
+      final identity = resolveBookSearchIdentity(
+        // Names the author, never the title — so only the unresolved rows can
+        // put the library record the guidance points at on screen.
+        query: 'kate stewart',
+        lookupResults: [
+          _result('Flock', author: 'Kate Stewart', foreignBookId: 'lookup-a'),
+          _result('Flock', author: 'Kate Stewart', foreignBookId: 'lookup-b'),
+        ],
+        digest: digest,
+      );
+
+      expect(identity.contested.keys, hasLength(2));
+      expect(identity.libraryRows, [same(digest.single)]);
+    });
+
+    test('an unowned shell a row might be is still offered as a choice', () {
+      // Shells stay out of query results, but a row that cannot be told apart
+      // from one has to be able to point at it.
+      final shell = _owned('Flock', 'Kate Stewart', foreignBookId: 'shell');
+      final identity = resolveBookSearchIdentity(
+        query: 'flock',
+        lookupResults: [
+          _result('Flock', author: 'Kate Stewart', foreignBookId: 'lookup-a'),
+          _result('Flock', author: 'Kate Stewart', foreignBookId: 'lookup-b'),
+        ],
+        digest: [shell],
+      );
+
+      expect(identity.libraryRows, [same(shell)]);
+    });
+  });
+
   group('ownedTitlesForQuery surfaces owned books lookup missed', () {
     final digest = [
       _owned('Heir to the Empire', 'Timothy Zahn', ebookDownloaded: true),

--- a/app/test/dashboard/dashboard_books_tab_test.dart
+++ b/app/test/dashboard/dashboard_books_tab_test.dart
@@ -261,23 +261,75 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text('Choose a matching library record'),
+      find.text('Choose the library record above'),
       findsNWidgets(2),
     );
-    expect(
-      find.byKey(const ValueKey(
-          'book-result:lookup-flock:lookup-flock:lookup:0')),
-      findsOneWidget,
+    final firstAmbiguous = find.byKey(
+      const ValueKey('book-result:lookup-flock:lookup-flock:lookup:0'),
     );
+    expect(firstAmbiguous, findsOneWidget);
     expect(
       find.byKey(const ValueKey(
           'book-result:lookup-flock:lookup-flock:lookup:1')),
       findsOneWidget,
     );
+    // The record the guidance points at is on screen, above both lookup rows.
     expect(
       find.byKey(const ValueKey(
           'book-result:library-flock:library-flock:library:0')),
       findsOneWidget,
+    );
+    expect(adapter.statusForeignIds, isEmpty);
+
+    // An unbindable row is still a real metadata record: it opens, addressed by
+    // its own lookup id rather than a guessed library one.
+    await tester.tap(firstAmbiguous);
+    await tester.pumpAndSettle();
+
+    final screen = tester.widget<RequesterBookDetailScreen>(
+      find.byType(RequesterBookDetailScreen),
+    );
+    expect(screen.foreignId, 'lookup-flock');
+    expect(adapter.statusForeignIds, everyElement('lookup-flock'));
+  });
+
+  testWidgets('an exact library id outranks a same-title sibling row',
+      (tester) async {
+    _usePhoneSize(tester);
+    final (:router, container: _, :adapter) =
+        await _pumpRouter(tester, aliasSibling: true);
+    router.go('/dashboard/books');
+    await tester.pumpAndSettle();
+
+    final searchField = find.byWidgetPredicate(
+      (widget) =>
+          widget is TextField &&
+          widget.decoration?.hintText == 'Search books or authors…',
+    );
+    await tester.enterText(searchField, 'flock');
+    await tester.pump(const Duration(milliseconds: 450));
+    await tester.pumpAndSettle();
+
+    // The row carrying the library's own id binds to it and reports its state;
+    // the sibling's resemblance no longer cancels that identity.
+    expect(
+      find.byKey(const ValueKey(
+          'book-result:library-flock:library-flock:lookup:0')),
+      findsOneWidget,
+    );
+    expect(find.text('Audiobook requested'), findsOneWidget);
+    // With the record spoken for, the sibling is simply a book they don't have.
+    expect(
+      find.byKey(const ValueKey(
+          'book-result:lookup-flock:lookup-flock:lookup:1')),
+      findsOneWidget,
+    );
+    expect(find.text('Choose the library record above'), findsNothing);
+    // The bound record is not repeated as a library row of its own.
+    expect(
+      find.byKey(const ValueKey(
+          'book-result:library-flock:library-flock:library:0')),
+      findsNothing,
     );
     expect(adapter.statusForeignIds, isEmpty);
   });
@@ -300,7 +352,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      find.text('Choose a matching library record'),
+      find.text('Choose the library record above'),
       findsOneWidget,
     );
     expect(
@@ -419,6 +471,7 @@ Future<({
   bool unresolvedIdentity = false,
   bool mixedOwnership = false,
   bool ambiguousLookup = false,
+  bool aliasSibling = false,
   bool duplicateLibraryRecords = false,
   bool blankIdentity = false,
 }) async {
@@ -428,6 +481,7 @@ Future<({
     unresolvedIdentity: unresolvedIdentity,
     mixedOwnership: mixedOwnership,
     ambiguousLookup: ambiguousLookup,
+    aliasSibling: aliasSibling,
     duplicateLibraryRecords: duplicateLibraryRecords,
     blankIdentity: blankIdentity,
   );
@@ -468,6 +522,7 @@ class _BooksSearchAdapter implements HttpClientAdapter {
     this.unresolvedIdentity = false,
     this.mixedOwnership = false,
     this.ambiguousLookup = false,
+    this.aliasSibling = false,
     this.duplicateLibraryRecords = false,
     this.blankIdentity = false,
   });
@@ -476,6 +531,10 @@ class _BooksSearchAdapter implements HttpClientAdapter {
   final bool unresolvedIdentity;
   final bool mixedOwnership;
   final bool ambiguousLookup;
+
+  /// Two lookup rows for one title where the first carries the library's own
+  /// foreignBookId and the second is a same-title provider sibling.
+  final bool aliasSibling;
   final bool duplicateLibraryRecords;
   final bool blankIdentity;
   int statusRequests = 0;
@@ -539,7 +598,7 @@ class _BooksSearchAdapter implements HttpClientAdapter {
                 },
               ],
             }
-          : (mismatchedIdentity || ambiguousLookup)
+          : (mismatchedIdentity || ambiguousLookup || aliasSibling)
           ? {
               'titles': [
                 {
@@ -601,12 +660,17 @@ class _BooksSearchAdapter implements HttpClientAdapter {
       body = (mismatchedIdentity ||
               unresolvedIdentity ||
               ambiguousLookup ||
+              aliasSibling ||
               duplicateLibraryRecords ||
               blankIdentity)
           ? [
               {
                 'title': 'Flock',
-                'foreignBookId': blankIdentity ? '' : 'lookup-flock',
+                'foreignBookId': blankIdentity
+                    ? ''
+                    : aliasSibling
+                        ? 'library-flock'
+                        : 'lookup-flock',
                 'year': 2024,
                 'author': {
                   'id': 0,
@@ -614,7 +678,7 @@ class _BooksSearchAdapter implements HttpClientAdapter {
                   'foreignAuthorId': 'author-flock',
                 },
               },
-              if (ambiguousLookup)
+              if (ambiguousLookup || aliasSibling)
                 {
                   'title': 'Flock',
                   'foreignBookId': 'lookup-flock',


### PR DESCRIPTION
## What broke

Searching for a book that had just been requested left every row for it unopenable, under a `Choose a matching library record` line pointing at a record that wasn't on screen:

- both rows say **Choose a matching library record**
- neither row is tappable
- there is no library record listed to choose

Three independent defects had to line up for that.

### 1. A resemblance cancelled an identity

`unambiguousOwnedMatches` refused a mapping whenever two lookup rows claimed the same library record — counting an exact `foreignBookId` match and a fuzzy title/author match as equally strong. But a lookup row carrying the library's own id *is* that record. So the row that created the library record could no longer recognise it the moment a same-title sibling appeared beside it.

Exact and fuzzy claims are now counted apart. A resemblance never outranks an identity; two rows carrying the *same* library id are still ambiguous. The sibling that lost is left plainly unowned rather than half-claiming a record already spoken for.

### 2. The library row that would have rescued the search was filtered out by its own title

`ownedTitlesForQuery` tested query containment against the series-stripped tokenization only, which drops everything before the first `": "`. Right for `Series: Title`; for `Headline: Subtitle` it throws away the words a requester types first. The screenshot's book tokenizes to `[shortest, paths, minimum, spanning, trees]` — so no query for its headline could ever surface it.

It also demanded whole words while search runs on every keystroke, so `…every fo` disqualified the record mid-word.

Both sides are now compared under both tokenizations, with the trailing word matched as a prefix. And records an unresolved row *might* be are surfaced regardless of the query — an author search never names a title, and the guidance has to point at something real.

### 3. Ambiguity blocked the tap itself

Which library record a row is has nothing to do with whether the requester may read it. The row still addresses a real metadata record, and refusing to open it left no way to reach the book at all — `app/README.md` already promised "search results stay navigable before and after a request".

Rows open again, addressed by their own lookup id. They still claim no ownership and still target no library id; the guidance (`Choose the library record above`) names the safer target, which is now guaranteed to be on screen.

## Verification

- `flutter analyze --no-fatal-infos` — clean
- `flutter test` — 768 pass
- New tests mutation-checked: restoring each old behavior (re-blocking the tap, dropping exact-claim precedence, restoring the old query matching) fails them.

## Docs

`app/README.md` owned-aware search entry now states the unresolved-row contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYVJFs66AFtUwneakcP4ZZ