### PR TITLE
fix(request): stop the stall reporter deadlocking the only DB connection

### DIFF
--- a/server/internal/request/service.go
+++ b/server/internal/request/service.go
@@ -3658,21 +3658,38 @@ func (s *Service) reportBookImportStalls() {
 		return
 	}
 
-	instances, err := s.db.Query("SELECT id, name FROM service_instances WHERE service_type = 'chaptarr'")
+	// The instance list is fully drained and the cursor closed BEFORE any sink
+	// call. The pool is capped at a single connection (SQLite is single-writer),
+	// so an open *sql.Rows holds the only connection there is: reporting from
+	// inside the loop would block the sink's own transaction forever, and that
+	// deadlocked goroutine would take every later query in the process with it.
+	type chaptarrInstance struct{ id, name string }
+	var instances []chaptarrInstance
+	instanceRows, err := s.db.Query("SELECT id, name FROM service_instances WHERE service_type = 'chaptarr'")
 	if err != nil {
 		log.Printf("request: query chaptarr instances for stall report: %v", err)
 		return
 	}
-	defer instances.Close()
-	for instances.Next() {
-		var id, name string
-		if err := instances.Scan(&id, &name); err != nil {
+	for instanceRows.Next() {
+		var inst chaptarrInstance
+		if err := instanceRows.Scan(&inst.id, &inst.name); err != nil {
+			_ = instanceRows.Close()
 			log.Printf("request: scan chaptarr instance for stall report: %v", err)
 			return
 		}
-		titles, isStalled := stalled[id]
-		if err := sink.RecordBookImportStall(id, name, titles, !isStalled); err != nil {
-			log.Printf("request: record book import stall for instance %s: %v", id, err)
+		instances = append(instances, inst)
+	}
+	instanceErr := instanceRows.Err()
+	_ = instanceRows.Close()
+	if instanceErr != nil {
+		log.Printf("request: read chaptarr instances for stall report: %v", instanceErr)
+		return
+	}
+
+	for _, inst := range instances {
+		titles, isStalled := stalled[inst.id]
+		if err := sink.RecordBookImportStall(inst.id, inst.name, titles, !isStalled); err != nil {
+			log.Printf("request: record book import stall for instance %s: %v", inst.id, err)
 		}
 	}
 }

--- a/server/internal/request/service_book_test.go
+++ b/server/internal/request/service_book_test.go
@@ -2350,6 +2350,81 @@ func TestReportBookImportStallsTransitionsPerInstance(t *testing.T) {
 	}
 }
 
+// TestReportBookImportStallsDoesNotDeadlockTheSingleConnection reproduces the
+// 2026-08-01 production deadlock: the pool is capped at one connection
+// (SQLite is single-writer), so reporting from inside an open instance cursor
+// left the sink's transaction waiting for a connection that could never be
+// freed. The goroutine hung forever holding that connection, and every later
+// query in the process — token refreshes above all — blocked behind it, which
+// is why the server went dark a few minutes after every restart while
+// static files and token-invalid requests still answered instantly.
+//
+// The sink here does real transactional DB work, exactly like the production
+// issue store. On the buggy code this test times out instead of passing.
+func TestReportBookImportStallsDoesNotDeadlockTheSingleConnection(t *testing.T) {
+	chaptarrServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer chaptarrServer.Close()
+
+	svc, uid := newChaptarrBookTestService(t, chaptarrServer.URL)
+	if _, err := svc.db.Exec(
+		`INSERT INTO request_log (user_id, tmdb_id, foreign_id, book_format, instance_id, media_type, title, status, park_reason, requested_at)
+		 VALUES (?, 0, 'gr:stuck', 'ebook', ?, 'book', 'A Stuck Book', ?, ?, datetime('now', '-2 days'))`,
+		uid, testInstanceID(t, svc), StatusPending, bookParkReasonAuthorImport,
+	); err != nil {
+		t.Fatalf("insert stalled park: %v", err)
+	}
+	sink := &transactionalStallSink{db: svc.db}
+	svc.SetBookImportStallSink(sink)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		svc.reportBookImportStalls()
+	}()
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("reportBookImportStalls deadlocked: it reported while its instance cursor still held the pool's only connection")
+	}
+	if sink.calls() == 0 {
+		t.Fatal("sink was never called; the reporter must still report after draining its cursor")
+	}
+}
+
+// transactionalStallSink mirrors the production sink's shape: it opens a
+// transaction, which is precisely the operation that cannot obtain a
+// connection while a caller's cursor is still open.
+type transactionalStallSink struct {
+	db    *sql.DB
+	mu    sync.Mutex
+	count int
+}
+
+func (s *transactionalStallSink) RecordBookImportStall(instanceID, instanceName string, titles []string, healthy bool) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	var n int
+	if err := tx.QueryRow("SELECT COUNT(*) FROM issues").Scan(&n); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.count++
+	s.mu.Unlock()
+	return tx.Commit()
+}
+
+func (s *transactionalStallSink) calls() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.count
+}
+
 type stallCall struct {
 	instanceID   string
 	instanceName string


### PR DESCRIPTION
## Root cause

`db.SetMaxOpenConns(1)` — SQLite is single-writer, so the pool has exactly one connection, and an open `*sql.Rows` holds it.

`reportBookImportStalls` (added in #352) queried `service_instances` and called `sink.RecordBookImportStall(...)` **from inside that cursor's loop**. The sink opens a transaction → waits for a connection → the only connection is held by the caller's own open cursor → **permanent deadlock**, with the hung goroutine keeping that connection forever. Every subsequent DB operation in the process blocks behind it.

## Why it looked like everything else

The sweep runs every 5 minutes, so the server went dark ~5 minutes after each restart. What stayed *working* is what made this so misleading:

- Static files: no DB → served fine (the web app loaded normally).
- Requests with an expired/invalid token: rejected during JWT validation *before* any DB access → instant 401s, fully logged.
- **Anything needing the DB — token refresh above all — hung forever with no log line**, because the access logger only writes after the handler returns.

Clients therefore saw `receive timeout` / "server unreachable" on refresh and looped 401s with valid, immortal sessions intact. It reproduced on iOS native and on web in Chrome and Safari simultaneously — which is exactly what sent the investigation into client transports (#354) rather than the server.

## Fix

Drain the instance rows and close the cursor before reporting. Audited the rest of the codebase for the same nested-DB-inside-an-open-cursor shape: no other occurrences.

## Verification

- New test `TestReportBookImportStallsDoesNotDeadlockTheSingleConnection` drives the reporter with a transactional sink under the real one-connection pool; **mutation-checked — it fails by timeout with the fix reverted**, passes with it applied.
- `go vet ./...`, `go test -race ./...` green.
- Post-deploy verification will deliberately run past two sweep cycles (>10 min), since anything shorter cannot distinguish fixed from broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TneZjV6WaCrWgC19dhXQ33