### PR TITLE
fix(agents): auto-detected pre-air issues never reached the agent

### DIFF
--- a/server/internal/remediation/observation.go
+++ b/server/internal/remediation/observation.go
@@ -1944,6 +1944,22 @@ func (s *Service) probeArrRecovery(issue *Issue) (arrRecoveryProbe, error) {
 	if serviceType != "radarr" && serviceType != "sonarr" && serviceType != "chaptarr" {
 		return arrRecoveryProbe{}, nil
 	}
+	// A pre-air season issue is not a queue incident: it deliberately has no
+	// issue_observations row, its season scope has no queue-shaped key, and
+	// recovery for this class means "no unaired episode holds a file" — never
+	// "the queue settled". Route it to its own proof; the queue-shaped flow
+	// below would misread the missing observation row as a hard error and park
+	// the issue for an admin before the agent ever ran. Gated on SourceAuto so a
+	// future problem-labelled user report keeps the never-machine-close rule.
+	if issue.Source == SourceAuto && serviceType == "sonarr" {
+		kind, err := s.storedProblemKind(issue.ID)
+		if err != nil {
+			return arrRecoveryProbe{}, err
+		}
+		if kind == arr.ProblemPreAirSeasonFill {
+			return s.probePreAirRecovery(issue)
+		}
+	}
 	now := time.Now().UTC() // request-start ordering; delayed reads remain stale.
 	items, err := s.fetchQueueSnapshot(serviceType, issue.InstanceID)
 	if err != nil {
@@ -1987,6 +2003,15 @@ func (s *Service) probeArrRecovery(issue *Issue) (arrRecoveryProbe, error) {
 	}
 	if len(matched) == 0 {
 		settled, err := s.queueAbsenceSettled(issue.ID, now)
+		if errors.Is(err, sql.ErrNoRows) {
+			// No observation row exists for this issue — nothing ever created
+			// one, so there is no absence timer to advance and nothing here can
+			// prove recovery. Report "no recovery detected" rather than failing
+			// the preflight: the runner's conclusion gate still holds its own
+			// proofs, and parking a never-observed issue over a missing timer
+			// row is how a whole incident class silently loses its agent.
+			return arrRecoveryProbe{}, nil
+		}
 		if err != nil {
 			return arrRecoveryProbe{}, err
 		}
@@ -2082,6 +2107,15 @@ func (s *Service) preflightArrRecovery(issueID int64) (bool, error) {
 	}
 	serviceType := mediaServiceType(issue.MediaType)
 	probe, err := s.probeArrRecovery(issue)
+	if errors.Is(err, errStaleObservation) {
+		// A fresher complete snapshot committed between this probe's queue fetch
+		// and its store; the stale read proves nothing about the present. Defer
+		// exactly like live recovery — report "the arr still owns this attempt"
+		// without touching any state — so the next enqueue or sweep retries
+		// against current data instead of parking a healthy issue for an admin
+		// over a pure timing artifact.
+		return true, nil
+	}
 	if err != nil {
 		return false, err
 	}

--- a/server/internal/remediation/pre_air_health.go
+++ b/server/internal/remediation/pre_air_health.go
@@ -246,14 +246,11 @@ func (s *Service) preAirRepairProven(issue *Issue) (bool, error) {
 	if issue == nil || issue.MediaType != "tv" || issue.SeasonNumber < 0 || issue.InstanceID == "" {
 		return false, nil
 	}
-	// problem_kind is read straight from the row rather than carried on Issue:
-	// it is server-authored, it is not part of the client contract, and the one
-	// consumer is this gate.
-	var problemKind sql.NullString
-	if err := s.db.QueryRow("SELECT problem_kind FROM issues WHERE id = ?", issue.ID).Scan(&problemKind); err != nil {
-		return false, fmt.Errorf("read problem kind: %w", err)
+	problemKind, err := s.storedProblemKind(issue.ID)
+	if err != nil {
+		return false, err
 	}
-	if problemKind.String != arr.ProblemPreAirSeasonFill {
+	if problemKind != arr.ProblemPreAirSeasonFill {
 		return false, nil
 	}
 	if s.registry == nil {
@@ -275,6 +272,35 @@ func (s *Service) preAirRepairProven(issue *Issue) (bool, error) {
 	// impossible file left behind would read as repaired. Nothing that has not
 	// aired may still hold a file.
 	return len(timeline.UnairedWithFile) == 0, nil
+}
+
+// storedProblemKind reads the server-authored detector label straight from the
+// issue row. Deliberately not carried on Issue: it is not part of the client
+// contract, and its consumers are server-side gates (this class's recovery
+// proof and the recovery preflight's class routing).
+func (s *Service) storedProblemKind(issueID int64) (string, error) {
+	var kind sql.NullString
+	if err := s.db.QueryRow("SELECT problem_kind FROM issues WHERE id = ?", issueID).Scan(&kind); err != nil {
+		return "", fmt.Errorf("read problem kind: %w", err)
+	}
+	return kind.String, nil
+}
+
+// probePreAirRecovery is the recovery preflight for the pre-air season class,
+// standing in for the queue-shaped probe that fits every other auto incident.
+// completed carries the queue probe's exact meaning — the incident's own
+// recovery proof holds, so pending work is cancelled or the issue closed
+// instead of dispatching over an already-repaired season. An unreadable season
+// fails closed like every other preflight read: no proof, no conclusion.
+func (s *Service) probePreAirRecovery(issue *Issue) (arrRecoveryProbe, error) {
+	proven, err := s.preAirRepairProven(issue)
+	if err != nil {
+		return arrRecoveryProbe{}, err
+	}
+	if proven {
+		return arrRecoveryProbe{completed: true}, nil
+	}
+	return arrRecoveryProbe{}, nil
 }
 
 // --- fallback for instances whose webhook was never configured ---

--- a/server/internal/remediation/pre_air_preflight_test.go
+++ b/server/internal/remediation/pre_air_preflight_test.go
@@ -1,0 +1,154 @@
+package remediation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/ai"
+	"github.com/windoze95/cantinarr-server/internal/mcp"
+)
+
+// A webhook-opened pre-air issue is the first auto incident that is not born
+// from a queue row: it deliberately has no issue_observations row and recovers
+// by its own season proof. These tests pin the recovery preflight's behavior
+// for that shape with the REAL probe path — no recoveryProbe stub — because the
+// stub is exactly the seam that let the original defect ship: every runner test
+// bypassed probeArrRecovery, so nothing noticed that the queue-shaped preflight
+// read the missing observation row as a hard error and parked the issue at
+// needs_admin before the agent ever ran.
+
+// preAirRunner builds a Runner over the pre-air fixture service (real registry,
+// fake Sonarr, feature enabled) with scripted turns and the shared fake tool
+// host. The Service's recoveryProbe stays nil on purpose.
+func preAirRunner(t *testing.T, svc *Service, script *scriptedTurn) *Runner {
+	t.Helper()
+	if _, err := svc.SetSettings(Settings{
+		Enabled: true, Mode: ModeSupervised,
+		MaxSteps: 12, MaxTurnTokens: 1024, MaxWallClockSecs: 30, DailyRunCap: 50,
+	}); err != nil {
+		t.Fatalf("set settings: %v", err)
+	}
+	return &Runner{
+		db:         svc.db,
+		svc:        svc,
+		toolServer: &fakeToolHost{},
+		turns:      scriptedTurnResolver(script),
+		procToken:  "test",
+	}
+}
+
+func agentRunRows(t *testing.T, svc *Service, issueID int64) (count int, lastStatus string) {
+	t.Helper()
+	rows, err := svc.db.Query("SELECT status FROM agent_runs WHERE issue_id = ? ORDER BY id", issueID)
+	if err != nil {
+		t.Fatalf("query agent_runs: %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		count++
+		if err := rows.Scan(&lastStatus); err != nil {
+			t.Fatalf("scan agent_runs: %v", err)
+		}
+	}
+	return count, lastStatus
+}
+
+// TestRunnerRunsWebhookOpenedPreAirIssue is the defect regression: the season
+// is still impossible, so the preflight must let the investigation start and
+// the run must park awaiting approval — never needs_admin with no run at all.
+func TestRunnerRunsWebhookOpenedPreAirIssue(t *testing.T) {
+	svc, _, _ := setupPreAirService(t)
+	if err := svc.recordPreAirSeason(preAirSonarrID, 73871, 615, 11, "Futurama"); err != nil {
+		t.Fatalf("record pre-air season: %v", err)
+	}
+	issue := soleIssue(t, svc)
+	if issue.Status != IssueOpen {
+		t.Fatalf("seed issue status = %q, want %q", issue.Status, IssueOpen)
+	}
+
+	script := &scriptedTurn{turns: []ai.TranscriptMessage{{
+		Role:    ai.RoleAssistant,
+		Content: []ai.TranscriptBlock{toolUse("p1", mcp.ToolProposeAction)},
+	}}}
+	r := preAirRunner(t, svc, script)
+
+	if err := r.Run(context.Background(), issue.ID); err != nil {
+		t.Fatalf("Run over a live pre-air issue: %v", err)
+	}
+
+	after := soleIssue(t, svc)
+	if after.Status != IssueAwaitingApproval {
+		t.Fatalf("issue status after run = %q, want %q (a parked proposal)", after.Status, IssueAwaitingApproval)
+	}
+	count, status := agentRunRows(t, svc, issue.ID)
+	if count != 1 || status != "waiting_approval" {
+		t.Fatalf("agent_runs = %d rows (last %q), want exactly one waiting_approval run", count, status)
+	}
+}
+
+// TestPreAirPreflightClosesRepairedSeason: the season was cleaned (say, by an
+// admin acting directly in Sonarr) before the agent got to it. The preflight's
+// class proof must close the issue as recovered arr-side and spend no run.
+func TestPreAirPreflightClosesRepairedSeason(t *testing.T) {
+	svc, _, fake := setupPreAirService(t)
+	if err := svc.recordPreAirSeason(preAirSonarrID, 73871, 615, 11, "Futurama"); err != nil {
+		t.Fatalf("record pre-air season: %v", err)
+	}
+	issue := soleIssue(t, svc)
+
+	// The repair happened out of band: aired episodes keep their (legitimate,
+	// post-air) files, and nothing unaired holds one any more.
+	episodes, files := buildPreAirSeason(28, 11, []preAirEpisode{
+		{number: 1, airsIn: -21 * 24 * time.Hour, hasFile: true},
+		{number: 2, airsIn: -14 * 24 * time.Hour, hasFile: true},
+		{number: 3, airsIn: 7 * 24 * time.Hour},
+		{number: 4, airsIn: 14 * 24 * time.Hour},
+	})
+	fake.setLibrary(episodes, files)
+
+	r := preAirRunner(t, svc, &scriptedTurn{})
+	if err := r.Run(context.Background(), issue.ID); err != nil {
+		t.Fatalf("Run over a repaired pre-air issue: %v", err)
+	}
+
+	after := soleIssue(t, svc)
+	if after.Status != IssueResolved || after.ResolutionKind != ResolutionArrStateCleared {
+		t.Fatalf("issue after run = status %q / kind %q, want %q / %q",
+			after.Status, after.ResolutionKind, IssueResolved, ResolutionArrStateCleared)
+	}
+	if count, _ := agentRunRows(t, svc, issue.ID); count != 0 {
+		t.Fatalf("agent_runs = %d rows, want none for a preflight-closed issue", count)
+	}
+}
+
+// TestPreflightDefersStaleObservation: a fresher snapshot committing between
+// the probe's fetch and its store is a timing artifact, not evidence. The
+// preflight must defer (report recovering) without touching issue state, so
+// the next enqueue retries against current data instead of parking a healthy
+// issue for an admin.
+func TestPreflightDefersStaleObservation(t *testing.T) {
+	svc, _, _ := setupPreAirService(t)
+	res, err := svc.db.Exec(
+		"INSERT INTO issues (source, status, media_type, tmdb_id, title, detail) VALUES ('user','open','movie',42,'Test Movie','wrong content')",
+	)
+	if err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+	issueID, _ := res.LastInsertId()
+	svc.recoveryProbe = func(*Issue) (arrRecoveryProbe, error) {
+		return arrRecoveryProbe{}, errStaleObservation
+	}
+
+	recovering, err := svc.preflightArrRecovery(issueID)
+	if err != nil || !recovering {
+		t.Fatalf("preflight on stale observation = (%v, %v), want deferred (true, nil)", recovering, err)
+	}
+	var status string
+	if err := svc.db.QueryRow("SELECT status FROM issues WHERE id = ?", issueID).Scan(&status); err != nil {
+		t.Fatalf("read issue status: %v", err)
+	}
+	if status != IssueOpen {
+		t.Fatalf("issue status after deferred preflight = %q, want untouched %q", status, IssueOpen)
+	}
+}


### PR DESCRIPTION
## The defect

Every **auto-detected** pre-air issue (#368's webhook gate and the 15-minute fallback sweep) parked at `needs_admin` before the agent ever ran — no proposal, no run row, no retry path (`recoverWork` only re-enqueues open/investigating). The flagship "the season is already waiting in your issues with a fix attached" flow delivered an issue with **no fix attached**. The user-reported season path was unaffected (`exactRecoveryGuard` lets a no-baseline user report proceed).

The chain, verified by trace:
1. `openPreAirIssue` deliberately writes no `issue_observations` row and enqueues the runner.
2. `Runner.Run` → `preflightArrRecovery` → `probeArrRecovery`: a season-scoped TV issue (`episode_number=0`, empty `download_id`) yields an empty `incidentScopeKey`, so `ensureIssueObservation` silently no-ops.
3. No queue group matches → `queueAbsenceSettled` `SELECT`s the never-written observation row and returns `sql.ErrNoRows` **as a hard error**.
4. `Run` treats any preflight error as "park at needs_admin".

Why tests missed it: every runner test stubs `recoveryProbe` — the seam replaces exactly the code that breaks. `pre_air_health_test.go` stops at issue creation.

## The fix

- `probeArrRecovery` routes `SourceAuto` sonarr issues whose stored `problem_kind` is `ProblemPreAirSeasonFill` to a class-specific probe backed by the existing `preAirRepairProven` proof: **completed** when nothing unaired holds a file (pending work cancels / the issue closes as recovered arr-side), proceed otherwise. Because the carve-out lives in the probe, all five preflight sites are covered — including the final pre-dispatch check, so approving a season delete after an admin already cleaned it by hand cancels cleanly instead of dispatching.
- The queue-shaped flow now reads a missing observation row as "nothing to settle, no recovery detected" instead of failing the whole preflight (defense for any future observation-less class).
- An `errStaleObservation` race (a fresher snapshot committing between the probe's fetch and its store) now **defers** — no state change, retried within a minute — instead of parking a healthy issue at `needs_admin` over a timing artifact.
- `preAirRepairProven`'s inline problem-kind read is extracted as `storedProblemKind` and shared, keeping the deliberate "problem_kind is not part of the client contract" design.

## Tests (mutation-verified)

New `pre_air_preflight_test.go` drives `Runner.Run` over a webhook-opened pre-air issue with the **real** probe path (no `recoveryProbe` stub, real registry over the fake Sonarr):
- live impossible season → run starts and parks `awaiting_approval` with exactly one `waiting_approval` run;
- season repaired out of band → preflight closes `resolved`/`arr_state_cleared`, zero runs spent;
- stale-observation race → preflight defers `(true, nil)` with issue state untouched.

All three fail with the fix reverted (verified by stash-revert run). The fake Sonarr serves no `/queue` route at all, pinning that the fixed pre-air path is queue-free.

`go vet ./...` and `go test ./...` green from `server/`. No documented surface changed — this makes the README's existing description of the auto pre-air flow true.

Manual-catalog note: `ISS-044` (LIVE) is the end-to-end case this unblocks; it was previously unpassable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1