### PR TITLE
test(sonarr): pin the monitored season with nothing monitored in it

### DIFF
--- a/app/test/sonarr/series_detail_seasons_test.dart
+++ b/app/test/sonarr/series_detail_seasons_test.dart
@@ -285,6 +285,32 @@ void main() {
       expect(find.byTooltip('Stop monitoring'), findsOneWidget);
     });
 
+    testWidgets('a monitored season with every episode left out is half-filled',
+        (tester) async {
+      // The other way the flags come apart: monitoring a season cascades onto
+      // its episodes, but unmonitoring them one by one leaves the season flag
+      // alone. Nothing in it is being searched for now — yet the flag is what
+      // the next episode Sonarr discovers inherits, so this is not a season
+      // nobody is watching either.
+      await _pump(
+        tester,
+        _SeriesAdapter(episodes: [
+          for (var e = 1; e <= 8; e++)
+            _episodeJson(id: 2100 + e, season: 21, monitored: true),
+          for (var e = 1; e <= 13; e++)
+            _episodeJson(id: 2200 + e, season: 22, monitored: false),
+        ]),
+      );
+
+      expect(_fillOf(tester, 'Season 22'), MonitorFill.partial);
+      // The season flag is on, so the card is not dimmed.
+      expect(_opacitiesOf(tester, 'Season 22'), everyElement(1.0));
+      expect(
+        find.byTooltip('Stop monitoring — 13 episodes are unmonitored'),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('an unmonitored season is hollow and dimmed', (tester) async {
       await _pump(
         tester,


### PR DESCRIPTION
Follow-up to #357. The season bookmark's truth table had one corner with no test on it: **season flag on, every episode unmonitored.**

It's reachable, because the two flags only cascade one way — `PUT /series` with a flipped season flag pushes onto every episode in that season, while `PUT /episode/monitor` never touches the season record. Monitor a season, then unmonitor its episodes one at a time, and the flag stays on with nothing monitored under it.

That has to read half-filled, not hollow: the season flag is what newly-discovered episodes inherit on the next refresh, so the season is armed for whatever airs next even though nothing is being searched for right now.

## Verification

- No behavior change — `sonarr_series_detail_screen.dart` is untouched; the shipped rule already returns `partial` here.
- Mutation-checked: the test fails against the obvious simplification of the fill rule (dropping `&& !season.monitored` from the hollow test, so "no monitored episodes" means hollow on its own) and passes on the shipped one.
- `flutter analyze --no-fatal-infos` clean, `flutter test` 920 passing from `app/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJiXoZwmHQPUzg4A2spg2L