### PR TITLE
Wait out ASC screenshot processing before deliver verifies

### DIFF
--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -68,6 +68,13 @@ platform :ios do
       end
     end
 
+    # ASC processes screenshot uploads asynchronously, and deliver's
+    # post-upload verification lists the set before processing settles: fresh
+    # uploads read as "missing", get re-uploaded, and the listing ends up with
+    # duplicates (observed twice in a row; fastlane#16851). Waiting for
+    # processing to finish before verification closes the race.
+    ENV["DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING"] = "false"
+
     # The ASC API intermittently returns empty bodies that spaceship surfaces
     # as "No data". Everything deliver does here is an idempotent PATCH/upload,
     # so retrying the whole call is safe.


### PR DESCRIPTION
Both storelisting runs today duplicated screenshots on App Store Connect: ASC processes uploads asynchronously, deliver's post-upload verification listed the set before processing settled, declared fresh uploads "missing", and re-uploaded them (`missing on App Store Connect` → `Too many screenshots` in both logs; [fastlane#16851](https://github.com/fastlane/fastlane/discussions/16851)). Setting `DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING=false` in the metadata lane makes deliver wait for processing to complete before verifying, closing the race. Play's `supply` has no such pass and was unaffected.

I'll re-dispatch `storelisting` after merge and confirm the log runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cYdeBKFECMSBP8StpeYbb