### PR TITLE
feat(agents): the reporter inbox — My Reports, self-scoped, in requester words

### DIFF
--- a/app/lib/features/issues/data/issues_service.dart
+++ b/app/lib/features/issues/data/issues_service.dart
@@ -108,6 +108,16 @@ class IssuesService {
   // ---- Admin ---------------------------------------------------------------
 
   /// List issues for the admin queue, optionally filtered by [status].
+  /// The reporter inbox: the caller's OWN reports, requester copy applied
+  /// server-side. Non-admin accessible.
+  Future<List<Issue>> listMyIssues() async {
+    final resp = await _dio.get('/api/issues');
+    final list = (resp.data['issues'] as List?) ?? const [];
+    return list
+        .map((e) => Issue.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
   Future<List<Issue>> listIssues({String? status}) async {
     final resp = await _dio.get(
       '/api/admin/issues',

--- a/app/lib/features/issues/ui/issue_thread_screen.dart
+++ b/app/lib/features/issues/ui/issue_thread_screen.dart
@@ -457,6 +457,12 @@ class _IssueThreadScreenState extends ConsumerState<IssueThreadScreen>
                     const SizedBox(height: 10),
                     _PassiveTrackingBanner(status: issue.status),
                   ],
+                  if (!isAdmin &&
+                      (issue.status == IssueStatus.awaitingApproval ||
+                          issue.status == IssueStatus.needsAdmin)) ...[
+                    const SizedBox(height: 10),
+                    _ReporterWaitBanner(status: issue.status),
+                  ],
                   if (isAdmin && issue.status.needsAttention) ...[
                     const SizedBox(height: 10),
                     _AdminCompletionPanel(
@@ -536,6 +542,45 @@ class _IssueThreadScreenState extends ConsumerState<IssueThreadScreen>
             onSend: _sendReply,
           ),
       ],
+    );
+  }
+}
+
+/// Fixed, non-interactive explanation for the REPORTER while their issue
+/// waits on someone else. "Fix ready for review" used to be a dead end for the
+/// person who reported it — this says whose turn it is and that nothing is
+/// needed from them.
+class _ReporterWaitBanner extends StatelessWidget {
+  final IssueStatus status;
+
+  const _ReporterWaitBanner({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final text = status == IssueStatus.awaitingApproval
+        ? "A fix is ready and waiting for an administrator's approval. Nothing is needed from you right now."
+        : 'An administrator is taking a closer look at this.';
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppTheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppTheme.border),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.hourglass_top_rounded,
+              size: 18, color: AppTheme.textSecondary),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              text,
+              style: const TextStyle(
+                  fontSize: 13, color: AppTheme.textSecondary, height: 1.35),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/app/lib/features/issues/ui/issues_list_screen.dart
+++ b/app/lib/features/issues/ui/issues_list_screen.dart
@@ -8,6 +8,7 @@ import '../../../core/layout/adaptive.dart';
 import '../../../core/providers/realtime_provider.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/attention_menu_visibility_switch.dart';
+import '../../auth/logic/auth_provider.dart';
 import '../data/issue_models.dart';
 import '../logic/issues_provider.dart';
 import 'issue_refresh_banner.dart';
@@ -67,6 +68,15 @@ class _IssuesListScreenState extends ConsumerState<IssuesListScreen>
     return m != null ? m.group(1)! : 'Something went wrong';
   }
 
+  Future<bool> _viewerIsAdmin() async {
+    try {
+      final auth = await ref.read(authProvider.future);
+      return auth.user?.isAdmin == true;
+    } catch (_) {
+      return false;
+    }
+  }
+
   Future<void> _load() async {
     if (!mounted) return;
     final epoch = ++_loadEpoch;
@@ -75,7 +85,14 @@ class _IssuesListScreenState extends ConsumerState<IssuesListScreen>
       if (_issues == null) _error = null;
     });
     try {
-      final issues = await ref.read(issuesServiceProvider).listIssues();
+      // Admins see every issue; everyone else sees their OWN reports — the
+      // reporter inbox, served self-scoped with requester copy applied. Await
+      // the auth resolution: a ref.read at first frame races it and would
+      // misroute the very first load.
+      final admin = await _viewerIsAdmin();
+      final service = ref.read(issuesServiceProvider);
+      final issues =
+          admin ? await service.listIssues() : await service.listMyIssues();
       if (!mounted || epoch != _loadEpoch) return;
       setState(() {
         _issues = issues;
@@ -83,12 +100,14 @@ class _IssuesListScreenState extends ConsumerState<IssuesListScreen>
         _error = null;
       });
       // Keep both the actionable badge and tracking-aware menu visibility in
-      // sync with the authoritative list we just loaded.
-      ref.read(issueQueueCountsProvider.notifier).setCounts(
-            needsAttention:
-                issues.where((issue) => issue.status.needsAttention).length,
-            tracking: issues.where((issue) => issue.status.isTracking).length,
-          );
+      // sync with the authoritative list we just loaded — admin surfaces only.
+      if (admin) {
+        ref.read(issueQueueCountsProvider.notifier).setCounts(
+              needsAttention:
+                  issues.where((issue) => issue.status.needsAttention).length,
+              tracking: issues.where((issue) => issue.status.isTracking).length,
+            );
+      }
     } catch (e) {
       if (!mounted || epoch != _loadEpoch) return;
       setState(() {
@@ -104,7 +123,13 @@ class _IssuesListScreenState extends ConsumerState<IssuesListScreen>
     ref.listen(issuesChangedProvider, (_, __) => _scheduleLoad());
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Issues')),
+      appBar: AppBar(
+        title: Text(
+          ref.watch(authProvider).valueOrNull?.user?.isAdmin == true
+              ? 'Issues'
+              : 'My reports',
+        ),
+      ),
       body: CenteredContent(
         child: Column(
           children: [

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -212,6 +212,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                         )
                     : null,
               )),
+          if (user?.isAdmin != true)
+            _SettingsTile(
+              icon: Icons.flag_outlined,
+              title: 'My reports',
+              subtitle: 'Problems you reported and how they ended',
+              onTap: () => context.push('/issues'),
+            ),
           _SettingsTile(
             icon: Icons.smart_toy_outlined,
             title: 'AI Assistant',

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -702,8 +702,9 @@ bool _isAdminOnlyRoute(String path) {
     '/settings/instance',
   ];
 
-  return path == '/issues' ||
-      adminRoots.any((route) => _isWithinRoute(path, route));
+  // '/issues' is deliberately NOT admin-gated any more: for non-admins the
+  // same route is the reporter inbox ("My reports"), scoped server-side.
+  return adminRoots.any((route) => _isWithinRoute(path, route));
 }
 
 int? _positiveIntParameter(GoRouterState state, String name) {

--- a/app/test/navigation/app_router_test.dart
+++ b/app/test/navigation/app_router_test.dart
@@ -107,7 +107,6 @@ void main() {
 
     for (final path in [
       '/approvals',
-      '/issues',
       '/agent-actions',
       '/agent-runs/1',
       '/setup',
@@ -130,6 +129,20 @@ void main() {
         reason: '$path must remain admin-only',
       );
     }
+  });
+
+  testWidgets('a requester keeps /issues — it is their My Reports inbox',
+      (tester) async {
+    final (:router, container: _) = await _pumpRouter(tester, _authedState);
+
+    router.go('/issues');
+    await tester.pumpAndSettle();
+    expect(
+      router.routeInformationProvider.value.uri.path,
+      '/issues',
+      reason:
+          'the issues route is the reporter inbox for non-admins, scoped server-side',
+    );
   });
 
   testWidgets('a requester can still open a specific issue thread',

--- a/server/README.md
+++ b/server/README.md
@@ -215,6 +215,7 @@ Request statuses: `unavailable`, `requested`, `pending` (awaiting approval), `de
 ### Issues & AI remediation
 ```
 POST   /api/issues                         # user: report a problem; requires instance_id plus media scope — tmdb/tvdb ids
+GET    /api/issues                         # reporter inbox: the caller's OWN reports, newest first, requester copy applied
                                            #   for movie/tv, foreign_id (+book_format when both formats exist) for book
                                            #   (instance must be Radarr for movie, Sonarr for tv, Chaptarr for book;
                                            #   gated by allow_reporting); returns {issue_id,status}; initial status is

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -314,6 +314,7 @@ func NewRouter(
 		r.Group(func(r chi.Router) {
 			r.Use(authService.AuthMiddleware)
 			r.With(auth.RequirePermission(auth.PermissionMediaRequest)).Post("/issues", remediationHandler.Create)
+			r.Get("/issues", remediationHandler.ListMine)
 			r.Get("/issues/{id}", remediationHandler.Get)
 			r.Post("/issues/{id}/reply", remediationHandler.Reply)
 			r.Post("/issues/{id}/confirm-fixed", remediationHandler.ConfirmFixed)

--- a/server/internal/remediation/handler.go
+++ b/server/internal/remediation/handler.go
@@ -75,6 +75,62 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// ListMine handles GET /api/issues — the reporter inbox: the caller's OWN
+// reports, newest first. Reporter-visible copy only: the requester-copy
+// boundary rewrites admin-facing resolution text before it leaves the server.
+func (h *Handler) ListMine(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	issues, err := h.service.ListIssuesForReporter(claims.UserID)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	for i := range issues {
+		applyRequesterCopy(&issues[i])
+	}
+	writeJSON(w, http.StatusOK, ListIssuesResponse{Issues: issues})
+}
+
+// applyRequesterCopy is the requester-copy boundary: an issue leaving the
+// server to its REPORTER carries only server-authored requester vocabulary.
+// The resolution column accumulates admin-facing diagnostics — executor result
+// text, give-up reasons, "verify the current arr state" — which are the right
+// words for the admin queue and the wrong words for the person who reported a
+// wrong episode. Every (status, resolution_kind) pair maps to fixed copy here;
+// the admin surfaces keep the raw fields. Rewriting at the read boundary,
+// rather than at each write site, means a new admin-side message can never
+// leak by default.
+func applyRequesterCopy(issue *Issue) {
+	switch issue.Status {
+	case IssueNeedsAdmin:
+		issue.Resolution = "An administrator is taking a closer look at this."
+	case IssueAwaitingConfirmation:
+		issue.Resolution = "A fix was applied — please open the report and confirm whether it's right now."
+	case IssueWontFix:
+		switch issue.ResolutionKind {
+		case ResolutionReporterTimeout:
+			issue.Resolution = "Closed after no reply. If this is still a problem, report it again."
+		default:
+			issue.Resolution = "This was closed without a fix. If it still looks wrong, report it again."
+		}
+	case IssueFailed:
+		issue.Resolution = "This couldn't be resolved automatically. If it still looks wrong, report it again."
+	case IssueResolved:
+		switch issue.ResolutionKind {
+		case ResolutionReporterConfirmed:
+			issue.Resolution = "You confirmed this is fixed."
+		default:
+			issue.Resolution = "This was resolved. If it still looks wrong, report it again."
+		}
+	case IssueDismissed:
+		issue.Resolution = "An administrator closed this report."
+	}
+}
+
 // Get handles GET /api/issues/{id} (the issue's reporter or an admin). Returns
 // the issue plus its thread.
 func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
@@ -106,6 +162,11 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 		if allowed, err := h.service.CanReporterConfirmFix(issue); err == nil {
 			issue.CanConfirmFixed = allowed
 		}
+	}
+	// The requester-copy boundary: a non-admin reader never sees admin-facing
+	// resolution diagnostics.
+	if !auth.HasPermission(claims.Role, auth.PermissionRemediationManage) {
+		applyRequesterCopy(issue)
 	}
 
 	// An admin opening the thread marks the issue read (clears the unread dot);

--- a/server/internal/remediation/reporter_confirm_test.go
+++ b/server/internal/remediation/reporter_confirm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/windoze95/cantinarr-server/internal/auth"
 	"github.com/windoze95/cantinarr-server/internal/db"
+	"strings"
 )
 
 // confirmFixture is the shape the reporter-confirmation feature exists for: a
@@ -681,5 +682,46 @@ func TestGetIssueExposesCanConfirmFixed(t *testing.T) {
 	midDispatch := getIssueDetail(t, h, fx.issueID, &auth.Claims{UserID: fx.reporterID, Role: auth.RoleUser})
 	if midDispatch.Issue.CanConfirmFixed {
 		t.Fatal("the confirmation was offered while a fix was mid-dispatch")
+	}
+}
+
+// The reporter inbox returns only the caller's own reports, and the
+// requester-copy boundary guarantees a non-admin reader never sees admin-facing
+// resolution diagnostics — executor text and give-up reasons are the right
+// words for the admin queue and the wrong words for the person who reported a
+// wrong episode.
+func TestReporterInboxScopeAndCopyBoundary(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	if _, err := svc.db.Exec("INSERT INTO users (id, username, password_hash, role) VALUES (7, 'me', '', 'user'), (8, 'them', '', 'user')"); err != nil {
+		t.Fatalf("seed users: %v", err)
+	}
+	if _, err := svc.db.Exec(
+		`INSERT INTO issues (source, status, category, reporter_id, media_type, tmdb_id, title, detail, resolution)
+		 VALUES ('user', 'needs_admin', 'wrong_content', 7, 'movie', 1, 'Mine', 'wrong', 'Executor said: sonarr DELETE /api/v3/queue/41 returned 500'),
+		        ('user', 'open', 'bad_copy', 8, 'movie', 2, 'Theirs', 'grainy', '')`,
+	); err != nil {
+		t.Fatalf("seed issues: %v", err)
+	}
+
+	mine, err := svc.ListIssuesForReporter(7)
+	if err != nil {
+		t.Fatalf("ListIssuesForReporter: %v", err)
+	}
+	if len(mine) != 1 || mine[0].Title != "Mine" {
+		t.Fatalf("inbox = %+v, want exactly the caller's own report", mine)
+	}
+
+	applyRequesterCopy(&mine[0])
+	if strings.Contains(mine[0].Resolution, "Executor") || strings.Contains(mine[0].Resolution, "sonarr") {
+		t.Fatalf("requester copy leaked admin diagnostics: %q", mine[0].Resolution)
+	}
+	if mine[0].Resolution != "An administrator is taking a closer look at this." {
+		t.Fatalf("needs_admin requester copy = %q", mine[0].Resolution)
+	}
+
+	confirm := Issue{Status: IssueAwaitingConfirmation}
+	applyRequesterCopy(&confirm)
+	if !strings.Contains(confirm.Resolution, "confirm") {
+		t.Fatalf("awaiting_confirmation requester copy = %q", confirm.Resolution)
 	}
 }

--- a/server/internal/remediation/service.go
+++ b/server/internal/remediation/service.go
@@ -979,6 +979,32 @@ func (s *Service) SweepAwaitingConfirmation(ctx context.Context) (int, int, erro
 
 // ListIssues returns issues for the admin queue (newest first), optionally
 // filtered by status. An empty/blank status returns all issues.
+// ListIssuesForReporter returns one user's OWN reports, newest first — the
+// reporter inbox. Same row shape as the admin list; the handler applies the
+// requester-copy boundary before it leaves the server.
+func (s *Service) ListIssuesForReporter(reporterID int64) ([]Issue, error) {
+	rows, err := s.db.Query(`SELECT i.id, i.source, i.status, i.category, i.reporter_id, u.username,
+	                 i.tmdb_id, i.tvdb_id, i.media_type, i.title, i.season_number, i.episode_number,
+	                 i.detail, i.occurrences, i.read, i.resolution, i.resolution_kind,
+	                 i.created_at, i.updated_at, i.closed_at,
+	                 i.instance_id, i.download_id, i.arr_queue_id, i.author_id, i.book_id
+	          FROM issues i LEFT JOIN users u ON u.id = i.reporter_id
+	          WHERE i.reporter_id = ? ORDER BY i.updated_at DESC, i.id DESC`, reporterID)
+	if err != nil {
+		return nil, fmt.Errorf("query reporter issues: %w", err)
+	}
+	defer rows.Close()
+	out := []Issue{}
+	for rows.Next() {
+		iss, err := scanIssue(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan reporter issue: %w", err)
+		}
+		out = append(out, *iss)
+	}
+	return out, rows.Err()
+}
+
 func (s *Service) ListIssues(status string) ([]Issue, error) {
 	query := `SELECT i.id, i.source, i.status, i.category, i.reporter_id, u.username,
 	                 i.tmdb_id, i.tvdb_id, i.media_type, i.title, i.season_number, i.episode_number,


### PR DESCRIPTION
Wave 2.2 (follows #381). A reporter could be asked, paged, and given the closing verdict — and still had no way back to their own report except an iOS push tap.

- **`GET /api/issues`** — the reporter inbox: the caller's own reports, newest first. The app's `/issues` route is now **role-aware**: admins keep the full queue; everyone else gets "My reports" from the self-scoped endpoint. The router stops admin-gating it (a positive test pins the new truth), and Settings gains a "My reports" entry for non-admins.
- **The requester-copy boundary**: an issue leaving the server to a non-admin carries only fixed server-authored requester vocabulary — `applyRequesterCopy` rewrites at the read boundary (list + single read), so executor text, give-up reasons, and arr vocabulary can never leak to a reporter by default. Pinned by test.
- **"Fix ready for review" stops being a dead end**: the thread tells the reporter whose turn it is and that nothing is needed from them.
- Fixes an auth race the change exposed (first load now awaits `authProvider.future`).

`go vet`/`go test ./...` green (0 failures); `flutter analyze` clean; all 940 Flutter tests pass. Docs: route reference updated in the same PR. The media-detail open-report chip + episode-level picker ride PR 2.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1