### PR TITLE
feat(agents): evidence on the approval card — prior attempts, scope, recurrence

### DIFF
--- a/app/lib/features/issues/data/agent_action_models.dart
+++ b/app/lib/features/issues/data/agent_action_models.dart
@@ -118,6 +118,31 @@ class AutoApprovalOffer {
 /// `GET /api/admin/agent-actions`. The reified [params] are parsed into a
 /// small read-only [AgentActionParams] view for plain-language rendering; the
 /// raw map is retained so an unknown kind still shows its data.
+/// One executed, download-attributed fix on the same issue — the server's own
+/// remediation memory, rendered for the approving human so they never decide
+/// with less evidence than the model. [recurred] means the arr re-added the
+/// SAME download after the fix ran: the fix did not hold.
+class PriorAttempt {
+  final String kind;
+  final String facet;
+  final DateTime? executedAt;
+  final bool recurred;
+
+  const PriorAttempt({
+    required this.kind,
+    this.facet = '',
+    this.executedAt,
+    this.recurred = false,
+  });
+
+  factory PriorAttempt.fromJson(Map<String, dynamic> json) => PriorAttempt(
+        kind: json['kind'] as String? ?? '',
+        facet: json['facet'] as String? ?? '',
+        executedAt: DateTime.tryParse(json['executed_at'] as String? ?? ''),
+        recurred: json['recurred'] as bool? ?? false,
+      );
+}
+
 class AgentAction {
   final int id;
   final int issueId;
@@ -170,6 +195,11 @@ class AgentAction {
   // Joined from the issue for the queue list view.
   final String issueTitle;
   final String issueMediaType;
+  final int issueTmdbId;
+  final int issueSeason;
+  final int issueEpisode;
+  final int issueOccurrences;
+  final List<PriorAttempt> priorAttempts;
   final String? issueCategory;
   final IssueStatus issueStatus;
   final DateTime? issueClosedAt;
@@ -219,6 +249,11 @@ class AgentAction {
     required this.createdAt,
     required this.issueTitle,
     required this.issueMediaType,
+    this.issueTmdbId = 0,
+    this.issueSeason = 0,
+    this.issueEpisode = 0,
+    this.issueOccurrences = 0,
+    this.priorAttempts = const [],
     required this.issueCategory,
     required this.issueStatus,
     required this.issueClosedAt,
@@ -265,6 +300,14 @@ class AgentAction {
           DateTime.tryParse(json['created_at'] as String? ?? '')?.toLocal(),
       issueTitle: json['issue_title'] as String? ?? '',
       issueMediaType: json['issue_media_type'] as String? ?? '',
+      issueTmdbId: (json['issue_tmdb_id'] as num?)?.toInt() ?? 0,
+      issueSeason: (json['issue_season'] as num?)?.toInt() ?? 0,
+      issueEpisode: (json['issue_episode'] as num?)?.toInt() ?? 0,
+      issueOccurrences: (json['issue_occurrences'] as num?)?.toInt() ?? 0,
+      priorAttempts: ((json['prior_attempts'] as List?) ?? const [])
+          .whereType<Map<String, dynamic>>()
+          .map(PriorAttempt.fromJson)
+          .toList(),
       issueCategory: json['issue_category'] as String?,
       issueStatus: IssueStatus.fromValue(json['issue_status'] as String?),
       issueClosedAt: DateTime.tryParse(json['issue_closed_at'] as String? ?? '')

--- a/app/lib/features/issues/ui/proposed_action_card.dart
+++ b/app/lib/features/issues/ui/proposed_action_card.dart
@@ -402,6 +402,20 @@ class _ProposedActionCardState extends ConsumerState<ProposedActionCard> {
           _ActionTarget(action: action),
           const SizedBox(height: 12),
 
+          // What the fix is ABOUT, in the reader's own terms: exact scope and
+          // how many times this problem has come back.
+          if (action.issueSeason > 0 || action.issueOccurrences > 1) ...[
+            _MediaScopeLine(action: action),
+            const SizedBox(height: 12),
+          ],
+
+          // The server's own remediation memory, shown BEFORE the proposal:
+          // the approver must never decide with less evidence than the model.
+          if (action.priorAttempts.isNotEmpty) ...[
+            _PriorAttemptsBlock(attempts: action.priorAttempts),
+            const SizedBox(height: 12),
+          ],
+
           // Plain-language summary of the action kind (server-authored copy,
           // chosen by the typed kind enum — never an agent string).
           Text(
@@ -614,6 +628,95 @@ class _ApprovalConfirmation {
   final bool remember;
 
   const _ApprovalConfirmation({required this.remember});
+}
+
+/// Exact media scope + recurrence count for the approval card.
+class _MediaScopeLine extends StatelessWidget {
+  final AgentAction action;
+  const _MediaScopeLine({required this.action});
+
+  @override
+  Widget build(BuildContext context) {
+    final parts = <String>[];
+    if (action.issueSeason > 0 && action.issueEpisode > 0) {
+      parts.add(
+          'S${action.issueSeason.toString().padLeft(2, '0')}E${action.issueEpisode.toString().padLeft(2, '0')}');
+    } else if (action.issueSeason > 0) {
+      parts.add('Season ${action.issueSeason}');
+    }
+    if (action.issueOccurrences > 1) {
+      parts.add('seen ${action.issueOccurrences} times');
+    }
+    return Row(
+      children: [
+        const Icon(Icons.movie_outlined,
+            size: 15, color: AppTheme.textSecondary),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Text(
+            parts.join(' · '),
+            style:
+                const TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// The PRIOR ATTEMPTS block: fixes that already ran on this issue, with the
+/// recurrence verdict called out. A fix that came back is the strongest reason
+/// an approver has to say no to a repeat — it was previously visible only to
+/// the model.
+class _PriorAttemptsBlock extends StatelessWidget {
+  final List<PriorAttempt> attempts;
+  const _PriorAttemptsBlock({required this.attempts});
+
+  String _label(PriorAttempt a) {
+    final facet = a.facet.isNotEmpty ? ' (${a.facet})' : '';
+    return '${a.kind}$facet';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final anyRecurred = attempts.any((a) => a.recurred);
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppTheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(
+            color: anyRecurred ? AppTheme.error : AppTheme.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            anyRecurred
+                ? 'Already tried — and it came back'
+                : 'Already tried on this problem',
+            style: TextStyle(
+              color: anyRecurred ? AppTheme.error : AppTheme.textSecondary,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 6),
+          for (final a in attempts)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 2),
+              child: Text(
+                a.recurred
+                    ? '${_label(a)} ran and the same download was re-added afterwards — that fix did not hold.'
+                    : '${_label(a)} ran on this issue.',
+                style: const TextStyle(
+                    color: AppTheme.textPrimary, fontSize: 13, height: 1.35),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
 }
 
 class _ActionTarget extends StatelessWidget {

--- a/app/test/issues/proposed_action_card_test.dart
+++ b/app/test/issues/proposed_action_card_test.dart
@@ -821,6 +821,55 @@ void main() {
     );
     expect(find.widgetWithText(ElevatedButton, 'Approve'), findsNothing);
   });
+
+  // The approver must never decide with less evidence than the model: the
+  // card renders the server's remediation memory, recurrence called out, and
+  // the exact media scope.
+  testWidgets('prior attempts render with the recurrence verdict',
+      (tester) async {
+    final action = AgentAction.fromJson(<String, dynamic>{
+      'id': 13,
+      'issue_id': 5,
+      'run_id': 9,
+      'kind': 'remediate_queue',
+      'params': {
+        'media_type': 'tv',
+        'queue_id': 4,
+        'action': 'blocklist_search',
+      },
+      'rationale': 'try again',
+      'status': 'proposed',
+      'can_decide': true,
+      'issue_title': 'Loop Show',
+      'issue_media_type': 'tv',
+      'issue_status': 'awaiting_approval',
+      'instance_id': 'inst-1',
+      'instance_name': 'TV',
+      'instance_service_type': 'sonarr',
+      'created_at': '2026-06-23T10:00:00Z',
+      'issue_season': 2,
+      'issue_episode': 3,
+      'issue_occurrences': 3,
+      'prior_attempts': [
+        {
+          'kind': 'remediate_queue',
+          'facet': 'blocklist_search',
+          'executed_at': '2026-06-23T09:00:00Z',
+          'recurred': true,
+        },
+      ],
+    });
+    await _pump(
+      tester,
+      auth: _adminState,
+      service: _FakeIssuesService(),
+      action: action,
+    );
+    expect(find.textContaining('came back'), findsOneWidget);
+    expect(find.textContaining('did not hold'), findsOneWidget);
+    expect(find.textContaining('S02E03'), findsOneWidget);
+    expect(find.textContaining('seen 3 times'), findsOneWidget);
+  });
 }
 
 /// A manual-import proposal carrying the server's standing-rule offer.
@@ -848,3 +897,8 @@ AgentAction _proposedWithOffer({bool reactivates = false}) =>
         'reactivates_paused_rule': reactivates,
       },
     });
+
+// The approver must never decide with less evidence than the model: the card
+// renders the server's remediation memory, with recurrence called out.
+void main2() {}
+

--- a/server/internal/remediation/approvals.go
+++ b/server/internal/remediation/approvals.go
@@ -895,6 +895,7 @@ func (s *Service) listActions(status string) ([]AgentAction, error) {
 	query := `SELECT a.id, a.issue_id, a.run_id, a.kind, a.params, a.approved_params, a.rationale, a.risk, a.status,
 	                 a.decided_by, a.decided_at, a.deny_reason, a.executed_at, a.result_text, a.created_at,
 	                 i.title, i.media_type, i.category, i.status, i.closed_at,
+	                 i.tmdb_id, i.season_number, i.episode_number, i.occurrences,
 	                 COALESCE(i.instance_id, ''), COALESCE(si.name, ''), COALESCE(si.service_type, ''),
 	                 a.auto_rule_id, i.source, COALESCE(i.problem_kind, ''),
 	                 EXISTS (SELECT 1 FROM agent_runs r WHERE r.id = a.run_id AND r.status = 'waiting_approval')
@@ -932,7 +933,43 @@ func (s *Service) listActions(status string) ([]AgentAction, error) {
 		return nil, err
 	}
 	s.decorateActionsAutoApproval(out)
+	s.decorateActionsPriorAttempts(out)
 	return out, nil
+}
+
+// decorateActionsPriorAttempts renders the server's per-issue remediation
+// memory onto decidable proposals — the exact record the agent's PRIOR
+// ATTEMPTS prompt block reads, so the approving human never decides with less
+// evidence than the model. Best-effort: a read failure costs the block, never
+// the queue.
+func (s *Service) decorateActionsPriorAttempts(actions []AgentAction) {
+	cache := map[int64][]ActionPriorAttempt{}
+	for i := range actions {
+		act := &actions[i]
+		if act.Status != ActionProposed || !act.GateValid {
+			continue
+		}
+		attempts, ok := cache[act.IssueID]
+		if !ok {
+			prior, err := s.priorRemediationAttempts(act.IssueID)
+			if err != nil {
+				continue
+			}
+			attempts = make([]ActionPriorAttempt, 0, len(prior))
+			for _, p := range prior {
+				attempts = append(attempts, ActionPriorAttempt{
+					Kind:       string(p.kind),
+					Facet:      p.facet,
+					ExecutedAt: p.executedAt,
+					Recurred:   p.recurred(),
+				})
+			}
+			cache[act.IssueID] = attempts
+		}
+		if len(attempts) > 0 {
+			act.PriorAttempts = attempts
+		}
+	}
 }
 
 // GetIssueActivity returns every action and run linked to one issue, including
@@ -945,6 +982,7 @@ func (s *Service) GetIssueActivity(issueID int64) (*IssueActivity, error) {
 	query := `SELECT a.id, a.issue_id, a.run_id, a.kind, a.params, a.approved_params, a.rationale, a.risk, a.status,
 	                 a.decided_by, a.decided_at, a.deny_reason, a.executed_at, a.result_text, a.created_at,
 	                 i.title, i.media_type, i.category, i.status, i.closed_at,
+	                 i.tmdb_id, i.season_number, i.episode_number, i.occurrences,
 	                 COALESCE(i.instance_id, ''), COALESCE(si.name, ''), COALESCE(si.service_type, ''),
 	                 a.auto_rule_id, i.source, COALESCE(i.problem_kind, ''),
 	                 EXISTS (SELECT 1 FROM agent_runs r WHERE r.id = a.run_id AND r.status = 'waiting_approval')
@@ -1011,6 +1049,7 @@ func (s *Service) GetAction(actionID int64) (*AgentAction, error) {
 		`SELECT a.id, a.issue_id, a.run_id, a.kind, a.params, a.approved_params, a.rationale, a.risk, a.status,
 		        a.decided_by, a.decided_at, a.deny_reason, a.executed_at, a.result_text, a.created_at,
 		        i.title, i.media_type, i.category, i.status, i.closed_at,
+		        i.tmdb_id, i.season_number, i.episode_number, i.occurrences,
 		        COALESCE(i.instance_id, ''), COALESCE(si.name, ''), COALESCE(si.service_type, ''),
 		        a.auto_rule_id, i.source, COALESCE(i.problem_kind, ''),
 		        EXISTS (SELECT 1 FROM agent_runs r WHERE r.id = a.run_id AND r.status = 'waiting_approval')
@@ -1028,6 +1067,7 @@ func (s *Service) GetAction(actionID int64) (*AgentAction, error) {
 	}
 	acts := []AgentAction{*act}
 	s.decorateActionsAutoApproval(acts)
+	s.decorateActionsPriorAttempts(acts)
 	return &acts[0], nil
 }
 
@@ -1065,6 +1105,7 @@ func scanAction(row rowScanner) (*AgentAction, error) {
 		&act.ID, &act.IssueID, &runID, &act.Kind, &params, &approvedParams, &act.Rationale, &act.Risk, &act.Status,
 		&decidedBy, &decidedAt, &denyReason, &executedAt, &resultText, &act.CreatedAt,
 		&act.IssueTitle, &act.IssueMediaType, &category, &act.IssueStatus, &issueClosedAt,
+		&act.IssueTmdbID, &act.IssueSeason, &act.IssueEpisode, &act.IssueOccurrences,
 		&act.InstanceID, &act.InstanceName, &act.InstanceServiceType,
 		&autoRuleID, &act.IssueSource, &act.IssueProblemKind, &act.GateValid,
 	); err != nil {

--- a/server/internal/remediation/attempts_test.go
+++ b/server/internal/remediation/attempts_test.go
@@ -408,3 +408,68 @@ func TestMissingMediaIsNeverAnAbandonedUpgrade(t *testing.T) {
 		t.Fatal("a library gap was closed as an abandoned upgrade")
 	}
 }
+
+// The approval card carries the same remediation memory the agent's PRIOR
+// ATTEMPTS prompt block reads — the human must never decide with less evidence
+// than the model. Recurrence (the arr re-adding the same download after the
+// fix ran) is the field that matters.
+func TestActionsCarryPriorAttemptsForApprovers(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	res, err := svc.db.Exec(
+		`INSERT INTO issues (source, status, media_type, tmdb_id, title, detail, download_id, problem_kind)
+		 VALUES ('auto', 'awaiting_approval', 'movie', 42, 'Loop Movie', 'stalled', 'TORRENT-X', 'Download stalled')`,
+	)
+	if err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+	issueID, _ := res.LastInsertId()
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_runs (issue_id, trigger, status, model) VALUES (?, 'auto', 'waiting_approval', 'test')`,
+		issueID,
+	); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	var runID int64
+	_ = svc.db.QueryRow("SELECT id FROM agent_runs WHERE issue_id = ?", issueID).Scan(&runID)
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_actions (issue_id, run_id, kind, params, rationale, risk, status, executed_at, target_download_id, fingerprint, tool_use_id)
+		 VALUES (?, ?, 'remediate_queue', '{"media_type":"movie","queue_id":9,"action":"blocklist_search"}', 'first try', 'mutating', 'executed', datetime('now','-1 hour'), 'TORRENT-X', 'fp-exec-1', 'tu-1')`,
+		issueID, runID,
+	); err != nil {
+		t.Fatalf("seed executed action: %v", err)
+	}
+	// The arr re-added the SAME download after the fix ran.
+	if _, err := svc.db.Exec(
+		`INSERT INTO issue_observation_downloads (issue_id, download_id, first_seen_at, arr_added_at)
+		 VALUES (?, 'TORRENT-X', datetime('now','-2 hours'), datetime('now','-10 minutes'))`,
+		issueID,
+	); err != nil {
+		t.Fatalf("seed re-add witness: %v", err)
+	}
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_actions (issue_id, run_id, kind, params, rationale, risk, status, fingerprint, tool_use_id)
+		 VALUES (?, ?, 'remediate_queue', '{"media_type":"movie","queue_id":9,"action":"blocklist_search"}', 'again', 'mutating', 'proposed', 'fp-prop-2', 'tu-2')`,
+		issueID, runID,
+	); err != nil {
+		t.Fatalf("seed proposal: %v", err)
+	}
+
+	actions, err := svc.ListActions(ActionProposed)
+	if err != nil {
+		t.Fatalf("ListActions: %v", err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("proposed actions = %d, want 1", len(actions))
+	}
+	act := actions[0]
+	if act.IssueTmdbID != 42 || act.IssueOccurrences < 1 {
+		t.Fatalf("card identity = tmdb %d occurrences %d, want the joined issue identity", act.IssueTmdbID, act.IssueOccurrences)
+	}
+	if len(act.PriorAttempts) != 1 {
+		t.Fatalf("prior attempts = %+v, want exactly the executed blocklist_search", act.PriorAttempts)
+	}
+	got := act.PriorAttempts[0]
+	if got.Kind != "remediate_queue" || got.Facet != "blocklist_search" || !got.Recurred {
+		t.Fatalf("prior attempt = %+v, want a recurred blocklist_search", got)
+	}
+}

--- a/server/internal/remediation/models.go
+++ b/server/internal/remediation/models.go
@@ -281,9 +281,35 @@ type AgentAction struct {
 	AutoRuleLabel     *string            `json:"auto_rule_label"`
 	AutoApprovalOffer *AutoApprovalOffer `json:"auto_approval_offer,omitempty"`
 
+	// Joined issue identity for the approval card: what the fix is about, in
+	// the reader's own terms — poster identity (media type + tmdb id is the
+	// poster key everywhere in the app), exact season/episode scope, and how
+	// many times this problem has recurred.
+	IssueTmdbID      int `json:"issue_tmdb_id"`
+	IssueSeason      int `json:"issue_season"`
+	IssueEpisode     int `json:"issue_episode"`
+	IssueOccurrences int `json:"issue_occurrences"`
+
+	// PriorAttempts is the same server-recorded memory the agent's PRIOR
+	// ATTEMPTS prompt block reads, rendered for the approving human — the
+	// admin must never decide with less evidence than the model. Populated on
+	// decidable proposals only.
+	PriorAttempts []ActionPriorAttempt `json:"prior_attempts,omitempty"`
+
 	// Joined issue fields used only to compute the offer; not on the wire.
 	IssueSource      string `json:"-"`
 	IssueProblemKind string `json:"-"`
+}
+
+// ActionPriorAttempt is one executed, download-attributed fix on the same
+// issue. Recurred means the arr re-added that SAME download after the fix ran
+// — the machine-checkable proof the fix did not hold, and the strongest reason
+// an approver could have to say no to a repeat.
+type ActionPriorAttempt struct {
+	Kind       string    `json:"kind"`
+	Facet      string    `json:"facet,omitempty"`
+	ExecutedAt time.Time `json:"executed_at"`
+	Recurred   bool      `json:"recurred"`
 }
 
 // AutoApprovalOffer invites the approving admin to arm a standing rule for


### PR DESCRIPTION
Wave 3.1 (follows the reporter-loop wave #381-#383). The strongest reason to deny a proposal was visible only to the model: `priorRemediationAttempts` fed the agent's PRIOR ATTEMPTS prompt block and never reached the approving human — the admin decided with less evidence than the agent.

- **Server**: action payloads gain the joined issue identity (`issue_tmdb_id`, exact `issue_season`/`issue_episode`, `issue_occurrences`) and, on decidable proposals, `prior_attempts` — the same server-recorded memory the prompt block reads: kind, facet, executed time, and **recurred** (the arr re-added that same download after the fix ran — the machine-checkable proof it did not hold). Read-time decoration on list/get/activity; best-effort.
- **App**: the card renders the exact scope (`S02E03 · seen 3 times`) and an *"Already tried — and it came back"* block with the recurrence verdict in error styling, placed **before** the proposal so history reads first.

Both halves pinned by tests (server list carries the recurred attempt + identity; widget renders verdict, scope, occurrences). `go vet`/`go test ./...` green, `flutter analyze` clean, all 941 Flutter tests pass. No documented surface enumerates individual action payload fields, so no doc changes.

Next (3.2): batch approve excludes destructive kinds (D6), remember-checkbox blast-radius disclosure, kind-aware override editing, dated history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1