### PR TITLE
feat(agents): approval ergonomics — destructive fixes leave the batch, rules disclose reach, dated history

### DIFF
--- a/app/lib/features/issues/ui/pending_agent_actions_screen.dart
+++ b/app/lib/features/issues/ui/pending_agent_actions_screen.dart
@@ -121,7 +121,14 @@ class _PendingAgentActionsScreenState
   /// that recovered or changed in the meantime and reports it per item.
   Future<void> _approveAll() async {
     if (_batchBusy || _error != null) return;
-    final targets = _decidableActions;
+    // D6: deleting imported files never rides a batch — the server refuses it
+    // per-item too; excluding it here keeps the dialog honest about what will
+    // actually run and leaves the destructive card its own confirm.
+    final all = _decidableActions;
+    final targets = all
+        .where((a) => a.kind != AgentActionKind.deleteMediaFiles)
+        .toList(growable: false);
+    final destructiveHeld = all.length - targets.length;
     if (targets.length < 2) return;
     final ids = targets.map((a) => a.id).toList();
     final confirmed = await showDialog<bool>(
@@ -137,7 +144,8 @@ class _PendingAgentActionsScreenState
           'at a time, in the connected media services shown on their cards. '
           'Each fix runs at most once, and a fix whose download already '
           'recovered or whose state changed is skipped. This cannot be '
-          'undone from Cantinarr.',
+          'undone from Cantinarr.'
+          '${destructiveHeld > 0 ? '\n\n$destructiveHeld fix(es) that delete imported files are NOT included — each needs its own approval.' : ''}',
           style: const TextStyle(color: AppTheme.textSecondary),
         ),
         actions: [
@@ -326,6 +334,20 @@ class _PendingAgentActionsScreenState
     };
   }
 
+  /// The history tab reads as a timeline: day headers over the same
+  /// issue-grouped cards, so "what did the agent do last Tuesday" is
+  /// answerable at a glance instead of an undated wall.
+  String _dayLabel(DateTime when) {
+    final local = when.toLocal();
+    final today = DateTime.now();
+    final thatDay = DateTime(local.year, local.month, local.day);
+    final startOfToday = DateTime(today.year, today.month, today.day);
+    final diff = startOfToday.difference(thatDay).inDays;
+    if (diff == 0) return 'Today';
+    if (diff == 1) return 'Yesterday';
+    return '${local.year}-${local.month.toString().padLeft(2, '0')}-${local.day.toString().padLeft(2, '0')}';
+  }
+
   Widget _buildGroupedList(List<AgentAction> actions) {
     // Group by issue id, preserving the server's newest-first order. The
     // grouped layout makes "two proposals for the same problem" legible.
@@ -338,6 +360,22 @@ class _PendingAgentActionsScreenState
       }).add(a);
     }
 
