### PR TITLE
fix: match TV search chips and arr deep links by id, never bare title

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -49,7 +49,7 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 
 ### Discovery & search
 - **TMDB + Trakt rows** -- trending, popular movies/TV, top rated, upcoming; all proxied through the backend so keys stay server-side (poster/backdrop images load straight from the TMDB CDN).
-- **Module-global search bar** -- debounced multi-search from every primary library/discovery surface. Secondary work screens hide it to avoid stacking global search above local filters. Results carry **requester-vocabulary availability chips** (Available / Partially Available / Requested -- never arr jargon), matched against the user's default library and kept fresh via WebSocket pings.
+- **Module-global search bar** -- debounced multi-search from every primary library/discovery surface. Secondary work screens hide it to avoid stacking global search above local filters. Results carry **requester-vocabulary availability chips** (Available / Partially Available / Requested -- never arr jargon), matched against the user's default library by TMDB id (title + premiere year as the fallback, so same-titled shows never borrow each other's state) and kept fresh via WebSocket pings.
 - **Search-to-AI hand-off** -- a query that looks like a question (or returns nothing) lights up an AI affordance; sending it opens the dedicated assistant with the prompt already in flight.
 
 ### Discover

--- a/app/lib/features/discover/data/tmdb_models.dart
+++ b/app/lib/features/discover/data/tmdb_models.dart
@@ -439,6 +439,13 @@ class PersonCredit {
   }
 }
 
