### PR TITLE
Auto-close external pull requests

### DIFF
--- a/.github/workflows/close-external-prs.yml
+++ b/.github/workflows/close-external-prs.yml
@@ -1,0 +1,27 @@
+name: Close external pull requests
+
+# Cantinarr doesn't accept external PRs: development happens by the
+# maintainer, and community input flows through the issue tracker and the
+# public roadmap (cantinarr.com/roadmap/). Maintainer and collaborator PRs
+# are unaffected. No PR code is ever checked out here.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close:
+    if: ${{ !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body \
+            "Thanks for taking the time to put this together — genuinely. Cantinarr doesn't accept external pull requests, though: development happens directly by the maintainer. Bugs and technical issues are very welcome on the [issue tracker](https://github.com/windoze95/cantinarr/issues), and feature ideas belong on the [public roadmap](https://cantinarr.com/roadmap/), where anyone can post and vote with no account. Closing this automatically."
+          gh pr close "$PR" --repo "$GITHUB_REPOSITORY"

--- a/README.md
+++ b/README.md
@@ -247,9 +247,12 @@ Full API documentation is in [`server/README.md`](server/README.md#api-reference
 
 ## Contributing
 
-Contributions are welcome! Please open an issue to discuss your idea before submitting a PR. `AGENTS.md` is the operating manual for contributors and AI agents -- branch protocol, verification commands, and the documentation standard live there.
+Cantinarr development happens directly by the maintainer, so external pull requests are closed automatically. The two ways to shape the project:
 
-Not a developer? Request features and vote on what ships next at [cantinarr.com/roadmap](https://cantinarr.com/roadmap/) -- no account needed.
+- **Bugs and technical issues** -- open one on the [issue tracker](https://github.com/windoze95/cantinarr/issues).
+- **Feature requests** -- post and vote at [cantinarr.com/roadmap](https://cantinarr.com/roadmap/), no account needed.
+
+`AGENTS.md` is the operating manual for the maintainer's own workflow (branch protocol, verification commands, documentation standard).
 
 ## Support
 


### PR DESCRIPTION
GitHub has no setting to disable PRs, so this adds the standard workaround: a `pull_request_target` workflow that politely comments and closes PRs from anyone who isn't OWNER/MEMBER/COLLABORATOR, pointing them at the issue tracker and [cantinarr.com/roadmap/](https://cantinarr.com/roadmap/). No PR code is ever checked out, so it's safe on fork PRs. README's Contributing section now states the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cYdeBKFECMSBP8StpeYbb