### PR TITLE
fix: load Trakt posters and proxied covers on the web client

### DIFF
--- a/app/lib/core/widgets/cached_image.dart
+++ b/app/lib/core/widgets/cached_image.dart
@@ -1,8 +1,59 @@
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
+    show ImageRenderMethodForWeb;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../features/auth/logic/auth_provider.dart';
 import '../network/app_image_cache.dart';
 import '../theme/app_theme.dart';
+
+/// A resolved image request: the URL to fetch plus any headers it needs.
+typedef ImageSource = ({String url, Map<String, String>? headers});
+
+/// Trakt's artwork CDN. Unlike TMDB's CDN it sends no CORS headers, so the
+/// web renderer is forbidden from reading its bytes; the backend relays these
+/// hosts at `/api/trakt/images/{host}/…` so web can fetch them same-origin.
+const _corslessTraktHosts = {'walter.trakt.tv', 'walter-r2.trakt.tv'};
+
+/// Resolves what [CachedImage] should actually fetch.
+///
+/// On native this is the identity function — native HTTP has no CORS, so every
+/// host works directly. On web, Trakt CDN URLs are rewritten to the backend's
+/// same-origin relay with the session bearer attached; everything else (TMDB,
+/// author art, the backend's own proxy URLs) passes through untouched.
+ImageSource resolveImageSource({
+  required String url,
+  Map<String, String>? headers,
+  String? serverUrl,
+  String? accessToken,
+  bool isWeb = kIsWeb,
+}) {
+  final passthrough = (url: url, headers: headers);
+  if (!isWeb) return passthrough;
+
+  final uri = Uri.tryParse(url);
+  if (uri == null ||
+      !_corslessTraktHosts.contains(uri.host) ||
+      !uri.path.startsWith('/images/')) {
+    return passthrough;
+  }
+  if (serverUrl == null || serverUrl.isEmpty) return passthrough;
+
+  final base = serverUrl.endsWith('/')
+      ? serverUrl.substring(0, serverUrl.length - 1)
+      : serverUrl;
+  final merged = <String, String>{
+    ...?headers,
+    if (accessToken != null && accessToken.isNotEmpty)
+      'Authorization': 'Bearer $accessToken',
+  };
+  return (
+    url: '$base/api/trakt/images/${uri.host}${uri.path}',
+    headers: merged.isEmpty ? null : merged,
+  );
+}
 
 /// The app's one network-image widget. Every poster/cover/photo goes through it
 /// so they share [appImageCache] and render a consistent placeholder, error
@@ -43,22 +94,46 @@ class CachedImage extends StatelessWidget {
         child: Icon(icon, color: AppTheme.textSecondary, size: iconSize),
       );
 
