### PR TITLE
fix: stop season packs livelocking dispatch at the recovery preflight

### DIFF
--- a/server/internal/remediation/observation.go
+++ b/server/internal/remediation/observation.go
@@ -1916,11 +1916,32 @@ func (s *Service) probeArrRecovery(issue *Issue) (arrRecoveryProbe, error) {
 	if _, err := s.ensureIssueObservation(issue, serviceType, now); err != nil {
 		return arrRecoveryProbe{}, err
 	}
+	// Partition the snapshot exactly as the observation sweep does and pick this
+	// incident's rows by its stored scope key. The preflight and the sweeper must
+	// agree on which queue rows constitute the incident: a season pack is one
+	// download but N per-episode incidents, so matching by shared download id
+	// would hand every sibling episode's row to this one issue. Its signature
+	// could then never equal the sweep's per-episode signature, every unchanged
+	// row read as "live arr signature changed", and each promotion bounced
+	// straight back to tracking with the dispatched run aborted.
+	var scopeKey string
+	if err := s.db.QueryRow(
+		"SELECT scope_key FROM issue_observations WHERE issue_id=?", issue.ID,
+	).Scan(&scopeKey); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return arrRecoveryProbe{}, err
+	}
+	groups := groupQueueObservations(serviceType, issue.InstanceID, items)
 	var matched []arr.QueueObservation
