### PR TITLE
feat: floating Ask AI pill for explicit search AI mode

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -50,7 +50,7 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 ### Discovery & search
 - **TMDB + Trakt rows** -- trending, popular movies/TV, top rated, upcoming; all proxied through the backend so keys stay server-side (poster/backdrop images load straight from the TMDB CDN).
 - **Module-global search bar** -- debounced multi-search from every primary library/discovery surface. Secondary work screens hide it to avoid stacking global search above local filters. Results carry **requester-vocabulary availability chips** (Available / Partially Available / Requested -- never arr jargon), matched against the user's default library by TMDB id (title + premiere year as the fallback, so same-titled shows never borrow each other's state) and kept fresh via WebSocket pings.
-- **Search-to-AI hand-off** -- a query that looks like a question (or returns nothing) lights up an AI affordance; sending it opens the dedicated assistant with the prompt already in flight.
+- **Search-to-AI hand-off** -- a query that looks like a question (or returns nothing) lights up an AI affordance, and a floating **Ask AI** pill under the focused bar switches explicitly -- sticking through any edit -- for prompts the heuristic would read as a title; sending opens the dedicated assistant with the prompt already in flight.
 
 ### Discover
 - **Movies / TV tabs** -- discovery rows plus live library rows from the user's default instances: Downloading Soon, Recently Downloaded (ordered by when the file landed, never when the title was added -- Radarr carries the file date on the movie, Sonarr does not, so series recency comes from its import history), Airing Next (soonest air date first).

--- a/app/lib/features/shell/logic/shell_search_provider.dart
+++ b/app/lib/features/shell/logic/shell_search_provider.dart
@@ -109,6 +109,11 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
   Timer? _searchDebounce;
   int _searchGeneration = 0;
 
+  /// True from an explicit [enterAiMode] (the "Ask AI" pill) until the next
+  /// [exitAiMode]. Unlike the typed-question heuristic, it pins aiReady
+  /// through any edit — deletions and rewrites included.
+  bool _manualAiMode = false;
+
   ShellSearchNotifier(this._api, {this.aiAvailable = false})
       : super(const ShellSearchState());
 
@@ -123,17 +128,19 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
         normalized.startsWith(previousNormalized);
     _searchDebounce?.cancel();
     final generation = ++_searchGeneration;
-    final mode =
-        continuingAiReadyInput || (aiAvailable && isAiPromptQuery(trimmed))
-            ? SearchMode.aiReady
-            : SearchMode.search;
+    final mode = _manualAiMode ||
+            continuingAiReadyInput ||
+            (aiAvailable && isAiPromptQuery(trimmed))
+        ? SearchMode.aiReady
+        : SearchMode.search;
 
     if (trimmed.isEmpty) {
       state = state.copyWith(
         searchQuery: '',
         searchResults: [],
         isLoadingSearch: false,
-        searchMode: SearchMode.search,
+        searchMode:
+            _manualAiMode ? SearchMode.aiReady : SearchMode.search,
       );
       _searchLoader.reset();
       return;
@@ -165,7 +172,8 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
         page: _searchLoader.page,
       );
 
