### PR TITLE
feat: batch approve for the agent-action approval queue

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -234,6 +234,11 @@ GET    /api/admin/agent-actions/{id}       # admin: reconcile one durable action
 POST   /api/admin/agent-actions/{id}/approve   # admin: claims and dispatches the stored proposal once;
                                            #   body {override?, remember?} — remember additionally arms a
                                            #   standing auto-approval rule for this (problem, fix, facet)
+POST   /api/admin/agent-actions/approve-batch  # admin: approve an explicit list of reviewed proposals;
+                                           #   body {ids} (≤100), decided sequentially by the single-
+                                           #   approve core; 200 with per-item verdicts (durable action
+                                           #   status, or skipped/error with a reason) — one conflict
+                                           #   never fails the rest
 POST   /api/admin/agent-actions/{id}/deny      # admin: denial resumes the investigation
 GET    /api/admin/agent-runs/{id}          # admin: full audit trail of one agent run
 GET    /api/admin/agent-approval-rules     # admin: standing auto-approval rules with status + counters

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -246,6 +246,7 @@ func NewRouter(
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/agent-actions", remediationHandler.ListActions)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/agent-actions/{id}", remediationHandler.GetAction)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Post("/agent-actions/{id}/approve", remediationHandler.ApproveAction)
+			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Post("/agent-actions/approve-batch", remediationHandler.BatchApproveActions)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Post("/agent-actions/{id}/deny", remediationHandler.DenyAction)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/agent-runs/{id}", remediationHandler.GetRun)
 

--- a/server/internal/remediation/batchapprove.go
+++ b/server/internal/remediation/batchapprove.go
@@ -1,0 +1,80 @@
+package remediation
+
+import "errors"
+
+// batchApproveMaxIDs bounds one approve-batch request. The one-proposed-per-
+// issue invariant keeps the real queue near the open awaiting-approval count,
+// so this is a defensive ceiling on serial arr I/O per request, not a product
+// limit an admin should ever meet.
+const batchApproveMaxIDs = 100
+
+// BatchApproveRequest is the POST /api/admin/agent-actions/approve-batch body:
+// the explicit action ids the admin reviewed. There is deliberately no
+// "approve everything currently proposed" form — a proposal that parks while
+// the batch is in flight must never be approved sight-unseen.
+type BatchApproveRequest struct {
+	IDs []int64 `json:"ids"`
+}
+
+// BatchApproveResponse carries one verdict per requested id (duplicates
+// collapsed to their first occurrence), in request order.
+type BatchApproveResponse struct {
+	Results []BatchApprovalItem `json:"results"`
+}
+
+// BatchApprovalItem is one id's outcome within an approve-batch request.
+// Status is the durable action status after the attempt ("executed", "failed",
+// "outcome_unknown", "superseded", ...) or one of two batch-only verdicts:
+// "skipped" — a decision, closure, or arr-recovery race owned the proposal
+// first and nothing was executed — and "error" — the id could not be decided
+// at all. Detail carries the human-readable reason for anything that did not
+// execute cleanly.
+type BatchApprovalItem struct {
+	ID     int64  `json:"id"`
+	Status string `json:"status"`
+	Detail string `json:"detail,omitempty"`
+}
+
+// ApproveActions approves a list of proposed actions through the same
+// per-item decision core as ApproveAction — one CAS claim, both arr-recovery
+// preflights, at-most-once dispatch — sequentially, so a batch never runs arr
+// mutations in parallel (sweepAutoApprovals sets that precedent). One item's
+// conflict or failure never stops the rest: the admin approved the whole
+// list, and each proposal's outcome is independent. The loop runs to
+// completion even if the requesting client disconnects, so "approve all"
+// never half-finishes because an app was backgrounded; every outcome is
+// durable and the client reconciles by re-reading the queue.
+//
+// No overrides and no remember: editing params or arming a standing
+// auto-approval rule are deliberate per-proposal decisions that keep their
+// own single-action flow.
+func (s *Service) ApproveActions(adminID int64, ids []int64) []BatchApprovalItem {
+	results := make([]BatchApprovalItem, 0, len(ids))
+	seen := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		act, err := s.ApproveAction(adminID, id, nil)
+		switch {
+		case errors.Is(err, ErrActionDecisionConflict):
+			// Nothing executed: the arr began recovering, media state changed,
+			// or another decision won. The proposal's durable state is whatever
+			// the winner left; the queue view shows it on the next read.
+			results = append(results, BatchApprovalItem{ID: id, Status: "skipped", Detail: err.Error()})
+		case err != nil:
+			results = append(results, BatchApprovalItem{ID: id, Status: "error", Detail: err.Error()})
+		default:
+			item := BatchApprovalItem{ID: id, Status: act.Status}
+			// Surface the stored (already-redacted) outcome text for anything
+			// that did not execute cleanly, so the batch response is
+			// self-sufficient without a follow-up read per item.
+			if act.Status != ActionExecuted && act.ResultText != nil {
+				item.Detail = *act.ResultText
+			}
+			results = append(results, item)
+		}
+	}
+	return results
+}

