### PR TITLE
fix(agents): make an empty read say whether it is absence or blindness

### DIFF
--- a/server/internal/mcp/absence.go
+++ b/server/internal/mcp/absence.go
@@ -1,0 +1,107 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A read tool that finds nothing has said one of two completely different
+// things: the thing is not there, or this tool could not see it. Rendered the
+// same way — "No TV history found." — they are indistinguishable, and a reader
+// that cannot tell them apart stops looking.
+//
+// That is not hypothetical. Issue #814 (a whole season of files imported before
+// the episodes aired) went undiagnosed because three reads came back empty and
+// were believed: history was filtering a page of recent GLOBAL events for a
+// title whose last event was two weeks old, and the queue was empty because the
+// download had finished — which is the expected state for every complaint about
+// CONTENT, not evidence of anything. The agent had no way to know either.
+//
+// So every empty result in this package should answer two questions: what was
+// actually searched, and what an empty answer does and does not rule out.
+
+// searchedScope renders what a scoped read looked at, in the caller's own terms.
+// Empty when the read was not narrowed to anything.
+func (s mediaReadScope) searchedScope() string {
+	switch {
+	case s.QueueID > 0:
+		return fmt.Sprintf("queue item %d", s.QueueID)
+	case s.BookID > 0:
+		return "this book"
+	case s.AuthorID > 0:
+		return "this author"
+	case s.EpisodeNumber > 0:
+		return fmt.Sprintf("season %d episode %d of this series", s.SeasonNumber, s.EpisodeNumber)
+	case s.SeasonNumber > 0:
+		return fmt.Sprintf("season %d of this series", s.SeasonNumber)
+	case s.hasTitleIdentity():
+		return "this title"
+	default:
+		return ""
+	}
+}
+
+// noHistoryText explains an empty history read.
+//
+// perTitle distinguishes the two cases that matter. A per-title read asked the
+// service for that title's own records, so empty means the service genuinely has
+// none — there is no older event hiding behind a page boundary. A global read is
+// a window on recent activity across the whole library, and an older event for
+// one title simply would not appear in it. Reporting both as "no history found"
+// is what made a two-week-old import invisible.
+func noHistoryText(mediaLabel string, scope mediaReadScope, perTitle bool, fetchLimit int) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "No %s history found", mediaLabel)
+	searched := scope.searchedScope()
+	if searched != "" {
+		fmt.Fprintf(&sb, " for %s", searched)
+	}
+	sb.WriteString(".")
+	switch {
+	case perTitle:
+		sb.WriteString(" This read asked the service for that title's own history rather than a slice of recent activity, so there is no older event to find: the service has no grab, import, or failure recorded for it.")
+	case searched != "":
+		fmt.Fprintf(&sb, " NOTE: the title could not be resolved in the library, so this fell back to the most recent %d events across the WHOLE library and filtered them. An older event for it would not appear here — an empty answer does not mean it has no history.", fetchLimit)
+	default:
+		fmt.Fprintf(&sb, " This is the most recent %d events across the whole library; anything older is outside this window.", fetchLimit)
+	}
+	return sb.String()
+}
+
+// emptyQueueText explains an empty queue read.
+//
+// The second sentence is the one that matters, and it only appears on a scoped
+// read because that is an issue investigation. An empty queue is the EXPECTED
+// state for any complaint about content — the download finished and imported,
+// possibly weeks ago — so reading it as "nothing is wrong" is exactly backwards.
+func emptyQueueText(label string, scope mediaReadScope) string {
+	searched := scope.searchedScope()
+	if searched == "" {
+		return label + ": empty — nothing is downloading."
+	}
+	return fmt.Sprintf("%s: empty — nothing for %s is downloading right now. "+
+		"That says nothing about the files already in the library: a download that finished and imported leaves the queue, "+
+		"so a complaint about wrong or bad content is EXPECTED to show an empty queue. Look at the library and the history instead.",
+		label, searched)
+}
+
+// noQueueProblemsText explains an Import Doctor pass that flagged nothing.
+//
+// Same trap in its strongest form: the Doctor only ever classifies queue rows,
+// so "no queue problems" is a statement about downloads in flight and about
+// nothing else at all. An empty queue makes it vacuous rather than reassuring.
+func noQueueProblemsText(healthy int, scope mediaReadScope) string {
+	var sb strings.Builder
+	sb.WriteString("Import Doctor: no queue problems found.")
+	if healthy > 0 {
+		fmt.Fprintf(&sb, " %d item(s) are downloading or importing normally.", healthy)
+		return sb.String()
+	}
+	if searched := scope.searchedScope(); searched != "" {
+		fmt.Fprintf(&sb, " Nothing for %s is in the queue at all, so there was nothing to diagnose. "+
+			"The Doctor reads downloads in flight and only those — it cannot see a problem with a file that already imported.", searched)
+		return sb.String()
+	}
+	sb.WriteString(" The queue is empty, so there was nothing to diagnose; the Doctor reads downloads in flight and only those.")
+	return sb.String()
+}

