### PR TITLE
Link the public feature-request board from Settings and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Your media server just learned to run itself.**
 
-**[cantinarr.com](https://cantinarr.com)** · **[Live demo](https://demo.cantinarr.com)**
+**[cantinarr.com](https://cantinarr.com)** · **[Live demo](https://demo.cantinarr.com)** · **[Request a feature](https://cantinarr.com/roadmap/)**
 
 Discover and request movies, TV shows, and books. Get push notifications. Manage Radarr, Sonarr, Chaptarr, and your download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step. You set the agent's operating boundaries. Your household gets the simple experience; you keep control of access, approvals, and quality.
 
@@ -248,6 +248,8 @@ Full API documentation is in [`server/README.md`](server/README.md#api-reference
 ## Contributing
 
 Contributions are welcome! Please open an issue to discuss your idea before submitting a PR. `AGENTS.md` is the operating manual for contributors and AI agents -- branch protocol, verification commands, and the documentation standard live there.
+
+Not a developer? Request features and vote on what ships next at [cantinarr.com/roadmap](https://cantinarr.com/roadmap/) -- no account needed.
 
 ## Support
 

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -418,6 +418,15 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               mode: LaunchMode.externalApplication,
             ),
           ),
+          _SettingsTile(
+            icon: Icons.how_to_vote_outlined,
+            title: 'Request a feature',
+            subtitle: 'Vote on the roadmap — no account needed',
+            onTap: () => launchUrl(
+              Uri.parse(_roadmapUrl),
+              mode: LaunchMode.externalApplication,
+            ),
+          ),
           if (_donateVisible)
             _SettingsTile(
               icon: Icons.favorite_outline,
@@ -677,6 +686,7 @@ String _aiAccessSubtitle(AiSettings? settings) {
 }
 
 const _githubUrl = 'https://github.com/windoze95/cantinarr';
+const _roadmapUrl = 'https://cantinarr.com/roadmap/';
 const _donateUrl = 'https://github.com/sponsors/windoze95';
 
 /// Apple and Google both treat links to external payment for the developer as


### PR DESCRIPTION
## What

[cantinarr.com/roadmap/](https://cantinarr.com/roadmap/) is Cantinarr's new public feature-request board — anyone can suggest features and upvote them with no account (built in [cantinarr-site#4](https://github.com/windoze95/cantinarr-site/pull/4)).

- **Settings → About**: new "Request a feature" tile (`how_to_vote` icon) between GitHub and Donate, opening the board externally — same pattern as the GitHub tile.
- **README**: board link in the header line and a non-developer pointer in Contributing.

## Verification

- `flutter analyze --no-fatal-infos`: no issues.
- `flutter test`: all 886 tests passed (no golden changes — the new tile follows the existing `_SettingsTile` pattern).

Note: the board goes live once cantinarr-site#4 merges after its Cloudflare provisioning; until then the URL 404s, so merge order is site first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cYdeBKFECMSBP8StpeYbb