### PR TITLE
fix: disable auto-correct in all search bars

### DIFF
--- a/app/lib/core/widgets/library_command_header.dart
+++ b/app/lib/core/widgets/library_command_header.dart
@@ -105,6 +105,7 @@ class LibraryCommandHeader extends StatelessWidget {
                       builder: (context, _) => TextField(
                         controller: searchController,
                         onChanged: onSearch,
+                        autocorrect: false,
                         textInputAction: TextInputAction.search,
                         decoration: InputDecoration(
                           hintText: searchHint,

--- a/app/lib/core/widgets/search_bar.dart
+++ b/app/lib/core/widgets/search_bar.dart
@@ -97,6 +97,7 @@ class CantinarrSearchBar extends StatelessWidget {
               controller: controller,
               focusNode: focusNode,
               keyboardType: TextInputType.text,
+              autocorrect: false,
               onChanged: onChanged,
               onSubmitted: submitAction == null ? null : (_) => submitAction(),
               onTapOutside: (_) => focusNode.unfocus(),

--- a/app/lib/features/dashboard/ui/dashboard_books_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_books_tab.dart
@@ -170,6 +170,7 @@ class _DashboardBooksTabState extends ConsumerState<DashboardBooksTab>
           padding: const EdgeInsets.all(12),
           child: TextField(
             controller: _controller,
+            autocorrect: false,
             textInputAction: TextInputAction.search,
             onChanged: (_) => _onChanged(),
             onSubmitted: (_) {


### PR DESCRIPTION
## Summary
- Sets `autocorrect: false` on every search input in the app: the global shell search bar (`CantinarrSearchBar`), the shared library filter field (`LibraryCommandHeader`), and the books tab search field.
- Search queries are overwhelmingly titles, names, and proper nouns, which mobile keyboard auto-correction mangles mid-query.

## Verification
- `flutter analyze --no-fatal-infos` — no issues
- `flutter test` — 868 tests passed

## Docs
- No documented surface changed (no routes, tools, env vars, tables, screens, or workflows added/removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzRdK282XAkDU5QqRPvjHZ