--- a/server/internal/mcp/absence_test.go
+++ b/server/internal/mcp/absence_test.go
@@ -1,0 +1,115 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+)
+
+// The distinction these tests defend: an empty read must say whether the thing
+// is absent or whether the tool could not see it. Issue #814 was misdiagnosed
+// because "No TV history found." meant the second and read like the first.
+
+func TestNoHistoryTextSeparatesAbsenceFromBlindness(t *testing.T) {
+	scoped := mediaReadScope{TmdbID: 615, TvdbID: 73871, SeasonNumber: 11}
+
+	perTitle := noHistoryText("TV", scoped, true, 100)
+	if !strings.Contains(perTitle, "season 11 of this series") {
+		t.Errorf("per-title text does not name what was searched: %q", perTitle)
+	}
+	if !strings.Contains(perTitle, "no older event to find") {
+		t.Errorf("per-title text does not rule out an older event: %q", perTitle)
+	}
+	if strings.Contains(perTitle, "whole library") {
+		t.Errorf("per-title text describes a global window: %q", perTitle)
+	}
+
+	// The fallback is the #814 shape exactly: a scoped question answered from a
+	// global window. It has to admit that.
+	fellBack := noHistoryText("TV", scoped, false, 100)
+	if !strings.Contains(fellBack, "fell back") || !strings.Contains(fellBack, "100") {
+		t.Errorf("fallback text hides that it read a global window: %q", fellBack)
+	}
+	if !strings.Contains(fellBack, "does not mean it has no history") {
+		t.Errorf("fallback text does not warn the answer is inconclusive: %q", fellBack)
+	}
+	if perTitle == fellBack {
+		t.Error("a per-title miss and a global-window miss read identically")
+	}
+
+	unscoped := noHistoryText("TV", mediaReadScope{}, false, 20)
+	if strings.Contains(unscoped, "fell back") {
+		t.Errorf("an unscoped read claims to have fallen back: %q", unscoped)
+	}
+	if !strings.Contains(unscoped, "20") || !strings.Contains(unscoped, "outside this window") {
+		t.Errorf("unscoped text does not bound its window: %q", unscoped)
+	}
+}
+
+func TestEmptyQueueTextWarnsOnlyWhenInvestigating(t *testing.T) {
+	// A scoped read is an issue investigation, and there the empty queue is the
+	// EXPECTED state for a content complaint — the single inference that broke
+	// #814.
+	scoped := emptyQueueText("TV queue", mediaReadScope{TmdbID: 615, SeasonNumber: 11})
+	if !strings.Contains(scoped, "season 11 of this series") {
+		t.Errorf("scoped text does not name what was searched: %q", scoped)
+	}
+	for _, want := range []string{"already in the library", "EXPECTED", "history"} {
+		if !strings.Contains(scoped, want) {
+			t.Errorf("scoped text missing %q: %q", want, scoped)
+		}
+	}
+
+	// An admin browsing the whole queue is not investigating anything, and does
+	// not need the lecture.
+	unscoped := emptyQueueText("TV queue", mediaReadScope{})
+	if strings.Contains(unscoped, "EXPECTED") {
+		t.Errorf("unscoped text carries investigation guidance: %q", unscoped)
+	}
+	if !strings.Contains(unscoped, "nothing is downloading") {
+		t.Errorf("unscoped text = %q", unscoped)
+	}
+}
+
+func TestNoQueueProblemsTextSaysWhatTheDoctorCannotSee(t *testing.T) {
+	// Healthy items in flight: the Doctor really did look at something.
+	withWork := noQueueProblemsText(3, mediaReadScope{TmdbID: 615})
+	if !strings.Contains(withWork, "3 item(s)") {
+		t.Errorf("healthy count lost: %q", withWork)
+	}
+	if strings.Contains(withWork, "nothing to diagnose") {
+		t.Errorf("a queue with work in it claimed there was nothing to diagnose: %q", withWork)
+	}
+
+	// Nothing in the queue at all: "no problems found" is vacuous, and saying so
+	// is the difference between an agent that stops and one that keeps looking.
+	empty := noQueueProblemsText(0, mediaReadScope{TmdbID: 615, SeasonNumber: 11})
+	if !strings.Contains(empty, "nothing to diagnose") {
+		t.Errorf("empty-queue pass did not say it diagnosed nothing: %q", empty)
+	}
+	if !strings.Contains(empty, "already imported") {
+		t.Errorf("empty-queue pass did not name what it cannot see: %q", empty)
+	}
+	if empty == withWork {
+		t.Error("a queue with healthy work and an empty queue read identically")
+	}
+}
+
+func TestSearchedScopeNarrowsToTheMostExactThingKnown(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		scope mediaReadScope
+		want  string
+	}{
+		{"queue id wins", mediaReadScope{QueueID: 41, TmdbID: 615, SeasonNumber: 11}, "queue item 41"},
+		{"episode", mediaReadScope{TmdbID: 615, SeasonNumber: 11, EpisodeNumber: 3}, "season 11 episode 3 of this series"},
+		{"season", mediaReadScope{TmdbID: 615, SeasonNumber: 11}, "season 11 of this series"},
+		{"title only", mediaReadScope{TmdbID: 615}, "this title"},
+		{"book", mediaReadScope{BookID: 9}, "this book"},
+		{"author", mediaReadScope{AuthorID: 4}, "this author"},
+		{"nothing", mediaReadScope{}, ""},
+	} {
+		if got := tc.scope.searchedScope(); got != tc.want {
+			t.Errorf("%s: searchedScope() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/server/internal/mcp/arr_tools.go
+++ b/server/internal/mcp/arr_tools.go
@@ -631,7 +631,7 @@ func (s *ToolServer) getQueue(input json.RawMessage, instanceID string) (*ToolRe
 				return nil, err
 			}
 			if len(items) == 0 {
-				sections = append(sections, "Movie queue: empty.")
+				sections = append(sections, emptyQueueText("Movie queue", scope))
 			} else {
 				matchedTargets += len(items)
 				shown := items
@@ -664,7 +664,7 @@ func (s *ToolServer) getQueue(input json.RawMessage, instanceID string) (*ToolRe
 				return nil, err
 			}
 			if len(items) == 0 {
-				sections = append(sections, "TV queue: empty.")
+				sections = append(sections, emptyQueueText("TV queue", scope))
 			} else {
 				matchedTargets += len(items)
 				shown := items
@@ -694,7 +694,7 @@ func (s *ToolServer) getQueue(input json.RawMessage, instanceID string) (*ToolRe
 			}
 			items = filterChaptarrQueue(items, scope)
 			if len(items) == 0 {
-				sections = append(sections, "Book queue: empty.")
+				sections = append(sections, emptyQueueText("Book queue", scope))
 			} else {
 				matchedTargets += len(items)
 				shown := items
@@ -1181,7 +1181,7 @@ func (s *ToolServer) getHistory(input json.RawMessage, instanceID string) (*Tool
 		if radarrClient == nil {
 			return &ToolResult{Text: "Radarr is not configured."}, nil
 		}
-		records, err := scopedRadarrHistory(radarrClient, scope, fetchLimit)
+		records, perTitle, err := scopedRadarrHistory(radarrClient, scope, fetchLimit)
 		if err != nil {
 			return nil, err
 		}
@@ -1193,7 +1193,7 @@ func (s *ToolServer) getHistory(input json.RawMessage, instanceID string) (*Tool
 			records = records[:limit]
 		}
 		if len(records) == 0 {
-			return &ToolResult{Text: "No movie history found."}, nil
+			return &ToolResult{Text: noHistoryText("movie", scope, perTitle, fetchLimit)}, nil
 		}
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "Recent movie history (%d records):", len(records))
@@ -1216,7 +1216,7 @@ func (s *ToolServer) getHistory(input json.RawMessage, instanceID string) (*Tool
 		if sonarrClient == nil {
 			return &ToolResult{Text: "Sonarr is not configured."}, nil
 		}
-		records, err := scopedSonarrHistory(s.bridge, sonarrClient, scope, fetchLimit)
+		records, perTitle, err := scopedSonarrHistory(s.bridge, sonarrClient, scope, fetchLimit)
 		if err != nil {
 			return nil, err
 		}
@@ -1228,7 +1228,7 @@ func (s *ToolServer) getHistory(input json.RawMessage, instanceID string) (*Tool
 			records = records[:limit]
 		}
 		if len(records) == 0 {
-			return &ToolResult{Text: "No TV history found."}, nil
+			return &ToolResult{Text: noHistoryText("TV", scope, perTitle, fetchLimit)}, nil
 		}
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "Recent TV history (%d records):", len(records))
@@ -1266,7 +1266,7 @@ func (s *ToolServer) getHistory(input json.RawMessage, instanceID string) (*Tool
 			records = records[:limit]
 		}
 		if len(records) == 0 {
-			return &ToolResult{Text: "No book history found."}, nil
+			return &ToolResult{Text: noHistoryText("book", scope, false, fetchLimit)}, nil
 		}
 		var sb strings.Builder
 		fmt.Fprintf(&sb, "Recent book history (%d records):", len(records))

--- a/server/internal/mcp/import_doctor.go
+++ b/server/internal/mcp/import_doctor.go
@@ -419,10 +419,7 @@ func (s *ToolServer) diagnoseQueue(input json.RawMessage, instanceID string) (*T
 
 	var header strings.Builder
 	if problems == 0 {
-		header.WriteString("Import Doctor: no queue problems found.")
-		if healthy > 0 {
-			fmt.Fprintf(&header, " %d item(s) are downloading or importing normally.", healthy)
-		}
+		header.WriteString(noQueueProblemsText(healthy, scope))
 	} else {
 		fmt.Fprintf(&header, "Import Doctor found %d queue item(s) needing attention", problems)
 		if healthy > 0 {

--- a/server/internal/mcp/media_scope.go
+++ b/server/internal/mcp/media_scope.go
@@ -196,14 +196,18 @@ func filterChaptarrHistory(records []chaptarr.HistoryRecord, scope mediaReadScop
 // endpoint has no such window.
 //
 // A resolution failure is never fatal: an unresolvable series just falls back to
-// the global page, which is exactly the behaviour that existed before.
-func scopedSonarrHistory(bridge *tmdb.Bridge, client *sonarr.Client, scope mediaReadScope, fetchLimit int) ([]sonarr.HistoryRecord, error) {
+// the global page, which is exactly the behaviour that existed before. The
+// returned perTitle flag reports which of the two happened, because an empty
+// result means opposite things in each case — see noHistoryText.
+func scopedSonarrHistory(bridge *tmdb.Bridge, client *sonarr.Client, scope mediaReadScope, fetchLimit int) (records []sonarr.HistoryRecord, perTitle bool, err error) {
 	if scope.hasTitleIdentity() {
 		if series := resolveScopedSeries(bridge, client, scope); series != nil {
-			return client.GetSeriesHistory(series.ID, scope.SeasonNumber, fetchLimit)
+			records, err = client.GetSeriesHistory(series.ID, scope.SeasonNumber, fetchLimit)
+			return records, err == nil, err
 		}
 	}
-	return client.GetHistory(fetchLimit)
+	records, err = client.GetHistory(fetchLimit)
+	return records, false, err
 }
 
 // resolveScopedSeries turns the scope's TVDB/TMDB identity into the series
@@ -222,14 +226,17 @@ func resolveScopedSeries(bridge *tmdb.Bridge, client *sonarr.Client, scope media
 	return nil
 }
 
-// scopedRadarrHistory is the movie half of scopedSonarrHistory.
-func scopedRadarrHistory(client *radarr.Client, scope mediaReadScope, fetchLimit int) ([]radarr.HistoryRecord, error) {
+// scopedRadarrHistory is the movie half of scopedSonarrHistory, including its
+// perTitle report.
+func scopedRadarrHistory(client *radarr.Client, scope mediaReadScope, fetchLimit int) (records []radarr.HistoryRecord, perTitle bool, err error) {
 	if scope.TmdbID > 0 {
 		if movie, err := client.GetMovieByTMDB(scope.TmdbID); err == nil && movie != nil {
-			return client.GetMovieHistory(movie.ID, fetchLimit)
+			records, err = client.GetMovieHistory(movie.ID, fetchLimit)
+			return records, err == nil, err
 		}
 	}
-	return client.GetHistory(fetchLimit)
+	records, err = client.GetHistory(fetchLimit)
+	return records, false, err
 }
 
 func filterRadarrHistory(client *radarr.Client, records []radarr.HistoryRecord, scope mediaReadScope) ([]radarr.HistoryRecord, error) {

--- a/server/internal/mcp/media_scope_test.go
+++ b/server/internal/mcp/media_scope_test.go
@@ -263,7 +263,7 @@ func TestScopedSonarrHistoryFallsBackWhenTheSeriesCannotBeResolved(t *testing.T)
 	}
 	arrServer := fake.start()
 
-	records, err := scopedSonarrHistory(nil, sonarr.NewClient(arrServer.URL, "key"),
+	records, _, err := scopedSonarrHistory(nil, sonarr.NewClient(arrServer.URL, "key"),
 		mediaReadScope{TmdbID: 615, SeasonNumber: 11}, 100)
 	if err != nil {
 		t.Fatalf("an unresolvable series must not fail the read: %v", err)
@@ -284,7 +284,7 @@ func TestScopedSonarrHistoryPrefersTVDBOverTheTMDBBridge(t *testing.T) {
 	fake := &sonarrFileFake{t: t, series: futuramaSeries(), history: futuramaSeriesHistory()}
 	arrServer := fake.start()
 
-	records, err := scopedSonarrHistory(nil, sonarr.NewClient(arrServer.URL, "key"),
+	records, _, err := scopedSonarrHistory(nil, sonarr.NewClient(arrServer.URL, "key"),
 		mediaReadScope{TmdbID: 615, TvdbID: 73871, SeasonNumber: 11}, 100)
 	if err != nil {
 		t.Fatalf("scopedSonarrHistory: %v", err)
@@ -445,7 +445,7 @@ func TestScopedRadarrHistoryFallsBackWhenTheMovieCannotBeResolved(t *testing.T) 
 	}
 	arrServer := fake.start()
 
-	records, err := scopedRadarrHistory(radarr.NewClient(arrServer.URL, "key"), mediaReadScope{TmdbID: 550}, 100)
+	records, _, err := scopedRadarrHistory(radarr.NewClient(arrServer.URL, "key"), mediaReadScope{TmdbID: 550}, 100)
 	if err != nil {
 		t.Fatalf("an unresolvable movie must not fail the read: %v", err)
 	}

--- a/server/internal/mcp/tool_execution_test.go
+++ b/server/internal/mcp/tool_execution_test.go
@@ -1178,7 +1178,12 @@ func TestGetQueueRendersProgressErrorsAndExactScopeVerification(t *testing.T) {
 	if err != nil {
 		t.Fatalf("absent-target get_queue: %v", err)
 	}
-	if !strings.Contains(result.Text, "Movie queue: empty.") {
+	// Empty, and explicit about what that does and does not rule out: the
+	// typed Verification below is the machine answer, this is the one the
+	// model reads.
+	if !strings.Contains(result.Text, "Movie queue: empty") ||
+		!strings.Contains(result.Text, "queue item 41") ||
+		!strings.Contains(result.Text, "already in the library") {
 		t.Fatalf("absent-target render = %q", result.Text)
 	}
 	if result.Verification == nil || !result.Verification.ExactScope || result.Verification.TargetPresent {


### PR DESCRIPTION
First of four agent-quality changes. This one is the general form of what actually broke #814.

A read tool that finds nothing has said one of two completely different things: **the thing is not there**, or **this tool could not see it**. Rendered identically — `No TV history found.` — they are indistinguishable, and a reader that cannot tell them apart stops looking.

In #814 the agent made three reasonable reads, got three empty answers, and gave up *correctly* on false information:

| read | what it said | what was true |
|---|---|---|
| `get_history` | "No TV history found." | it filtered a page of recent **global** events for a title whose last event was two weeks old |
| `get_queue` | "TV queue: empty." | the download finished and imported — the expected state for any content complaint |
| `diagnose_queue` | "no queue problems found" | the queue was empty, so it diagnosed nothing at all |

Every one of those is now explicit about what was searched and what an empty answer does and does not rule out.

- **`get_history`** separates a per-title read (the service genuinely has no record — there is no older event behind a page boundary) from a fallback to the global window (an older event would not appear, so empty proves nothing). `scopedSonarrHistory` / `scopedRadarrHistory` now report which they did, so the message can't lie about it.
- **`get_queue`**, when scoped to a title, says a download that finished and imported has left the queue, so a content complaint is *expected* to show an empty one, and points at the library and history instead. An unscoped admin read gets none of that lecture.
- **`diagnose_queue`** finding no problems in an *empty* queue says so, and names its own blind spot: it reads downloads in flight and only those.

New `internal/mcp/absence.go` holds the vocabulary, with the reasoning and the #814 reference in the file header so the next person adding a read tool inherits the rule rather than rediscovering it.

## Verification

`go vet ./...`, `go test -race ./...`. Three mutations — the per-title branch disabled, the scoped/unscoped inversion, and the empty-queue note suppressed — each confirmed failing its specific test before restore. One existing assertion updated from an exact-string match to the facts it was actually protecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdcqzKjASUWWW9bMYi9GDR