### PR TITLE
test(agents): pre-air season repair end-to-end through the real Executor

### DIFF
--- a/server/internal/remediation/pipeline_harness_test.go
+++ b/server/internal/remediation/pipeline_harness_test.go
@@ -3,6 +3,7 @@ package remediation
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -224,5 +225,90 @@ func TestPipelineStalledUpgradeFullLoop(t *testing.T) {
 	count, runStatus := agentRunRows(t, h.svc, issue.ID)
 	if count != 2 || runStatus != "succeeded" {
 		t.Fatalf("agent_runs = %d rows (last %q), want the orphaned-resume + succeeded fresh-run pair", count, runStatus)
+	}
+}
+
+// TestPipelinePreAirSeasonRepairFullLoop drives the flagship season repair the
+// way production runs it: the webhook detector opens ONE season issue, the
+// agent investigates and proposes delete_media_files, ONE approval deletes all
+// nine impossible files and marks their grabs failed at the real arr boundary,
+// and — with the failed-download policy ON — the service owns the replacement
+// search, so Cantinarr posts no command of its own (the fake treats any
+// /command call as an unexpected request). The issue then closes through the
+// class's own recovery proof at the resume preflight: nothing unaired holds a
+// file. This is ISS-044's hermetic twin.
+func TestPipelinePreAirSeasonRepairFullLoop(t *testing.T) {
+	h := newPipelineHarness(t)
+
+	// The default library IS the incident: nine files imported thirteen days
+	// before their episodes air. History carries the grab+import pair per file,
+	// which is the join the blocklist walk stands releases down by.
+	var hist []map[string]any
+	for n := 1; n <= 9; n++ {
+		downloadID := fmt.Sprintf("NZB-%d", n)
+		epID := 28*1000 + 11*100 + n
+		hist = append(hist,
+			map[string]any{"id": 9000 + n, "eventType": "downloadFolderImported", "episodeId": epID, "downloadId": downloadID},
+			map[string]any{"id": 8000 + n, "eventType": "grabbed", "episodeId": epID, "downloadId": downloadID},
+		)
+	}
+	h.fake.setSeriesHistory(hist)
+
+	if err := h.svc.recordPreAirSeason(preAirSonarrID, 73871, 615, 11, "Futurama"); err != nil {
+		t.Fatalf("record pre-air season: %v", err)
+	}
+	issue := soleIssue(t, h.svc)
+	if issue.Status != IssueOpen || issueProblemKind(t, h.svc, issue.ID) == "" {
+		t.Fatalf("pre-air issue = status %q kind %q, want open with a problem kind", issue.Status, issueProblemKind(t, h.svc, issue.ID))
+	}
+
+	script := &scriptedTurn{turns: []ai.TranscriptMessage{
+		toolCall("r1", "get_episode_timeline", `{}`),
+		toolCall("p1", mcp.ToolProposeAction, `{"issue_id":0,"kind":"delete_media_files","params":{"media_type":"tv","tmdb_id":615,"season":11,"episodes":[1,2,3,4,5,6,7,8,9],"blocklist":true},"rationale":"Nine files imported thirteen days before their episodes air cannot be those episodes."}`),
+	}}
+	r := h.runner(script)
+
+	if err := r.Run(context.Background(), issue.ID); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if after := soleIssue(t, h.svc); after.Status != IssueAwaitingApproval {
+		t.Fatalf("issue after run = %q, want %q", after.Status, IssueAwaitingApproval)
+	}
+
+	var actionID int64
+	if err := h.svc.db.QueryRow(
+		"SELECT id FROM agent_actions WHERE issue_id = ? AND status = ?", issue.ID, ActionProposed,
+	).Scan(&actionID); err != nil {
+		t.Fatalf("find proposed action: %v", err)
+	}
+	act, err := h.svc.ApproveAction(1, actionID, nil)
+	if err != nil {
+		t.Fatalf("ApproveAction: %v", err)
+	}
+	if act.Status != ActionExecuted {
+		t.Fatalf("approved action = %q (result %v), want %q", act.Status, act.ResultText, ActionExecuted)
+	}
+
+	fileDeletes, failedGrabs := h.fake.mutationsSeen()
+	if len(fileDeletes) != 9 || len(failedGrabs) != 9 {
+		t.Fatalf("arr mutations = %d file deletes / %d failed grabs, want 9 / 9", len(fileDeletes), len(failedGrabs))
+	}
+
+	// The resume preflight closes the issue through preAirRepairProven: the
+	// live season no longer holds any unaired file. The staged resume itself is
+	// never consumed — this class recovers by its own proof, not by the model
+	// narrating one.
+	if err := r.Resume(context.Background(), issue.ID); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+	final := soleIssue(t, h.svc)
+	if final.Status != IssueResolved || final.ResolutionKind != ResolutionArrStateCleared {
+		t.Fatalf("final issue = status %q / kind %q, want %q / %q",
+			final.Status, final.ResolutionKind, IssueResolved, ResolutionArrStateCleared)
+	}
+	// The aggregate close aborts the staged resume the proof outran — a truthful
+	// terminal state, not a dangling handoff.
+	if count, last := agentRunRows(t, h.svc, issue.ID); count != 1 || last != "aborted" {
+		t.Fatalf("agent_runs = %d rows (last %q), want one investigation aborted by its own proof", count, last)
 	}
 }