+    // Day headers for the history tab: the first group of each calendar day
+    // (by the newest action's decided/created time) carries the label.
+    final dayForGroup = <int, String>{};
+    if (_tab == _AgentActionsTab.history) {
+      String? lastDay;
+      for (final issueId in order) {
+        final newest = groups[issueId]!.first;
+        final when = newest.decidedAt ?? newest.createdAt;
+        final label = when != null ? _dayLabel(when) : '';
+        if (label.isNotEmpty && label != lastDay) {
+          dayForGroup[issueId] = label;
+          lastDay = label;
+        }
+      }
+    }
+
     return ListView.builder(
       physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.fromLTRB(12, 8, 12, 24),
@@ -348,9 +386,23 @@ class _PendingAgentActionsScreenState
         final title = group.first.issueTitle.isEmpty
             ? 'Issue #$issueId'
             : group.first.issueTitle;
+        final dayHeader = dayForGroup[issueId];
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            if (dayHeader != null)
+              Padding(
+                padding: const EdgeInsets.fromLTRB(4, 18, 4, 0),
+                child: Text(
+                  dayHeader,
+                  style: const TextStyle(
+                    color: AppTheme.textSecondary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.4,
+                  ),
+                ),
+              ),
             // Issue header — tap to open the full thread.
             InkWell(
               onTap: () async {

--- a/app/lib/features/issues/ui/proposed_action_card.dart
+++ b/app/lib/features/issues/ui/proposed_action_card.dart
@@ -192,7 +192,8 @@ class _ProposedActionCardState extends ConsumerState<ProposedActionCard> {
                     '${offer.label}'
                     '${offer.reactivatesPausedRule ? ' · re-enables a paused rule' : ''}'
                     ' — applies to future auto-detected issues and any already '
-                    'waiting; pauses itself if a fix fails.',
+                    'waiting; pauses itself if a fix fails. Applies on every '
+                    'connected service and media type.',
                     style: const TextStyle(
                       color: AppTheme.textSecondary,
                       fontSize: 12,

--- a/server/internal/remediation/batchapprove.go
+++ b/server/internal/remediation/batchapprove.go
@@ -47,7 +47,8 @@ type BatchApprovalItem struct {
 //
 // No overrides and no remember: editing params or arming a standing
 // auto-approval rule are deliberate per-proposal decisions that keep their
-// own single-action flow.
+// own single-action flow. Destructive kinds are refused per-item for the same
+// reason (see the D6 skip below): file deletion keeps its single-card confirm.
 func (s *Service) ApproveActions(adminID int64, ids []int64) []BatchApprovalItem {
 	results := make([]BatchApprovalItem, 0, len(ids))
 	seen := make(map[int64]struct{}, len(ids))
@@ -56,6 +57,21 @@ func (s *Service) ApproveActions(adminID int64, ids []int64) []BatchApprovalItem
 			continue
 		}
 		seen[id] = struct{}{}
+		// D6: a destructive fix never rides a batch. delete_media_files is the
+		// one kind that destroys files on disk, and its single-card confirm
+		// (which repeats the exact episodes and says it cannot be undone) is
+		// the decision surface it deserves — a batch dialog's per-card warnings
+		// are exactly the ones nobody read. Structural, not UI copy: the server
+		// refuses it here whatever client sent the list.
+		var kind string
+		if err := s.db.QueryRow("SELECT kind FROM agent_actions WHERE id = ?", id).Scan(&kind); err == nil &&
+			ActionKind(kind) == ActionDeleteMediaFiles {
+			results = append(results, BatchApprovalItem{
+				ID: id, Status: "skipped",
+				Detail: "Deleting imported files needs its own approval — open this fix and approve it individually.",
+			})
+			continue
+		}
 		act, err := s.ApproveAction(adminID, id, nil)
 		switch {
 		case errors.Is(err, ErrActionDecisionConflict):

--- a/server/internal/remediation/batchapprove_test.go
+++ b/server/internal/remediation/batchapprove_test.go
@@ -230,3 +230,44 @@ func TestBatchApproveHandler(t *testing.T) {
 		t.Fatalf("executor ran %d times after rejected requests, want still 1", fx.count())
 	}
 }
+
+// D6: a destructive fix never rides a batch — the server refuses it per-item
+// whatever client sent the list, and the rest of the batch still runs.
+func TestBatchApproveRefusesDestructiveKinds(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	res, err := svc.db.Exec(
+		`INSERT INTO issues (source, status, media_type, tmdb_id, title, detail)
+		 VALUES ('auto', 'awaiting_approval', 'tv', 615, 'Show', 'pre-air')`,
+	)
+	if err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+	issueID, _ := res.LastInsertId()
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_runs (issue_id, trigger, status, model) VALUES (?, 'auto', 'waiting_approval', 'test')`,
+		issueID,
+	); err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	var runID int64
+	_ = svc.db.QueryRow("SELECT id FROM agent_runs WHERE issue_id = ?", issueID).Scan(&runID)
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_actions (issue_id, run_id, kind, params, rationale, risk, status, fingerprint, tool_use_id)
+		 VALUES (?, ?, 'delete_media_files', '{"media_type":"tv","tmdb_id":615,"season":11,"episodes":[1],"blocklist":true}', 'impossible files', 'mutating', 'proposed', 'fp-del', 'tu-del')`,
+		issueID, runID,
+	); err != nil {
+		t.Fatalf("seed destructive proposal: %v", err)
+	}
+	var actionID int64
+	_ = svc.db.QueryRow("SELECT id FROM agent_actions WHERE issue_id = ?", issueID).Scan(&actionID)
+
+	results := svc.ApproveActions(1, []int64{actionID})
+	if len(results) != 1 || results[0].Status != "skipped" {
+		t.Fatalf("batch over a destructive kind = %+v, want a per-item skip", results)
+	}
+	var status string
+	_ = svc.db.QueryRow("SELECT status FROM agent_actions WHERE id = ?", actionID).Scan(&status)
+	if status != ActionProposed {
+		t.Fatalf("destructive proposal after batch = %q, want untouched %q", status, ActionProposed)
+	}
+}


### PR DESCRIPTION
Wave 3.2, closing the informed-approvals wave (follows #384).

- **D6, structural**: `delete_media_files` never rides a batch. `ApproveActions` refuses it per-item server-side whatever client sent the list (rest of the batch still runs; pinned by test), and Approve All excludes it client-side with honest dialog copy about how many destructive fixes were held out — file deletion keeps its single-card cannot-be-undone confirm.
- **Blast-radius disclosure**: the "Always approve" offer now says a standing rule applies on every connected service and media type.
- **Dated history**: Today/Yesterday/date headers over the issue-grouped history cards.

The kind-aware override editor rides the wave-4 card work. `go vet`/`go test ./...` green; `flutter analyze` clean; all 941 Flutter tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1