--- a/server/internal/remediation/batchapprove_test.go
+++ b/server/internal/remediation/batchapprove_test.go
@@ -1,0 +1,232 @@
+package remediation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/arr"
+	"github.com/windoze95/cantinarr-server/internal/auth"
+)
+
+// seedExtraProposal seeds another issue with its own parked run and proposed
+// action, mirroring approvalFixture's rows, so batch tests can operate on
+// several independent proposals against the shared fixture service.
+func seedExtraProposal(t *testing.T, svc *Service, n int) (issueID, actionID int64) {
+	t.Helper()
+	res, err := svc.db.Exec(
+		"INSERT INTO issues (source, status, media_type, tmdb_id, title, detail, instance_id) VALUES ('user','awaiting_approval','movie',?,?,'wrong content','radarr-main')",
+		42+n, fmt.Sprintf("Test Movie %d", n),
+	)
+	if err != nil {
+		t.Fatalf("seed extra issue: %v", err)
+	}
+	issueID, _ = res.LastInsertId()
+
+	toolUseID := fmt.Sprintf("toolu_propose_batch_%d", n)
+	history := []map[string]any{
+		{"role": "user", "content": []map[string]any{{"type": "text", "text": "investigate"}}},
+		{"role": "assistant", "content": []map[string]any{{"type": "tool_use", "id": toolUseID, "name": "propose_action", "input": map[string]any{}}}},
+		{"role": "user", "content": []map[string]any{{"type": "tool_result", "tool_use_id": toolUseID, "name": "propose_action", "content": "Proposal recorded; awaiting admin approval."}}},
+	}
+	htData, _ := json.Marshal(history)
+	runRes, err := svc.db.Exec(
+		"INSERT INTO agent_runs (issue_id, trigger, status, model, step_count, transcript_json) VALUES (?, 'user_report', ?, 'claude-haiku-4-5', 3, ?)",
+		issueID, runStatusWaitingApproval, string(htData),
+	)
+	if err != nil {
+		t.Fatalf("seed extra run: %v", err)
+	}
+	runID, _ := runRes.LastInsertId()
+
+	params := fmt.Sprintf(`{"media_type":"movie","queue_id":%d,"action":"blocklist_search"}`, 100+n)
+	fp := fingerprint(issueID, runID, toolUseID, ActionRemediateQueue, json.RawMessage(params))
+	actRes, err := svc.db.Exec(
+		"INSERT INTO agent_actions (issue_id, run_id, tool_use_id, kind, params, rationale, risk, status, fingerprint) VALUES (?, ?, ?, ?, ?, 'because', 'mutating', ?, ?)",
+		issueID, runID, toolUseID, string(ActionRemediateQueue), params, ActionProposed, fp,
+	)
+	if err != nil {
+		t.Fatalf("seed extra action: %v", err)
+	}
+	actionID, _ = actRes.LastInsertId()
+	return issueID, actionID
+}
+
+// TestBatchApproveExecutesEachExactlyOnce: a batch over N proposals dispatches
+// each underlying mutation exactly once, attributes every decision to the
+// admin, and reports each item executed in request order.
+func TestBatchApproveExecutesEachExactlyOnce(t *testing.T) {
+	svc, fx, _, action1 := approvalFixture(t)
+	_, action2 := seedExtraProposal(t, svc, 1)
+	_, action3 := seedExtraProposal(t, svc, 2)
+
+	ids := []int64{action1, action2, action3}
+	results := svc.ApproveActions(testAdminID, ids)
+
+	if len(results) != 3 {
+		t.Fatalf("results = %d, want 3", len(results))
+	}
+	for i, r := range results {
+		if r.ID != ids[i] {
+			t.Fatalf("result[%d].ID = %d, want %d (request order preserved)", i, r.ID, ids[i])
+		}
+		if r.Status != ActionExecuted {
+			t.Fatalf("result[%d] = %+v, want executed", i, r)
+		}
+	}
+	if fx.count() != 3 {
+		t.Fatalf("executor ran %d times, want exactly 3", fx.count())
+	}
+	for _, id := range ids {
+		var decidedBy int64
+		if err := svc.db.QueryRow("SELECT decided_by FROM agent_actions WHERE id = ?", id).Scan(&decidedBy); err != nil {
+			t.Fatalf("read decided_by for %d: %v", id, err)
+		}
+		if decidedBy != testAdminID {
+			t.Fatalf("action %d decided_by = %d, want admin %d", id, decidedBy, testAdminID)
+		}
+	}
+}
+
+// TestBatchApproveMixedOutcomesDoNotStopTheBatch: an already-decided id
+// returns its durable outcome without re-running, an unknown id reports
+// "error", and both leave the rest of the batch untouched.
+func TestBatchApproveMixedOutcomesDoNotStopTheBatch(t *testing.T) {
+	svc, fx, _, decided := approvalFixture(t)
+	_, fresh := seedExtraProposal(t, svc, 1)
+
+	// Decide the first proposal ahead of the batch (executor call #1).
+	if _, err := svc.ApproveAction(testAdminID, decided, nil); err != nil {
+		t.Fatalf("pre-approve: %v", err)
+	}
+
+	results := svc.ApproveActions(testAdminID, []int64{decided, 999999, fresh})
+	if len(results) != 3 {
+		t.Fatalf("results = %d, want 3", len(results))
+	}
+	if results[0].Status != ActionExecuted {
+		t.Fatalf("already-decided item = %+v, want durable executed", results[0])
+	}
+	if results[1].Status != "error" || results[1].Detail == "" {
+		t.Fatalf("unknown-id item = %+v, want error with detail", results[1])
+	}
+	if results[2].Status != ActionExecuted {
+		t.Fatalf("fresh item = %+v, want executed", results[2])
+	}
+	// One pre-batch execution + the fresh item; the already-decided id must
+	// not have re-run (at-most-once holds inside a batch too).
+	if fx.count() != 2 {
+		t.Fatalf("executor ran %d times, want exactly 2", fx.count())
+	}
+}
+
+// TestBatchApproveSkipsRecoveringConflictAndContinues: an item whose arr
+// began recovering between the preflight and its execution claim is reported
+// "skipped" with the conflict reason, executes nothing, and the batch moves
+// on to the next proposal.
+func TestBatchApproveSkipsRecoveringConflictAndContinues(t *testing.T) {
+	svc, fx, _, action1 := approvalFixture(t)
+	skipIssue, skipAction := seedExtraProposal(t, svc, 1)
+
+	// Mirror TestPostClaimRecoveryCancelsApprovalBeforeExecutor: the skip
+	// issue's first probe (pre-CAS preflight) passes, its post-claim re-read
+	// reports the arr actively recovering. Every other issue stays quiet.
+	calls := map[int64]int{}
+	svc.recoveryProbe = func(iss *Issue) (arrRecoveryProbe, error) {
+		calls[iss.ID]++
+		if iss.ID == skipIssue && calls[iss.ID] > 1 {
+			return arrRecoveryProbe{active: true, item: arr.QueueObservation{
+				DownloadID: "retry-batch",
+				Media:      arr.QueueMediaContext{QueueID: 101, TmdbID: 43},
+			}}, nil
+		}
+		return arrRecoveryProbe{}, nil
+	}
+
+	results := svc.ApproveActions(testAdminID, []int64{skipAction, action1})
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	if results[0].Status != "skipped" || !strings.Contains(results[0].Detail, "recovering") {
+		t.Fatalf("recovering item = %+v, want skipped with recovery detail", results[0])
+	}
+	if results[1].Status != ActionExecuted {
+		t.Fatalf("second item = %+v, want executed (batch continued past the conflict)", results[1])
+	}
+	if fx.count() != 1 {
+		t.Fatalf("executor ran %d times, want exactly 1 (skipped item must not mutate)", fx.count())
+	}
+}
+
+// TestBatchApproveCollapsesDuplicateIDs: repeating an id in one request
+// decides it once and yields one result row.
+func TestBatchApproveCollapsesDuplicateIDs(t *testing.T) {
+	svc, fx, _, actionID := approvalFixture(t)
+
+	results := svc.ApproveActions(testAdminID, []int64{actionID, actionID})
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1 (duplicates collapse)", len(results))
+	}
+	if results[0].Status != ActionExecuted {
+		t.Fatalf("result = %+v, want executed", results[0])
+	}
+	if fx.count() != 1 {
+		t.Fatalf("executor ran %d times, want exactly 1", fx.count())
+	}
+}
+
+// batchApproveHTTP posts the given body to the approve-batch handler as the
+// seeded admin and returns the recorder.
+func batchApproveHTTP(t *testing.T, svc *Service, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/admin/agent-actions/approve-batch", strings.NewReader(body))
+	ctx := context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{UserID: testAdminID, Role: auth.RoleAdmin})
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	NewHandler(svc).BatchApproveActions(rec, req)
+	return rec
+}
+
+// TestBatchApproveHandler pins the wire contract: a valid body returns 200
+// with per-item results; an empty/absent id list and an oversized one are
+// rejected with 400 before any decision is attempted.
+func TestBatchApproveHandler(t *testing.T) {
+	svc, fx, _, actionID := approvalFixture(t)
+
+	rec := batchApproveHTTP(t, svc, fmt.Sprintf(`{"ids":[%d]}`, actionID))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s; want 200", rec.Code, rec.Body.String())
+	}
+	var resp BatchApproveResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Results) != 1 || resp.Results[0].ID != actionID || resp.Results[0].Status != ActionExecuted {
+		t.Fatalf("response = %+v, want one executed result for %d", resp, actionID)
+	}
+	if fx.count() != 1 {
+		t.Fatalf("executor ran %d times, want 1", fx.count())
+	}
+
+	if rec := batchApproveHTTP(t, svc, `{"ids":[]}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("empty ids status = %d, want 400", rec.Code)
+	}
+	if rec := batchApproveHTTP(t, svc, `{}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing ids status = %d, want 400", rec.Code)
+	}
+	over := make([]string, batchApproveMaxIDs+1)
+	for i := range over {
+		over[i] = fmt.Sprint(i + 1)
+	}
+	if rec := batchApproveHTTP(t, svc, `{"ids":[`+strings.Join(over, ",")+`]}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("oversized ids status = %d, want 400", rec.Code)
+	}
+	// Validation rejections must not have decided anything.
+	if fx.count() != 1 {
+		t.Fatalf("executor ran %d times after rejected requests, want still 1", fx.count())
+	}
+}

--- a/server/internal/remediation/handler.go
+++ b/server/internal/remediation/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"
@@ -296,6 +297,34 @@ func (h *Handler) ApproveAction(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, action)
+}
+
+// BatchApproveActions handles POST /api/admin/agent-actions/approve-batch
+// (PermissionRemediationManage). Body {ids}: the explicit proposals the admin
+// reviewed. Items are decided sequentially by the same core as single
+// approve, and the response is HTTP 200 with a per-item verdict — one
+// recovering download must not fail the admin's whole gesture.
+func (h *Handler) BatchApproveActions(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	var body BatchApproveRequest
+	if err := decodeJSON(w, r, &body, false); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid request body"})
+		return
+	}
+	if len(body.IDs) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "ids is required"})
+		return
+	}
+	if len(body.IDs) > batchApproveMaxIDs {
+		writeJSON(w, http.StatusBadRequest,
+			map[string]string{"error": fmt.Sprintf("at most %d ids per request", batchApproveMaxIDs)})
+		return
+	}
+	writeJSON(w, http.StatusOK, BatchApproveResponse{Results: h.service.ApproveActions(claims.UserID, body.IDs)})
 }
 
 // ListApprovalRules handles GET /api/admin/agent-approval-rules


### PR DESCRIPTION
## What

Adds `POST /api/admin/agent-actions/approve-batch` so an admin can approve an entire reviewed list of agent fixes in one gesture (app surface lands in a follow-up PR). The body takes the explicit `ids` the admin was shown — deliberately no "approve everything currently proposed" form, so a proposal that parks mid-flight is never approved sight-unseen. Each id goes through the exact single-approve decision core (CAS claim, both arr-recovery preflights, at-most-once dispatch) sequentially, mirroring `sweepAutoApprovals`' serial arr I/O. One item's conflict/failure never stops the rest, the loop runs to completion even if the client disconnects, and the 200 response carries a per-item verdict (durable action status, or `skipped`/`error` with the reason). No overrides and no remember in batch — those stay deliberate per-proposal decisions.

## Verification

- `go vet ./...` — clean
- `go test ./...` — all green, including new coverage: batch executes each proposal exactly once with admin attribution, already-decided ids return durable outcomes without re-running, unknown ids report `error` without halting the batch, a recovery conflict reports `skipped` and continues, duplicate ids collapse, and the handler rejects empty/oversized id lists before deciding anything.

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [x] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure (follow-up app PR)
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6JqbCjRgkNUafpMrTrnP5