--- a/server/internal/remediation/pre_air_health_test.go
+++ b/server/internal/remediation/pre_air_health_test.go
@@ -43,6 +43,9 @@ type preAirFake struct {
 	history       []map[string]any
 	queue         []map[string]any
 	queueDeletes  []string
+	seriesHistory []map[string]any
+	failedGrabs   []string
+	fileDeletes   []string
 	episodeStatus int
 	historyStatus int
 }
@@ -89,6 +92,38 @@ func (f *preAirFake) start() *httptest.Server {
 			records := copyPreAirRecords(f.history)
 			f.mu.Unlock()
 			_ = json.NewEncoder(w).Encode(map[string]any{"totalRecords": len(records), "records": records})
+		case r.URL.Path == "/api/v3/history/series":
+			f.mu.Lock()
+			records := copyPreAirRecords(f.seriesHistory)
+			f.mu.Unlock()
+			// Bare JSON array — /history/series has no records envelope.
+			_ = json.NewEncoder(w).Encode(records)
+		case strings.HasPrefix(r.URL.Path, "/api/v3/history/failed/") && r.Method == http.MethodPost:
+			f.mu.Lock()
+			f.failedGrabs = append(f.failedGrabs, strings.TrimPrefix(r.URL.Path, "/api/v3/history/failed/"))
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+		case r.URL.Path == "/api/v3/config/downloadclient":
+			_ = json.NewEncoder(w).Encode(map[string]any{"autoRedownloadFailed": true})
+		case strings.HasPrefix(r.URL.Path, "/api/v3/episodefile/") && r.Method == http.MethodDelete:
+			id := strings.TrimPrefix(r.URL.Path, "/api/v3/episodefile/")
+			f.mu.Lock()
+			f.fileDeletes = append(f.fileDeletes, id)
+			keptFiles := f.files[:0]
+			for _, file := range f.files {
+				if fmt.Sprint(file["id"]) != id {
+					keptFiles = append(keptFiles, file)
+				}
+			}
+			f.files = keptFiles
+			for _, ep := range f.episodes {
+				if fmt.Sprint(ep["episodeFileId"]) == id {
+					ep["hasFile"] = false
+					delete(ep, "episodeFileId")
+				}
+			}
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{})
 		case r.URL.Path == "/api/v3/queue" && r.Method == http.MethodGet:
 			f.mu.Lock()
 			records := copyPreAirRecords(f.queue)
@@ -165,6 +200,18 @@ func (f *preAirFake) queueDeletesSeen() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.queueDeletes...)
+}
+
+func (f *preAirFake) setSeriesHistory(records []map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.seriesHistory = records
+}
+
+func (f *preAirFake) mutationsSeen() (fileDeletes, failedGrabs []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.fileDeletes...), append([]string(nil), f.failedGrabs...)
 }
 
 func (f *preAirFake) setEpisodeStatus(code int) {


### PR DESCRIPTION
Wave-1 scenario S2 on the #376 harness — **ISS-044's hermetic twin**, and the first test that drives the flagship one-approval season repair through the real Executor at the arr boundary:

- webhook detector opens ONE season-scoped issue (nine impossible files);
- agent reads the real `get_episode_timeline` and proposes `delete_media_files` for episodes 1-9 with blocklist;
- ONE approval → real Executor: **9 `episodefile` DELETEs, 9 `history/failed` POSTs** (grab join via bare-array `/history/series` — the pinned no-envelope shape), and with `autoRedownloadFailed` on, **zero** search commands of Cantinarr's own — the #363 stand-down is asserted structurally (any `/command` call is an unexpected request in the fake);
- the issue closes through `preAirRepairProven` at the resume preflight (nothing unaired holds a file), and the aggregate close **aborts** the staged resume the proof outran — pinned as the truthful terminal state.

The fake Sonarr gains the four endpoints the delete path calls (stateful `episodefile` DELETE that patches `hasFile` back, bare-array `history/series`, `history/failed`, `config/downloadclient`).

Tests only; no production code or documented surface changed. `go vet` + full `go test ./...` green from `server/`. Remaining Wave-1 scenarios (user complaint, rule auto-approve + repeat guard, `outcome_unknown`) continue on this harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1