-      if (generation != _searchGeneration ||
+      if (!mounted ||
+          generation != _searchGeneration ||
           state.searchQuery != query ||
           state.searchMode != mode) {
         return;
@@ -185,7 +193,8 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
       }
       _searchLoader.endLoading(page.totalPages);
     } catch (e) {
-      if (generation != _searchGeneration ||
+      if (!mounted ||
+          generation != _searchGeneration ||
           state.searchQuery != query ||
           state.searchMode != mode) {
         return;
@@ -198,8 +207,38 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
     }
   }
 
+  /// Explicitly enter AI mode (the search bar's "Ask AI" pill).
+  ///
+  /// Sticky, unlike the typed-question heuristic: the mode survives every
+  /// subsequent edit until send or clear calls [exitAiMode]. Already-typed
+  /// text is kept, and a fetch that was scheduled under normal search is
+  /// re-run so the results backing the aiReady overlay still arrive.
+  void enterAiMode() {
+    if (!aiAvailable || state.searchMode == SearchMode.aiReady) return;
+    _manualAiMode = true;
+    _searchDebounce?.cancel();
+    final generation = ++_searchGeneration;
+    final query = state.searchQuery;
+    final needsFetch = query.trim().isNotEmpty &&
+        (state.isLoadingSearch || state.searchResults.isEmpty);
+    state = state.copyWith(
+      searchMode: SearchMode.aiReady,
+      isLoadingSearch: needsFetch,
+    );
+    if (needsFetch) {
+      // The query is already settled (the user is switching modes, not
+      // typing), so skip the debounce.
+      _executeSearch(
+        query: query,
+        generation: generation,
+        mode: SearchMode.aiReady,
+      );
+    }
+  }
+
   /// Exit the AI-ready hand-off and return to normal search.
   void exitAiMode() {
+    _manualAiMode = false;
     _searchDebounce?.cancel();
     _searchGeneration++;
     state = state.copyWith(
@@ -229,7 +268,8 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
         query: query,
         page: _searchLoader.page,
       );
-      if (generation != _searchGeneration ||
+      if (!mounted ||
+          generation != _searchGeneration ||
           state.searchQuery != query ||
           state.searchMode != mode) {
         return;
@@ -240,7 +280,8 @@ class ShellSearchNotifier extends StateNotifier<ShellSearchState> {
       );
       _searchLoader.endLoading(page.totalPages);
     } catch (_) {
-      if (generation != _searchGeneration ||
+      if (!mounted ||
+          generation != _searchGeneration ||
           state.searchQuery != query ||
           state.searchMode != mode) {
         return;

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -237,6 +237,14 @@ class _AppShellState extends ConsumerState<AppShell>
     _dismissKeyboard();
   }
 
+  /// Explicit entry into AI mode from the search bar's "Ask AI" pill.
+  void _enterAiMode() {
+    ref.read(shellSearchProvider.notifier).enterAiMode();
+    // The pill sits in a TextFieldTapRegion so tapping it doesn't blur the
+    // field; re-assert focus anyway so typing can continue immediately.
+    _searchFocusNode.requestFocus();
+  }
+
   /// Submit top-bar input through the full-screen assistant route.
   void _submitSearchBarToAi() {
     final text = _searchController.text.trim();
@@ -416,7 +424,7 @@ class _AppShellState extends ConsumerState<AppShell>
           controller: _searchController,
           focusNode: _searchFocusNode,
           hintText: isAiReady
-              ? 'Edit your question or press send...'
+              ? 'Ask the AI anything...'
               : (hasAi
                   ? 'Search or ask AI...'
                   : 'Search by title or person...'),
@@ -612,9 +620,11 @@ class _AppShellState extends ConsumerState<AppShell>
                                             .withValues(alpha: 0.5),
                                       ),
                                       const SizedBox(height: 8),
-                                      const Text(
-                                        'Press send to ask AI',
-                                        style: TextStyle(
+                                      Text(
+                                        searchState.isSearching
+                                            ? 'Press send to ask AI'
+                                            : 'Type a question, then press send',
+                                        style: const TextStyle(
                                           color: AppTheme.textSecondary,
                                           fontSize: 14,
                                         ),
@@ -656,6 +666,60 @@ class _AppShellState extends ConsumerState<AppShell>
                               onLoadMore: searchNotifier.loadMoreSearch,
                               libraryStatus: libraryStatus,
                               onResultTap: _dismissKeyboard,
+                            ),
+                          ),
+                        ),
+                      // Floating "Ask AI" pill: the explicit door into AI
+                      // mode while the field is focused. Typing something
+                      // question-shaped remains the implicit path; the pill
+                      // is for prompts the heuristic would read as a title.
+                      if (showGlobalSearch && hasAi && !isAiReady)
+                        Positioned(
+                          top: 6,
+                          left: 0,
+                          right: 0,
+                          child: Center(
+                            child: ConstrainedBox(
+                              constraints: BoxConstraints(
+                                maxWidth: desktop ? 880 : double.infinity,
+                              ),
+                              child: Align(
+                                alignment: Alignment.centerRight,
+                                child: Padding(
+                                  padding: EdgeInsets.only(
+                                    right: desktop ? 24 : 12,
+                                  ),
+                                  child: ListenableBuilder(
+                                    listenable: _searchFocusNode,
+                                    builder: (context, child) {
+                                      final visible =
+                                          _searchFocusNode.hasFocus;
+                                      final duration = reduceMotion
+                                          ? Duration.zero
+                                          : AppTheme.motionFast;
+                                      return IgnorePointer(
+                                        ignoring: !visible,
+                                        child: AnimatedSlide(
+                                          offset: visible
+                                              ? Offset.zero
+                                              : const Offset(0, -0.4),
+                                          duration: duration,
+                                          curve: Curves.easeOutCubic,
+                                          child: AnimatedOpacity(
+                                            opacity: visible ? 1 : 0,
+                                            duration: duration,
+                                            child: child,
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                    child: TextFieldTapRegion(
+                                      child:
+                                          _AskAiPill(onTap: _enterAiMode),
+                                    ),
+                                  ),
+                                ),
+                              ),
                             ),
                           ),
                         ),
@@ -1443,6 +1507,73 @@ class _CountPill extends StatelessWidget {
           color: AppTheme.onAccent,
           fontSize: 12,
           fontWeight: FontWeight.w700,
+        ),
+      ),
+    );
+  }
+}
+
+/// Floating capsule under the focused search bar offering the explicit
+/// switch into AI mode (typing something question-shaped is the implicit
+/// one).
+class _AskAiPill extends StatelessWidget {
+  final VoidCallback onTap;
+
+  const _AskAiPill({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      identifier: 'search-ask-ai',
+      button: true,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(AppTheme.radiusPill),
+          child: Ink(
+            decoration: BoxDecoration(
+              color: AppTheme.surfaceRaised,
+              borderRadius: BorderRadius.circular(AppTheme.radiusPill),
+              border: Border.all(
+                color: AppTheme.signal.withValues(alpha: 0.45),
+              ),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.35),
+                  blurRadius: 12,
+                  offset: const Offset(0, 4),
+                ),
+                BoxShadow(
+                  color: AppTheme.signal.withValues(alpha: 0.18),
+                  blurRadius: 14,
+                ),
+              ],
+            ),
+            child: const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.auto_awesome_rounded,
+                    size: 14,
+                    color: AppTheme.signal,
+                  ),
+                  SizedBox(width: 6),
+                  Text(
+                    'Ask AI',
+                    style: TextStyle(
+                      color: AppTheme.signal,
+                      fontSize: 11.5,
+                      fontWeight: FontWeight.w700,
+                      letterSpacing: 0.4,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
         ),
       ),
     );

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -304,6 +304,76 @@ void main() {
     expect(find.text('What should I watch tonight?'), findsNothing);
   });
 
+  testWidgets('Ask AI pill shows on focus and enters sticky AI mode',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final router = GoRouter(
+      initialLocation: '/dashboard/movies',
+      routes: [
+        ShellRoute(
+          builder: (context, state, child) =>
+              AppShell(currentPath: state.uri.path, child: child),
+          routes: [
+            GoRoute(
+              path: '/dashboard/movies',
+              builder: (_, __) => const Scaffold(body: Text('Dashboard home')),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith(
+            () => _FakeAuthNotifier(_authenticatedAiState),
+          ),
+          backendClientProvider.overrideWithValue(_fakeDio()),
+          realtimeEventsProvider
+              .overrideWithValue(const Stream<WsEvent>.empty()),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // Hidden (not tappable) until the search field takes focus.
+    expect(find.text('Ask AI').hitTestable(), findsNothing);
+
+    await tester.tap(find.byType(TextField).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 150));
+    expect(find.text('Ask AI').hitTestable(), findsOneWidget);
+
+    // The shimmer repeats while aiReady, so bounded pumps only from here.
+    await tester.tap(find.text('Ask AI'));
+    await tester.pump();
+
+    // AI mode engaged with an empty field, and the field kept focus.
+    expect(find.text('Type a question, then press send'), findsOneWidget);
+    final field = tester.widget<TextField>(find.byType(TextField).first);
+    expect(field.focusNode!.hasFocus, isTrue);
+    expect(find.text('Ask AI').hitTestable(), findsNothing);
+
+    // A title-like edit doesn't knock the explicit choice back to search.
+    await tester.enterText(find.byType(TextField).first, 'Severance');
+    await tester.pump();
+    expect(find.text('Press send to ask AI'), findsOneWidget);
+
+    // Clear exits AI mode (and cancels the debounced fetch).
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pump();
+    expect(find.text('Press send to ask AI'), findsNothing);
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('non-admin drawer hides instance app modules', (tester) async {
     final semantics = tester.ensureSemantics();
     tester.view.physicalSize = const Size(390, 844);

--- a/app/test/shell/shell_search_provider_test.dart
+++ b/app/test/shell/shell_search_provider_test.dart
@@ -53,4 +53,65 @@ void main() {
     expect(notifier.state.searchMode, SearchMode.aiReady);
     expect(notifier.state.isLoadingSearch, true);
   });
+
+  group('enterAiMode', () {
+    ShellSearchNotifier makeNotifier({bool aiAvailable = true}) {
+      final notifier = ShellSearchNotifier(
+        DiscoverApiService(backendDio: Dio()),
+        aiAvailable: aiAvailable,
+      );
+      addTearDown(notifier.dispose);
+      return notifier;
+    }
+
+    test('is a no-op when AI is unavailable', () {
+      final notifier = makeNotifier(aiAvailable: false);
+
+      notifier.enterAiMode();
+      expect(notifier.state.searchMode, SearchMode.search);
+    });
+
+    test('enters with an empty query and sticks through any edit', () {
+      final notifier = makeNotifier();
+
+      notifier.enterAiMode();
+      expect(notifier.state.searchMode, SearchMode.aiReady);
+
+      // Title-like text would flip the heuristic back to normal search; the
+      // explicit choice must survive it — rewrites, deletions, and an
+      // emptied field included.
+      notifier.updateSearch('Severance');
+      expect(notifier.state.searchMode, SearchMode.aiReady);
+
+      notifier.updateSearch('Sev');
+      expect(notifier.state.searchMode, SearchMode.aiReady);
+
+      notifier.updateSearch('');
+      expect(notifier.state.searchMode, SearchMode.aiReady);
+    });
+
+    test('keeps already-typed text and its pending fetch alive', () {
+      final notifier = makeNotifier();
+
+      notifier.updateSearch('dark comedies');
+      expect(notifier.state.searchMode, SearchMode.search);
+
+      notifier.enterAiMode();
+      expect(notifier.state.searchMode, SearchMode.aiReady);
+      expect(notifier.state.searchQuery, 'dark comedies');
+      expect(notifier.state.isLoadingSearch, true);
+    });
+
+    test('exitAiMode clears the explicit choice', () {
+      final notifier = makeNotifier();
+
+      notifier.enterAiMode();
+      notifier.exitAiMode();
+      expect(notifier.state.searchMode, SearchMode.search);
+
+      // Back on the heuristic: a title stays a title.
+      notifier.updateSearch('Severance');
+      expect(notifier.state.searchMode, SearchMode.search);
+    });
+  });
 }


### PR DESCRIPTION
## What

A floating **Ask AI** pill under the focused shell search bar that switches into AI mode explicitly. Until now AI mode was only reachable implicitly — the typed-question heuristic (`isAiPromptQuery`) or the zero-result fallback — so a prompt the heuristic reads as a title ("dark comedies set in winter") had no way in.

## How

- **`ShellSearchNotifier.enterAiMode()`** — explicit, sticky entry: unlike the heuristic, it survives every edit (rewrites, deletions, emptied field) until send or clear calls `exitAiMode()`. Already-typed text is kept, and a fetch scheduled under normal search is re-run under `aiReady` so the results behind the overlay still arrive.
- **`mounted` guards after awaits** in `_executeSearch`/`_loadMoreSearchResults` — `enterAiMode` fires `_executeSearch` directly (no cancellable timer), so a response can now land after dispose; the load-more path had the same latent gap.
- **Pill UI** (`_AskAiPill` in `app_shell.dart`) — shown only while the field is focused, AI is available (`connection.services.ai`, same coarse gate as the heuristic), and mode isn't already `aiReady`. Wrapped in `TextFieldTapRegion` so tapping it doesn't blur the field; right edge aligns with the bar on both desktop (880 cap, 24px inset) and mobile (12px inset); fades/slides with `motionFast`, honors reduced motion, and hides via `IgnorePointer` when unfocused.
- **Copy** — the aiReady hint (previously unreachable: hints only render when the field is empty, and aiReady always had text) becomes "Ask the AI anything...", and the scrim caption reads "Type a question, then press send" until there's text.

## Verification

- `flutter analyze --no-fatal-infos` clean; full `flutter test` suite green (882 tests).
- New provider tests: no-op without AI, sticky through title-like edits/deletions/empty, pending-fetch preservation, exit clears the choice.
- New widget test (390x844): pill hidden until focus, tap enters AI mode with focus retained, sticky through a title edit, clear exits.
- Shell goldens unchanged (they never focus the field).
- Verified live in Chrome via the preview harness at desktop width: pill placement/style, tap-to-enter with shimmer + scrim, sticky "Severance" edit, X exit.

## Docs

- `app/README.md` search-to-AI bullet updated in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LafuyGSmY5hg6nJKRy3q2Z