### PR TITLE
fix(remediation): keep the newer queue snapshot when timestamps tie

### DIFF
--- a/server/internal/remediation/autodispatch.go
+++ b/server/internal/remediation/autodispatch.go
@@ -69,17 +69,26 @@ func (a *AutoDispatcher) enqueueSnapshotJob(job queueSnapshotJob) {
 	// success and latest failure only, then preserve success -> failure when the
 	// failure actually happened later. This keeps the queue small without
 	// dropping newer evidence before the durable DB watermark can inspect it.
+	//
+	// candidates is ordered oldest-arrival first, and ties resolve to the LAST
+	// one (>= rather than >). Observation timestamps are stamped with
+	// time.Now().UTC(), and .UTC() strips Go's monotonic reading, so two reads
+	// inside one wall-clock tick compare equal — on a coarse platform clock that
+	// is entirely reachable. Preferring the earlier arrival there would throw
+	// away the newer snapshot, which is the exact recovery evidence this
+	// coalescer exists to keep. With no clock difference to go on, arrival order
+	// is the only ordering left.
 	candidates := append(append([]queueSnapshotJob(nil), a.pendingSnapshots[key]...), job)
 	var latestSuccess, latestFailure queueSnapshotJob
 	hasSuccess, hasFailure := false, false
 	for _, candidate := range candidates {
 		if candidate.failure == nil {
-			if !hasSuccess || candidate.observedAt.After(latestSuccess.observedAt) {
+			if !hasSuccess || !candidate.observedAt.Before(latestSuccess.observedAt) {
 				latestSuccess, hasSuccess = candidate, true
 			}
 			continue
 		}
-		if !hasFailure || candidate.observedAt.After(latestFailure.observedAt) {
+		if !hasFailure || !candidate.observedAt.Before(latestFailure.observedAt) {
 			latestFailure, hasFailure = candidate, true
 		}
 	}

--- a/server/internal/remediation/autodispatch_test.go
+++ b/server/internal/remediation/autodispatch_test.go
@@ -143,6 +143,34 @@ func TestDispatcherCoalescesToNewestCompleteSnapshotPerInstance(t *testing.T) {
 	}
 }
 
+// Two reads inside one wall-clock tick carry the SAME observedAt: snapshots are
+// stamped with time.Now().UTC(), and .UTC() strips Go's monotonic reading, so
+// the clock cannot separate them. The newer snapshot must still win — it is the
+// recovery evidence the coalescer exists to preserve. Frozen clock, because the
+// real one only produces this tie by luck.
+func TestDispatcherKeepsNewestSnapshotWhenTimestampsTie(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	dispatcher := NewAutoDispatcher(svc)
+	frozen := time.Date(2026, 8, 2, 4, 0, 0, 0, time.UTC)
+	dispatcher.now = func() time.Time { return frozen }
+
+	stale := observedProblem("old", 1, 100)
+	recovered := stale
+	recovered.DownloadID = "replacement"
+	recovered.Signal = arr.QueueSignal{Status: "downloading", TrackedDownloadStatus: "ok", Size: 100, SizeLeft: 75}
+	recovered.Diagnosis = arr.Diagnose(recovered.Signal)
+
+	dispatcher.ObserveQueueSnapshot("radarr", testRadarrInstanceID, []arr.QueueObservation{stale})
+	dispatcher.ObserveQueueSnapshot("radarr", testRadarrInstanceID, []arr.QueueObservation{recovered})
+
+	dispatcher.snapshotMu.Lock()
+	defer dispatcher.snapshotMu.Unlock()
+	pending := dispatcher.pendingSnapshots["radarr\x00"+testRadarrInstanceID]
+	if len(pending) != 1 || len(pending[0].items) != 1 || pending[0].items[0].DownloadID != "replacement" {
+		t.Fatalf("tied timestamps kept the stale snapshot: %+v", pending)
+	}
+}
+
 func TestDispatcherPreservesSuccessResetBeforeLatestFailure(t *testing.T) {
 	svc, _, _ := setupTestService(t)
 	dispatcher := NewAutoDispatcher(svc)


### PR DESCRIPTION
Found while running the remediation suite for unrelated work: `TestDispatcherCoalescesToNewestCompleteSnapshotPerInstance` fails roughly **1 run in 3** on `main`.

It isn't only a test problem. Snapshots are stamped `time.Now().UTC()`, and `.UTC()` strips Go's monotonic reading — so two queue reads landing inside one wall-clock tick compare exactly equal. `enqueueSnapshotJob` kept a candidate only on a *strictly later* `observedAt`, so a tie retained the **older** snapshot and discarded the newer one. That newer snapshot is the recovery/progress evidence the coalescer exists to preserve.

Ties now resolve to the later arrival. Observation time still wins whenever the clock can separate two reads; arrival order is only the fallback when it cannot — which is the same reasoning the existing comment already applies to out-of-order arrivals.

## Verification

`go vet ./...` and `go test ./...` green from `server/`. The flaky test now passes 12/12. The new test freezes the dispatcher clock so the tie is deterministic rather than a matter of luck, and is mutation-verified: reverting to the strict `After` comparison fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eu8Jm5i8mnwTmJdichjYQ7