### PR TITLE
fix(push): stop every server condition announcing itself as a shared-AI failure

### DIFF
--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -217,9 +217,21 @@ func issueAlertText(source string, count int) (title, body string) {
 		return "Problem needs attention",
 			"Cantinarr found a media problem that did not recover automatically"
 	case "system":
-		// Shared-AI health is a single server-wide condition; it never batches.
-		return "Shared AI needs attention",
-			"Cantinarr's shared AI model failed its daily response test"
+		// A system issue is a condition on the SERVER rather than on a piece of
+		// media, and there are several distinct ones: the shared AI model, push
+		// delivery, a stalled book-metadata import. This copy was written when
+		// shared-AI health was the only one and named it outright, which has been
+		// wrong on the lock screen for every other kind ever since — and there is
+		// nothing safe to say more specifically, because the only fields that
+		// would distinguish them are the issue's own untrusted title and detail.
+		// So it stays deliberately generic, and counted like the auto branch: two
+		// server conditions clearing the hold-down together really do coalesce.
+		if count > 1 {
+			return "Cantinarr needs attention",
+				fmt.Sprintf("%d server conditions need an administrator", count)
+		}
+		return "Cantinarr needs attention",
+			"Something on the server needs an administrator"
 	default:
 		if count > 1 {
 			return "New problems reported",

--- a/server/internal/push/notifier_test.go
+++ b/server/internal/push/notifier_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -351,6 +352,73 @@ func TestNotifyAdminsUsesAutomaticIssueCopy(t *testing.T) {
 	}
 }
 
+// A system issue is a condition on the server, and there are several distinct
+// ones. This copy used to name shared-AI health outright, which was wrong on
+// every push-delivery and book-import-stall alert it ever sent. It must stay
+// generic: the only fields that could tell them apart are the issue's own
+// untrusted title and detail, which never reach a lock screen.
+func TestNotifyAdminsUsesGenericSystemIssueCopy(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'admin1', '', 'admin')")
+
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
+
+	n.NotifyAdmins("issue_created", map[string]interface{}{
+		"issue_id":   7,
+		"source":     "system",
+		"open_count": 1,
+	})
+
+	body := cap.waitForNotification(t)
+	notif, _ := body["notification"].(map[string]any)
+	if notif["title"] != "Cantinarr needs attention" {
+		t.Errorf("title = %v, want generic server-condition copy", notif["title"])
+	}
+	text, _ := notif["body"].(string)
+	if text != "Something on the server needs an administrator" {
+		t.Errorf("body = %v, want generic server-condition copy", text)
+	}
+	// The specific regression: a push-delivery or book-import issue must never
+	// announce itself as a shared-AI failure.
+	if strings.Contains(strings.ToLower(text), "ai") {
+		t.Errorf("system copy still names one particular condition: %q", text)
+	}
+}
+
+// Two server conditions clearing the hold-down on the same tick really do
+// coalesce, so the system branch has to carry the count the way the auto branch
+// does. It used to discard it and send the singular shared-AI line twice over.
+func TestNotifyAdminsCoalescesSystemConditions(t *testing.T) {
+	database, err := dbOpen(t)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'admin1', '', 'admin')")
+
+	mgr, cap := newNotifierTestGateway(t, database)
+	n := NewNotifier(database, mgr, nil)
+
+	n.NotifyAdmins("issue_created", map[string]interface{}{
+		"source":     "system",
+		"count":      2,
+		"open_count": 2,
+	})
+
+	body := cap.waitForNotification(t)
+	notif, _ := body["notification"].(map[string]any)
+	if notif["body"] != "2 server conditions need an administrator" {
+		t.Errorf("body = %v, want the counted system copy", notif["body"])
+	}
+	opts, _ := body["options"].(map[string]any)
+	if opts["collapse_id"] != "issue_created:system" {
+		t.Errorf("collapse_id = %v, want a per-source summary collapse", opts["collapse_id"])
+	}
+}
+
 // A batch cause produces one incident per exact media scope, so a coalesced
 // alert has to say how many rather than fan out one identical line per episode.
 // It also collapses by source: the summary is a state, and a later summary
@@ -476,30 +544,6 @@ func TestNotifyAdminsKeepsSingleApprovalPushUncollapsed(t *testing.T) {
 	opts, _ := body["options"].(map[string]any)
 	if _, ok := opts["collapse_id"]; ok {
 		t.Errorf("single approval push collapsed: %v", opts["collapse_id"])
-	}
-}
-
-func TestNotifyAdminsUsesSharedAIHealthIssueCopy(t *testing.T) {
-	database, err := dbOpen(t)
-	if err != nil {
-		t.Fatalf("open db: %v", err)
-	}
-	mustExec(t, database, "INSERT INTO users (id, username, password_hash, role) VALUES (1, 'admin1', '', 'admin')")
-
-	mgr, capture := newNotifierTestGateway(t, database)
-	notifier := NewNotifier(database, mgr, nil)
-	notifier.NotifyAdmins("issue_created", map[string]interface{}{
-		"issue_id": 51,
-		"source":   "system",
-	})
-
-	body := capture.waitForNotification(t)
-	notification, _ := body["notification"].(map[string]any)
-	if notification["title"] != "Shared AI needs attention" {
-		t.Fatalf("title=%v", notification["title"])
-	}
-	if notification["body"] != "Cantinarr's shared AI model failed its daily response test" {
-		t.Fatalf("body=%v", notification["body"])
 	}
 }
 


### PR DESCRIPTION
Groundwork for prevention notices, but a shipped bug on its own.

`issueAlertText`'s `"system"` branch (`push/notifier.go:219`) was written when shared-AI health was the only `source='system'` issue, and it names that condition outright:

```go
case "system":
    // Shared-AI health is a single server-wide condition; it never batches.
    return "Shared AI needs attention",
        "Cantinarr's shared AI model failed its daily response test"
```

Push delivery failing (`push_health.go:108`) and a stalled book-metadata import (`book_import_health.go:107`) have both been sending that exact text to a lock screen ever since. And the comment is wrong twice over — system issues *do* batch: two clearing the alert hold-down on the same tick coalesce into `notifyIssueBatch("system", 2)`, whose count this branch discarded, so an admin got the singular shared-AI line for a wave of unrelated conditions.

There is nothing safe to say more specifically. The only fields that would distinguish these conditions are the issue's own `title` and `detail`, which are untrusted and deliberately never reach a lock screen. So the copy stays generic and gains the count, matching the shape the `auto` branch already uses:

- one — *"Cantinarr needs attention" / "Something on the server needs an administrator"*
- many — *"%d server conditions need an administrator"*, with the same per-source `collapse_id` so a later summary replaces the previous one instead of stacking

`TestNotifyAdminsUsesSharedAIHealthIssueCopy` is deleted rather than adjusted — it asserted the bug. Two tests replace it: one pinning the generic singular copy (including that it never names one particular condition), one pinning the coalesced count and collapse id.

## Verification

`go vet ./...`, `go test -race ./...`. Two mutations — restoring the old shared-AI copy, and removing the count branch — each confirmed failing its specific test before restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UdcqzKjASUWWW9bMYi9GDR