+  Widget _image(ImageSource source) => CachedNetworkImage(
+        imageUrl: source.url,
+        httpHeaders: source.headers,
+        cacheManager: appImageCache,
+        // The default HtmlImage decode path on web drops httpHeaders entirely,
+        // which silently unauthenticates covers behind the backend proxy. Any
+        // headered request goes through the cache manager's real HTTP fetch
+        // instead; header-free CDN images keep the browser-native path.
+        imageRenderMethodForWeb: source.headers == null
+            ? ImageRenderMethodForWeb.HtmlImage
+            : ImageRenderMethodForWeb.HttpGet,
+        fit: fit,
+        width: width,
+        height: height,
+        fadeInDuration: const Duration(milliseconds: 200),
+        // Keep the same fallback visible while the network image resolves. A
+        // blank rectangle briefly reads as a missing cover on slower devices.
+        placeholder: (_, __) => _fallback(),
+        errorWidget: (_, __, ___) => _fallback(),
+      );
+
   @override
   Widget build(BuildContext context) {
     final src = url;
     if (src == null || src.isEmpty) return _fallback();
-    return CachedNetworkImage(
-      imageUrl: src,
-      httpHeaders: headers,
-      cacheManager: appImageCache,
-      fit: fit,
-      width: width,
-      height: height,
-      fadeInDuration: const Duration(milliseconds: 200),
-      // Keep the same fallback visible while the network image resolves. A
-      // blank rectangle briefly reads as a missing cover on slower devices.
-      placeholder: (_, __) => _fallback(),
-      errorWidget: (_, __, ___) => _fallback(),
+    if (!kIsWeb) return _image((url: src, headers: headers));
+    // Web only: the Trakt relay rewrite needs the session's server URL and
+    // bearer, so reach for them lazily here rather than making every native
+    // poster read a provider.
+    return Consumer(
+      builder: (context, ref, _) {
+        final conn =
+            ref.watch(authProvider.select((s) => s.valueOrNull?.connection));
+        return _image(resolveImageSource(
+          url: src,
+          headers: headers,
+          serverUrl: conn?.serverUrl,
+          accessToken: conn?.accessToken,
+        ));
+      },
     );
   }
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -25,6 +25,8 @@ dependencies:
 
   # Image loading
   cached_network_image: ^3.4.1
+  # Direct dep for ImageRenderMethodForWeb (not re-exported by the main lib).
+  cached_network_image_platform_interface: ^4.1.1
   flutter_cache_manager: ^3.4.1
 
   # Storage

--- a/app/test/core/widgets/cached_image_test.dart
+++ b/app/test/core/widgets/cached_image_test.dart
@@ -1,0 +1,142 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:cached_network_image_platform_interface/cached_network_image_platform_interface.dart'
+    show ImageRenderMethodForWeb;
+import 'package:cantinarr/core/widgets/cached_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('resolveImageSource', () {
+    const walterUrl =
+        'https://walter-r2.trakt.tv/images/movies/000/337/posters/thumb/faaa819377.jpg.webp';
+
+    test('native fetches every host directly, Trakt CDN included', () {
+      final source = resolveImageSource(
+        url: walterUrl,
+        serverUrl: 'https://cantina.example',
+        accessToken: 'tok',
+        isWeb: false,
+      );
+      expect(source.url, walterUrl);
+      expect(source.headers, isNull);
+    });
+
+    test('web rewrites Trakt CDN urls to the backend relay with the bearer',
+        () {
+      final source = resolveImageSource(
+        url: walterUrl,
+        serverUrl: 'https://cantina.example',
+        accessToken: 'tok',
+        isWeb: true,
+      );
+      expect(
+        source.url,
+        'https://cantina.example/api/trakt/images/walter-r2.trakt.tv'
+        '/images/movies/000/337/posters/thumb/faaa819377.jpg.webp',
+      );
+      expect(source.headers, {'Authorization': 'Bearer tok'});
+    });
+
+    test('web rewrites the legacy walter host too', () {
+      final source = resolveImageSource(
+        url: 'https://walter.trakt.tv/images/shows/000/001/posters/a.jpg',
+        serverUrl: 'https://cantina.example',
+        accessToken: 'tok',
+        isWeb: true,
+      );
+      expect(
+        source.url,
+        'https://cantina.example/api/trakt/images/walter.trakt.tv'
+        '/images/shows/000/001/posters/a.jpg',
+      );
+    });
+
+    test('a trailing-slash server url never doubles the slash', () {
+      final source = resolveImageSource(
+        url: walterUrl,
+        serverUrl: 'https://cantina.example/',
+        accessToken: 'tok',
+        isWeb: true,
+      );
+      expect(source.url, startsWith('https://cantina.example/api/'));
+    });
+
+    test('web leaves CORS-friendly hosts alone', () {
+      const tmdb = 'https://image.tmdb.org/t/p/w342/abc.jpg';
+      final source = resolveImageSource(
+        url: tmdb,
+        serverUrl: 'https://cantina.example',
+        accessToken: 'tok',
+        isWeb: true,
+      );
+      expect(source.url, tmdb);
+      expect(source.headers, isNull);
+    });
+
+    test('web leaves backend proxy urls and their headers alone', () {
+      const proxied =
+          'https://cantina.example/api/instances/abc/api/v1/MediaCover/1/cover.jpg';
+      final source = resolveImageSource(
+        url: proxied,
+        headers: const {'Authorization': 'Bearer tok'},
+        serverUrl: 'https://cantina.example',
+        accessToken: 'tok',
+        isWeb: true,
+      );
+      expect(source.url, proxied);
+      expect(source.headers, const {'Authorization': 'Bearer tok'});
+    });
+
+    test('web without a session passes through rather than half-rewriting',
+        () {
+      final source = resolveImageSource(url: walterUrl, isWeb: true);
+      expect(source.url, walterUrl);
+      expect(source.headers, isNull);
+    });
+
+    test('web refuses to relay a walter path outside images/', () {
+      const odd = 'https://walter-r2.trakt.tv/other/thing.jpg';
+      final source = resolveImageSource(
+        url: odd,
+        serverUrl: 'https://cantina.example',
+        accessToken: 'tok',
+        isWeb: true,
+      );
+      expect(source.url, odd);
+    });
+  });
+
+  group('CachedImage render method', () {
+    testWidgets('headered requests use the HTTP fetch path on web',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CachedImage(
+            url: 'https://cantina.example/api/instances/x/api/v1/MediaCover/1.jpg',
+            headers: {'Authorization': 'Bearer tok'},
+          ),
+        ),
+      );
+      final provider = tester.widget<Image>(find.byType(Image)).image
+          as CachedNetworkImageProvider;
+      expect(provider.imageRenderMethodForWeb, ImageRenderMethodForWeb.HttpGet);
+      // Let the (failing, test-environment) fetch resolve into the error
+      // fallback so nothing is pending when the test ends.
+      await tester.pump(const Duration(seconds: 1));
+    });
+
+    testWidgets('header-free requests keep the browser-native path',
+        (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: CachedImage(url: 'https://image.tmdb.org/t/p/w342/abc.jpg'),
+        ),
+      );
+      final provider = tester.widget<Image>(find.byType(Image)).image
+          as CachedNetworkImageProvider;
+      expect(
+          provider.imageRenderMethodForWeb, ImageRenderMethodForWeb.HtmlImage);
+      await tester.pump(const Duration(seconds: 1));
+    });
+  });
+}

