### PR TITLE
Neutralize deliver's checksum re-upload sweep

### DIFF
--- a/app/ios/fastlane/Fastfile
+++ b/app/ios/fastlane/Fastfile
@@ -75,6 +75,30 @@ platform :ios do
     # processing to finish before verification closes the race.
     ENV["DELIVER_SKIP_WAIT_FOR_SCREENSHOT_PROCESSING"] = "false"
 
+    # Waiting is not enough: ASC also surfaces source_file_checksum lazily, so
+    # deliver's checksum sweep still declares the largest files (the discover
+    # shots, on every sync run) "missing" and re-uploads them into duplicates.
+    # The sweep is belt-and-braces on top of the delete-all + full upload this
+    # lane already does, and genuinely failed uploads still retry via the
+    # FAILED-state check, so neutralize only the checksum-driven re-upload.
+    has_verify = Deliver::UploadScreenshots.method_defined?(:verify_local_screenshots_are_uploaded) ||
+                 Deliver::UploadScreenshots.private_method_defined?(:verify_local_screenshots_are_uploaded)
+    already_patched = Deliver::UploadScreenshots.method_defined?(:cantinarr_orig_verify_screenshots) ||
+                      Deliver::UploadScreenshots.private_method_defined?(:cantinarr_orig_verify_screenshots)
+    if has_verify && !already_patched
+      Deliver::UploadScreenshots.class_eval do
+        alias_method :cantinarr_orig_verify_screenshots, :verify_local_screenshots_are_uploaded
+        def verify_local_screenshots_are_uploaded(iterator, screenshots_per_language)
+          unless cantinarr_orig_verify_screenshots(iterator, screenshots_per_language)
+            FastlaneCore::UI.important("ASC has not surfaced every screenshot checksum yet; skipping deliver's re-upload sweep (it duplicates screenshots).")
+          end
+          true
+        end
+      end
+    elsif !has_verify
+      UI.important("deliver no longer defines verify_local_screenshots_are_uploaded; checksum-sweep patch inactive - watch for duplicate screenshots.")
+    end
+
     # The ASC API intermittently returns empty bodies that spaceship surfaces
     # as "No data". Everything deliver does here is an idempotent PATCH/upload,
     # so retrying the whole call is safe.


### PR DESCRIPTION
Follow-up to #340, which didn't close the duplicate-screenshot race: even after waiting for processing, ASC surfaces `source_file_checksum` lazily, so `verify_local_screenshots_are_uploaded` keeps reading the largest files (the discover shots — same two, all three sync runs) as missing and re-uploads them into duplicates.

This guards-and-patches the sweep to log-and-continue instead of re-uploading, matching the existing review-attachment monkeypatch's style. Safety intact: the lane always runs delete-all + full 18-file upload, and genuinely failed uploads still retry via the `FAILED`-state check; if a future fastlane renames the method, the patch deactivates with a loud warning instead of breaking.

I'll dispatch `storelisting` after merge and confirm a clean log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cYdeBKFECMSBP8StpeYbb