### PR TITLE
fix(qbittorrent): accept the 5.x login contract (204 No Content)

### DIFF
--- a/server/internal/qbittorrent/client.go
+++ b/server/internal/qbittorrent/client.go
@@ -58,22 +58,40 @@ func (c *Client) Login() error {
 	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
 		return fmt.Errorf("qbittorrent login failed: redirect status %d to %q (redirects are not followed; use the WebUI's final URL)", resp.StatusCode, resp.Header.Get("Location"))
 	}
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("qbittorrent login failed: status %d", resp.StatusCode)
-	}
+
+	// Two WebUI generations answer this endpoint differently, and both are in
+	// the wild:
+	//   - qBittorrent 5.x succeeds with 204 No Content and an empty body, and
+	//     rejects bad credentials with 401 Unauthorized.
+	//   - qBittorrent 4.x succeeds with 200 and the plain text "Ok.", and
+	//     answers "Fails." (also 200) for bad credentials.
+	// Accept both rather than pinning either one.
 	trimmed := strings.TrimSpace(string(body))
-	if !strings.HasPrefix(trimmed, "Ok") {
-		// The login endpoint answers plain "Ok." or "Fails."; an HTML body is
-		// some other page entirely (wrong port or path), not a bad password.
-		if strings.HasPrefix(trimmed, "<") {
-			return fmt.Errorf("qbittorrent login failed: unexpected response (is this the qBittorrent WebUI URL?)")
+	switch {
+	case resp.StatusCode == http.StatusNoContent:
+		// 5.x success: nothing to inspect in the body.
+	case resp.StatusCode == http.StatusOK:
+		// 4.x success is "Ok."; 5.x never lands here, so an empty 200 body is
+		// treated as success rather than as a missing "Ok.".
+		if trimmed != "" && !strings.HasPrefix(trimmed, "Ok") {
+			// An HTML body is some other page entirely (wrong port or path),
+			// not a bad password.
+			if strings.HasPrefix(trimmed, "<") {
+				return fmt.Errorf("qbittorrent login failed: unexpected response (is this the qBittorrent WebUI URL?)")
+			}
+			return fmt.Errorf("qbittorrent login failed: invalid credentials")
 		}
+	case resp.StatusCode == http.StatusUnauthorized:
 		return fmt.Errorf("qbittorrent login failed: invalid credentials")
+	default:
+		// The body is deliberately not echoed: it can carry the submitted
+		// credentials back (see TestLoginFailuresDoNotEchoCredentials).
+		return fmt.Errorf("qbittorrent login failed: status %d", resp.StatusCode)
 	}
 
 	// When the WebUI has auth bypass enabled (localhost/whitelisted IPs),
-	// login succeeds with "Ok." but returns no SID cookie — requests work
-	// without one, so an empty cookie set is not an error.
+	// login succeeds but returns no SID cookie — requests work without one,
+	// so an empty cookie set is not an error.
 	c.mu.Lock()
 	c.cookies = resp.Cookies()
 	c.authenticated = true

--- a/server/internal/qbittorrent/client_test.go
+++ b/server/internal/qbittorrent/client_test.go
@@ -175,6 +175,74 @@ func TestLoginDistinguishesWrongPageFromBadPassword(t *testing.T) {
 	}
 }
 
+// TestLoginAcceptsBothWebUIGenerations pins the two login contracts we have to
+// live with: qBittorrent 5.x answers a successful login with 204 No Content and
+// an empty body (and 401 for bad credentials), while 4.x answers 200 "Ok."
+// (and 200 "Fails."). Reading 204 as a failure locked every 5.x WebUI out.
+func TestLoginAcceptsBothWebUIGenerations(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     int
+		body       string
+		wantErr    string // "" means the login must succeed
+		setsCookie bool
+	}{
+		{name: "5.x success", status: http.StatusNoContent, body: "", setsCookie: true},
+		{name: "5.x success behind auth bypass", status: http.StatusNoContent, body: ""},
+		{name: "5.x bad credentials", status: http.StatusUnauthorized, body: "Unauthorized", wantErr: "invalid credentials"},
+		{name: "4.x success", status: http.StatusOK, body: "Ok.", setsCookie: true},
+		{name: "4.x bad credentials", status: http.StatusOK, body: "Fails.", wantErr: "invalid credentials"},
+		{name: "empty 200 body", status: http.StatusOK, body: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.setsCookie {
+					http.SetCookie(w, &http.Cookie{Name: "SID", Value: "sid-1"})
+				}
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, tc.body)
+			}))
+			t.Cleanup(srv.Close)
+
+			err := NewClient(srv.URL, "admin", "adminadmin").Login()
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Login() = %v, want success for a %d response", err, tc.status)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Login() accepted a %d %q response", tc.status, tc.body)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %v, want it to mention %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestLoginStillRejectsWrongPageOn204Path pins that accepting an empty body no
+// longer being proof of failure did not also make an HTML page look like a
+// success: a wrong port answering 200 with a page must still be reported as the
+// wrong URL, not as a working WebUI.
+func TestLoginStillRejectsWrongPageOn204Path(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "<!doctype html><html><body>login</body></html>")
+	}))
+	t.Cleanup(srv.Close)
+
+	err := NewClient(srv.URL, "admin", "adminadmin").Login()
+	if err == nil {
+		t.Fatal("Login accepted an HTML 200 response")
+	}
+	if !strings.Contains(err.Error(), "unexpected response") {
+		t.Errorf("error = %v, want the wrong-page explanation", err)
+	}
+}
+
 // TestLoginRedirectNamesLocation pins that a refused login redirect reports
 // where the WebUI tried to send us, so scheme misconfigurations are
 // self-diagnosing.


### PR DESCRIPTION
qBittorrent 5.x answers a successful POST /api/v2/auth/login with 204 No
Content and an empty body, and rejects bad credentials with 401. The
client only accepted 200 plus a body starting with "Ok." — the 4.x
contract — so every 5.x WebUI failed with "qbittorrent login failed:
status 204" and no instance could be added: validateConnection runs on
instance create and update alike.

Accept both generations: 204, or 200 with "Ok." or an empty body, is a
success; 401 reports invalid credentials. An HTML body on 200 is still
reported as the wrong URL rather than a bad password, and failure bodies
are still never echoed back — they can contain the submitted password.

Verified against qBittorrent 5.2.3.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SjVbx4E5XmfdEa7wt5zhrL

## What

<!-- What changed and why, in a sentence or two. -->

## Verification

<!-- Paste the checks you ran (server: `go test ./...`; app: `flutter analyze`, `flutter test`).
     Note anything that could not be run and why. -->

## Docs

Docs are part of the change, not a follow-up. Tick what you updated, or tick the last box and say why nothing needed it:

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above
