### PR TITLE
fix: follow Trakt's CDN host migration in the artwork relay

### DIFF
--- a/app/lib/core/widgets/cached_image.dart
+++ b/app/lib/core/widgets/cached_image.dart
@@ -12,10 +12,12 @@ import '../theme/app_theme.dart';
 /// A resolved image request: the URL to fetch plus any headers it needs.
 typedef ImageSource = ({String url, Map<String, String>? headers});
 
-/// Trakt's artwork CDN. Unlike TMDB's CDN it sends no CORS headers, so the
-/// web renderer is forbidden from reading its bytes; the backend relays these
-/// hosts at `/api/trakt/images/{host}/…` so web can fetch them same-origin.
-const _corslessTraktHosts = {'walter.trakt.tv', 'walter-r2.trakt.tv'};
+/// True for Trakt's artwork CDNs (media.trakt.tv today, walter*.trakt.tv
+/// before July 2026 — Trakt migrates these hosts, so match the domain rather
+/// than pinning names). Unlike TMDB's CDN they send no CORS headers, so the
+/// web renderer is forbidden from reading their bytes; the backend relays them
+/// at `/api/trakt/images/{host}/…` so web can fetch same-origin.
+bool _isTraktCdnHost(String host) => host.endsWith('.trakt.tv');
 
 /// Resolves what [CachedImage] should actually fetch.
 ///