--- a/server/README.md
+++ b/server/README.md
@@ -264,8 +264,11 @@ GET /api/media/person/{id} | /api/media/person/{id}/credits
 GET /api/genres/movie | /api/genres/tv | /api/providers/movie
 GET /api/trakt/trending | popular | lists | lists/{user}/{slug}/items
 GET /api/trakt/calendar | anticipated | recommendations
+GET /api/trakt/images/{host}/*                       # Trakt artwork relay for the web client
 ```
 TMDB and Trakt are proxied server-side -- client devices never hold those keys. `/featured` serves whichever feed the admin selected (see [Discovery settings](#discovery-settings-admin)), normalized to the TMDB page shape plus a `source` field so one client parser handles every source and the row can name what it is showing. The discovery and recommendation feeds also honor the admin's `english_only` preference; search and detail lookups never do.
+
+Trakt's artwork CDN (`walter*.trakt.tv`) is public but sends no CORS headers, so a browser-rendered client cannot fetch it directly the way it can TMDB's CDN. `/api/trakt/images/{host}/*` relays exactly those hosts (allowlisted, `images/…` paths only, no query passthrough) so the web app loads Trakt posters same-origin; native clients keep hitting the CDN directly.
 
 ### AI chat (user)
 ```

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -362,6 +362,10 @@ func NewRouter(
 			r.Get("/trakt/calendar", discoverHandler.TraktCalendar)
 			r.Get("/trakt/anticipated", discoverHandler.TraktAnticipated)
 			r.Get("/trakt/recommendations", discoverHandler.TraktRecommendations)
+			// Trakt artwork relay: walter*.trakt.tv sends no CORS headers, so
+			// the web client fetches Trakt posters through this same-origin
+			// path instead of the CDN. Host-allowlisted in the handler.
+			r.Get("/trakt/images/{host}/*", discoverHandler.TraktImage)
 		})
 
 		// AI routes (authenticated)

--- a/server/internal/discover/handler_test.go
+++ b/server/internal/discover/handler_test.go
@@ -180,6 +180,7 @@ func newEnv(t *testing.T, configured bool) *env {
 	router.Get("/media/movie/{id}", handler.MovieDetail)
 	router.Get("/media/tv/{id}", handler.TVDetail)
 	router.Get("/trakt/trending", handler.TraktTrending)
+	router.Get("/trakt/images/{host}/*", handler.TraktImage)
 
 	upstream := &fakeUpstream{respond: echoUpstream}
 	previous := http.DefaultTransport

--- a/server/internal/discover/images.go
+++ b/server/internal/discover/images.go
@@ -1,0 +1,113 @@
+package discover
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// traktImageHosts is the closed set of Trakt CDN hosts the relay will fetch
+// from. The relay exists because these hosts send no CORS headers, so the web
+// renderer cannot read their bytes directly the way it can TMDB's; the
+// allowlist is what keeps the endpoint a Trakt-artwork relay rather than an
+// open proxy.
+var traktImageHosts = map[string]bool{
+	"walter.trakt.tv":    true,
+	"walter-r2.trakt.tv": true,
+}
+
+// traktImageClient has a zero Transport on purpose: it consults
+// http.DefaultTransport per request, which is how the test harness intercepts
+// outbound traffic. The timeout is generous because fanart files run larger
+// than poster thumbs.
+var traktImageClient = &http.Client{Timeout: 15 * time.Second}
+
+// TraktImage relays one Trakt CDN image to the client. Trakt artwork URLs are
+// public CDN assets, but unlike TMDB's CDN they carry no
+// Access-Control-Allow-Origin header, so a browser-rendered client is not
+// allowed to fetch them cross-origin. Native clients keep hitting the CDN
+// directly; the web client routes the same URL through here, same-origin.
+func (h *Handler) TraktImage(w http.ResponseWriter, r *http.Request) {
+	// Same posture as every other /trakt/* endpoint: without a configured
+	// Trakt credential nothing hands out walter URLs, so nothing should be
+	// relayed either.
+	if h.creds.Trakt() == nil {
+		http.Error(w, `{"error":"trakt not configured"}`, http.StatusServiceUnavailable)
+		return
+	}
+	host := chi.URLParam(r, "host")
+	if !traktImageHosts[host] {
+		http.Error(w, `{"error":"image not found"}`, http.StatusNotFound)
+		return
+	}
+	path := chi.URLParam(r, "*")
+	if !validTraktImagePath(path) {
+		http.Error(w, `{"error":"image not found"}`, http.StatusNotFound)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet,
+		fmt.Sprintf("https://%s/%s", host, path), nil)
+	if err != nil {
+		http.Error(w, `{"error":"image fetch failed"}`, http.StatusBadGateway)
+		return
+	}
+	upstream, err := traktImageClient.Do(req)
+	if err != nil {
+		http.Error(w, `{"error":"image fetch failed"}`, http.StatusBadGateway)
+		return
+	}
+	defer upstream.Body.Close()
+
+	switch {
+	case upstream.StatusCode == http.StatusOK:
+	case upstream.StatusCode == http.StatusNotFound:
+		http.Error(w, `{"error":"image not found"}`, http.StatusNotFound)
+		return
+	default:
+		http.Error(w, `{"error":"image fetch failed"}`, http.StatusBadGateway)
+		return
+	}
+
+	contentType := upstream.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	// Overwrites the router group's blanket application/json header.
+	w.Header().Set("Content-Type", contentType)
+	// Artwork files are immutable-in-practice: a day of client caching keeps
+	// reloads off both this relay and the CDN.
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	if upstream.ContentLength > 0 {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", upstream.ContentLength))
+	}
+	io.Copy(w, upstream.Body)
+}
+
+// validTraktImagePath accepts only the shape Trakt artwork URLs actually have:
+// an images/… path of simple hyphen/dot/underscore file segments. Everything
+// else — traversal, encodings, queries smuggled into a segment — is rejected
+// rather than normalized.
+func validTraktImagePath(path string) bool {
+	if path == "" || len(path) > 512 || !strings.HasPrefix(path, "images/") {
+		return false
+	}
+	for _, segment := range strings.Split(path, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return false
+		}
+		for _, c := range segment {
+			switch {
+			case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+			case c == '.', c == '_', c == '-':
+			default:
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/server/internal/discover/images_test.go
+++ b/server/internal/discover/images_test.go
@@ -1,0 +1,110 @@
+package discover
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestTraktImageRelaysAllowedHosts pins the relay contract: the request path
+// maps onto the CDN host verbatim, bytes and Content-Type pass through, the
+// response is client-cacheable, and no query parameters are forwarded.
+func TestTraktImageRelaysAllowedHosts(t *testing.T) {
+	e := newEnv(t, true)
+	e.upstream.setRespond(func(*http.Request) (int, string) { return http.StatusOK, "IMAGEBYTES" })
+
+	for i, host := range []string{"walter.trakt.tv", "walter-r2.trakt.tv"} {
+		path := fmt.Sprintf("/trakt/images/%s/images/movies/000/337/posters/thumb/faaa819377.jpg.webp?width=300", host)
+		rec := e.do(t, path)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s: status = %d, body = %s", host, rec.Code, rec.Body.String())
+		}
+		if rec.Body.String() != "IMAGEBYTES" {
+			t.Errorf("%s: body = %q, want the upstream bytes verbatim", host, rec.Body.String())
+		}
+		// The fake upstream stamps application/json on everything; seeing it
+		// here proves the relay copies the upstream type instead of inventing
+		// one or leaving the router group's default in place.
+		if got := rec.Header().Get("Content-Type"); got != "application/json" {
+			t.Errorf("%s: content-type = %q, want the upstream's passed through", host, got)
+		}
+		if got := rec.Header().Get("Cache-Control"); got != "public, max-age=86400" {
+			t.Errorf("%s: cache-control = %q, want a day of client caching", host, got)
+		}
+
+		hit := e.upstream.hit(t, i)
+		if hit.host != host {
+			t.Errorf("upstream host = %s, want %s", hit.host, host)
+		}
+		if hit.path != "/images/movies/000/337/posters/thumb/faaa819377.jpg.webp" {
+			t.Errorf("upstream path = %s, want the image path verbatim", hit.path)
+		}
+		if len(hit.query) != 0 {
+			t.Errorf("upstream query = %v, want none forwarded", hit.query)
+		}
+	}
+}
+
+// TestTraktImageRejectsNonAllowlistedTargets pins the not-a-proxy contract:
+// any host outside the walter allowlist and any path that is not a plain
+// images/… file path is refused before an upstream connection is attempted.
+func TestTraktImageRejectsNonAllowlistedTargets(t *testing.T) {
+	e := newEnv(t, true)
+
+	requests := []string{
+		// Hosts that are real but not artwork CDNs, and one attacker-shaped.
+		"/trakt/images/api.trakt.tv/images/a.jpg",
+		"/trakt/images/image.tmdb.org/images/a.jpg",
+		"/trakt/images/evil.example.com/images/a.jpg",
+		// Paths outside images/, traversal in both raw and encoded forms,
+		// and characters walter filenames never contain.
+		"/trakt/images/walter-r2.trakt.tv/posters/a.jpg",
+		"/trakt/images/walter-r2.trakt.tv/images/../oauth/token",
+		"/trakt/images/walter-r2.trakt.tv/images/%2e%2e/oauth/token",
+		"/trakt/images/walter-r2.trakt.tv/images/a%20b.jpg",
+		"/trakt/images/walter-r2.trakt.tv/",
+	}
+	for _, path := range requests {
+		rec := e.do(t, path)
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("GET %s status = %d, want 404", path, rec.Code)
+		}
+	}
+	if e.upstream.hitCount() != 0 {
+		t.Fatalf("upstream hits = %d, want 0 — a rejected target must never be dialed", e.upstream.hitCount())
+	}
+}
+
+// TestTraktImageUpstreamFailures maps CDN answers onto client statuses: a
+// missing image is the client's 404, anything else upstream is a 502, and
+// neither leaks the upstream body.
+func TestTraktImageUpstreamFailures(t *testing.T) {
+	e := newEnv(t, true)
+
+	e.upstream.setRespond(func(*http.Request) (int, string) { return http.StatusNotFound, "walter says no" })
+	rec := e.do(t, "/trakt/images/walter-r2.trakt.tv/images/movies/000/1/posters/a.jpg")
+	if rec.Code != http.StatusNotFound || strings.Contains(rec.Body.String(), "walter says no") {
+		t.Errorf("missing image: status = %d body = %s, want a clean 404", rec.Code, rec.Body.String())
+	}
+
+	e.upstream.setRespond(func(*http.Request) (int, string) { return http.StatusInternalServerError, "cdn guts" })
+	rec = e.do(t, "/trakt/images/walter-r2.trakt.tv/images/movies/000/1/posters/a.jpg")
+	if rec.Code != http.StatusBadGateway || strings.Contains(rec.Body.String(), "cdn guts") {
+		t.Errorf("cdn error: status = %d body = %s, want a clean 502", rec.Code, rec.Body.String())
+	}
+}
+
+// TestTraktImageRequiresTraktConfigured mirrors the sibling /trakt/* posture:
+// with no Trakt credential nothing hands out walter URLs, so the relay answers
+// 503 without dialing anywhere.
+func TestTraktImageRequiresTraktConfigured(t *testing.T) {
+	e := newEnv(t, false)
+	rec := e.do(t, "/trakt/images/walter-r2.trakt.tv/images/movies/000/1/posters/a.jpg")
+	if rec.Code != http.StatusServiceUnavailable || !strings.Contains(rec.Body.String(), "trakt not configured") {
+		t.Errorf("status = %d body = %s, want 503 not-configured", rec.Code, rec.Body.String())
+	}
+	if e.upstream.hitCount() != 0 {
+		t.Fatalf("upstream hits = %d, want 0 without credentials", e.upstream.hitCount())
+	}
+}


### PR DESCRIPTION
## What

On web, the Trakt discovery rows and the books Recently Added row showed placeholder icons while iOS rendered posters fine. Two separate web-only causes, one PR because the second fix supplies the mechanism the first one rides on:

- **Trakt artwork is CORS-less.** `walter*.trakt.tv` is a public CDN but sends no `Access-Control-Allow-Origin` header (verified against a live asset; TMDB's CDN sends `*`, which is why every TMDB row worked). Browsers therefore forbid the web renderer from reading its bytes. New authenticated relay `GET /api/trakt/images/{host}/*` — host-allowlisted to the two walter hosts, `images/…` paths only, strict segment charset, no query passthrough, `Cache-Control: public, max-age=86400` — and `CachedImage` rewrites walter URLs through it **on web only**. Native clients keep fetching the CDN directly.
- **Web image loads dropped auth headers.** Chaptarr covers are served through the backend's bearer-authed instance proxy, but `cached_network_image`'s default `HtmlImage` web path ignores `httpHeaders` (and the cache manager) entirely, so every proxied cover 401'd on web. `CachedImage` now uses the `HttpGet` render method whenever headers are present — the cache-manager fetch that actually sends them; header-free CDN images keep the browser-native decode path. This also fixes book search covers, author art, and any other proxied artwork on web, and is what authenticates the new Trakt relay fetches.

`resolveImageSource` is a pure helper (web/native switch injectable) so the rewrite rules are unit-tested; the relay handler is covered for passthrough, allowlist/traversal rejection (with zero upstream dials), upstream failure mapping, and the not-configured 503.

## Verification

- `server/`: `go vet ./...`, `go test ./...` — all pass
- `app/`: `flutter analyze --no-fatal-infos` (no issues), `flutter test` — 896 tests pass
- Not run: a live browser check against a deployed build (needs a Trakt-configured backend + this image; the CORS gap itself was confirmed with `curl -I` against a real walter-r2 asset)

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [x] `server/README.md` — added the `/api/trakt/images/{host}/*` route and a paragraph on why the relay exists
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYjVwrmjA1cfAyAJZcB6tM