### PR TITLE
fix(web): move auth calls onto the Fetch transport; hard-guard refresh

### DIFF
--- a/app/lib/core/network/ai_chat_streaming_http_client_adapter.dart
+++ b/app/lib/core/network/ai_chat_streaming_http_client_adapter.dart
@@ -7,18 +7,26 @@ import 'package:http/http.dart' as http;
 /// Routes the AI chat SSE request through `package:http` so browser responses
 /// are delivered incrementally by Fetch's `ReadableStream` implementation.
 ///
-/// Every other request stays on Dio's normal platform adapter. This keeps the
-/// streaming transport narrowly scoped while preserving the existing client
-/// behavior for the rest of the API.
+/// Every other request stays on Dio's normal platform adapter, keeping the
+/// Fetch transport narrowly scoped — unless [routeAllThroughFetch] is set, in
+/// which case every request rides Fetch. The auth clients use that mode on
+/// web: their session-critical calls were observed stalling for the full
+/// receive timeout on the default browser adapter (Chrome and Safari alike,
+/// live-diagnosed 2026-08-01) while Fetch-based requests from the same pages
+/// completed in milliseconds, so auth rides the transport that demonstrably
+/// works.
 class AiChatStreamingHttpClientAdapter implements HttpClientAdapter {
   final HttpClientAdapter _fallbackAdapter;
   final http.Client _streamingClient;
+  final bool _routeAllThroughFetch;
 
   AiChatStreamingHttpClientAdapter({
     required HttpClientAdapter fallbackAdapter,
     http.Client? streamingClient,
+    bool routeAllThroughFetch = false,
   })  : _fallbackAdapter = fallbackAdapter,
-        _streamingClient = streamingClient ?? http.Client();
+        _streamingClient = streamingClient ?? http.Client(),
+        _routeAllThroughFetch = routeAllThroughFetch;
 
   @override
   Future<ResponseBody> fetch(
@@ -26,7 +34,7 @@ class AiChatStreamingHttpClientAdapter implements HttpClientAdapter {
     Stream<Uint8List>? requestStream,
     Future<void>? cancelFuture,
   ) {
-    if (!_isAiChatStream(options)) {
+    if (!_routeAllThroughFetch && !_isAiChatStream(options)) {
       return _fallbackAdapter.fetch(options, requestStream, cancelFuture);
     }
     return _fetchAiChatStream(options, requestStream, cancelFuture);
@@ -147,7 +155,7 @@ class AiChatStreamingHttpClientAdapter implements HttpClientAdapter {
     } catch (_) {
       throw DioException.connectionError(
         requestOptions: options,
-        reason: 'The AI chat request body could not be sent.',
+        reason: 'The request body could not be sent.',
       );
     }
     return bytes.takeBytes();
@@ -168,7 +176,7 @@ class AiChatStreamingHttpClientAdapter implements HttpClientAdapter {
             ? _cancelled(options)
             : DioException.connectionError(
                 requestOptions: options,
-                reason: 'The AI chat response stream was interrupted.',
+                reason: 'The response stream was interrupted.',
               ),
         stackTrace,
       );
@@ -200,14 +208,14 @@ class AiChatStreamingHttpClientAdapter implements HttpClientAdapter {
     }
     return DioException.connectionError(
       requestOptions: options,
-      reason: 'The AI chat connection could not be established.',
+      reason: 'The connection could not be established.',
     );
   }
 
   DioException _cancelled(RequestOptions options) =>
       DioException.requestCancelled(
         requestOptions: options,
-        reason: 'The AI chat request was cancelled.',
+        reason: 'The request was cancelled.',
       );
 
   @override

--- a/app/lib/core/network/backend_auth_interceptor.dart
+++ b/app/lib/core/network/backend_auth_interceptor.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import '../config/app_config.dart';
+import 'backend_http_adapter.dart';
 
 /// Dio interceptor that handles JWT authentication and automatic token refresh.
 ///
@@ -90,18 +91,31 @@ class BackendAuthInterceptor extends Interceptor {
     try {
       // A dedicated client with explicit timeouts: a hung refresh would
       // otherwise block every queued 401 retry behind the shared completer.
+      // On web it rides the Fetch transport — the default browser adapter was
+      // observed stalling this exact call for the full receive timeout while
+      // Fetch requests from the same page completed instantly.
       final dio = Dio(BaseOptions(
         connectTimeout: AppConfig.requestTimeout,
         receiveTimeout: AppConfig.requestTimeout,
       ));
+      final authAdapter = createAuthHttpClientAdapter();
+      if (authAdapter != null) {
+        dio.httpClientAdapter = authAdapter;
+      }
       final serverUrl = getServerUrl();
       final refreshToken = getRefreshToken();
 
-      final resp = await dio.post(
-        '$serverUrl/api/auth/refresh',
-        data: {'refresh_token': refreshToken},
-        options: Options(headers: {'Content-Type': 'application/json'}),
-      );
+      // The outer timeout is the last line of defense: no adapter behavior may
+      // leave the shared completer unsettled, or every future 401 retry queues
+      // behind it forever. A TimeoutException lands in the generic catch below
+      // and is treated as a transport failure (session kept).
+      final resp = await dio
+          .post(
+            '$serverUrl/api/auth/refresh',
+            data: {'refresh_token': refreshToken},
+            options: Options(headers: {'Content-Type': 'application/json'}),
+          )
+          .timeout(AppConfig.requestTimeout * 2);
 
       if (resp.statusCode == 200) {
         final data = resp.data as Map<String, dynamic>;

--- a/app/lib/core/network/backend_http_adapter.dart
+++ b/app/lib/core/network/backend_http_adapter.dart
@@ -6,3 +6,11 @@ import 'backend_http_adapter_stub.dart'
 /// Returns the platform-specific backend adapter override, when one is needed.
 HttpClientAdapter? createBackendHttpClientAdapter() =>
     platform.createBackendHttpClientAdapter();
+
+/// Returns the platform-specific adapter for auth calls (login, refresh,
+/// session validation), when one is needed. On web this routes everything
+/// through Fetch: the default browser adapter was observed stalling these
+/// session-critical requests for the full receive timeout while Fetch requests
+/// from the same page completed instantly.
+HttpClientAdapter? createAuthHttpClientAdapter() =>
+    platform.createAuthHttpClientAdapter();

--- a/app/lib/core/network/backend_http_adapter_stub.dart
+++ b/app/lib/core/network/backend_http_adapter_stub.dart
@@ -1,3 +1,7 @@
 import 'package:dio/dio.dart';
 
 HttpClientAdapter? createBackendHttpClientAdapter() => null;
+
+/// Native platforms keep Dio's dart:io adapter for auth calls; only web needs
+/// the Fetch transport override.
+HttpClientAdapter? createAuthHttpClientAdapter() => null;

--- a/app/lib/core/network/backend_http_adapter_web.dart
+++ b/app/lib/core/network/backend_http_adapter_web.dart
@@ -9,3 +9,15 @@ HttpClientAdapter createBackendHttpClientAdapter() =>
       fallbackAdapter: BrowserHttpClientAdapter(),
       streamingClient: BrowserClient(),
     );
+
+/// The transport for auth calls (login, refresh, session validation) on web:
+/// everything rides Fetch. The default browser adapter was observed stalling
+/// these session-critical requests for the full receive timeout while Fetch
+/// requests from the same page completed instantly; a session must never
+/// depend on the flakier transport.
+HttpClientAdapter createAuthHttpClientAdapter() =>
+    AiChatStreamingHttpClientAdapter(
+      fallbackAdapter: BrowserHttpClientAdapter(),
+      streamingClient: BrowserClient(),
+      routeAllThroughFetch: true,
+    );

--- a/app/lib/features/auth/data/auth_service.dart
+++ b/app/lib/features/auth/data/auth_service.dart
@@ -2,19 +2,30 @@ import 'package:dio/dio.dart';
 import '../../../core/config/app_config.dart';
 import '../../../core/models/backend_connection.dart';
 import '../../../core/models/user_profile.dart';
+import '../../../core/network/backend_http_adapter.dart';
 import 'server_status.dart';
 
 /// Handles authentication requests against the Cantinarr backend.
 ///
 /// Uses a plain Dio instance (no auth interceptor) since these endpoints
-/// are called before/during authentication.
+/// are called before/during authentication. On web the instance rides the
+/// Fetch transport: these calls decide whether a session lives, and the
+/// default browser adapter was observed stalling them for the full receive
+/// timeout while Fetch requests from the same page completed instantly.
 class AuthService {
-  Dio _createDio(String serverUrl) => Dio(BaseOptions(
-        baseUrl: serverUrl,
-        connectTimeout: AppConfig.requestTimeout,
-        receiveTimeout: AppConfig.requestTimeout,
-        headers: {'Content-Type': 'application/json'},
-      ));
+  Dio _createDio(String serverUrl) {
+    final dio = Dio(BaseOptions(
+      baseUrl: serverUrl,
+      connectTimeout: AppConfig.requestTimeout,
+      receiveTimeout: AppConfig.requestTimeout,
+      headers: {'Content-Type': 'application/json'},
+    ));
+    final adapter = createAuthHttpClientAdapter();
+    if (adapter != null) {
+      dio.httpClientAdapter = adapter;
+    }
+    return dio;
+  }
 
   /// Check server status (needs setup, webauthn available).
   Future<ServerStatus> getServerStatus(String serverUrl) async {

--- a/app/test/core/network/ai_chat_streaming_http_client_adapter_test.dart
+++ b/app/test/core/network/ai_chat_streaming_http_client_adapter_test.dart
@@ -83,6 +83,39 @@ void main() {
         isTrue);
   });
 
+  test('routeAllThroughFetch sends every request via the Fetch client',
+      () async {
+    final fallback = _FallbackAdapter();
+    final client = _RecordingClient((_) async => http.StreamedResponse(
+        Stream.value(utf8.encode('{"ok":true}')), 200,
+        headers: {'content-type': 'application/json'}));
+    final adapter = AiChatStreamingHttpClientAdapter(
+      fallbackAdapter: fallback,
+      streamingClient: client,
+      routeAllThroughFetch: true,
+    );
+    // The shape of an auth call: a JSON POST nowhere near the AI chat route.
+    final refresh = RequestOptions(
+      path: '/api/auth/refresh',
+      method: 'POST',
+      baseUrl: 'http://localhost',
+      responseType: ResponseType.json,
+    );
+
+    final response = await adapter.fetch(
+        refresh, Stream.value(Uint8List.fromList(utf8.encode('{}'))), null);
+    final bytes = <int>[];
+    await for (final chunk in response.stream) {
+      bytes.addAll(chunk);
+    }
+
+    expect(fallback.requests, isEmpty,
+        reason: 'auth transport must never fall back to the default adapter');
+    expect(client.requests, hasLength(1));
+    expect(response.statusCode, 200);
+    expect(utf8.decode(bytes), '{"ok":true}');
+  });
+
   test('forwards URL, method, headers, body, and response metadata', () async {
     late http.AbortableRequest sent;
     final client = _RecordingClient((request) async {


### PR DESCRIPTION
## Incident

Web clients (Chrome on macOS, Safari on iOS) fell into permanent 401 loops today: access tokens expired and were never renewed, while the server held valid immortal refresh tokens the whole time. Live diagnosis inside a reproducing tab pinned it to the transport layer:

- Every auth call made through a plain `Dio()` (login, `/api/auth/refresh`, session validation) stalled for the full 15 s receive timeout and aborted — `Token refresh deferred (server unreachable): DioException [receive timeout]` in the console, request never reaching the server.
- Raw `fetch` and raw `XMLHttpRequest` to the identical endpoint from the same page: **401 in 15 ms** (probe token), server-logged.
- Every request through the app's Fetch-based streaming adapter (PR #260) kept working all day.

The precise browser-level trigger for the default-adapter stall remains unexplained (it succeeded intermittently earlier in the day); what's proven is which transport is reliable. Session survival must not depend on the flakier one.

## Fix

- `AiChatStreamingHttpClientAdapter` gains `routeAllThroughFetch` (error strings neutralized — they'd otherwise claim auth failures are "AI chat").
- New `createAuthHttpClientAdapter()`: on web returns the route-all Fetch adapter; on native returns null (dart:io stays).
- `AuthService._createDio` and the interceptor's refresh client attach it.
- The interceptor's refresh future gets an outer `Future.timeout` (2× request timeout): no adapter behavior may leave the single-flight completer unsettled, or every later 401 queues behind it forever. A trip lands in the existing transport-failure branch (session kept).

## Verification

- `flutter analyze --no-fatal-infos`, `flutter test` (917 tests) — green
- New adapter test: route-all mode sends a JSON POST via the Fetch client, never the fallback
- Post-deploy live verification planned in the reproducing tab: reload → expect `POST /api/auth/refresh 200` in the server log and the session to heal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TneZjV6WaCrWgC19dhXQ33