-	for _, item := range items {
-		if mediaScopeMatches(issueMediaContext(issue), item.Media, issue.MediaType) ||
-			(item.DownloadID != "" && item.DownloadID == issue.DownloadID) {
-			matched = append(matched, item)
+	if group, ok := groups[scopeKey]; ok {
+		matched = group.items
+	} else if issue.Source == SourceUser {
+		for _, candidate := range groups {
+			for _, item := range candidate.items {
+				if mediaScopeMatches(issueMediaContext(issue), item.Media, issue.MediaType) {
+					matched = append(matched, candidate.items...)
+					break
+				}
+			}
 		}
 	}
 	if len(matched) == 0 {

--- a/server/internal/remediation/observation_preflight_test.go
+++ b/server/internal/remediation/observation_preflight_test.go
@@ -1,0 +1,134 @@
+package remediation
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/instance"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+// setupSeasonPackService serves a Sonarr instance whose queue holds one season
+// pack: two episodes of the same series stuck at importPending under a single
+// shared download id. Series/episode endpoints report neither episode has a
+// file, so baselines capture and neither incident can prove recovery.
+func setupSeasonPackService(t *testing.T) *Service {
+	t.Helper()
+	queueRecord := func(queueID, episodeID, episodeNumber int) string {
+		return fmt.Sprintf(`{"id":%d,"seriesId":2,"episodeId":%d,"title":"Tremors.S01.1080p",
+		 "status":"completed","trackedDownloadStatus":"warning","trackedDownloadState":"importPending",
+		 "statusMessages":[{"title":"Tremors.S01.1080p","messages":["One or more episodes expected in this release were not imported or missing"]}],
+		 "downloadId":"pack-1","protocol":"usenet","size":1000,"sizeleft":0,"added":"2026-07-27T10:00:00Z",
+		 "series":{"id":2,"title":"Tremors","tvdbId":100},
+		 "episode":{"id":%d,"seriesId":2,"seasonNumber":1,"episodeNumber":%d,"hasFile":false,"episodeFileId":0}}`,
+			queueID, episodeID, episodeID, episodeNumber)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v3/queue":
+			fmt.Fprintf(w, `{"totalRecords":2,"records":[%s,%s]}`,
+				queueRecord(11, 101, 1), queueRecord(12, 102, 2))
+		case "/api/v3/series":
+			fmt.Fprint(w, `[{"id":2,"title":"Tremors","tvdbId":100}]`)
+		case "/api/v3/episode":
+			fmt.Fprint(w, `[{"id":101,"seriesId":2,"seasonNumber":1,"episodeNumber":1,"hasFile":false,"episodeFileId":0},
+			 {"id":102,"seriesId":2,"seasonNumber":1,"episodeNumber":2,"hasFile":false,"episodeFileId":0}]`)
+		case "/api/v3/history":
+			fmt.Fprint(w, `{"totalRecords":0,"records":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { database.Close() })
+	cipher, _ := secrets.NewCipher(bytes.Repeat([]byte{0x37}, 32))
+	store := instance.NewStore(database, cipher)
+	if err := store.Create(&instance.Instance{
+		ID: "sonarr-pack", ServiceType: "sonarr", Name: "TV", URL: server.URL, APIKey: "key",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return NewService(database, instance.NewRegistry(store), nil, &fakeNotifier{})
+}
+
+// A season pack is one download but N per-episode incidents. The dispatch
+// preflight must partition the live queue exactly as the observation sweep
+// does; matching by the shared download id instead hands every sibling
+// episode's row to each incident, the signature can never equal the sweep's
+// per-episode signature, and an unchanged stuck import reads as "live arr
+// signature changed": every promotion bounces straight back to tracking with
+// its run aborted, so the pack loops forever and is never remediated.
+func TestPreflightKeepsPromotedSeasonPackEpisodeActionable(t *testing.T) {
+	svc := setupSeasonPackService(t)
+	enableAutoDispatch(t, svc, 5)
+
+	// Fetch through the real client so the sweep sees byte-identical
+	// observations to the ones the preflight will re-fetch itself.
+	items, err := svc.fetchQueueSnapshot("sonarr", "sonarr-pack")
+	if err != nil || len(items) != 2 {
+		t.Fatalf("queue snapshot = %d items, err=%v", len(items), err)
+	}
+	base := time.Now().UTC().Add(-30 * time.Minute)
+	if err := svc.observeQueueSnapshot("sonarr", "sonarr-pack", items, base); err != nil {
+		t.Fatal(err)
+	}
+	issues, _ := svc.ListIssues("")
+	if len(issues) != 2 {
+		t.Fatalf("pack episodes did not scope per incident: %+v", issues)
+	}
+	for _, issue := range issues {
+		if issue.Status != IssueObserving {
+			t.Fatalf("issue %d status = %s, want observing", issue.ID, issue.Status)
+		}
+	}
+	if err := svc.observeQueueSnapshot("sonarr", "sonarr-pack", items, base.Add(16*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	drainJobs(svc)
+
+	for _, issue := range issues {
+		promoted, err := svc.GetIssue(issue.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if promoted.Status != IssueOpen {
+			t.Fatalf("issue %d status = %s, want open after the observation window", issue.ID, promoted.Status)
+		}
+		var before string
+		if err := svc.db.QueryRow("SELECT signature FROM issue_observations WHERE issue_id=?", issue.ID).Scan(&before); err != nil {
+			t.Fatal(err)
+		}
+
+		recovering, err := svc.preflightArrRecovery(issue.ID)
+		if err != nil {
+			t.Fatalf("preflight issue %d: %v", issue.ID, err)
+		}
+		if recovering {
+			t.Fatalf("issue %d: unchanged stuck import classified as arr recovery in flight", issue.ID)
+		}
+		after, err := svc.GetIssue(issue.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if after.Status != IssueOpen {
+			t.Fatalf("issue %d bounced back to %s during preflight", issue.ID, after.Status)
+		}
+		var signature string
+		if err := svc.db.QueryRow("SELECT signature FROM issue_observations WHERE issue_id=?", issue.ID).Scan(&signature); err != nil {
+			t.Fatal(err)
+		}
+		if signature != before {
+			t.Fatalf("issue %d: preflight rewrote the sweep's per-episode signature", issue.ID)
+		}
+	}
+}


### PR DESCRIPTION
## What

Why the 13 stuck "waiting to import" Tremors episodes sat under **Tracking → "Watching the download"** for a day with no push, no agent run, and no fix — and the fix.

The observation sweep scopes a season pack **per episode**: one download id, N incidents, each storing a signature over its own queue row. The dispatch preflight (`probeArrRecovery`) rebuilt the incident's rows with `mediaScopeMatches || item.DownloadID == issue.DownloadID` — for a pack, the download-id clause pulls in **every sibling episode's row**, so the preflight's signature could never equal the sweep's per-episode one. `matchingGroupStillActive` then reported "live arr signature changed during execution preflight" for a byte-for-byte unchanged stuck import, every dispatch:

1. Sweep promotes the stuck incident → `IssueOpen`, agent enqueued.
2. Runner preflight computes the widened group → signature mismatch → "active recovery" → `suspendIssueForRecovery`: run aborted (`arr_recovery_in_flight`), issue back to tracking.
3. Next sweep flips it Recovering → Observing, quiet window restarts, ~5 minutes later promote again → goto 2. Forever.

The agent never got past preflight, so packs were never remediated. Pre-#302 the first promotion still paged (the 13-push storm that motivated #302); post-#302 the flap re-arms the owed alert's hold-down every sweep, so the loop is completely silent — noticed by nobody until a human opened the app.

The preflight now partitions the live snapshot with the sweep's own grouping (`groupQueueObservations`) and picks this incident's rows by its stored `scope_key`; user reports keep their media-scope aggregation, mirroring `observeQueueSnapshot` exactly. Both readers now compute the same verdict from the same state, so a genuinely unchanged incident stays promoted, dispatched, and remediable — and if it truly can't be fixed, the hold-down finally elapses and the coalesced page from #302 is delivered.

## Verification

- `go vet ./...` — clean.
- `go test ./...` — all green.
- New regression test `TestPreflightKeepsPromotedSeasonPackEpisodeActionable` drives the real fetch→observe→promote→preflight path over an httptest Sonarr serving a two-episode season pack stuck at `importPending`. Confirmed it **fails on main** with `unchanged stuck import classified as arr recovery in flight` and passes with the fix; it also pins that the preflight no longer rewrites the sweep's per-episode signature.

## Docs

- [x] No docs impact — explained above

Internal observation/dispatch behavior only; no route, tool, env var, table, or screen changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hxp3j3M4Y384bmAZ7JMd9g