### PR TITLE
fix: give arr wanted and calendar screens posters, context, and tap-through

### DIFF
--- a/app/lib/core/widgets/day_sections.dart
+++ b/app/lib/core/widgets/day_sections.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../theme/app_theme.dart';
+
+/// Groups [items] by the calendar day of [dateOf], days ascending, each day's
+/// items ordered by time ascending.
+List<MapEntry<DateTime, List<T>>> groupItemsByDay<T>(
+  Iterable<T> items,
+  DateTime Function(T item) dateOf,
+) {
+  final byDay = <DateTime, List<T>>{};
+  for (final item in items) {
+    final d = dateOf(item);
+    byDay.putIfAbsent(DateTime(d.year, d.month, d.day), () => []).add(item);
+  }
+  final entries = byDay.entries.toList()
+    ..sort((a, b) => a.key.compareTo(b.key));
+  for (final entry in entries) {
+    entry.value.sort((a, b) => dateOf(a).compareTo(dateOf(b)));
+  }
+  return entries;
+}
+
+/// Date separator shown above each day's group in a day-sectioned list
+/// ("Today", "Tomorrow", a near weekday, or the full date).
+class DaySectionHeader extends StatelessWidget {
+  final DateTime day;
+  final DateTime today;
+
+  const DaySectionHeader({super.key, required this.day, required this.today});
+
+  @override
+  Widget build(BuildContext context) {
+    final diff = day.difference(today).inDays;
+    final String label;
+    String? secondary;
+    if (diff == 0) {
+      label = 'Today';
+      secondary = DateFormat('EEE, MMM d').format(day);
+    } else if (diff == 1) {
+      label = 'Tomorrow';
+      secondary = DateFormat('EEE, MMM d').format(day);
+    } else if (diff > 1 && diff < 7) {
+      label = DateFormat('EEEE').format(day);
+      secondary = DateFormat('MMM d').format(day);
+    } else {
+      label = DateFormat('EEE, MMM d').format(day);
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 18, 16, 6),
+      child: Row(
+        children: [
+          Text(
+            label,
+            style: TextStyle(
+              color: diff == 0 ? AppTheme.accent : AppTheme.textPrimary,
+              fontSize: 15,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          if (secondary != null) ...[
+            const SizedBox(width: 8),
+            Text(
+              secondary,
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 13,
+              ),
+            ),
+          ],
+          const SizedBox(width: 12),
+          const Expanded(child: Divider(color: AppTheme.border)),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/features/dashboard/ui/dashboard_releases_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_releases_tab.dart
@@ -6,6 +6,7 @@ import 'package:intl/intl.dart';
 import '../../../core/network/app_image_cache.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/day_sections.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../radarr/data/radarr_api_service.dart';
 import '../../sonarr/data/sonarr_api_service.dart';
@@ -229,7 +230,7 @@ class _DashboardReleasesTabState extends ConsumerState<DashboardReleasesTab> {
         itemBuilder: (context, index) {
           final item = items[index];
           if (item is DateTime) {
-            return _DateHeader(day: item, today: today);
+            return DaySectionHeader(day: item, today: today);
           }
           return _ReleaseTile(event: item as ReleaseEvent);
         },
@@ -356,61 +357,6 @@ class _ViewToggle extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-}
-
-/// Date separator shown above each day's group in the list view.
-class _DateHeader extends StatelessWidget {
-  final DateTime day;
-  final DateTime today;
-
-  const _DateHeader({required this.day, required this.today});
-
-  @override
-  Widget build(BuildContext context) {
-    final diff = day.difference(today).inDays;
-    final String label;
-    String? secondary;
-    if (diff == 0) {
-      label = 'Today';
-      secondary = DateFormat('EEE, MMM d').format(day);
-    } else if (diff == 1) {
-      label = 'Tomorrow';
-      secondary = DateFormat('EEE, MMM d').format(day);
-    } else if (diff > 1 && diff < 7) {
-      label = DateFormat('EEEE').format(day);
-      secondary = DateFormat('MMM d').format(day);
-    } else {
-      label = DateFormat('EEE, MMM d').format(day);
-    }
-
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 18, 16, 6),
-      child: Row(
-        children: [
-          Text(
-            label,
-            style: TextStyle(
-              color: diff == 0 ? AppTheme.accent : AppTheme.textPrimary,
-              fontSize: 15,
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-          if (secondary != null) ...[
-            const SizedBox(width: 8),
-            Text(
-              secondary,
-              style: const TextStyle(
-                color: AppTheme.textSecondary,
-                fontSize: 13,
-              ),
-            ),
-          ],
-          const SizedBox(width: 12),
-          const Expanded(child: Divider(color: AppTheme.border)),
-        ],
       ),
     );
   }

--- a/app/lib/features/radarr/data/radarr_calendar.dart
+++ b/app/lib/features/radarr/data/radarr_calendar.dart
@@ -1,0 +1,77 @@
+import 'radarr_models.dart';
+
+/// One dated release of a movie on the Radarr calendar.
+///
+/// A movie carries up to three release dates (cinema, digital, physical); the
+/// calendar shows one row per date inside the fetched window, each labelled
+/// with its release type so a date is never shown without what kind of release
+/// it is.
+class RadarrCalendarRelease {
+  final RadarrMovie movie;
+
+  /// Calendar date of the release, at midnight. Built from the arr date's own
+  /// components — release dates are calendar dates, so converting time zones
+  /// would shift a midnight-UTC date into the prior day.
+  final DateTime date;
+
+  /// 'In cinemas', 'Digital' or 'Physical'.
+  final String label;
+
+  const RadarrCalendarRelease({
+    required this.movie,
+    required this.date,
+    required this.label,
+  });
+}
+
+/// Expands calendar [movies] into labelled per-date rows within [start]..[end],
+/// date ascending. A movie none of whose dates lands in the window (time-zone
+/// edges, clock skew) still yields one row — its soonest upcoming date relative
+/// to [now], else its most recent past one — so nothing Radarr returned is
+/// silently dropped.
+List<RadarrCalendarRelease> radarrCalendarReleases(
+  Iterable<RadarrMovie> movies, {
+  required DateTime start,
+  required DateTime end,
+  DateTime? now,
+}) {
+  DateTime dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
+  final startDay = dateOnly(start);
+  final endDay = dateOnly(end);
+  final today = dateOnly(now ?? DateTime.now());
+
+  final rows = <RadarrCalendarRelease>[];
+  for (final movie in movies) {
+    final candidates = <RadarrCalendarRelease>[
+      if (movie.inCinemas != null)
+        RadarrCalendarRelease(
+            movie: movie,
+            date: dateOnly(movie.inCinemas!),
+            label: 'In cinemas'),
+      if (movie.digitalRelease != null)
+        RadarrCalendarRelease(
+            movie: movie,
+            date: dateOnly(movie.digitalRelease!),
+            label: 'Digital'),
+      if (movie.physicalRelease != null)
+        RadarrCalendarRelease(
+            movie: movie,
+            date: dateOnly(movie.physicalRelease!),
+            label: 'Physical'),
+    ];
+    if (candidates.isEmpty) continue;
+
+    final inWindow = candidates
+        .where((c) => !c.date.isBefore(startDay) && !c.date.isAfter(endDay))
+        .toList();
+    if (inWindow.isNotEmpty) {
+      rows.addAll(inWindow);
+      continue;
+    }
+    candidates.sort((a, b) => a.date.compareTo(b.date));
+    final upcoming = candidates.where((c) => !c.date.isBefore(today)).toList();
+    rows.add(upcoming.isNotEmpty ? upcoming.first : candidates.last);
+  }
+  rows.sort((a, b) => a.date.compareTo(b.date));
+  return rows;
+}

--- a/app/lib/features/radarr/ui/radarr_calendar_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_calendar_screen.dart
@@ -3,9 +3,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
+import '../../../core/widgets/day_sections.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/radarr_api_service.dart';
+import '../data/radarr_calendar.dart';
+import '../data/radarr_models.dart';
+import 'radarr_movie_detail_screen.dart';
 
-/// Shows upcoming movie releases from Radarr's calendar.
+/// Radarr calendar: movie releases grouped by day, one labelled row per
+/// release type (cinema / digital / physical), each opening the movie detail
+/// screen.
 class RadarrCalendarScreen extends ConsumerStatefulWidget {
   const RadarrCalendarScreen({super.key});
 
@@ -15,8 +24,12 @@ class RadarrCalendarScreen extends ConsumerStatefulWidget {
 }
 
 class _RadarrCalendarScreenState extends ConsumerState<RadarrCalendarScreen> {
-  List<Map<String, dynamic>> _events = [];
+  List<RadarrCalendarRelease> _releases = [];
   bool _isLoading = true;
+
+  /// Bumped by every fresh load (instance switch, refresh) so in-flight
+  /// responses from a superseded fetch are dropped.
+  int _loadGeneration = 0;
   String? _error;
 
   @override
@@ -26,8 +39,7 @@ class _RadarrCalendarScreenState extends ConsumerState<RadarrCalendarScreen> {
   }
 
   Future<void> _loadCalendar() async {
-    final instanceState = ref.read(instanceProvider);
-    final instanceId = instanceState.activeRadarrInstance?.id;
+    final instanceId = ref.read(instanceProvider).activeRadarrInstance?.id;
     if (instanceId == null) {
       setState(() {
         _isLoading = false;
@@ -36,11 +48,13 @@ class _RadarrCalendarScreenState extends ConsumerState<RadarrCalendarScreen> {
       return;
     }
 
+    final gen = ++_loadGeneration;
     setState(() => _isLoading = true);
     try {
-      final backendDio = ref.read(backendClientProvider);
-      final service =
-          RadarrApiService(backendDio: backendDio, instanceId: instanceId);
+      final service = RadarrApiService(
+        backendDio: ref.read(backendClientProvider),
+        instanceId: instanceId,
+      );
       final now = DateTime.now();
       final start = now.subtract(const Duration(days: 7));
       final end = now.add(const Duration(days: 30));
@@ -48,17 +62,36 @@ class _RadarrCalendarScreenState extends ConsumerState<RadarrCalendarScreen> {
         start: start.toIso8601String(),
         end: end.toIso8601String(),
       );
+      if (!mounted || gen != _loadGeneration) return;
       setState(() {
-        _events = events;
+        _releases = radarrCalendarReleases(
+          events.map((e) => RadarrMovie.fromJson(e)),
+          start: start,
+          end: end,
+        );
         _isLoading = false;
         _error = null;
       });
     } catch (e) {
+      if (!mounted || gen != _loadGeneration) return;
       setState(() {
         _isLoading = false;
         _error = 'Failed to load calendar: $e';
       });
     }
+  }
+
+  Future<void> _openMovie(RadarrMovie movie) async {
+    final instanceId = ref.read(instanceProvider).activeRadarrInstance?.id;
+    if (instanceId == null) return;
+    await Navigator.of(context, rootNavigator: true).push(
+      AmbientPageRoute(
+        builder: (_) =>
+            RadarrMovieDetailScreen(instanceId: instanceId, movie: movie),
+      ),
+    );
+    // The detail screen can edit or remove the movie; refresh on return.
+    _loadCalendar();
   }
 
   @override
@@ -71,67 +104,105 @@ class _RadarrCalendarScreenState extends ConsumerState<RadarrCalendarScreen> {
           child: CircularProgressIndicator(color: AppTheme.accent));
     }
     if (_error != null) {
-      return Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(_error!,
-                style: const TextStyle(color: AppTheme.textSecondary)),
-            const SizedBox(height: 16),
-            ElevatedButton(
-                onPressed: _loadCalendar, child: const Text('Retry')),
-          ],
-        ),
-      );
+      return FullScreenError(message: _error!, onRetry: _loadCalendar);
     }
-    if (_events.isEmpty) {
-      return const Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
+    if (_releases.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _loadCalendar,
+        color: AppTheme.accent,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [
+            SizedBox(height: 160),
             Icon(Icons.calendar_today_outlined,
                 size: 48, color: AppTheme.textSecondary),
             SizedBox(height: 12),
-            Text('No upcoming releases',
-                style: TextStyle(
-                    color: AppTheme.textSecondary, fontSize: 16)),
+            Center(
+              child: Text('No upcoming releases',
+                  style: TextStyle(
+                      color: AppTheme.textSecondary, fontSize: 16)),
+            ),
           ],
         ),
       );
     }
+
+    final groups = groupItemsByDay(_releases, (r) => r.date);
+    // Flatten day groups into a single list of headers + tiles.
+    final items = <Object>[];
+    for (final group in groups) {
+      items.add(group.key);
+      items.addAll(group.value);
+    }
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
 
     return RefreshIndicator(
       onRefresh: _loadCalendar,
       color: AppTheme.accent,
       child: ListView.builder(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        itemCount: _events.length,
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.only(top: 4, bottom: 24),
+        itemCount: items.length,
         itemBuilder: (context, index) {
-          final event = _events[index];
-          final title = event['title'] as String? ?? 'Unknown';
-          final date = event['inCinemas'] as String? ??
-              event['digitalRelease'] as String? ??
-              event['physicalRelease'] as String? ??
-              '';
-          final hasFile = event['hasFile'] as bool? ?? false;
-
-          return ListTile(
-            leading: Icon(
-              hasFile ? Icons.check_circle : Icons.calendar_today,
-              color: hasFile ? AppTheme.available : AppTheme.accent,
-            ),
-            title: Text(title,
-                style: const TextStyle(
-                    color: AppTheme.textPrimary,
-                    fontWeight: FontWeight.w500)),
-            subtitle: Text(
-              date.isNotEmpty ? date.substring(0, 10) : 'TBA',
-              style: const TextStyle(
-                  color: AppTheme.textSecondary, fontSize: 13),
-            ),
+          final item = items[index];
+          if (item is DateTime) {
+            return DaySectionHeader(day: item, today: today);
+          }
+          final release = item as RadarrCalendarRelease;
+          return _CalendarTile(
+            release: release,
+            onTap: () => _openMovie(release.movie),
           );
         },
       ),
+    );
+  }
+}
+
+class _CalendarTile extends StatelessWidget {
+  final RadarrCalendarRelease release;
+  final VoidCallback? onTap;
+
+  const _CalendarTile({required this.release, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final movie = release.movie;
+
+    return ListTile(
+      onTap: onTap,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      leading: ClipRRect(
+        borderRadius: BorderRadius.circular(6),
+        child: SizedBox(
+          width: 45,
+          height: 67,
+          child: CachedImage(
+            url: movie.posterUrl,
+            fit: BoxFit.cover,
+            icon: Icons.movie,
+          ),
+        ),
+      ),
+      title: Text(
+        movie.year > 0 ? '${movie.title} (${movie.year})' : movie.title,
+        style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 13.5,
+            fontWeight: FontWeight.w500),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        release.label,
+        style: const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: movie.hasFile
+          ? const Icon(Icons.check_circle, size: 16, color: AppTheme.available)
+          : null,
     );
   }
 }

--- a/app/lib/features/radarr/ui/radarr_wanted_screen.dart
+++ b/app/lib/features/radarr/ui/radarr_wanted_screen.dart
@@ -4,10 +4,12 @@ import 'package:intl/intl.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../../../navigation/ambient_page_route.dart';
 import '../data/radarr_api_service.dart';
 import '../data/radarr_models.dart';
+import 'radarr_movie_detail_screen.dart';
 import 'radarr_releases_screen.dart';
 
 enum _WantedView { missing, cutoff }
@@ -170,6 +172,20 @@ class _RadarrWantedScreenState extends ConsumerState<RadarrWantedScreen> {
     );
   }
 
+  Future<void> _openMovie(RadarrMovie movie) async {
+    final instanceId = ref.read(instanceProvider).activeRadarrInstance?.id;
+    if (instanceId == null) return;
+    await Navigator.of(context, rootNavigator: true).push(
+      AmbientPageRoute(
+        builder: (_) =>
+            RadarrMovieDetailScreen(instanceId: instanceId, movie: movie),
+      ),
+    );
+    // The detail screen can trigger searches or edit/remove the movie;
+    // refresh on return.
+    _load();
+  }
+
   @override
   Widget build(BuildContext context) {
     // Reload when the active instance changes.
@@ -256,6 +272,7 @@ class _RadarrWantedScreenState extends ConsumerState<RadarrWantedScreen> {
           return _WantedTile(
             movie: movie,
             showQuality: _view == _WantedView.cutoff,
+            onTap: () => _openMovie(movie),
             onAutomaticSearch: () => _automaticSearch(movie),
             onInteractiveSearch: () => _openInteractiveSearch(movie),
           );
@@ -266,15 +283,18 @@ class _RadarrWantedScreenState extends ConsumerState<RadarrWantedScreen> {
 }
 
 String _releaseLabel(RadarrMovie movie) {
-  final format = DateFormat('MMM d, yyyy');
+  // Release dates are calendar dates; format their components directly —
+  // converting time zones would shift a midnight-UTC date to the prior day.
+  String fmt(DateTime d) =>
+      DateFormat('MMM d, yyyy').format(DateTime(d.year, d.month, d.day));
   if (movie.digitalRelease != null) {
-    return 'Digital ${format.format(movie.digitalRelease!.toLocal())}';
+    return 'Digital ${fmt(movie.digitalRelease!)}';
   }
   if (movie.physicalRelease != null) {
-    return 'Physical ${format.format(movie.physicalRelease!.toLocal())}';
+    return 'Physical ${fmt(movie.physicalRelease!)}';
   }
   if (movie.inCinemas != null) {
-    return 'In cinemas ${format.format(movie.inCinemas!.toLocal())}';
+    return 'In cinemas ${fmt(movie.inCinemas!)}';
   }
   return movie.status ?? 'Unreleased';
 }
@@ -282,12 +302,14 @@ String _releaseLabel(RadarrMovie movie) {
 class _WantedTile extends StatelessWidget {
   final RadarrMovie movie;
   final bool showQuality;
+  final VoidCallback? onTap;
   final VoidCallback onAutomaticSearch;
   final VoidCallback onInteractiveSearch;
 
   const _WantedTile({
     required this.movie,
     required this.showQuality,
+    this.onTap,
     required this.onAutomaticSearch,
     required this.onInteractiveSearch,
   });
@@ -301,7 +323,20 @@ class _WantedTile extends StatelessWidget {
     ];
 
     return ListTile(
+      onTap: onTap,
       contentPadding: const EdgeInsets.only(left: 16, right: 4),
+      leading: ClipRRect(
+        borderRadius: BorderRadius.circular(6),
+        child: SizedBox(
+          width: 45,
+          height: 67,
+          child: CachedImage(
+            url: movie.posterUrl,
+            fit: BoxFit.cover,
+            icon: Icons.movie,
+          ),
+        ),
+      ),
       title: Text(
         movie.year > 0 ? '${movie.title} (${movie.year})' : movie.title,
         style: const TextStyle(

--- a/app/lib/features/sonarr/data/sonarr_api_service.dart
+++ b/app/lib/features/sonarr/data/sonarr_api_service.dart
@@ -144,12 +144,19 @@ class SonarrApiService {
     return records?.cast<Map<String, dynamic>>() ?? [];
   }
 
+  /// Fetches calendar episodes for a date window. Pass [includeSeries] when
+  /// the caller needs the embedded series (title, poster, drill-down) rather
+  /// than joining against a separately fetched library.
   Future<List<Map<String, dynamic>>> getCalendar({
     required String start,
     required String end,
+    bool includeSeries = false,
   }) async {
-    final resp = await _dio.get('$_basePath/calendar',
-        queryParameters: {'start': start, 'end': end});
+    final resp = await _dio.get('$_basePath/calendar', queryParameters: {
+      'start': start,
+      'end': end,
+      if (includeSeries) 'includeSeries': true,
+    });
     return (resp.data as List<dynamic>).cast<Map<String, dynamic>>();
   }
 

--- a/app/lib/features/sonarr/data/sonarr_models.dart
+++ b/app/lib/features/sonarr/data/sonarr_models.dart
@@ -325,6 +325,48 @@ class SonarrEpisode {
       airDateUtc != null && airDateUtc!.isBefore(DateTime.now().toUtc());
 }
 
+/// One episode on the Sonarr calendar. Carries the embedded series (fetched
+/// with includeSeries=true) for its title, poster and drill-down navigation.
+class SonarrCalendarEntry {
+  final int id;
+  final int seriesId;
+  final int seasonNumber;
+  final int episodeNumber;
+  final String? title;
+  final DateTime? airDateUtc;
+  final bool hasFile;
+  final SonarrSeries? series;
+
+  const SonarrCalendarEntry({
+    required this.id,
+    this.seriesId = 0,
+    this.seasonNumber = 0,
+    this.episodeNumber = 0,
+    this.title,
+    this.airDateUtc,
+    this.hasFile = false,
+    this.series,
+  });
+
+  factory SonarrCalendarEntry.fromJson(Map<String, dynamic> json) =>
+      SonarrCalendarEntry(
+        id: json['id'] as int? ?? 0,
+        seriesId: json['seriesId'] as int? ?? 0,
+        seasonNumber: json['seasonNumber'] as int? ?? 0,
+        episodeNumber: json['episodeNumber'] as int? ?? 0,
+        title: json['title'] as String?,
+        airDateUtc: DateTime.tryParse(json['airDateUtc'] as String? ?? ''),
+        hasFile: json['hasFile'] as bool? ?? false,
+        series: json['series'] != null
+            ? SonarrSeries.fromJson(json['series'] as Map<String, dynamic>)
+            : null,
+      );
+
+  /// e.g. "S01E05".
+  String get seasonEpisodeLabel => 'S${seasonNumber.toString().padLeft(2, '0')}'
+      'E${episodeNumber.toString().padLeft(2, '0')}';
+}
+
 class SonarrQualityProfile {
   final int id;
   final String name;
@@ -599,6 +641,10 @@ class SonarrWantedRecord {
   final bool monitored;
   final String? seriesTitle;
 
+  /// Full embedded series (fetched with includeSeries=true); carries the
+  /// poster and everything the series detail screen needs.
+  final SonarrSeries? series;
+
   /// Current file quality; only present on cutoff-unmet records fetched
   /// with includeEpisodeFile.
   final String? quality;
@@ -612,23 +658,26 @@ class SonarrWantedRecord {
     this.airDateUtc,
     this.monitored = true,
     this.seriesTitle,
+    this.series,
     this.quality,
   });
 
-  factory SonarrWantedRecord.fromJson(Map<String, dynamic> json) =>
-      SonarrWantedRecord(
-        id: json['id'] as int? ?? 0,
-        seriesId: json['seriesId'] as int? ?? 0,
-        seasonNumber: json['seasonNumber'] as int? ?? 0,
-        episodeNumber: json['episodeNumber'] as int? ?? 0,
-        title: json['title'] as String?,
-        airDateUtc: DateTime.tryParse(json['airDateUtc'] as String? ?? ''),
-        monitored: json['monitored'] as bool? ?? true,
-        seriesTitle:
-            (json['series'] as Map<String, dynamic>?)?['title'] as String?,
-        quality: (json['episodeFile'] as Map<String, dynamic>?)?['quality']
-            ?['quality']?['name'] as String?,
-      );
+  factory SonarrWantedRecord.fromJson(Map<String, dynamic> json) {
+    final seriesJson = json['series'] as Map<String, dynamic>?;
+    return SonarrWantedRecord(
+      id: json['id'] as int? ?? 0,
+      seriesId: json['seriesId'] as int? ?? 0,
+      seasonNumber: json['seasonNumber'] as int? ?? 0,
+      episodeNumber: json['episodeNumber'] as int? ?? 0,
+      title: json['title'] as String?,
+      airDateUtc: DateTime.tryParse(json['airDateUtc'] as String? ?? ''),
+      monitored: json['monitored'] as bool? ?? true,
+      seriesTitle: seriesJson?['title'] as String?,
+      series: seriesJson != null ? SonarrSeries.fromJson(seriesJson) : null,
+      quality: (json['episodeFile'] as Map<String, dynamic>?)?['quality']
+          ?['quality']?['name'] as String?,
+    );
+  }
 
   /// e.g. "S01E05".
   String get seasonEpisodeLabel => 'S${seasonNumber.toString().padLeft(2, '0')}'

--- a/app/lib/features/sonarr/ui/sonarr_calendar_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_calendar_screen.dart
@@ -1,11 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
+import '../../../core/widgets/day_sections.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../../../navigation/ambient_page_route.dart';
 import '../data/sonarr_api_service.dart';
+import '../data/sonarr_models.dart';
+import 'sonarr_series_detail_screen.dart';
 
-/// Shows upcoming episode releases from Sonarr's calendar.
+/// Sonarr calendar: recent and upcoming episodes grouped by air day, each row
+/// carrying the series poster and opening the series detail screen.
 class SonarrCalendarScreen extends ConsumerStatefulWidget {
   const SonarrCalendarScreen({super.key});
 
@@ -15,8 +23,12 @@ class SonarrCalendarScreen extends ConsumerStatefulWidget {
 }
 
 class _SonarrCalendarScreenState extends ConsumerState<SonarrCalendarScreen> {
-  List<Map<String, dynamic>> _events = [];
+  List<SonarrCalendarEntry> _entries = [];
   bool _isLoading = true;
+
+  /// Bumped by every fresh load (instance switch, refresh) so in-flight
+  /// responses from a superseded fetch are dropped.
+  int _loadGeneration = 0;
   String? _error;
 
   @override
@@ -26,8 +38,7 @@ class _SonarrCalendarScreenState extends ConsumerState<SonarrCalendarScreen> {
   }
 
   Future<void> _loadCalendar() async {
-    final instanceState = ref.read(instanceProvider);
-    final instanceId = instanceState.activeSonarrInstance?.id;
+    final instanceId = ref.read(instanceProvider).activeSonarrInstance?.id;
     if (instanceId == null) {
       setState(() {
         _isLoading = false;
@@ -36,29 +47,48 @@ class _SonarrCalendarScreenState extends ConsumerState<SonarrCalendarScreen> {
       return;
     }
 
+    final gen = ++_loadGeneration;
     setState(() => _isLoading = true);
     try {
-      final backendDio = ref.read(backendClientProvider);
-      final service =
-          SonarrApiService(backendDio: backendDio, instanceId: instanceId);
-      final now = DateTime.now();
-      final start = now.subtract(const Duration(days: 7));
-      final end = now.add(const Duration(days: 14));
-      final events = await service.getCalendar(
-        start: start.toIso8601String(),
-        end: end.toIso8601String(),
+      final service = SonarrApiService(
+        backendDio: ref.read(backendClientProvider),
+        instanceId: instanceId,
       );
+      final now = DateTime.now();
+      final events = await service.getCalendar(
+        start: now.subtract(const Duration(days: 7)).toIso8601String(),
+        end: now.add(const Duration(days: 14)).toIso8601String(),
+        includeSeries: true,
+      );
+      if (!mounted || gen != _loadGeneration) return;
       setState(() {
-        _events = events;
+        _entries = events
+            .map((e) => SonarrCalendarEntry.fromJson(e))
+            .toList();
         _isLoading = false;
         _error = null;
       });
     } catch (e) {
+      if (!mounted || gen != _loadGeneration) return;
       setState(() {
         _isLoading = false;
         _error = 'Failed to load calendar: $e';
       });
     }
+  }
+
+  Future<void> _openSeries(SonarrCalendarEntry entry) async {
+    final series = entry.series;
+    final instanceId = ref.read(instanceProvider).activeSonarrInstance?.id;
+    if (series == null || instanceId == null) return;
+    await Navigator.of(context, rootNavigator: true).push(
+      AmbientPageRoute(
+        builder: (_) =>
+            SonarrSeriesDetailScreen(instanceId: instanceId, series: series),
+      ),
+    );
+    // The detail screen can edit or remove the series; refresh on return.
+    _loadCalendar();
   }
 
   @override
@@ -71,68 +101,127 @@ class _SonarrCalendarScreenState extends ConsumerState<SonarrCalendarScreen> {
           child: CircularProgressIndicator(color: AppTheme.accent));
     }
     if (_error != null) {
-      return Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text(_error!,
-                style: const TextStyle(color: AppTheme.textSecondary)),
-            const SizedBox(height: 16),
-            ElevatedButton(
-                onPressed: _loadCalendar, child: const Text('Retry')),
-          ],
-        ),
-      );
+      return FullScreenError(message: _error!, onRetry: _loadCalendar);
     }
-    if (_events.isEmpty) {
-      return const Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
+    if (_entries.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _loadCalendar,
+        color: AppTheme.accent,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [
+            SizedBox(height: 160),
             Icon(Icons.calendar_today_outlined,
                 size: 48, color: AppTheme.textSecondary),
             SizedBox(height: 12),
-            Text('No upcoming episodes',
-                style: TextStyle(
-                    color: AppTheme.textSecondary, fontSize: 16)),
+            Center(
+              child: Text('No upcoming episodes',
+                  style: TextStyle(
+                      color: AppTheme.textSecondary, fontSize: 16)),
+            ),
           ],
         ),
       );
     }
+
+    final groups = groupItemsByDay(
+      _entries.where((e) => e.airDateUtc != null),
+      (e) => e.airDateUtc!.toLocal(),
+    );
+    // Flatten day groups into a single list of headers + tiles.
+    final items = <Object>[];
+    for (final group in groups) {
+      items.add(group.key);
+      items.addAll(group.value);
+    }
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
 
     return RefreshIndicator(
       onRefresh: _loadCalendar,
       color: AppTheme.accent,
       child: ListView.builder(
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        itemCount: _events.length,
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.only(top: 4, bottom: 24),
+        itemCount: items.length,
         itemBuilder: (context, index) {
-          final event = _events[index];
-          final seriesTitle = (event['series'] as Map<String, dynamic>?)?['title'] as String? ?? '';
-          final episodeTitle = event['title'] as String? ?? '';
-          final season = event['seasonNumber'] as int? ?? 0;
-          final episode = event['episodeNumber'] as int? ?? 0;
-          final airDate = event['airDateUtc'] as String? ?? '';
-          final hasFile = event['hasFile'] as bool? ?? false;
-
-          return ListTile(
-            leading: Icon(
-              hasFile ? Icons.check_circle : Icons.schedule,
-              color: hasFile ? AppTheme.available : AppTheme.accent,
-            ),
-            title: Text(seriesTitle,
-                style: const TextStyle(
-                    color: AppTheme.textPrimary,
-                    fontWeight: FontWeight.w500)),
-            subtitle: Text(
-              'S${season.toString().padLeft(2, '0')}E${episode.toString().padLeft(2, '0')} - $episodeTitle'
-              '${airDate.isNotEmpty ? '\n${airDate.substring(0, 10)}' : ''}',
-              style: const TextStyle(
-                  color: AppTheme.textSecondary, fontSize: 13),
-            ),
-            isThreeLine: airDate.isNotEmpty,
+          final item = items[index];
+          if (item is DateTime) {
+            return DaySectionHeader(day: item, today: today);
+          }
+          final entry = item as SonarrCalendarEntry;
+          return _CalendarTile(
+            entry: entry,
+            onTap: entry.series != null ? () => _openSeries(entry) : null,
           );
         },
+      ),
+    );
+  }
+}
+
+class _CalendarTile extends StatelessWidget {
+  final SonarrCalendarEntry entry;
+  final VoidCallback? onTap;
+
+  const _CalendarTile({required this.entry, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final episodeTitle = entry.title;
+    final subtitle = (episodeTitle != null && episodeTitle.isNotEmpty)
+        ? '${entry.seasonEpisodeLabel} • $episodeTitle'
+        : entry.seasonEpisodeLabel;
+    final air = entry.airDateUtc?.toLocal();
+
+    return ListTile(
+      onTap: onTap,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      leading: ClipRRect(
+        borderRadius: BorderRadius.circular(6),
+        child: SizedBox(
+          width: 45,
+          height: 67,
+          child: CachedImage(
+            url: entry.series?.posterUrl,
+            fit: BoxFit.cover,
+            icon: Icons.tv,
+          ),
+        ),
+      ),
+      title: Text(
+        entry.series?.title ?? 'Unknown series',
+        style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 13.5,
+            fontWeight: FontWeight.w500),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        subtitle,
+        style: const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          if (air != null)
+            Text(
+              DateFormat('h:mm a').format(air),
+              style: const TextStyle(
+                  color: AppTheme.textSecondary, fontSize: 12),
+            ),
+          if (entry.hasFile)
+            Padding(
+              padding: EdgeInsets.only(top: air != null ? 4 : 0),
+              child: const Icon(Icons.check_circle,
+                  size: 16, color: AppTheme.available),
+            ),
+        ],
       ),
     );
   }

--- a/app/lib/features/sonarr/ui/sonarr_wanted_screen.dart
+++ b/app/lib/features/sonarr/ui/sonarr_wanted_screen.dart
@@ -4,11 +4,13 @@ import 'package:intl/intl.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/providers/instance_provider.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
 import '../../../core/widgets/error_banner.dart';
 import '../../../navigation/ambient_page_route.dart';
 import '../data/sonarr_api_service.dart';
 import '../data/sonarr_models.dart';
 import 'sonarr_releases_screen.dart';
+import 'sonarr_series_detail_screen.dart';
 
 enum _WantedView { missing, cutoff }
 
@@ -176,6 +178,21 @@ class _SonarrWantedScreenState extends ConsumerState<SonarrWantedScreen> {
     );
   }
 
+  Future<void> _openSeries(SonarrWantedRecord record) async {
+    final series = record.series;
+    final instanceId = ref.read(instanceProvider).activeSonarrInstance?.id;
+    if (series == null || instanceId == null) return;
+    await Navigator.of(context, rootNavigator: true).push(
+      AmbientPageRoute(
+        builder: (_) =>
+            SonarrSeriesDetailScreen(instanceId: instanceId, series: series),
+      ),
+    );
+    // The detail screen can trigger searches or edit/remove the series;
+    // refresh on return.
+    _load();
+  }
+
   @override
   Widget build(BuildContext context) {
     // Reload when the active instance changes.
@@ -262,6 +279,7 @@ class _SonarrWantedScreenState extends ConsumerState<SonarrWantedScreen> {
           return _WantedTile(
             record: record,
             showQuality: _view == _WantedView.cutoff,
+            onTap: record.series != null ? () => _openSeries(record) : null,
             onAutomaticSearch: () => _automaticSearch(record),
             onInteractiveSearch: () => _openInteractiveSearch(record),
           );
@@ -282,12 +300,14 @@ String _airDateLabel(DateTime? airDateUtc) {
 class _WantedTile extends StatelessWidget {
   final SonarrWantedRecord record;
   final bool showQuality;
+  final VoidCallback? onTap;
   final VoidCallback onAutomaticSearch;
   final VoidCallback onInteractiveSearch;
 
   const _WantedTile({
     required this.record,
     required this.showQuality,
+    this.onTap,
     required this.onAutomaticSearch,
     required this.onInteractiveSearch,
   });
@@ -304,7 +324,20 @@ class _WantedTile extends StatelessWidget {
     ];
 
     return ListTile(
+      onTap: onTap,
       contentPadding: const EdgeInsets.only(left: 16, right: 4),
+      leading: ClipRRect(
+        borderRadius: BorderRadius.circular(6),
+        child: SizedBox(
+          width: 45,
+          height: 67,
+          child: CachedImage(
+            url: record.series?.posterUrl,
+            fit: BoxFit.cover,
+            icon: Icons.tv,
+          ),
+        ),
+      ),
       title: Text(
         record.seriesTitle ?? 'Unknown series',
         style: const TextStyle(

--- a/app/test/core/day_sections_test.dart
+++ b/app/test/core/day_sections_test.dart
@@ -1,0 +1,48 @@
+import 'package:cantinarr/core/widgets/day_sections.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/intl.dart';
+
+void main() {
+  group('groupItemsByDay', () {
+    test('groups by calendar day, days ascending, items time ascending', () {
+      final lateNight = DateTime(2026, 7, 2, 23, 30);
+      final earlier = DateTime(2026, 7, 1, 9);
+      final morning = DateTime(2026, 7, 2, 8, 15);
+
+      final groups =
+          groupItemsByDay([lateNight, earlier, morning], (d) => d);
+
+      expect(groups.map((g) => g.key).toList(),
+          [DateTime(2026, 7, 1), DateTime(2026, 7, 2)]);
+      expect(groups[0].value, [earlier]);
+      expect(groups[1].value, [morning, lateNight]);
+    });
+
+    test('returns no groups for no items', () {
+      expect(groupItemsByDay(<DateTime>[], (d) => d), isEmpty);
+    });
+  });
+
+  testWidgets('DaySectionHeader labels today, tomorrow and far dates',
+      (tester) async {
+    final today = DateTime(2026, 7, 28);
+    final far = DateTime(2026, 8, 20);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Column(
+          children: [
+            DaySectionHeader(day: today, today: today),
+            DaySectionHeader(
+                day: today.add(const Duration(days: 1)), today: today),
+            DaySectionHeader(day: far, today: today),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('Today'), findsOneWidget);
+    expect(find.text('Tomorrow'), findsOneWidget);
+    expect(find.text(DateFormat('EEE, MMM d').format(far)), findsOneWidget);
+  });
+}

--- a/app/test/preview/screenshot_data.dart
+++ b/app/test/preview/screenshot_data.dart
@@ -907,6 +907,18 @@ List<Map<String, dynamic>> _sonarrCalendar() => [
           '2026-08-03T01:00:00Z', false),
     ];
 
+/// Poster per series id, joined into embedded `series` objects (calendar and
+/// wanted responses fetched with includeSeries carry the full series, images
+/// included) so the arr calendar/wanted screens render artwork.
+final Map<int, String> _seriesPosters = {
+  101: _hotd.poster,
+  102: '/in1R2dDc421JxsoRWaIIAqVI2KE.jpg',
+  106: '/hjJkrLXhWvGHpLeLBDFznpBTY1S.jpg',
+  108: '/uWpG7GqfKGQqX4YMAo3nv5OrglV.jpg',
+  110: '/xsiecCxd8lkcAluw0wWwbW5CwSv.jpg',
+  111: '/70kTz0OmjjZe7zHvIDrq2iKW7PJ.jpg',
+};
+
 Map<String, dynamic> _sonarrCalEntry(int seriesId, String seriesTitle,
         int season, int episode, String epTitle, String airUtc, bool hasFile) =>
     {
@@ -918,8 +930,44 @@ Map<String, dynamic> _sonarrCalEntry(int seriesId, String seriesTitle,
       'airDateUtc': airUtc,
       'hasFile': hasFile,
       'monitored': true,
-      'series': {'title': seriesTitle},
+      'series': {
+        'id': seriesId,
+        'title': seriesTitle,
+        if (_seriesPosters[seriesId] != null)
+          'images': _posterImage(_seriesPosters[seriesId]!),
+      },
     };
+
+/// Sonarr wanted (GET /wanted/missing|cutoff) -> paged episodes with embedded
+/// series. Feeds the Sonarr Wanted screen.
+Map<String, dynamic> _sonarrWanted() => {
+      'page': 1,
+      'pageSize': 50,
+      'totalRecords': 4,
+      'records': [
+        _sonarrCalEntry(101, 'House of the Dragon', 3, 4, 'A Dance of Dragons',
+            '2026-07-06T01:00:00Z', false),
+        _sonarrCalEntry(102, 'The Boys', 5, 2, 'Kill Your Heroes',
+            '2026-07-15T02:00:00Z', false),
+        _sonarrCalEntry(106, "Grey's Anatomy", 21, 15, 'Wishin and Hopin',
+            '2026-07-09T01:00:00Z', false),
+        _sonarrCalEntry(111, 'The Rookie', 7, 9, 'Crossfire',
+            '2026-07-14T01:00:00Z', false),
+      ],
+    };
+
+/// Radarr wanted (GET /wanted/missing|cutoff) -> paged missing movies
+/// (the calendar movies that lack files). Feeds the Radarr Wanted screen.
+Map<String, dynamic> _radarrWanted() {
+  final records =
+      _radarrCalendar().where((m) => m['hasFile'] == false).toList();
+  return {
+    'page': 1,
+    'pageSize': 50,
+    'totalRecords': records.length,
+    'records': records,
+  };
+}
 
 // ─── Downloads (normalized /api/downloads/{id}/queue) ────────────────────────
 
@@ -1201,6 +1249,26 @@ Object? screenshotBodyFor(String rawPath, Map<String, dynamic> query) {
   if (path.endsWith('/api/v3/calendar')) {
     // The instance id disambiguates movie vs episode calendars.
     return path.contains('/sonarr') ? _sonarrCalendar() : _radarrCalendar();
+  }
+  if (path.endsWith('/api/v3/wanted/missing') ||
+      path.endsWith('/api/v3/wanted/cutoff')) {
+    return path.contains('/sonarr') ? _sonarrWanted() : _radarrWanted();
+  }
+  // By-id lookups so calendar/wanted tap-through lands on a populated detail.
+  if (path.contains('/api/v3/movie/')) {
+    final id = _lastIntSegment(path);
+    if (id != null) {
+      final match = [..._radarrLibrary(), ..._radarrCalendar()]
+          .where((m) => m['id'] == id);
+      if (match.isNotEmpty) return match.first;
+    }
+  }
+  if (path.contains('/api/v3/series/')) {
+    final id = _lastIntSegment(path);
+    if (id != null) {
+      final match = _sonarrLibrary().where((s) => s['id'] == id);
+      if (match.isNotEmpty) return match.first;
+    }
   }
 
   // ── Download client queues (per instance) ──

--- a/app/test/radarr/radarr_wanted_calendar_test.dart
+++ b/app/test/radarr/radarr_wanted_calendar_test.dart
@@ -1,0 +1,308 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/providers/instance_provider.dart';
+import 'package:cantinarr/core/widgets/cached_image.dart';
+import 'package:cantinarr/features/radarr/data/radarr_calendar.dart';
+import 'package:cantinarr/features/radarr/data/radarr_models.dart';
+import 'package:cantinarr/features/radarr/ui/radarr_calendar_screen.dart';
+import 'package:cantinarr/features/radarr/ui/radarr_movie_detail_screen.dart';
+import 'package:cantinarr/features/radarr/ui/radarr_wanted_screen.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fake Dio adapter: serves the configured movies from the wanted and calendar
+/// endpoints and records every request for assertions.
+class _FakeAdapter implements HttpClientAdapter {
+  final List<({String method, String path, Map<String, dynamic> query})>
+      requests = [];
+
+  /// Movies returned by /wanted/missing|cutoff, /calendar and /movie/{id}.
+  List<Map<String, dynamic>> movies = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final path = options.uri.path;
+    requests.add((
+      method: options.method,
+      path: path,
+      query: options.uri.queryParameters,
+    ));
+
+    dynamic response = <String, dynamic>{};
+    if (options.method == 'GET') {
+      if (path.contains('/wanted/')) {
+        response = {
+          'page': 1,
+          'pageSize': 50,
+          'totalRecords': movies.length,
+          'records': movies,
+        };
+      } else if (path.endsWith('/calendar')) {
+        response = movies;
+      } else if (path.endsWith('/history/movie')) {
+        response = <dynamic>[];
+      } else if (path.endsWith('/queue')) {
+        response = {'records': <dynamic>[]};
+      } else if (path.contains('/movie/')) {
+        final id = int.tryParse(path.split('/').last);
+        response = movies.firstWhere((m) => m['id'] == id,
+            orElse: () => movies.first);
+      }
+    }
+    return ResponseBody.fromString(
+      jsonEncode(response),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _RadarrInstances extends InstanceNotifier {
+  @override
+  InstanceState build() => const InstanceState(
+        radarrInstances: [
+          ServiceInstance(id: 'radarr-1', serviceType: 'radarr', name: 'Radarr'),
+        ],
+      );
+}
+
+Map<String, dynamic> _movie({
+  required int id,
+  required String title,
+  String? inCinemas,
+  String? digitalRelease,
+  String? physicalRelease,
+  bool hasFile = false,
+}) =>
+    {
+      'id': id,
+      'title': title,
+      'year': 2026,
+      'monitored': true,
+      'hasFile': hasFile,
+      'images': <Map<String, dynamic>>[],
+      if (inCinemas != null) 'inCinemas': inCinemas,
+      if (digitalRelease != null) 'digitalRelease': digitalRelease,
+      if (physicalRelease != null) 'physicalRelease': physicalRelease,
+    };
+
+RadarrMovie _parsed(Map<String, dynamic> json) => RadarrMovie.fromJson(json);
+
+/// A midnight-UTC calendar date string for the local calendar day of [d].
+String _utcDate(DateTime d) =>
+    '${d.year.toString().padLeft(4, '0')}-'
+    '${d.month.toString().padLeft(2, '0')}-'
+    '${d.day.toString().padLeft(2, '0')}T00:00:00Z';
+
+Future<_FakeAdapter> _pump(
+  WidgetTester tester,
+  Widget screen,
+  List<Map<String, dynamic>> movies,
+) async {
+  tester.view.physicalSize = const Size(800, 1400);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
+
+  final adapter = _FakeAdapter()..movies = movies;
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+    ..httpClientAdapter = adapter;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        backendClientProvider.overrideWithValue(dio),
+        instanceProvider.overrideWith(_RadarrInstances.new),
+      ],
+      child: MaterialApp(home: Scaffold(body: screen)),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return adapter;
+}
+
+void main() {
+  group('radarrCalendarReleases', () {
+    test('one labelled row per release date inside the window', () {
+      final rows = radarrCalendarReleases(
+        [
+          _parsed(_movie(
+              id: 1,
+              title: 'Both',
+              inCinemas: '2026-07-10T00:00:00Z',
+              digitalRelease: '2026-07-24T00:00:00Z')),
+        ],
+        start: DateTime(2026, 7, 5),
+        end: DateTime(2026, 7, 30),
+      );
+
+      expect(rows, hasLength(2));
+      expect(rows[0].label, 'In cinemas');
+      expect(rows[0].date, DateTime(2026, 7, 10));
+      expect(rows[1].label, 'Digital');
+      expect(rows[1].date, DateTime(2026, 7, 24));
+    });
+
+    test('drops dates outside the window when another is inside', () {
+      final rows = radarrCalendarReleases(
+        [
+          _parsed(_movie(
+              id: 1,
+              title: 'Late digital',
+              inCinemas: '2026-01-10T00:00:00Z',
+              digitalRelease: '2026-07-24T00:00:00Z')),
+        ],
+        start: DateTime(2026, 7, 5),
+        end: DateTime(2026, 7, 30),
+      );
+
+      expect(rows.map((r) => r.label).toList(), ['Digital']);
+    });
+
+    test('a movie with no date in the window keeps its soonest upcoming one',
+        () {
+      final rows = radarrCalendarReleases(
+        [
+          _parsed(_movie(
+              id: 1,
+              title: 'Edge',
+              inCinemas: '2026-06-01T00:00:00Z',
+              digitalRelease: '2026-08-15T00:00:00Z')),
+        ],
+        start: DateTime(2026, 7, 5),
+        end: DateTime(2026, 7, 30),
+        now: DateTime(2026, 7, 10),
+      );
+
+      expect(rows.single.label, 'Digital');
+      expect(rows.single.date, DateTime(2026, 8, 15));
+    });
+
+    test('falls back to the most recent past date when nothing is upcoming',
+        () {
+      final rows = radarrCalendarReleases(
+        [
+          _parsed(_movie(
+              id: 1,
+              title: 'Old',
+              inCinemas: '2026-05-01T00:00:00Z',
+              physicalRelease: '2026-06-20T00:00:00Z')),
+        ],
+        start: DateTime(2026, 7, 5),
+        end: DateTime(2026, 7, 30),
+        now: DateTime(2026, 7, 10),
+      );
+
+      expect(rows.single.label, 'Physical');
+      expect(rows.single.date, DateTime(2026, 6, 20));
+    });
+
+    test('midnight-UTC dates keep their calendar day in any time zone', () {
+      final rows = radarrCalendarReleases(
+        [_parsed(_movie(id: 1, title: 'M', digitalRelease: '2026-08-07T00:00:00Z'))],
+        start: DateTime(2026, 8, 1),
+        end: DateTime(2026, 8, 31),
+      );
+
+      expect(rows.single.date, DateTime(2026, 8, 7));
+    });
+
+    test('rows are date ascending across movies; dateless movies are skipped',
+        () {
+      final rows = radarrCalendarReleases(
+        [
+          _parsed(_movie(id: 1, title: 'B', digitalRelease: '2026-07-20T00:00:00Z')),
+          _parsed(_movie(id: 2, title: 'A', inCinemas: '2026-07-08T00:00:00Z')),
+          _parsed(_movie(id: 3, title: 'None')),
+        ],
+        start: DateTime(2026, 7, 5),
+        end: DateTime(2026, 7, 30),
+      );
+
+      expect(rows.map((r) => r.movie.title).toList(), ['A', 'B']);
+    });
+  });
+
+  group('RadarrWantedScreen', () {
+    testWidgets('rows carry a poster slot and a typed release label',
+        (tester) async {
+      await _pump(
+        tester,
+        const RadarrWantedScreen(),
+        [
+          _movie(
+              id: 5,
+              title: 'Example Movie',
+              digitalRelease: '2026-08-07T00:00:00Z'),
+        ],
+      );
+
+      expect(find.text('Example Movie (2026)'), findsOneWidget);
+      expect(find.textContaining('Digital Aug 7, 2026'), findsOneWidget);
+      expect(find.byType(CachedImage), findsOneWidget);
+    });
+
+    testWidgets('tapping a row opens the movie detail screen', (tester) async {
+      await _pump(
+        tester,
+        const RadarrWantedScreen(),
+        [
+          _movie(
+              id: 5,
+              title: 'Example Movie',
+              digitalRelease: '2026-08-07T00:00:00Z'),
+        ],
+      );
+
+      await tester.tap(find.text('Example Movie (2026)'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RadarrMovieDetailScreen), findsOneWidget);
+    });
+  });
+
+  group('RadarrCalendarScreen', () {
+    testWidgets(
+        'groups releases by day with typed labels and opens detail on tap',
+        (tester) async {
+      final now = DateTime.now();
+      await _pump(
+        tester,
+        const RadarrCalendarScreen(),
+        [
+          _movie(id: 5, title: 'Movie A', digitalRelease: _utcDate(now)),
+          _movie(
+              id: 6,
+              title: 'Movie B',
+              inCinemas: _utcDate(now.add(const Duration(days: 1)))),
+        ],
+      );
+
+      expect(find.text('Today'), findsOneWidget);
+      expect(find.text('Tomorrow'), findsOneWidget);
+      expect(find.text('Movie A (2026)'), findsOneWidget);
+      expect(find.text('Digital'), findsOneWidget);
+      expect(find.text('In cinemas'), findsOneWidget);
+
+      await tester.tap(find.text('Movie A (2026)'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(RadarrMovieDetailScreen), findsOneWidget);
+    });
+  });
+}

--- a/app/test/sonarr/sonarr_wanted_calendar_test.dart
+++ b/app/test/sonarr/sonarr_wanted_calendar_test.dart
@@ -1,0 +1,262 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/core/models/backend_connection.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
+import 'package:cantinarr/core/providers/instance_provider.dart';
+import 'package:cantinarr/core/widgets/cached_image.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:cantinarr/features/sonarr/ui/sonarr_calendar_screen.dart';
+import 'package:cantinarr/features/sonarr/ui/sonarr_series_detail_screen.dart';
+import 'package:cantinarr/features/sonarr/ui/sonarr_wanted_screen.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Map<String, dynamic> _embeddedSeries() => {
+      'id': 7,
+      'title': 'Example',
+      'images': <Map<String, dynamic>>[],
+    };
+
+Map<String, dynamic> _wantedRecord() => {
+      'id': 11,
+      'seriesId': 7,
+      'seasonNumber': 1,
+      'episodeNumber': 5,
+      'title': 'Pilot',
+      'airDateUtc': '2026-07-01T01:00:00Z',
+      'monitored': true,
+      'series': _embeddedSeries(),
+    };
+
+Map<String, dynamic> _calendarEntry(DateTime airUtc,
+        {int episode = 1, bool hasFile = false}) =>
+    {
+      'id': 100 + episode,
+      'seriesId': 7,
+      'seasonNumber': 1,
+      'episodeNumber': episode,
+      'title': 'Episode $episode',
+      'airDateUtc': airUtc.toIso8601String(),
+      'hasFile': hasFile,
+      'series': _embeddedSeries(),
+    };
+
+/// Fake Dio adapter: serves configured wanted/calendar bodies plus the canned
+/// series detail endpoints, and records every request for assertions.
+class _FakeAdapter implements HttpClientAdapter {
+  final List<({String method, String path, Map<String, dynamic> query})>
+      requests = [];
+
+  List<Map<String, dynamic>> wantedRecords = [];
+  List<Map<String, dynamic>> calendar = [];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final path = options.uri.path;
+    requests.add((
+      method: options.method,
+      path: path,
+      query: options.uri.queryParameters,
+    ));
+
+    dynamic response = <String, dynamic>{};
+    if (options.method == 'GET') {
+      if (path.contains('/wanted/')) {
+        response = {
+          'page': 1,
+          'pageSize': 50,
+          'totalRecords': wantedRecords.length,
+          'records': wantedRecords,
+        };
+      } else if (path.endsWith('/calendar')) {
+        response = calendar;
+      } else if (path.endsWith('/series/7')) {
+        response = _embeddedSeries();
+      } else if (path.endsWith('/qualityprofile') ||
+          path.endsWith('/tag') ||
+          path.endsWith('/episode')) {
+        response = <dynamic>[];
+      } else if (path.endsWith('/queue')) {
+        response = {'records': <dynamic>[]};
+      }
+    }
+    return ResponseBody.fromString(
+      jsonEncode(response),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _SonarrInstances extends InstanceNotifier {
+  @override
+  InstanceState build() => const InstanceState(
+        sonarrInstances: [
+          ServiceInstance(id: 'sonarr-1', serviceType: 'sonarr', name: 'Sonarr'),
+        ],
+      );
+}
+
+Future<_FakeAdapter> _pump(
+  WidgetTester tester,
+  Widget screen,
+  void Function(_FakeAdapter adapter) seed,
+) async {
+  tester.view.physicalSize = const Size(800, 1400);
+  tester.view.devicePixelRatio = 1;
+  addTearDown(() {
+    tester.view.resetPhysicalSize();
+    tester.view.resetDevicePixelRatio();
+  });
+
+  final adapter = _FakeAdapter();
+  seed(adapter);
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+    ..httpClientAdapter = adapter;
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        backendClientProvider.overrideWithValue(dio),
+        instanceProvider.overrideWith(_SonarrInstances.new),
+      ],
+      child: MaterialApp(home: Scaffold(body: screen)),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return adapter;
+}
+
+void main() {
+  group('SonarrWantedRecord.fromJson', () {
+    test('parses the embedded series alongside the flat title', () {
+      final record = SonarrWantedRecord.fromJson({
+        ..._wantedRecord(),
+        'series': {
+          'id': 7,
+          'title': 'Example',
+          'images': [
+            {'coverType': 'poster', 'remoteUrl': 'https://img.example/p.jpg'},
+          ],
+        },
+      });
+
+      expect(record.seriesTitle, 'Example');
+      expect(record.series?.id, 7);
+      expect(record.series?.posterUrl, 'https://img.example/p.jpg');
+    });
+
+    test('tolerates a record without a series object', () {
+      final record = SonarrWantedRecord.fromJson({'id': 11});
+
+      expect(record.series, isNull);
+      expect(record.seriesTitle, isNull);
+    });
+  });
+
+  group('SonarrCalendarEntry.fromJson', () {
+    test('parses the episode and its embedded series', () {
+      final entry = SonarrCalendarEntry.fromJson({
+        'id': 3,
+        'seriesId': 7,
+        'seasonNumber': 1,
+        'episodeNumber': 5,
+        'title': 'Pilot',
+        'airDateUtc': '2026-07-01T01:00:00Z',
+        'hasFile': true,
+        'series': _embeddedSeries(),
+      });
+
+      expect(entry.seasonEpisodeLabel, 'S01E05');
+      expect(entry.airDateUtc, DateTime.utc(2026, 7, 1, 1));
+      expect(entry.hasFile, isTrue);
+      expect(entry.series?.title, 'Example');
+    });
+
+    test('tolerates a bare entry', () {
+      final entry = SonarrCalendarEntry.fromJson({'id': 3});
+
+      expect(entry.series, isNull);
+      expect(entry.airDateUtc, isNull);
+      expect(entry.hasFile, isFalse);
+    });
+  });
+
+  group('SonarrWantedScreen', () {
+    testWidgets('shows the series with a poster slot and requests the series',
+        (tester) async {
+      final adapter = await _pump(
+        tester,
+        const SonarrWantedScreen(),
+        (a) => a.wantedRecords = [_wantedRecord()],
+      );
+
+      final wanted = adapter.requests
+          .where((r) => r.path.endsWith('/wanted/missing'))
+          .toList();
+      expect(wanted, hasLength(1));
+      expect(wanted.first.query['includeSeries'], 'true');
+
+      expect(find.text('Example'), findsOneWidget);
+      expect(find.textContaining('S01E05 • Pilot'), findsOneWidget);
+      expect(find.byType(CachedImage), findsOneWidget);
+    });
+
+    testWidgets('tapping a row opens the series detail screen',
+        (tester) async {
+      await _pump(
+        tester,
+        const SonarrWantedScreen(),
+        (a) => a.wantedRecords = [_wantedRecord()],
+      );
+
+      await tester.tap(find.text('Example'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SonarrSeriesDetailScreen), findsOneWidget);
+    });
+  });
+
+  group('SonarrCalendarScreen', () {
+    testWidgets(
+        'requests embedded series, groups by day and opens detail on tap',
+        (tester) async {
+      final now = DateTime.now();
+      final adapter = await _pump(
+        tester,
+        const SonarrCalendarScreen(),
+        (a) => a.calendar = [
+          _calendarEntry(now.toUtc(), episode: 1),
+          _calendarEntry(now.add(const Duration(days: 1)).toUtc(), episode: 2),
+        ],
+      );
+
+      final calendar = adapter.requests
+          .where((r) => r.path.endsWith('/calendar'))
+          .toList();
+      expect(calendar, hasLength(1));
+      expect(calendar.first.query['includeSeries'], 'true');
+
+      expect(find.text('Today'), findsOneWidget);
+      expect(find.text('Tomorrow'), findsOneWidget);
+      expect(find.text('Example'), findsNWidgets(2));
+      expect(find.textContaining('S01E01 • Episode 1'), findsOneWidget);
+
+      await tester.tap(find.text('Example').first);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SonarrSeriesDetailScreen), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The Radarr/Sonarr **Wanted** and **Calendar** screens looked and felt incomplete: rows had no artwork, nothing was tappable, the Sonarr calendar rendered blank series names (it read the embedded `series` object without ever sending `includeSeries=true`), and the Radarr calendar showed a bare date with no hint whether it was a theatrical, digital, or physical release.

### Wanted (Radarr + Sonarr)
- Poster leading on every row (`images[].remoteUrl` via `CachedImage`, per the client-reachable-URL rule).
- Rows are tappable and open the movie/series detail screen (`AmbientPageRoute`), refreshing the list on return; the trailing automatic/interactive search buttons are unchanged.
- `SonarrWantedRecord` now parses the full embedded series it was already fetching, which supplies both the poster and the `SonarrSeriesDetailScreen` argument.
- Fixed a release-date off-by-one: labels formatted `digitalRelease.toLocal()`, shifting midnight-UTC calendar dates to the prior day in western time zones. Labels now format the date components directly (same rule the dashboard already followed).

### Calendar (Radarr + Sonarr)
- Rewritten from raw `Map<String, dynamic>` lists to typed models (`SonarrCalendarEntry`, `RadarrCalendarRelease`).
- Day-sectioned layout with Today/Tomorrow/weekday headers, posters, tap-through to detail, pull-to-refresh + error/empty states matching the wanted screens, and the same in-flight generation guard the wanted screens use.
- Sonarr: requests `includeSeries=true` (opt-in service param; dashboard callers unchanged), shows series name, SxxEyy • episode title, local air time, and a has-file check.
- Radarr: one labelled row per release type (**In cinemas / Digital / Physical**) inside the fetched window — matching Radarr's own calendar semantics — and a movie whose dates all fall outside the window still surfaces its nearest release instead of being silently dropped.

### Shared
- `core/widgets/day_sections.dart`: `DaySectionHeader` + `groupItemsByDay`, also adopted by the dashboard Releases tab in place of its private header copy.
- Preview/screenshot fixtures: sonarr calendar series carry ids + posters, wanted pages are populated, and by-id `/movie/{id}` / `/series/{id}` lookups let tap-through land on populated detail screens in the harness.

No server changes: the instance proxy forwards query params verbatim, and `wanted`/`calendar` are already allowlisted read resources.

## Verification
- `flutter analyze --no-fatal-infos` — clean.
- `flutter test` — 787 tests pass, including new coverage: `radarrCalendarReleases` windowing/labels/fallbacks, `SonarrWantedRecord`/`SonarrCalendarEntry` parsing, day grouping/headers, and widget tests proving `includeSeries` is sent and each screen's rows tap through to the detail screens.
- Runtime-verified in the browser via the screenshot preview harness: all four screens render posters/labels/day sections, and tap-through was exercised into both detail screens.

## Docs
- No documented surface changed (module tabs, routes, env vars, tools, and tables all as before), so no doc updates are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0163jjtwMVJJrWmsgVDRR6Hg