### PR TITLE
chore: drop the auth-screen tagline

### DIFF
--- a/app/lib/features/auth/ui/auth_screen.dart
+++ b/app/lib/features/auth/ui/auth_screen.dart
@@ -159,16 +159,6 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
                         letterSpacing: 2.2,
                       ),
                     ),
-                    const SizedBox(height: 5),
-                    const Text(
-                      'YOUR MEDIA, ONE SIGNAL',
-                      style: TextStyle(
-                        color: AppTheme.signal,
-                        fontSize: 10,
-                        fontWeight: FontWeight.w800,
-                        letterSpacing: 1.45,
-                      ),
-                    ),
                     const SizedBox(height: 12),
                     Text(
                       showPasskeyOffer ? 'Secure your account' : _subtitle,


### PR DESCRIPTION
## Summary
- Remove the "YOUR MEDIA, ONE SIGNAL" caption under the CANTINARR wordmark on the auth screen. It added a third text layer to the login header without earning it; the card now goes logo → wordmark → subtitle. The "How you doing, you old pirate?" greeting stays where it lives, in the post-login shell.

## Verification
- `flutter analyze --no-fatal-infos` — no issues
- `flutter test` — 897 passed
- Visually verified the login card at ~357 px (phone) and ~606 px widths via `flutter run -d web-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYjVwrmjA1cfAyAJZcB6tM