@@ -35,7 +37,7 @@ ImageSource resolveImageSource({
 
   final uri = Uri.tryParse(url);
   if (uri == null ||
-      !_corslessTraktHosts.contains(uri.host) ||
+      !_isTraktCdnHost(uri.host) ||
       !uri.path.startsWith('/images/')) {
     return passthrough;
   }

--- a/app/test/core/widgets/cached_image_test.dart
+++ b/app/test/core/widgets/cached_image_test.dart
@@ -37,18 +37,44 @@ void main() {
       expect(source.headers, {'Authorization': 'Bearer tok'});
     });
 
-    test('web rewrites the legacy walter host too', () {
-      final source = resolveImageSource(
-        url: 'https://walter.trakt.tv/images/shows/000/001/posters/a.jpg',
-        serverUrl: 'https://cantina.example',
-        accessToken: 'tok',
-        isWeb: true,
-      );
-      expect(
-        source.url,
-        'https://cantina.example/api/trakt/images/walter.trakt.tv'
-        '/images/shows/000/001/posters/a.jpg',
-      );
+    test('web rewrites whichever trakt.tv CDN host the payload carries', () {
+      // media.trakt.tv is what Trakt serves today; walter*.trakt.tv is what
+      // it served before July 2026. The rewrite follows the domain so a CDN
+      // migration on Trakt's side cannot silently blank the posters again.
+      for (final host in [
+        'media.trakt.tv',
+        'walter.trakt.tv',
+        'walter-r2.trakt.tv',
+      ]) {
+        final source = resolveImageSource(
+          url: 'https://$host/images/shows/000/001/posters/a.jpg',
+          serverUrl: 'https://cantina.example',
+          accessToken: 'tok',
+          isWeb: true,
+        );
+        expect(
+          source.url,
+          'https://cantina.example/api/trakt/images/$host'
+          '/images/shows/000/001/posters/a.jpg',
+        );
+      }
+    });
+
+    test('web never relays lookalike or apex trakt hosts', () {
+      for (final url in [
+        'https://notrakt.tv/images/a.jpg',
+        'https://media.trakt.tv.evil.com/images/a.jpg',
+        'https://trakt.tv/images/a.jpg',
+      ]) {
+        final source = resolveImageSource(
+          url: url,
+          serverUrl: 'https://cantina.example',
+          accessToken: 'tok',
+          isWeb: true,
+        );
+        expect(source.url, url);
+        expect(source.headers, isNull);
+      }
     });
 
     test('a trailing-slash server url never doubles the slash', () {

--- a/server/README.md
+++ b/server/README.md
@@ -268,7 +268,7 @@ GET /api/trakt/images/{host}/*                       # Trakt artwork relay for t
 ```
 TMDB and Trakt are proxied server-side -- client devices never hold those keys. `/featured` serves whichever feed the admin selected (see [Discovery settings](#discovery-settings-admin)), normalized to the TMDB page shape plus a `source` field so one client parser handles every source and the row can name what it is showing. The discovery and recommendation feeds also honor the admin's `english_only` preference; search and detail lookups never do.
 
-Trakt's artwork CDN (`walter*.trakt.tv`) is public but sends no CORS headers, so a browser-rendered client cannot fetch it directly the way it can TMDB's CDN. `/api/trakt/images/{host}/*` relays exactly those hosts (allowlisted, `images/…` paths only, no query passthrough) so the web app loads Trakt posters same-origin; native clients keep hitting the CDN directly.
+Trakt's artwork CDN (`media.trakt.tv` today; `walter*.trakt.tv` before July 2026 -- Trakt migrates these hosts) is public but sends no CORS headers, so a browser-rendered client cannot fetch it directly the way it can TMDB's CDN. `/api/trakt/images/{host}/*` relays any `*.trakt.tv` host (strictly validated, `images/…` paths only, no query passthrough) so the web app loads Trakt posters same-origin and a CDN migration on Trakt's side cannot blank them again; native clients keep hitting the CDN directly.
 
 ### AI chat (user)
 ```

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -362,9 +362,9 @@ func NewRouter(
 			r.Get("/trakt/calendar", discoverHandler.TraktCalendar)
 			r.Get("/trakt/anticipated", discoverHandler.TraktAnticipated)
 			r.Get("/trakt/recommendations", discoverHandler.TraktRecommendations)
-			// Trakt artwork relay: walter*.trakt.tv sends no CORS headers, so
+			// Trakt artwork relay: Trakt's image CDNs send no CORS headers, so
 			// the web client fetches Trakt posters through this same-origin
-			// path instead of the CDN. Host-allowlisted in the handler.
+			// path instead of the CDN. Host validation lives in the handler.
 			r.Get("/trakt/images/{host}/*", discoverHandler.TraktImage)
 		})
 

--- a/server/internal/discover/featured.go
+++ b/server/internal/discover/featured.go
@@ -300,8 +300,9 @@ func (m *traktMedia) releaseDate(raw string) string {
 }
 
 // traktImageURL returns the first image as an absolute URL. Trakt serves these
-// host-relative ("walter-r2.trakt.tv/images/..."), and they are public CDN
-// assets like TMDB's — not an arr origin the client must avoid.
+// host-relative ("media.trakt.tv/images/...", walter-r2 before July 2026), and
+// they are public CDN assets — though unlike TMDB's they send no CORS headers,
+// which is why the web client loads them through the /api/trakt/images relay.
 func traktImageURL(images []string) string {
 	for _, raw := range images {
 		trimmed := strings.TrimSpace(raw)

--- a/server/internal/discover/images.go
+++ b/server/internal/discover/images.go
@@ -10,14 +10,31 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// traktImageHosts is the closed set of Trakt CDN hosts the relay will fetch
-// from. The relay exists because these hosts send no CORS headers, so the web
-// renderer cannot read their bytes directly the way it can TMDB's; the
-// allowlist is what keeps the endpoint a Trakt-artwork relay rather than an
+// validTraktImageHost accepts any *.trakt.tv subdomain rather than naming CDN
+// hosts, because Trakt migrates them: payloads moved from walter-r2.trakt.tv
+// (still what their docs show) to media.trakt.tv in July 2026, and a pinned
+// allowlist silently lost every poster when they did. The relay exists because
+// these CDNs send no CORS headers, so the web renderer cannot read their bytes
+// directly the way it can TMDB's. The suffix plus the strict charset (which
+// also excludes '@', ':' and '/', so the fetched URL cannot be steered to
+// another origin) keeps the endpoint a Trakt-artwork relay rather than an
 // open proxy.
-var traktImageHosts = map[string]bool{
-	"walter.trakt.tv":    true,
-	"walter-r2.trakt.tv": true,
+func validTraktImageHost(host string) bool {
+	if len(host) < len("x.trakt.tv") || len(host) > 64 {
+		return false
+	}
+	if !strings.HasSuffix(host, ".trakt.tv") || strings.Contains(host, "..") {
+		return false
+	}
+	for _, c := range host {
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		case c == '.', c == '-':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // traktImageClient has a zero Transport on purpose: it consults
@@ -40,7 +57,7 @@ func (h *Handler) TraktImage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	host := chi.URLParam(r, "host")
-	if !traktImageHosts[host] {
+	if !validTraktImageHost(host) {
 		http.Error(w, `{"error":"image not found"}`, http.StatusNotFound)
 		return
 	}

--- a/server/internal/discover/images_test.go
+++ b/server/internal/discover/images_test.go
@@ -14,7 +14,9 @@ func TestTraktImageRelaysAllowedHosts(t *testing.T) {
 	e := newEnv(t, true)
 	e.upstream.setRespond(func(*http.Request) (int, string) { return http.StatusOK, "IMAGEBYTES" })
 
-	for i, host := range []string{"walter.trakt.tv", "walter-r2.trakt.tv"} {
+	// media.trakt.tv is what Trakt serves today; the walter hosts are what it
+	// served before July 2026 — the relay must follow their CDN migrations.
+	for i, host := range []string{"media.trakt.tv", "walter.trakt.tv", "walter-r2.trakt.tv"} {
 		path := fmt.Sprintf("/trakt/images/%s/images/movies/000/337/posters/thumb/faaa819377.jpg.webp?width=300", host)
 		rec := e.do(t, path)
 		if rec.Code != http.StatusOK {
@@ -53,10 +55,21 @@ func TestTraktImageRejectsNonAllowlistedTargets(t *testing.T) {
 	e := newEnv(t, true)
 
 	requests := []string{
-		// Hosts that are real but not artwork CDNs, and one attacker-shaped.
-		"/trakt/images/api.trakt.tv/images/a.jpg",
+		// Hosts outside *.trakt.tv, including lookalikes: a domain merely
+		// ending in the letters, a trakt.tv prefix on an attacker's domain,
+		// and the bare apex.
 		"/trakt/images/image.tmdb.org/images/a.jpg",
 		"/trakt/images/evil.example.com/images/a.jpg",
+		"/trakt/images/notrakt.tv/images/a.jpg",
+		"/trakt/images/media.trakt.tv.evil.com/images/a.jpg",
+		"/trakt/images/trakt.tv/images/a.jpg",
+		// The suffix check rejects a host whose real origin is the attacker's
+		// ("media.trakt.tv" as userinfo), and the charset rejects '@' even
+		// when the suffix looks right, so the built URL can never carry
+		// userinfo, a port, or an odd label.
+		"/trakt/images/media.trakt.tv@evil.com/images/a.jpg",
+		"/trakt/images/evil.com@media.trakt.tv/images/a.jpg",
+		"/trakt/images/MEDIA.TRAKT.TV/images/a.jpg",
 		// Paths outside images/, traversal in both raw and encoded forms,
 		// and characters walter filenames never contain.
 		"/trakt/images/walter-r2.trakt.tv/posters/a.jpg",


### PR DESCRIPTION
## What

PR #343's Trakt poster fix never fired in production: the relay allowlist pinned `walter*.trakt.tv` (what Trakt's docs and their own web client fixtures still show), but live payloads now serve artwork from **`media.trakt.tv`** — verified against the deployed instance, whose featured/anticipated responses carry `media.trakt.tv` URLs, and that host answers with no CORS headers just like walter did. So the web client's rewrite passed every URL through untouched and the browser kept CORS-blocking them; the Chaptarr cover fix (which doesn't depend on the allowlist) worked, which is exactly the split observed.

Fix: match the domain instead of naming CDN hosts. The server accepts any `*.trakt.tv` host with strict validation (lowercase charset `[a-z0-9.-]`, suffix check, length cap — no userinfo/port/origin smuggling possible in the built URL), and the app rewrites any `*.trakt.tv` image URL through the relay. Lookalikes (`notrakt.tv`, `media.trakt.tv.evil.com`, `media.trakt.tv@evil.com`, bare apex) are pinned rejected by tests on both ends, still with zero upstream dials.

## Verification

- `server/`: `go vet ./...`, `go test ./...` — all pass
- `app/`: `flutter analyze --no-fatal-infos` (no issues), `flutter test` — 897 tests pass
- Live diagnosis: reproduced the blank rows against the deployed web app, confirmed the payload host migration and `media.trakt.tv`'s missing CORS header with a live asset; will re-verify visually after deploy

## Docs

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [x] `server/README.md` — relay paragraph now names `media.trakt.tv`, the migration, and the `*.trakt.tv` validation policy
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYjVwrmjA1cfAyAJZcB6tM