### PR TITLE
fix(auth): name every 401's cause and source in the server log

### DIFF
--- a/server/internal/auth/handler.go
+++ b/server/internal/auth/handler.go
@@ -76,8 +76,10 @@ func (h *Handler) Refresh(w http.ResponseWriter, r *http.Request) {
 		// 503 so the client keeps the token and retries later.
 		switch {
 		case errors.Is(err, ErrDeviceRevoked):
+			log.Printf("auth: refresh 401 from %s: device revoked (client will clear its session)", r.RemoteAddr)
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "device has been revoked"})
 		case errors.Is(err, ErrInvalidCredentials):
+			log.Printf("auth: refresh 401 from %s: refresh token unknown (client will clear its session)", r.RemoteAddr)
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "invalid refresh token"})
 		default:
 			log.Printf("auth: refresh answered 503 (client will retry, session kept): %v", err)

--- a/server/internal/auth/middleware.go
+++ b/server/internal/auth/middleware.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"errors"
+	"log"
 	"net/http"
 	"strings"
 )
@@ -28,12 +29,17 @@ func (s *Service) AuthMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		authHeader := r.Header.Get("Authorization")
 		if authHeader == "" {
+			// Every 401 names its cause and source in the log: a client dying on
+			// silent 401s is otherwise undiagnosable from the server side. Only
+			// the reason and remote address are logged — never token material.
+			log.Printf("auth: 401 %s %s from %s: no authorization header", r.Method, r.URL.Path, r.RemoteAddr)
 			http.Error(w, `{"error":"missing authorization header"}`, http.StatusUnauthorized)
 			return
 		}
 
 		token := strings.TrimPrefix(authHeader, "Bearer ")
 		if token == authHeader {
+			log.Printf("auth: 401 %s %s from %s: malformed authorization header", r.Method, r.URL.Path, r.RemoteAddr)
 			http.Error(w, `{"error":"invalid authorization format"}`, http.StatusUnauthorized)
 			return
 		}
@@ -44,9 +50,13 @@ func (s *Service) AuthMiddleware(next http.Handler) http.Handler {
 			// rejection: clients treat 401 as "session dead". Answer 503 so
 			// they retry with the same credentials.
 			if errors.Is(err, ErrAuthUnavailable) {
+				log.Printf("auth: 503 %s %s from %s (session kept, client retries): %v", r.Method, r.URL.Path, r.RemoteAddr, err)
 				http.Error(w, `{"error":"temporarily unavailable, retry shortly"}`, http.StatusServiceUnavailable)
 				return
 			}
+			// The validation error text describes the failure class (expired,
+			// bad signature, revoked device) and never contains the token.
+			log.Printf("auth: 401 %s %s from %s: %v", r.Method, r.URL.Path, r.RemoteAddr, err)
 			http.Error(w, `{"error":"invalid or expired token"}`, http.StatusUnauthorized)
 			return
 		}

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -349,6 +349,7 @@ func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 	// Flutter sends protocols: ['Bearer', 'actualToken']
 	protocols := websocket.Subprotocols(r)
 	if len(protocols) < 2 || protocols[0] != "Bearer" {
+		log.Printf("websocket: 401 from %s: no bearer subprotocol", r.RemoteAddr)
 		http.Error(w, "missing auth", http.StatusUnauthorized)
 		return
 	}
@@ -356,6 +357,9 @@ func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 
 	claims, _, err := h.authService.AuthenticateToken(token)
 	if err != nil {
+		// Reason and source only — never token material (see the subprotocol
+		// echo note below for the same rule on the success path).
+		log.Printf("websocket: 401 from %s: %v", r.RemoteAddr, err)
 		http.Error(w, "invalid token", http.StatusUnauthorized)
 		return
 	}


### PR DESCRIPTION
Live incident today: a phone client looped silent 401s for hours (API + websocket), never attempting refresh, and the access log's status-only lines couldn't distinguish a missing header from a bad signature from a revoked device — the server side was undiagnosable by design.

Every 401 now logs its cause and remote address: the auth middleware (missing/malformed header, validation failure class), the refresh handler's two genuine rejections (unknown token / revoked device — the ones that make clients clear their sessions), and the websocket upgrade. The middleware's 503 fault path gets the same line the refresh handler already had. No token material is ever logged — validation errors carry only the failure class.

- `go vet ./...`, `go test ./...` — green (log lines only; no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TneZjV6WaCrWgC19dhXQ33