### PR TITLE
fix: verify series identity on Sonarr title-lookup fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Request: "Add The Last of Us" (TMDB ID 100088)
 5. Add to Sonarr with the user's effective quality profile + root folder
 ```
 
-If TMDB doesn't have a TVDB mapping (rare), the bridge falls back to Trakt's cross-reference database, then to a title+year search as a last resort.
+If TMDB doesn't have a TVDB mapping (rare), the bridge falls back to Trakt's cross-reference database, then to a Sonarr title search as a last resort -- accepted only when the candidate's premiere year matches TMDB's (±1), because same-titled series (a reboot vs the original) are distinct records and a request fails rather than fulfilling the wrong one.
 
 Movies don't need bridging -- Radarr natively supports TMDB IDs. Books are keyed by Chaptarr/Readarr `foreignBookId` directly.
 

--- a/server/README.md
+++ b/server/README.md
@@ -28,7 +28,7 @@ A single Go binary that bridges your arr stack, serves the web UI, and keeps API
 - **One-tap requests with an approval queue** -- Users browse and tap request; the server handles ID bridging, arr lookups, quality profiles, and root folders. Admins can require approval globally or per user, and per user allow season-level choice, quality choice, and per-service default quality profiles.
 - **Books via Chaptarr** -- A Readarr-API (v1) books module with per-format (ebook/audiobook) monitoring, requesting, and library awareness. Chaptarr access is granted per user by an admin.
 - **Completed-media downloads** -- Opt-in delivery of ebook, audiobook, movie, and episode files from read-only library mounts. Deployment roots form the outer filesystem allowlist; per-instance path mappings translate each arr namespace into that boundary. The server accepts only live arr file IDs and streams through short-lived file-scoped links with HEAD and Range support.
-- **Automatic ID bridging** -- Transparently translates TMDB IDs to TVDB IDs for Sonarr. Falls back to Trakt cross-references, then title+year search. Results cached in SQLite for 30 days.
+- **Automatic ID bridging** -- Transparently translates TMDB IDs to TVDB IDs for Sonarr. Falls back to Trakt cross-references, then a premiere-year-verified title search (a same-titled series years apart is never substituted). Results cached in SQLite for 30 days.
 - **Availability computed live** -- Request status is derived from the arrs' real episode/file state (never from a stale snapshot or monitored-only stats), refreshed by queue polling and instant arr webhooks.
 - **Connect link auth, passwordless by default** -- Admins generate connect links; redeeming one starts a permanent device session (an opaque refresh token validated against the DB -- never expires, never rotates, independent of the JWT secret) that mints 15-minute access JWTs. Sessions end only by device revocation or user deletion. Passwords and passkeys (WebAuthn, incl. native iOS/Android/Windows) are admin-gated per user.
 - **AI assistant + remediation agent** -- Interactive chat resolves a personal Anthropic/OpenAI/Gemini key or OpenAI (OAuth) link first; that personal choice works without an included-access grant and need not match the server provider. An admin-funded provider is available only to users granted included access. A selected personal provider fails closed instead of silently consuming the shared account. The autonomous investigation agent is server-owned, always uses the admin shared API key or shared OpenAI OAuth connection without consulting user grants, may use a separately tested remediation model designation, and proposes fixes an admin approves.
@@ -416,7 +416,7 @@ User taps "Request" on Breaking Bad (TMDB 1396)
 3. GET api.trakt.tv/search/tmdb/1396?type=show -> extract TVDB from Trakt IDs
   |  or (last resort)
   v
-4. Sonarr title+year search as fallback
+4. Sonarr title search as fallback (premiere year must match TMDB's, ±1)
   |
   v
 GET sonarr/api/v3/series/lookup?term=tvdb:81189  (exact match)

--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1799,11 +1800,27 @@ func (s *Service) addSeries(r *resolvedRequest) (string, string, error) {
 		if r.title == "" {
 			return "", "", fmt.Errorf("series lookup failed: could not resolve a TVDB ID for tmdb %d and no title was provided", r.tmdbID)
 		}
-		lookup, err = sonarrClient.LookupByTitle(r.title)
+		lookup, err = s.lookupSeriesByTitleIdentity(sonarrClient, r.tmdbID, r.title)
 		if err != nil {
-			return "", "", fmt.Errorf("series lookup failed: %w", err)
+			return "", "", err
 		}
-		tvdbID = lookup.TvdbID
+		if lookup.TvdbID != tvdbID {
+			// The text search resolved an id the bridge couldn't. That id may
+			// name a series the library already tracks (TMDB just has no TVDB
+			// mapping for it), so honor the existing-series flows instead of
+			// an add Sonarr would reject as a duplicate.
+			tvdbID = lookup.TvdbID
+			if existing, exErr := sonarrClient.GetSeriesByTVDB(tvdbID); exErr == nil && existing != nil {
+				r.tvdbID = tvdbID
+				if len(r.seasonNumbers) > 0 {
+					if err := s.monitorAndSearchSeasons(sonarrClient, existing, r.seasonNumbers); err != nil {
+						return "", "", err
+					}
+					return StatusRequested, existing.Title, nil
+				}
+				return s.requestExistingSeries(sonarrClient, existing, r)
+			}
+		}
 	}
 	// Persist the resolved TVDB id so an approved title-only request stores it.
 	r.tvdbID = tvdbID
@@ -1856,6 +1873,64 @@ func (s *Service) addSeries(r *resolvedRequest) (string, string, error) {
 		return "", "", fmt.Errorf("add series failed: %w", err)
 	}
 	return StatusRequested, lookup.Title, nil
+}
+
+// lookupSeriesByTitleIdentity resolves a series through Sonarr's text search
+// when no TVDB id could be bridged, verifying identity instead of trusting
+// relevance order: same-titled series are distinct records — the 2018
+// "Tremors" reboot pilot and the 2003 "Tremors" series share a title — and
+// blindly taking the first result would fulfil the request with the wrong
+// one. The premiere year of the TMDB record the requester actually chose is
+// the discriminator; ±1 absorbs TMDB and TVDB dating the same premiere
+// differently without reaching the years-apart gap that means a different
+// show. When TMDB can't supply a year at all (no client configured, fetch
+// failed), the first result is accepted as before — a TMDB-less deployment
+// keeps a working request path rather than a dead one.
+func (s *Service) lookupSeriesByTitleIdentity(client *sonarr.Client, tmdbID int, title string) (*sonarr.LookupResult, error) {
+	candidates, err := client.LookupByTitle(title)
+	if err != nil {
+		return nil, fmt.Errorf("series lookup failed: %w", err)
+	}
+	year := s.tmdbTVYear(tmdbID)
+	if year == 0 {
+		return &candidates[0], nil
+	}
+	for i := range candidates {
+		c := &candidates[i]
+		if c.Year == 0 {
+			continue
+		}
+		if diff := c.Year - year; diff >= -1 && diff <= 1 {
+			return c, nil
+		}
+	}
+	closest := &candidates[0]
+	return nil, fmt.Errorf(
+		"series lookup could not verify a match for %q: the requested series premiered in %d, but the closest result is %q (%d) — a same-titled but different series is never substituted",
+		title, year, closest.Title, closest.Year,
+	)
+}
+
+// tmdbTVYear returns the premiere year TMDB records for a series, or 0 when
+// no TMDB client is configured or the lookup fails. Callers treat 0 as "no
+// year truth available", never as a year.
+func (s *Service) tmdbTVYear(tmdbID int) int {
+	if s.bridge == nil {
+		return 0
+	}
+	client := s.bridge.TMDB()
+	if client == nil {
+		return 0
+	}
+	details, err := client.GetTVDetails(tmdbID)
+	if err != nil || details == nil || len(details.FirstAir) < 4 {
+		return 0
+	}
+	year, err := strconv.Atoi(details.FirstAir[:4])
+	if err != nil {
+		return 0
+	}
+	return year
 }
 
 // monitorAndSearchSeasons additively monitors the chosen seasons on an existing

--- a/server/internal/request/service_tv_test.go
+++ b/server/internal/request/service_tv_test.go
@@ -5,7 +5,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/tmdb"
+	"github.com/windoze95/cantinarr-server/internal/trakt"
 )
 
 // fakeSonarrTV simulates the Sonarr endpoints the TV request/status flows
@@ -462,4 +466,171 @@ func TestGetTVStatusUnresolvable(t *testing.T) {
 			t.Errorf("status = %+v err=%v, want unavailable", st, err)
 		}
 	})
+}
+
+// bridgeClients satisfies tmdb.ServiceClients for tests: a real TMDB client
+// pointed at a fake server, and no Trakt (the bridge skips its fallback).
+type bridgeClients struct{ client *tmdb.Client }
+
+func (b bridgeClients) TMDB() *tmdb.Client   { return b.client }
+func (b bridgeClients) Trakt() *trakt.Client { return nil }
+
+// installTitleFallbackBridge wires a real tmdb.Bridge over a fake TMDB whose
+// external_ids carry no TVDB mapping — the bridge must fail to resolve, which
+// is exactly the shape of a TMDB-only record like an unaired reboot pilot —
+// while the TV details endpoint still answers with the premiere date the
+// identity gate verifies against.
+func installTitleFallbackBridge(t *testing.T, s *Service, firstAirDate string) {
+	t.Helper()
+	tmdbSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/external_ids"):
+			_, _ = w.Write([]byte(`{"tvdb_id": null, "imdb_id": null}`))
+		case strings.HasPrefix(r.URL.Path, "/tv/"):
+			_, _ = w.Write([]byte(`{"id": 1, "name": "Lookup Show", "first_air_date": "` + firstAirDate + `"}`))
+		default:
+			t.Errorf("unexpected tmdb request %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(tmdbSrv.Close)
+	s.bridge = tmdb.NewBridge(bridgeClients{tmdb.NewClientWithBaseURL("test-key", tmdbSrv.URL)}, s.db)
+}
+
+// TestCreateTVRequestTitleFallbackRejectsWrongYear pins the identity gate on
+// the title fallback: TMDB knows no TVDB id for the 2018 "Tremors" reboot
+// pilot, Sonarr's text search answers with the 2003 series of the same name,
+// and the years-apart mismatch must fail the request instead of monitoring
+// the wrong show. Nothing may be added and nothing logged.
+func TestCreateTVRequestTitleFallbackRejectsWrongYear(t *testing.T) {
+	f := &fakeSonarrTV{
+		lookupJSON: `[{"title":"Tremors","tvdbId":71262,"year":2003,"seasons":[{"seasonNumber":1}]}]`,
+	}
+	srv := newFakeSonarrServer(t, f)
+	s, uid := newHistoryTestService(t, "", srv.URL, "")
+	installTitleFallbackBridge(t, s, "2018-03-19")
+
+	_, err := s.CreateMediaRequest(uid, &CreateRequest{
+		TmdbID:    75977,
+		MediaType: "tv",
+		Title:     "Tremors",
+	})
+	if err == nil {
+		t.Fatal("CreateMediaRequest succeeded, want identity mismatch error")
+	}
+	if !strings.Contains(err.Error(), "2018") || !strings.Contains(err.Error(), "2003") {
+		t.Errorf("error = %v, want both premiere years named", err)
+	}
+	if f.addBody != nil {
+		t.Errorf("AddSeries was called with %v, want no add", f.addBody)
+	}
+	var n int
+	if err := s.db.QueryRow("SELECT COUNT(*) FROM request_log WHERE tmdb_id = 75977").Scan(&n); err != nil {
+		t.Fatalf("count request_log: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("request_log rows = %d, want 0", n)
+	}
+}
+
+// TestCreateTVRequestTitleFallbackVerifiedByYear covers the legitimate
+// fallback: TMDB has no TVDB mapping yet, the text search finds the series,
+// and a premiere year within ±1 (TVDB and TMDB routinely date the same
+// premiere differently) accepts it. The add and the log row must carry the
+// looked-up TVDB id.
+func TestCreateTVRequestTitleFallbackVerifiedByYear(t *testing.T) {
+	for name, firstAir := range map[string]string{
+		"exact year":  "2022-09-21",
+		"dating skew": "2021-12-31",
+	} {
+		t.Run(name, func(t *testing.T) {
+			f := &fakeSonarrTV{
+				lookupJSON: `[{"title":"Andor","tvdbId":121361,"year":2022,"seasons":[{"seasonNumber":1}]}]`,
+			}
+			srv := newFakeSonarrServer(t, f)
+			s, uid := newHistoryTestService(t, "", srv.URL, "")
+			installTitleFallbackBridge(t, s, firstAir)
+
+			resp, err := s.CreateMediaRequest(uid, &CreateRequest{
+				TmdbID:    83867,
+				MediaType: "tv",
+				Title:     "Andor",
+			})
+			if err != nil {
+				t.Fatalf("CreateMediaRequest: %v", err)
+			}
+			if resp.Status != StatusRequested || resp.Title != "Andor" {
+				t.Fatalf("response = %+v, want requested/Andor", resp)
+			}
+			if f.addBody == nil || f.addBody["tvdbId"] != float64(121361) {
+				t.Fatalf("add body = %v, want tvdbId 121361", f.addBody)
+			}
+			var tvdb int
+			if err := s.db.QueryRow("SELECT tvdb_id FROM request_log WHERE tmdb_id = 83867").Scan(&tvdb); err != nil {
+				t.Fatalf("read request_log: %v", err)
+			}
+			if tvdb != 121361 {
+				t.Errorf("logged tvdb_id = %d, want 121361", tvdb)
+			}
+		})
+	}
+}
+
+// TestCreateTVRequestTitleFallbackFindsExistingSeries: the verified lookup id
+// may name a series the library already tracks even though the bridge had no
+// mapping (it was added directly in Sonarr). The request must flow through
+// the existing-series path — here a fully-downloaded series reads available —
+// never an add Sonarr would reject as a duplicate.
+func TestCreateTVRequestTitleFallbackFindsExistingSeries(t *testing.T) {
+	f := &fakeSonarrTV{
+		libraryJSON: `[{"id":42,"title":"Andor","tvdbId":121361,"year":2022,"monitored":true,"seasons":[
+			{"seasonNumber":1,"monitored":true,"statistics":{"episodeFileCount":12,"episodeCount":12,"totalEpisodeCount":12}}]}]`,
+		lookupJSON: `[{"title":"Andor","tvdbId":121361,"year":2022,"seasons":[{"seasonNumber":1}]}]`,
+	}
+	srv := newFakeSonarrServer(t, f)
+	s, uid := newHistoryTestService(t, "", srv.URL, "")
+	installTitleFallbackBridge(t, s, "2022-09-21")
+
+	resp, err := s.CreateMediaRequest(uid, &CreateRequest{
+		TmdbID:    83867,
+		MediaType: "tv",
+		Title:     "Andor",
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if resp.Status != StatusAvailable || resp.Title != "Andor" {
+		t.Fatalf("response = %+v, want available/Andor (existing series)", resp)
+	}
+	if f.addBody != nil {
+		t.Errorf("AddSeries was called with %v, want the existing series honored", f.addBody)
+	}
+}
+
+// TestCreateTVRequestTitleFallbackWithoutYearTruth pins the availability
+// choice: with no bridge there is no TMDB year to verify against, and the
+// first lookup result is accepted exactly as before, so TMDB-less
+// deployments keep a working title request path.
+func TestCreateTVRequestTitleFallbackWithoutYearTruth(t *testing.T) {
+	f := &fakeSonarrTV{
+		lookupJSON: `[{"title":"Andor","tvdbId":121361,"year":2022,"seasons":[{"seasonNumber":1}]}]`,
+	}
+	srv := newFakeSonarrServer(t, f)
+	s, uid := newHistoryTestService(t, "", srv.URL, "") // bridge stays nil
+
+	resp, err := s.CreateMediaRequest(uid, &CreateRequest{
+		TmdbID:    83867,
+		MediaType: "tv",
+		Title:     "andor",
+	})
+	if err != nil {
+		t.Fatalf("CreateMediaRequest: %v", err)
+	}
+	if resp.Status != StatusRequested {
+		t.Fatalf("status = %s, want requested", resp.Status)
+	}
+	if f.addBody == nil || f.addBody["tvdbId"] != float64(121361) {
+		t.Fatalf("add body = %v, want tvdbId 121361", f.addBody)
+	}
 }

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -220,7 +220,11 @@ func (c *Client) LookupByTVDB(tvdbID int) (*LookupResult, error) {
 	return &results[0], nil
 }
 
-func (c *Client) LookupByTitle(title string) (*LookupResult, error) {
+// LookupByTitle returns Sonarr's metadata search results for a text term, in
+// relevance order. Text search is fuzzy and same-titled series are distinct
+// records (a reboot vs the original), so callers must verify identity (year,
+// ids) against the result they pick — never act on the ordering alone.
+func (c *Client) LookupByTitle(title string) ([]LookupResult, error) {
 	resp, err := c.doRequest("GET", "/api/v3/series/lookup?term="+url.QueryEscape(title))
 	if err != nil {
 		return nil, fmt.Errorf("sonarr title lookup: %w", err)
@@ -234,7 +238,7 @@ func (c *Client) LookupByTitle(title string) (*LookupResult, error) {
 	if len(results) == 0 {
 		return nil, fmt.Errorf("no results found for title %q", title)
 	}
-	return &results[0], nil
+	return results, nil
 }
 
 func (c *Client) GetSeries(id int) (*Series, error) {

--- a/server/internal/tmdb/client.go
+++ b/server/internal/tmdb/client.go
@@ -20,9 +20,15 @@ type Client struct {
 }
 
 func NewClient(accessToken string) *Client {
+	return NewClientWithBaseURL(accessToken, "https://api.themoviedb.org/3")
+}
+
+// NewClientWithBaseURL is NewClient with the API root overridden — for tests
+// that point the client at a local fake server.
+func NewClientWithBaseURL(accessToken, baseURL string) *Client {
 	return &Client{
 		accessToken: accessToken,
-		baseURL:     "https://api.themoviedb.org/3",
+		baseURL:     baseURL,
 		httpClient: &http.Client{
 			Timeout:       10 * time.Second,
 			CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },


### PR DESCRIPTION
## Problem

Companion to #328 (server-side leg of the same investigation). When the TMDB→TVDB bridge can't resolve a series — TMDB has no TVDB mapping, which is exactly the shape of the 2018 "Tremors" reboot pilot (never aired, TMDB-only record) — `addSeries` fell back to `LookupByTitle` and took `results[0]` blindly. Skyhook's only "Tremors" is the 2003 series, so a request for the 2018 record would resolve to tvdb 71262 and act on the wrong show (in the reported case Sonarr's duplicate-add rejection masked it; with the library entry absent it would add the wrong series outright). The README already claimed "title+year search" — the year part didn't exist.

## Change

- `lookupSeriesByTitleIdentity` verifies the text-search candidate against the premiere year of the TMDB record the requester actually chose (server-fetched via `GetTVDetails`; ±1 tolerance for TMDB-vs-TVDB dating skew). No candidate within the window fails the request with both years named — a same-titled but different series is never substituted.
- **Availability carve-out**: when TMDB can't supply a year at all (no client configured, fetch failed), the first result is accepted exactly as before, so TMDB-less deployments keep a working title request path. The gate binds precisely in the dangerous zone: TMDB alive but genuinely mapping-less.
- A verified fallback id that names a series the library already tracks now flows through the existing-series monitor/search path instead of an add Sonarr rejects as a duplicate (the common "added directly in Sonarr, TMDB can't map it" case).
- `sonarr.LookupByTitle` returns the full candidate list (single caller); `tmdb.NewClientWithBaseURL` added for test fakes.
- Docs updated in the same PR: bridge step 4 in `server/README.md` (diagram + feature bullet) and the root README's bridge paragraph now describe the verified behavior.

## Verification

- `go vet ./...` — clean
- `go test ./...` — all packages pass; new tests pin the wrong-year rejection (no add, no log row, both years in the error), the exact-year and ±1-skew acceptances (add carries the looked-up id; log row stores it), the existing-series routing, and the no-year-truth legacy path (bridge nil → first result accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LJWESXmKDdNbuJ43GKSgZR