+/// Year of a TMDB date string (`release_date` / `first_air_date`), or null
+/// when absent or unparseable.
+int? tmdbPremiereYear(String? date) {
+  if (date == null || date.length < 4) return null;
+  return int.tryParse(date.substring(0, 4));
+}
+
 /// Helper to parse the nested videos response.
 List<Video> _parseVideos(Map<String, dynamic> json) {
   final videosData = json['videos'];

--- a/app/lib/features/discover/logic/search_library_status.dart
+++ b/app/lib/features/discover/logic/search_library_status.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/theme/app_theme.dart';
+import '../../radarr/data/radarr_models.dart';
+import '../../sonarr/data/sonarr_models.dart';
+import '../data/tmdb_models.dart';
+
+/// Library presence indicator for search results.
+class LibraryStatus {
+  final String label;
+  final Color color;
+  const LibraryStatus({required this.label, required this.color});
+}
+
+const _available = LibraryStatus(
+  label: 'Available',
+  color: AppTheme.available,
+);
+const _partial = LibraryStatus(
+  label: 'Partially Available',
+  color: AppTheme.requested,
+);
+const _requested = LibraryStatus(
+  label: 'Requested',
+  color: AppTheme.requested,
+);
+
+/// Availability chips for search results, in the requester's vocabulary
+/// (Available / Partially Available / Requested) so they agree with what the
+/// detail page will say — never library-manager jargon (Complete / Missing /
+/// Unmonitored). A title that's in the library but has nothing on disk and
+/// isn't being fetched gets no chip: to a requester it's simply not
+/// available yet, same as a title that isn't in the library at all.
+///
+/// Chips are keyed by (media type, TMDB id) — TMDB movie and TV ids are
+/// separate namespaces, so a bare-id map would let a library movie's chip
+/// land on an unrelated show that happens to share the number. Matching is
+/// by id wherever possible: Radarr stores each movie's TMDB id and Sonarr
+/// (v4) stamps series with theirs. Series fall back to title + premiere year
+/// only for libraries that predate the tmdbId field. A bare title is never
+/// enough — same-named shows are distinct records (the 2003 "Tremors" series
+/// and the 2018 reboot pilot, say), and a title-only match dresses the one
+/// you can't have in the availability of the one you own.
+Map<(MediaType, int), LibraryStatus> buildSearchLibraryStatus({
+  required List<MediaItem> searchResults,
+  required List<RadarrMovie> movies,
+  required List<SonarrSeries> series,
+}) {
+  final map = <(MediaType, int), LibraryStatus>{};
+
+  // Radarr: match by TMDB ID
+  for (final movie in movies) {
+    final tmdbId = movie.tmdbId;
+    if (tmdbId == null) continue;
+    if (movie.hasFile) {
+      map[(MediaType.movie, tmdbId)] = _available;
+    } else if (movie.monitored) {
+      map[(MediaType.movie, tmdbId)] = _requested;
+    }
+  }
+
+  if (series.isEmpty) return map;
+
+  final byTmdbId = <int, SonarrSeries>{
+    for (final s in series)
+      if ((s.tmdbId ?? 0) > 0) s.tmdbId!: s,
+  };
+  final byTitleYear = <(String, int), SonarrSeries>{
+    for (final s in series)
+      if ((s.year ?? 0) > 0) (s.title.toLowerCase(), s.year!): s,
+  };
+
+  for (final item in searchResults) {
+    if (item.mediaType != MediaType.tv) continue;
+    final match = byTmdbId[item.id] ?? _titleYearMatch(byTitleYear, item);
+    if (match == null) continue;
+    // episodeTotals, not percentComplete: percentComplete only counts
+    // monitored episodes, so a series with one downloaded season and
+    // the rest unmonitored would read "Available" while most of it is
+    // missing.
+    final (:files, :total) = match.episodeTotals;
+    if (total > 0 && files >= total) {
+      map[(MediaType.tv, item.id)] = _available;
+    } else if (files > 0) {
+      map[(MediaType.tv, item.id)] = _partial;
+    } else if (match.monitored) {
+      map[(MediaType.tv, item.id)] = _requested;
+    }
+  }
+
+  return map;
+}
+
+/// Same-titled series whose premiere year is within one of the result's. ±1
+/// absorbs TMDB and TVDB dating the same premiere differently without
+/// reaching the years-apart gap that means a different show; an unknown year
+/// on either side matches nothing rather than guessing.
+SonarrSeries? _titleYearMatch(
+  Map<(String, int), SonarrSeries> byTitleYear,
+  MediaItem item,
+) {
+  final year = tmdbPremiereYear(item.releaseDate);
+  if (year == null) return null;
+  final title = item.title.toLowerCase();
+  return byTitleYear[(title, year)] ??
+      byTitleYear[(title, year - 1)] ??
+      byTitleYear[(title, year + 1)];
+}

--- a/app/lib/features/discover/ui/search_results_view.dart
+++ b/app/lib/features/discover/ui/search_results_view.dart
@@ -7,13 +7,7 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/cached_image.dart';
 import '../../person/ui/person_detail_sheet.dart';
 import '../data/tmdb_models.dart';
-
-/// Library presence indicator for search results.
-class LibraryStatus {
-  final String label;
-  final Color color;
-  const LibraryStatus({required this.label, required this.color});
-}
+import '../logic/search_library_status.dart';
 
 /// List view of search results with poster thumbnails and metadata.
 class SearchResultsView extends StatelessWidget {
@@ -22,7 +16,10 @@ class SearchResultsView extends StatelessWidget {
   final String query;
   final void Function(MediaItem)? onLoadMore;
   final VoidCallback? onResultTap;
-  final Map<int, LibraryStatus> libraryStatus;
+
+  /// Availability chips keyed by (media type, TMDB id) — see
+  /// [buildSearchLibraryStatus] for why a bare id is not identity.
+  final Map<(MediaType, int), LibraryStatus> libraryStatus;
 
   const SearchResultsView({
     super.key,
@@ -82,7 +79,7 @@ class SearchResultsView extends StatelessWidget {
           final item = results[index];
           final tile = _SearchResultTile(
             item: item,
-            status: libraryStatus[item.id],
+            status: libraryStatus[(item.mediaType, item.id)],
             onTap: onResultTap,
           );
           final triggerIndex = results.length > 5 ? results.length - 5 : 0;

--- a/app/lib/features/media_detail/logic/arr_deep_link.dart
+++ b/app/lib/features/media_detail/logic/arr_deep_link.dart
@@ -34,14 +34,24 @@ RadarrMovie? matchRadarrMovie(List<RadarrMovie> movies, int tmdbId) {
 /// when it isn't in the Sonarr library yet.
 ///
 /// Matches on the TVDB id (Sonarr's natural key) when the discovery side
-/// supplies one; when it doesn't, falls back to a case-insensitive title match.
-/// A known [tvdbId] with no hit is treated as "not in the library" rather than
-/// falling through to a title match, which avoids linking two distinct shows
-/// that happen to share a title.
+/// supplies one. A known [tvdbId] with no hit is treated as "not in the
+/// library" rather than falling through to weaker keys, which avoids linking
+/// two distinct shows that happen to share a title.
+///
+/// Without a TVDB id (TMDB has no mapping — unaired pilots, brand-new shows),
+/// the [tmdbId] Sonarr v4 stamps on each series is the next-strongest key.
+/// Last comes a case-insensitive title match gated on premiere [year] (±1 for
+/// TMDB-vs-TVDB dating skew): a bare title is never identity, because
+/// same-named shows are distinct records — the 2018 "Tremors" reboot pilot
+/// must not deep link into the 2003 "Tremors" series just because the
+/// library owns the latter. No year on either side means no match rather
+/// than a guess.
 SonarrSeries? matchSonarrSeries(
   List<SonarrSeries> series, {
   int? tvdbId,
+  int? tmdbId,
   String? title,
+  int? year,
 }) {
   if (tvdbId != null) {
     for (final s in series) {
@@ -49,10 +59,20 @@ SonarrSeries? matchSonarrSeries(
     }
     return null;
   }
-  if (title != null && title.isNotEmpty) {
+  if (tmdbId != null) {
+    for (final s in series) {
+      if (s.tmdbId == tmdbId) return s;
+    }
+  }
+  if (title != null && title.isNotEmpty && year != null) {
     final lower = title.toLowerCase();
     for (final s in series) {
-      if (s.title.toLowerCase() == lower) return s;
+      final seriesYear = s.year ?? 0;
+      if (seriesYear > 0 &&
+          (seriesYear - year).abs() <= 1 &&
+          s.title.toLowerCase() == lower) {
+        return s;
+      }
     }
   }
   return null;

--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -611,7 +611,9 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
         final match = matchSonarrSeries(
           series,
           tvdbId: _detailNotifier.state.tvDetail?.externalIds?.tvdbId,
+          tmdbId: widget.id,
           title: _detailNotifier.state.title,
+          year: tmdbPremiereYear(_detailNotifier.state.tvDetail?.firstAirDate),
         );
         var episodes = const <SonarrEpisode>[];
         if (downloadsEnabled && match != null && match.id > 0) {

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -20,6 +20,7 @@ import '../../../core/widgets/shimmer_border.dart';
 import '../../ai_assistant/logic/ai_chat_provider.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../../discover/data/tmdb_models.dart';
+import '../../discover/logic/search_library_status.dart';
 import '../../discover/ui/search_results_view.dart';
 import '../../issues/logic/issues_provider.dart';
 import '../../radarr/data/radarr_api_service.dart';
@@ -167,7 +168,8 @@ class _AppShellState extends ConsumerState<AppShell>
     _sonarrNotifier = null;
   }
 
-  /// Re-pulls the search-chip library snapshot (see [_buildLibraryStatus]),
+  /// Re-pulls the search-chip library snapshot (see
+  /// [buildSearchLibraryStatus]),
   /// which is otherwise loaded once per session and would drift whenever the
   /// libraries change without this app's involvement. Passive triggers are
   /// throttled by [_libraryRefreshThrottle]; [force] callers (websocket pings,
@@ -259,69 +261,6 @@ class _AppShellState extends ConsumerState<AppShell>
     }
 
     _dismissKeyboard();
-  }
-
-  /// Availability chips for search results, in the requester's vocabulary
-  /// (Available / Partially Available / Requested) so they agree with what the
-  /// detail page will say — never library-manager jargon (Complete / Missing /
-  /// Unmonitored). A title that's in the library but has nothing on disk and
-  /// isn't being fetched gets no chip: to a requester it's simply not
-  /// available yet, same as a title that isn't in the library at all.
-  Map<int, LibraryStatus> _buildLibraryStatus(List<MediaItem> searchResults) {
-    final map = <int, LibraryStatus>{};
-
-    const available = LibraryStatus(
-      label: 'Available',
-      color: AppTheme.available,
-    );
-    const partial = LibraryStatus(
-      label: 'Partially Available',
-      color: AppTheme.requested,
-    );
-    const requested = LibraryStatus(
-      label: 'Requested',
-      color: AppTheme.requested,
-    );
-
-    // Radarr: match by TMDB ID
-    final movies = _radarrNotifier?.state.movies ?? [];
-    for (final movie in movies) {
-      final tmdbId = movie.tmdbId;
-      if (tmdbId == null) continue;
-      if (movie.hasFile) {
-        map[tmdbId] = available;
-      } else if (movie.monitored) {
-        map[tmdbId] = requested;
-      }
-    }
-
-    // Sonarr: match by title (Sonarr model lacks TMDB IDs)
-    final seriesList = _sonarrNotifier?.state.series ?? [];
-    if (seriesList.isNotEmpty) {
-      final titleMap = {
-        for (final s in seriesList) s.title.toLowerCase(): s,
-      };
-      for (final item in searchResults) {
-        if (item.mediaType == MediaType.tv && !map.containsKey(item.id)) {
-          final match = titleMap[item.title.toLowerCase()];
-          if (match == null) continue;
-          // episodeTotals, not percentComplete: percentComplete only counts
-          // monitored episodes, so a series with one downloaded season and
-          // the rest unmonitored would read "Available" while most of it is
-          // missing.
-          final (:files, :total) = match.episodeTotals;
-          if (total > 0 && files >= total) {
-            map[item.id] = available;
-          } else if (files > 0) {
-            map[item.id] = partial;
-          } else if (match.monitored) {
-            map[item.id] = requested;
-          }
-        }
-      }
-    }
-
-    return map;
   }
 
   /// Module owning [path], or null for paths outside the module shells.
@@ -437,8 +376,12 @@ class _AppShellState extends ConsumerState<AppShell>
     final showSearchResults = searchState.searchMode == SearchMode.search ||
         searchState.searchMode == SearchMode.aiReady;
     final libraryStatus = searchState.isSearching && showSearchResults
-        ? _buildLibraryStatus(searchState.searchResults)
-        : const <int, LibraryStatus>{};
+        ? buildSearchLibraryStatus(
+            searchResults: searchState.searchResults,
+            movies: _radarrNotifier?.state.movies ?? const [],
+            series: _sonarrNotifier?.state.series ?? const [],
+          )
+        : const <(MediaType, int), LibraryStatus>{};
 
     final mobile = AppBreakpoints.isMobile(context);
     final desktop = AppBreakpoints.isDesktop(context);

--- a/app/test/discover/search_library_status_test.dart
+++ b/app/test/discover/search_library_status_test.dart
@@ -1,0 +1,157 @@
+import 'package:cantinarr/features/discover/data/tmdb_models.dart';
+import 'package:cantinarr/features/discover/logic/search_library_status.dart';
+import 'package:cantinarr/features/radarr/data/radarr_models.dart';
+import 'package:cantinarr/features/sonarr/data/sonarr_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  // The user's Sonarr library: the 2003 "Tremors" series, complete.
+  const tremors2003 = SonarrSeries(
+    id: 1,
+    title: 'Tremors',
+    tvdbId: 71262,
+    tmdbId: 2664,
+    year: 2003,
+    monitored: true,
+    statistics: SonarrStatistics(
+      episodeFileCount: 13,
+      episodeCount: 13,
+      totalEpisodeCount: 13,
+    ),
+  );
+
+  MediaItem tv(int id, String title, String? firstAirDate) => MediaItem(
+        id: id,
+        title: title,
+        mediaType: MediaType.tv,
+        releaseDate: firstAirDate,
+      );
+
+  group('buildSearchLibraryStatus', () {
+    test('movie chips match by TMDB id and media type', () {
+      const movies = [
+        RadarrMovie(id: 1, title: 'Tremors', year: 1990, tmdbId: 9362, hasFile: true),
+        RadarrMovie(id: 2, title: 'Wanted', year: 2008, tmdbId: 8909, monitored: true),
+        RadarrMovie(id: 3, title: 'Idle', year: 2010, tmdbId: 777, monitored: false),
+      ];
+      final map = buildSearchLibraryStatus(
+        searchResults: const [],
+        movies: movies,
+        series: const [],
+      );
+      expect(map[(MediaType.movie, 9362)]?.label, 'Available');
+      expect(map[(MediaType.movie, 8909)]?.label, 'Requested');
+      expect(map[(MediaType.movie, 777)], isNull);
+    });
+
+    test('series chip matches by the Sonarr-stamped tmdbId', () {
+      final map = buildSearchLibraryStatus(
+        searchResults: [tv(2664, 'Tremors', '2003-03-28')],
+        movies: const [],
+        series: const [tremors2003],
+      );
+      expect(map[(MediaType.tv, 2664)]?.label, 'Available');
+    });
+
+    test('a same-titled show years apart gets no chip', () {
+      // The 2018 reboot pilot is a distinct TMDB record; owning the 2003
+      // series must not dress it in an "Available" chip.
+      final map = buildSearchLibraryStatus(
+        searchResults: [tv(75977, 'Tremors', '2018-03-19')],
+        movies: const [],
+        series: const [tremors2003],
+      );
+      expect(map[(MediaType.tv, 75977)], isNull);
+    });
+
+    test('title+year fallback covers libraries without tmdbId', () {
+      const legacy = SonarrSeries(
+        id: 9,
+        title: 'Tremors',
+        tvdbId: 71262,
+        year: 2003,
+        monitored: true,
+        statistics: SonarrStatistics(
+          episodeFileCount: 13,
+          episodeCount: 13,
+          totalEpisodeCount: 13,
+        ),
+      );
+      final map = buildSearchLibraryStatus(
+        searchResults: [
+          tv(2664, 'Tremors', '2003-03-28'),
+          // ±1 absorbs TMDB-vs-TVDB dating skew on the same show.
+          tv(2665, 'tremors', '2004-01-01'),
+          tv(75977, 'Tremors', '2018-03-19'),
+          tv(2666, 'Tremors', null),
+        ],
+        movies: const [],
+        series: const [legacy],
+      );
+      expect(map[(MediaType.tv, 2664)]?.label, 'Available');
+      expect(map[(MediaType.tv, 2665)]?.label, 'Available');
+      expect(map[(MediaType.tv, 75977)], isNull);
+      // No year truth on the result: no chip rather than a guess.
+      expect(map[(MediaType.tv, 2666)], isNull);
+    });
+
+    test('a library movie id never chips a TV result', () {
+      const movies = [
+        RadarrMovie(id: 1, title: 'Some Film', year: 1999, tmdbId: 550, hasFile: true),
+      ];
+      final map = buildSearchLibraryStatus(
+        searchResults: [tv(550, 'Some Show', '2015-01-01')],
+        movies: movies,
+        series: const [],
+      );
+      expect(map[(MediaType.movie, 550)]?.label, 'Available');
+      expect(map[(MediaType.tv, 550)], isNull);
+    });
+
+    test('partial and requested series states map to requester vocabulary',
+        () {
+      const partial = SonarrSeries(
+        id: 5,
+        title: 'Halfway',
+        tmdbId: 100,
+        year: 2020,
+        monitored: true,
+        statistics: SonarrStatistics(
+          episodeFileCount: 4,
+          episodeCount: 8,
+          totalEpisodeCount: 8,
+        ),
+      );
+      const empty = SonarrSeries(
+        id: 6,
+        title: 'Nothing Yet',
+        tmdbId: 200,
+        year: 2024,
+        monitored: true,
+        statistics: SonarrStatistics(totalEpisodeCount: 10),
+      );
+      const abandoned = SonarrSeries(
+        id: 7,
+        title: 'Abandoned',
+        tmdbId: 300,
+        year: 2019,
+        monitored: false,
+        statistics: SonarrStatistics(totalEpisodeCount: 10),
+      );
+      final map = buildSearchLibraryStatus(
+        searchResults: [
+          tv(100, 'Halfway', '2020-01-01'),
+          tv(200, 'Nothing Yet', '2024-01-01'),
+          tv(300, 'Abandoned', '2019-01-01'),
+        ],
+        movies: const [],
+        series: const [partial, empty, abandoned],
+      );
+      expect(map[(MediaType.tv, 100)]?.label, 'Partially Available');
+      expect(map[(MediaType.tv, 200)]?.label, 'Requested');
+      // In the library but unmonitored with nothing on disk: to a requester
+      // it is simply not available — no chip.
+      expect(map[(MediaType.tv, 300)], isNull);
+    });
+  });
+}

--- a/app/test/media_detail/arr_deep_link_test.dart
+++ b/app/test/media_detail/arr_deep_link_test.dart
@@ -27,10 +27,21 @@ void main() {
 
   group('matchSonarrSeries', () {
     final series = [
-      const SonarrSeries(id: 1, title: 'The Wire', tvdbId: 79126),
-      const SonarrSeries(id: 2, title: 'Breaking Bad', tvdbId: 81189),
-      // A library entry Sonarr couldn't stamp with a TVDB id.
-      const SonarrSeries(id: 3, title: 'Homegrown Show'),
+      const SonarrSeries(
+          id: 1, title: 'The Wire', tvdbId: 79126, tmdbId: 1438, year: 2002),
+      const SonarrSeries(
+          id: 2,
+          title: 'Breaking Bad',
+          tvdbId: 81189,
+          tmdbId: 1396,
+          year: 2008),
+      // A library entry Sonarr couldn't stamp with ids beyond title/year.
+      const SonarrSeries(id: 3, title: 'Homegrown Show', year: 2020),
+      // The confusable pair's library half: the 2003 series is owned; the
+      // 2018 reboot pilot (a distinct TMDB record with no TVDB identity)
+      // is not, and must never resolve to this entry.
+      const SonarrSeries(
+          id: 4, title: 'Tremors', tvdbId: 71262, tmdbId: 2664, year: 2003),
     ];
 
     test('matches on tvdbId when the discovery side supplies one', () {
@@ -47,21 +58,47 @@ void main() {
       expect(match, isNull);
     });
 
-    test('falls back to a case-insensitive title match when tvdbId is null', () {
-      final match =
-          matchSonarrSeries(series, tvdbId: null, title: 'homegrown show');
+    test('matches on the Sonarr-stamped tmdbId when tvdbId is null', () {
+      final match = matchSonarrSeries(series,
+          tmdbId: 1396, title: 'Renamed On TMDB', year: 2011);
       expect(match, isNotNull);
-      expect(match!.id, 3);
+      expect(match!.id, 2);
+    });
+
+    test('title fallback requires a premiere year within one', () {
+      final exact =
+          matchSonarrSeries(series, title: 'homegrown show', year: 2020);
+      expect(exact, isNotNull);
+      expect(exact!.id, 3);
+
+      // ±1 absorbs TMDB-vs-TVDB dating skew on the same show.
+      final skewed =
+          matchSonarrSeries(series, title: 'Homegrown Show', year: 2021);
+      expect(skewed, isNotNull);
+      expect(skewed!.id, 3);
+    });
+
+    test('a same-titled show years apart never links (2018 pilot vs 2003)',
+        () {
+      final match = matchSonarrSeries(series,
+          tmdbId: 75977, title: 'Tremors', year: 2018);
+      expect(match, isNull);
+    });
+
+    test('a title without year truth never links', () {
+      expect(matchSonarrSeries(series, title: 'homegrown show'), isNull);
     });
 
     test('returns null when neither tvdbId nor title matches', () {
-      final match =
-          matchSonarrSeries(series, tvdbId: null, title: 'Unknown Series');
+      final match = matchSonarrSeries(series,
+          tvdbId: null, title: 'Unknown Series', year: 2020);
       expect(match, isNull);
     });
 
     test('returns null when tvdbId is null and title is empty', () {
-      expect(matchSonarrSeries(series, tvdbId: null, title: ''), isNull);
+      expect(
+          matchSonarrSeries(series, tvdbId: null, title: '', year: 2020),
+          isNull);
     });
   });
 


### PR DESCRIPTION
## Problem

Searching "tremors" showed the 2018 Syfy reboot pilot as **Available** — it never aired and only exists as a TMDB record — because the 2003 "Tremors" series is in the Sonarr library and the search chips matched TV results **by lowercase title alone**. Opening the 2018 entry also offered **Open in Sonarr**, deep-linking into the 2003 series via the same bare-title fallback (`matchSonarrSeries`'s tvdb-null branch). Verified upstream while investigating: Skyhook/TheTVDB have exactly one "Tremors" series (tvdb 71262); the 2018 pilot has no TVDB identity at all, so any title-based match lands on the wrong show.

## Change

- **Chips** (`buildSearchLibraryStatus`, extracted from `app_shell` to `discover/logic` as a pure function): series match by the TMDB id Sonarr v4 stamps on each entry, with title + premiere year (±1 for TMDB-vs-TVDB dating skew) as the only fallback for libraries predating `tmdbId`. A result or library entry without year truth matches nothing rather than guessing.
- **Chip identity is (media type, TMDB id)** — movie and TV ids are separate TMDB namespaces, so a library movie's chip can no longer land on an unrelated show sharing the number.
- **Deep link** (`matchSonarrSeries`): unchanged authoritative tvdbId-first semantics (known id + no hit still means "not in library"); the tvdb-null branch now tries the Sonarr-stamped tmdbId, then title gated on year — never bare title.

The stale `// Sonarr model lacks TMDB IDs` excuse was outdated: `SonarrSeries` already parses `tmdbId`.

## Verification

- `flutter analyze --no-fatal-infos` — clean
- `flutter test` — 877 passing, including new unit tests pinning the 2018-pilot case for both chips and deep link, the ±1 skew, the no-year-no-match rule, and the movie/TV id-namespace split

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJWESXmKDdNbuJ43GKSgZR