### PR TITLE
feat(agents): rules that come back — pause evidence, the resume argument, one connected surface

### DIFF
--- a/app/lib/features/issues/data/agent_approval_rule_models.dart
+++ b/app/lib/features/issues/data/agent_approval_rule_models.dart
@@ -22,6 +22,8 @@ class AgentApprovalRule {
   /// it). Null while active.
   final String? pausedReason;
   final DateTime? pausedAt;
+  final int? pausedByIssueId;
+  final int approvedSincePause;
 
   final int? createdBy;
   final String? createdByName;
@@ -47,6 +49,8 @@ class AgentApprovalRule {
     required this.status,
     required this.pausedReason,
     required this.pausedAt,
+    this.pausedByIssueId,
+    this.approvedSincePause = 0,
     required this.createdBy,
     required this.createdByName,
     required this.seedActionId,
@@ -72,6 +76,9 @@ class AgentApprovalRule {
       status: json['status'] as String? ?? '',
       pausedReason: json['paused_reason'] as String?,
       pausedAt: time('paused_at'),
+      pausedByIssueId: (json['paused_by_issue_id'] as num?)?.toInt(),
+      approvedSincePause:
+          (json['approved_since_pause'] as num?)?.toInt() ?? 0,
       createdBy: (json['created_by'] as num?)?.toInt(),
       createdByName: json['created_by_name'] as String?,
       seedActionId: (json['seed_action_id'] as num?)?.toInt(),

--- a/app/lib/features/issues/ui/agent_approval_rules_screen.dart
+++ b/app/lib/features/issues/ui/agent_approval_rules_screen.dart
@@ -1,3 +1,4 @@
+import 'package:go_router/go_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -12,6 +13,11 @@ import '../logic/issues_provider.dart';
 /// checkbox. Each card shows the rule's fixed server-authored label, its
 /// active/paused state (with the server's pause reason), and its track record,
 /// with explicit Pause / Resume / Delete actions.
+String _dayLabel(DateTime when) {
+  final local = when.toLocal();
+  return '${local.year}-${local.month.toString().padLeft(2, '0')}-${local.day.toString().padLeft(2, '0')}';
+}
+
 class AgentApprovalRulesScreen extends ConsumerStatefulWidget {
   const AgentApprovalRulesScreen({super.key});
 
@@ -294,13 +300,42 @@ class _RuleCard extends StatelessWidget {
           if (rule.isPaused && (rule.pausedReason?.isNotEmpty ?? false)) ...[
             const SizedBox(height: 6),
             Text(
-              rule.pausedReason!,
+              rule.pausedAt != null
+                  ? '${rule.pausedReason!} (since ${_dayLabel(rule.pausedAt!)})'
+                  : rule.pausedReason!,
               style: const TextStyle(
                 color: AppTheme.requested,
                 fontSize: 12,
                 fontWeight: FontWeight.w600,
               ),
             ),
+            if (rule.pausedByIssueId != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: InkWell(
+                  onTap: () => context.push('/issues/${rule.pausedByIssueId}'),
+                  child: const Text(
+                    'See the issue that paused it →',
+                    style: TextStyle(
+                      color: AppTheme.textSecondary,
+                      fontSize: 12,
+                      decoration: TextDecoration.underline,
+                    ),
+                  ),
+                ),
+              ),
+            if (rule.approvedSincePause > 0)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  "You've approved this exact fix ${rule.approvedSincePause} time(s) by hand since it paused — Resume puts it back on autopilot.",
+                  style: const TextStyle(
+                    color: AppTheme.textPrimary,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
           ],
           const SizedBox(height: 8),
           Text(

--- a/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
+++ b/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
@@ -1,3 +1,4 @@
+import 'package:go_router/go_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -201,6 +202,31 @@ class _AiRemediationSettingsScreenState
             'access switches are never used.',
             style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
           ),
+        ),
+        // The pipeline's other two surfaces, one tap away — the queue, its
+        // governing rules, and this config are one system, not three
+        // destinations an admin must already know about.
+        ListTile(
+          leading:
+              const Icon(Icons.rule_folder_outlined, color: AppTheme.accent),
+          title: const Text('Standing auto-approvals',
+              style: TextStyle(color: AppTheme.textPrimary)),
+          subtitle: const Text('The fixes approved without paging you',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 12)),
+          trailing: const Icon(Icons.chevron_right,
+              color: AppTheme.textSecondary, size: 18),
+          onTap: () => context.push('/settings/agent-approval-rules'),
+        ),
+        ListTile(
+          leading: const Icon(Icons.build_circle_outlined,
+              color: AppTheme.accent),
+          title: const Text('Agent fixes',
+              style: TextStyle(color: AppTheme.textPrimary)),
+          subtitle: const Text('Awaiting review, and everything already done',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 12)),
+          trailing: const Icon(Icons.chevron_right,
+              color: AppTheme.textSecondary, size: 18),
+          onTap: () => context.push('/agent-actions'),
         ),
         const _SectionLabel('General'),
         SwitchListTile(

--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -827,6 +827,10 @@ func Open(dbPath string) (*sql.DB, error) {
 		// One gentle re-ask before an unanswered confirm-wait is handed to an
 		// admin; the stamp is what makes the nudge happen exactly once.
 		{alter: "ALTER TABLE issues ADD COLUMN confirm_nudged_at DATETIME"},
+		// The evidence link a paused rule was missing: WHICH issue's outcome
+		// stood it down. Written by every failure pause; the rules screen
+		// deep-links it.
+		{alter: "ALTER TABLE agent_approval_rules ADD COLUMN paused_by_issue_id INTEGER"},
 	}
 	for _, m := range migrations {
 		if err := applySchemaMigration(db, m); err != nil {

--- a/server/internal/remediation/approvalrules.go
+++ b/server/internal/remediation/approvalrules.go
@@ -130,7 +130,7 @@ func approvalRuleLabel(problemKind string, kind ActionKind, facet string) string
 func (s *Service) ListApprovalRules() ([]AgentApprovalRule, error) {
 	rows, err := s.db.Query(
 		`SELECT r.id, r.problem_kind, r.action_kind, r.action_facet, r.status,
-		        r.paused_reason, r.paused_at, r.created_by, u.username, r.seed_action_id,
+		        r.paused_reason, r.paused_at, r.paused_by_issue_id, r.created_by, u.username, r.seed_action_id,
 		        r.approved_count, r.resolved_count, r.last_approved_at, r.last_resolved_at,
 		        r.created_at, r.updated_at
 		 FROM agent_approval_rules r
@@ -149,14 +149,54 @@ func (s *Service) ListApprovalRules() ([]AgentApprovalRule, error) {
 		}
 		out = append(out, *rule)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range out {
+		if out[i].Status == ApprovalRulePaused && out[i].PausedAt != nil {
+			out[i].ApprovedSincePause = s.manualApprovalsSince(&out[i])
+		}
+	}
+	return out, nil
+}
+
+// manualApprovalsSince counts HUMAN approvals of a paused rule's exact triple
+// since the pause — the server-computed argument for resuming ("you have
+// automated this and keep doing it by hand"). Best-effort: zero on any read
+// error, facet derived by the same function the sweep matches with.
+func (s *Service) manualApprovalsSince(rule *AgentApprovalRule) int64 {
+	rows, err := s.db.Query(
+		`SELECT COALESCE(NULLIF(a.approved_params, ''), a.params)
+		 FROM agent_actions a
+		 JOIN issues i ON i.id = a.issue_id
+		 WHERE a.kind = ? AND i.problem_kind = ?
+		   AND a.decided_by IS NOT NULL AND a.executed_at IS NOT NULL
+		   AND a.decided_at >= ?`,
+		rule.ActionKind, rule.ProblemKind, rule.PausedAt.UTC(),
+	)
+	if err != nil {
+		return 0
+	}
+	defer rows.Close()
+	var n int64
+	for rows.Next() {
+		var params string
+		if err := rows.Scan(&params); err != nil {
+			continue
+		}
+		facet, ok := actionAutoFacet(ActionKind(rule.ActionKind), json.RawMessage(params))
+		if ok && facet == rule.ActionFacet {
+			n++
+		}
+	}
+	return n
 }
 
 // GetApprovalRule loads one rule with its creator name.
 func (s *Service) GetApprovalRule(ruleID int64) (*AgentApprovalRule, error) {
 	row := s.db.QueryRow(
 		`SELECT r.id, r.problem_kind, r.action_kind, r.action_facet, r.status,
-		        r.paused_reason, r.paused_at, r.created_by, u.username, r.seed_action_id,
+		        r.paused_reason, r.paused_at, r.paused_by_issue_id, r.created_by, u.username, r.seed_action_id,
 		        r.approved_count, r.resolved_count, r.last_approved_at, r.last_resolved_at,
 		        r.created_at, r.updated_at
 		 FROM agent_approval_rules r
@@ -179,6 +219,7 @@ func scanApprovalRule(row rowScanner) (*AgentApprovalRule, error) {
 		rule           AgentApprovalRule
 		pausedReason   sql.NullString
 		pausedAt       sql.NullTime
+		pausedByIssue  sql.NullInt64
 		createdBy      sql.NullInt64
 		createdByName  sql.NullString
 		seedActionID   sql.NullInt64
@@ -187,11 +228,15 @@ func scanApprovalRule(row rowScanner) (*AgentApprovalRule, error) {
 	)
 	if err := row.Scan(
 		&rule.ID, &rule.ProblemKind, &rule.ActionKind, &rule.ActionFacet, &rule.Status,
-		&pausedReason, &pausedAt, &createdBy, &createdByName, &seedActionID,
+		&pausedReason, &pausedAt, &pausedByIssue, &createdBy, &createdByName, &seedActionID,
 		&rule.ApprovedCount, &rule.ResolvedCount, &lastApprovedAt, &lastResolvedAt,
 		&rule.CreatedAt, &rule.UpdatedAt,
 	); err != nil {
 		return nil, err
+	}
+	if pausedByIssue.Valid {
+		v := pausedByIssue.Int64
+		rule.PausedByIssueID = &v
 	}
 	if pausedReason.Valid && pausedReason.String != "" {
 		v := pausedReason.String
@@ -300,11 +345,19 @@ func (s *Service) DeleteApprovalRule(ruleID int64) error {
 // transitioned the rule so callers notify exactly once. One failure pauses
 // today; a future N-strikes policy changes only this helper's body.
 func pauseApprovalRuleTx(tx *sql.Tx, ruleID int64, reason string) (bool, error) {
+	return pauseApprovalRuleForIssueTx(tx, ruleID, 0, reason)
+}
+
+// pauseApprovalRuleForIssueTx records WHICH issue's outcome stood the rule
+// down beside the pause itself — the evidence link the rules screen renders.
+func pauseApprovalRuleForIssueTx(tx *sql.Tx, ruleID, issueID int64, reason string) (bool, error) {
 	res, err := tx.Exec(
 		`UPDATE agent_approval_rules
-		 SET status = ?, paused_reason = ?, paused_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
+		 SET status = ?, paused_reason = ?, paused_at = CURRENT_TIMESTAMP,
+		     paused_by_issue_id = CASE WHEN ? > 0 THEN ? ELSE paused_by_issue_id END,
+		     updated_at = CURRENT_TIMESTAMP
 		 WHERE id = ? AND status = ?`,
-		ApprovalRulePaused, reason, ruleID, ApprovalRuleActive,
+		ApprovalRulePaused, reason, issueID, issueID, ruleID, ApprovalRuleActive,
 	)
 	if err != nil {
 		return false, fmt.Errorf("pause approval rule %d: %w", ruleID, err)
@@ -332,7 +385,7 @@ func approvalRuleLabelTx(tx *sql.Tx, ruleID int64) (string, error) {
 // transitioned the rule (false = it was already paused or deleted), so callers
 // notify post-commit exactly once per real transition.
 func pauseRuleForFailureTx(tx *sql.Tx, ruleID, issueID int64, reason string) (bool, error) {
-	paused, err := pauseApprovalRuleTx(tx, ruleID, reason)
+	paused, err := pauseApprovalRuleForIssueTx(tx, ruleID, issueID, reason)
 	if err != nil || !paused {
 		return false, err
 	}

--- a/server/internal/remediation/approvalrules_test.go
+++ b/server/internal/remediation/approvalrules_test.go
@@ -738,3 +738,51 @@ func TestProblemKindPersistedForAutoIssues(t *testing.T) {
 		t.Fatalf("problem_kind after refresh = %q (%v)", stored, err)
 	}
 }
+
+// A paused rule carries its evidence: WHICH issue stood it down, and how many
+// times the admin has approved the same triple by hand since — the
+// server-computed argument for resuming.
+func TestPausedRuleCarriesEvidenceAndSincePauseCount(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_approval_rules (problem_kind, action_kind, action_facet, status, paused_reason, paused_at, paused_by_issue_id, created_at, updated_at)
+		 VALUES ('Download stalled', 'remediate_queue', 'blocklist_search', 'paused', 'failed once', datetime('now', '-2 days'), 41, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+	); err != nil {
+		t.Fatalf("seed paused rule: %v", err)
+	}
+	res, err := svc.db.Exec(
+		`INSERT INTO issues (source, status, category, media_type, tmdb_id, title, detail, problem_kind)
+		 VALUES ('auto', 'resolved', NULL, 'movie', 9, 'M', 'stalled', 'Download stalled')`,
+	)
+	if err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+	issueID, _ := res.LastInsertId()
+	if _, err := svc.db.Exec("INSERT INTO users (id, username, password_hash, role) VALUES (3, 'boss', '', 'admin')"); err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+	// One matching MANUAL approval since the pause, one non-matching facet.
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_actions (issue_id, kind, params, rationale, risk, status, decided_by, decided_at, executed_at, fingerprint, tool_use_id)
+		 VALUES (?, 'remediate_queue', '{"media_type":"movie","queue_id":1,"action":"blocklist_search"}', 'r', 'mutating', 'executed', 3, datetime('now','-1 day'), datetime('now','-1 day'), 'fp-a', 'tu-a'),
+		        (?, 'remediate_queue', '{"media_type":"movie","queue_id":2,"action":"remove"}', 'r', 'mutating', 'executed', 3, datetime('now','-1 day'), datetime('now','-1 day'), 'fp-b', 'tu-b')`,
+		issueID, issueID,
+	); err != nil {
+		t.Fatalf("seed manual approvals: %v", err)
+	}
+
+	rules, err := svc.ListApprovalRules()
+	if err != nil {
+		t.Fatalf("ListApprovalRules: %v", err)
+	}
+	if len(rules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(rules))
+	}
+	rule := rules[0]
+	if rule.PausedByIssueID == nil || *rule.PausedByIssueID != 41 {
+		t.Fatalf("paused_by_issue_id = %v, want the pausing issue", rule.PausedByIssueID)
+	}
+	if rule.ApprovedSincePause != 1 {
+		t.Fatalf("approved_since_pause = %d, want exactly the matching-facet manual approval", rule.ApprovedSincePause)
+	}
+}

--- a/server/internal/remediation/models.go
+++ b/server/internal/remediation/models.go
@@ -335,6 +335,14 @@ type AgentApprovalRule struct {
 	Status         string     `json:"status"` // active | paused
 	PausedReason   *string    `json:"paused_reason"`
 	PausedAt       *time.Time `json:"paused_at"`
+	// PausedByIssueID deep-links the issue whose outcome stood the rule down —
+	// the evidence, not just the verdict.
+	PausedByIssueID *int64 `json:"paused_by_issue_id"`
+	// ApprovedSincePause counts MANUAL approvals of this rule's exact triple
+	// since it paused: "you have automated this and keep doing it by hand" is
+	// the argument for resuming, computed by the server so clients never
+	// re-derive facets.
+	ApprovedSincePause int64 `json:"approved_since_pause"`
 	CreatedBy      *int64     `json:"created_by"`
 	CreatedByName  *string    `json:"created_by_name"`
 	SeedActionID   *int64     `json:"seed_action_id"`


### PR DESCRIPTION
Wave 4.2 (follows #386). A paused rule showed *why* but not the evidence, and nothing ever argued for resuming — automation stayed off indefinitely while the admin hand-approved the same fix forever.

- **Pause evidence**: every failure pause records `paused_by_issue_id` (same transaction path); the rules screen deep-links *"See the issue that paused it"* and shows since-when.
- **The resume argument**: the server computes `approved_since_pause` — manual approvals of the rule's exact triple since the pause, facet-matched by the same function the sweep uses — and the screen says *"You've approved this exact fix N times by hand since it paused — Resume puts it back on autopilot."*
- **One connected surface**: AI Remediation links Standing auto-approvals and Agent fixes one tap away.

Pinned by test (evidence id on the wire; count includes only matching-facet human approvals). `go vet`/`go test ./...` green; `flutter analyze` clean; all 941 Flutter tests pass. Schema: one ALTER (`paused_by_issue_id`).

Next: 4.3 — the weekly digest + discoverability + setup-status rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1