### PR TITLE
feat(agents): the scoreboard — a digest that makes the quiet weeks legible

### DIFF
--- a/app/lib/features/issues/data/issues_service.dart
+++ b/app/lib/features/issues/data/issues_service.dart
@@ -108,6 +108,13 @@ class IssuesService {
   // ---- Admin ---------------------------------------------------------------
 
   /// List issues for the admin queue, optionally filtered by [status].
+  /// The agent scoreboard: what the pipeline did over the trailing window.
+  Future<Map<String, dynamic>> agentDigest({int days = 7}) async {
+    final resp = await _dio
+        .get('/api/admin/agent-digest', queryParameters: {'days': days});
+    return (resp.data as Map).cast<String, dynamic>();
+  }
+
   /// The reporter inbox: the caller's OWN reports, requester copy applied
   /// server-side. Non-admin accessible.
   Future<List<Issue>> listMyIssues() async {

--- a/app/lib/features/issues/ui/pending_agent_actions_screen.dart
+++ b/app/lib/features/issues/ui/pending_agent_actions_screen.dart
@@ -41,12 +41,16 @@ class _PendingAgentActionsScreenState
   Timer? _poll;
 
   static const _pollInterval = Duration(seconds: 30);
+  Map<String, dynamic>? _digest;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _load();
+      _loadDigest();
+    });
     _poll = Timer.periodic(_pollInterval, (_) => _load());
   }
 
@@ -119,6 +123,59 @@ class _PendingAgentActionsScreenState
   /// before the confirmation dialog, so a proposal that parks while the admin
   /// is reading it is never approved sight-unseen; the server skips anything
   /// that recovered or changed in the meantime and reports it per item.
+  Future<void> _loadDigest() async {
+    try {
+      final digest = await ref.read(issuesServiceProvider).agentDigest();
+      if (mounted) setState(() => _digest = digest);
+    } catch (_) {
+      // The scoreboard is a convenience; the queue works without it.
+    }
+  }
+
+  /// The week at a glance: what ran itself, what the rules did, what needs a
+  /// human. The system deliberately never pages on success — this is where the
+  /// quiet weeks become legible.
+  Widget? _digestCard() {
+    final d = _digest;
+    if (d == null) return null;
+    int n(String key) => (d[key] as num?)?.toInt() ?? 0;
+    final resolved = n('issues_resolved');
+    final zeroTouch = n('zero_touch');
+    final byRules = n('rule_approved');
+    final needsAdmin = n('needs_admin_open');
+    final paused = n('paused_rules');
+    final parts = <String>[
+      '$resolved resolved',
+      if (zeroTouch > 0) '$zeroTouch zero-touch',
+      if (byRules > 0) '$byRules by your rules',
+      if (needsAdmin > 0) '$needsAdmin need you',
+      if (paused > 0) '$paused rule(s) paused',
+    ];
+    return Container(
+      margin: const EdgeInsets.fromLTRB(12, 10, 12, 0),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: AppTheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppTheme.border),
+      ),
+      child: Row(
+        children: [
+          const Icon(Icons.insights_outlined,
+              size: 18, color: AppTheme.accent),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Text(
+              'Last 7 days: ${parts.join(' · ')}',
+              style: const TextStyle(
+                  color: AppTheme.textPrimary, fontSize: 13, height: 1.3),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Future<void> _approveAll() async {
     if (_batchBusy || _error != null) return;
     // D6: deleting imported files never rides a batch — the server refuses it
@@ -248,6 +305,7 @@ class _PendingAgentActionsScreenState
       body: CenteredContent(
         child: Column(
           children: [
+            if (_digestCard() case final card?) card,
             Padding(
               padding: const EdgeInsets.fromLTRB(12, 10, 12, 4),
               child: SizedBox(

--- a/server/README.md
+++ b/server/README.md
@@ -216,6 +216,7 @@ Request statuses: `unavailable`, `requested`, `pending` (awaiting approval), `de
 ```
 POST   /api/issues                         # user: report a problem; requires instance_id plus media scope — tmdb/tvdb ids
 GET    /api/issues                         # reporter inbox: the caller's OWN reports, newest first, requester copy applied
+GET    /api/admin/agent-digest             # the agent scoreboard: rolling window of resolved/zero-touch/rule-approved counts, tokens, and what needs a human
                                            #   for movie/tv, foreign_id (+book_format when both formats exist) for book
                                            #   (instance must be Radarr for movie, Sonarr for tv, Chaptarr for book;
                                            #   gated by allow_reporting); returns {issue_id,status}; initial status is

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -237,6 +237,7 @@ func NewRouter(
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Post("/issues/{id}/dismiss", remediationHandler.Dismiss)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Post("/issues/{id}/resolve", remediationHandler.ResolveIssue)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/issues/{id}/activity", remediationHandler.GetIssueActivity)
+			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/agent-digest", remediationHandler.Digest)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/remediation-settings", remediationHandler.GetSettings)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Put("/remediation-settings", remediationHandler.UpdateSettings)
 

--- a/server/internal/remediation/attempts_test.go
+++ b/server/internal/remediation/attempts_test.go
@@ -473,3 +473,46 @@ func TestActionsCarryPriorAttemptsForApprovers(t *testing.T) {
 		t.Fatalf("prior attempt = %+v, want a recurred blocklist_search", got)
 	}
 }
+
+// The digest is the scoreboard: zero-touch counts only resolved issues no
+// human decided on, and the rules that did the work are named.
+func TestAgentDigestCountsZeroTouch(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	if _, err := svc.db.Exec("INSERT INTO users (id, username, password_hash, role) VALUES (9, 'boss', '', 'admin')"); err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_approval_rules (id, problem_kind, action_kind, action_facet, status, created_at, updated_at)
+		 VALUES (5, 'Download stalled', 'remediate_queue', 'blocklist_only', 'active', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+	); err != nil {
+		t.Fatalf("seed rule: %v", err)
+	}
+	// Issue A: resolved, its one action rule-approved (zero-touch).
+	// Issue B: resolved, its action human-approved.
+	if _, err := svc.db.Exec(
+		`INSERT INTO issues (id, source, status, media_type, tmdb_id, title, detail, resolution_kind, closed_at)
+		 VALUES (101, 'auto', 'resolved', 'movie', 1, 'A', 'd', 'arr_state_cleared', CURRENT_TIMESTAMP),
+		        (102, 'auto', 'resolved', 'movie', 2, 'B', 'd', 'arr_state_cleared', CURRENT_TIMESTAMP)`,
+	); err != nil {
+		t.Fatalf("seed issues: %v", err)
+	}
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_actions (issue_id, kind, params, rationale, risk, status, executed_at, auto_rule_id, decided_by, fingerprint, tool_use_id)
+		 VALUES (101, 'remediate_queue', '{}', 'r', 'mutating', 'executed', CURRENT_TIMESTAMP, 5, NULL, 'fp-1', 'tu-1'),
+		        (102, 'remediate_queue', '{}', 'r', 'mutating', 'executed', CURRENT_TIMESTAMP, NULL, 9, 'fp-2', 'tu-2')`,
+	); err != nil {
+		t.Fatalf("seed actions: %v", err)
+	}
+
+	d, err := svc.Digest(7)
+	if err != nil {
+		t.Fatalf("Digest: %v", err)
+	}
+	if d.IssuesResolved != 2 || d.ZeroTouch != 1 || d.ActionsExecuted != 2 || d.RuleApproved != 1 {
+		t.Fatalf("digest = resolved %d zeroTouch %d executed %d ruleApproved %d, want 2/1/2/1",
+			d.IssuesResolved, d.ZeroTouch, d.ActionsExecuted, d.RuleApproved)
+	}
+	if len(d.RuleCounts) != 1 || d.RuleCounts[0].Count != 1 {
+		t.Fatalf("rule counts = %+v, want the one rule with one execution", d.RuleCounts)
+	}
+}

--- a/server/internal/remediation/digest.go
+++ b/server/internal/remediation/digest.go
@@ -1,0 +1,99 @@
+package remediation
+
+import (
+	"fmt"
+	"time"
+)
+
+// AgentDigest is the rolling scoreboard: what the agent pipeline did over a
+// window, computed live from the tables that already record everything. The
+// system pages reliably when it needs a decision and says nothing when
+// automation works — this is the deliberate pull surface that makes the quiet
+// weeks legible, so a well-tuned agent stops reading as "the thing that only
+// ever brings me problems".
+type AgentDigest struct {
+	Days int `json:"days"`
+
+	IssuesOpened   int64 `json:"issues_opened"`
+	IssuesResolved int64 `json:"issues_resolved"`
+	// ZeroTouch counts resolved issues in the window where no human made any
+	// action decision — the earned-autonomy lane doing its job end to end.
+	ZeroTouch        int64 `json:"zero_touch"`
+	ActionsExecuted  int64 `json:"actions_executed"`
+	RuleApproved     int64 `json:"rule_approved"`
+	ReporterClosed   int64 `json:"reporter_closed"`
+	TokensIn         int64 `json:"tokens_in"`
+	TokensOut        int64 `json:"tokens_out"`
+	NeedsAdminOpen   int64 `json:"needs_admin_open"`
+	PendingProposals int64 `json:"pending_proposals"`
+	PausedRules      int64 `json:"paused_rules"`
+
+	// RuleCounts names the rules that did the work: label -> executed count in
+	// the window, newest-heavy rules first in the slice.
+	RuleCounts []DigestRuleCount `json:"rule_counts"`
+
+	GeneratedAt time.Time `json:"generated_at"`
+}
+
+// DigestRuleCount is one standing rule's contribution to the window.
+type DigestRuleCount struct {
+	Label string `json:"label"`
+	Count int64  `json:"count"`
+}
+
+// Digest computes the agent scoreboard for the trailing N days (1..90).
+func (s *Service) Digest(days int) (*AgentDigest, error) {
+	if days <= 0 {
+		days = 7
+	}
+	if days > 90 {
+		days = 90
+	}
+	cutoff := fmt.Sprintf("-%d days", days)
+	d := &AgentDigest{Days: days, GeneratedAt: time.Now().UTC()}
+
+	row := s.db.QueryRow(`SELECT
+		(SELECT COUNT(1) FROM issues WHERE created_at >= datetime('now', ?1)),
+		(SELECT COUNT(1) FROM issues WHERE closed_at >= datetime('now', ?1) AND status = 'resolved'),
+		(SELECT COUNT(1) FROM issues i WHERE i.closed_at >= datetime('now', ?1) AND i.status = 'resolved'
+		   AND NOT EXISTS (SELECT 1 FROM agent_actions a WHERE a.issue_id = i.id AND a.decided_by IS NOT NULL)),
+		(SELECT COUNT(1) FROM agent_actions WHERE executed_at >= datetime('now', ?1) AND status = 'executed'),
+		(SELECT COUNT(1) FROM agent_actions WHERE executed_at >= datetime('now', ?1) AND status = 'executed' AND auto_rule_id IS NOT NULL AND decided_by IS NULL),
+		(SELECT COUNT(1) FROM issues WHERE closed_at >= datetime('now', ?1) AND resolution_kind = ?2),
+		(SELECT COALESCE(SUM(input_tokens), 0) FROM agent_runs WHERE started_at >= datetime('now', ?1)),
+		(SELECT COALESCE(SUM(output_tokens), 0) FROM agent_runs WHERE started_at >= datetime('now', ?1)),
+		(SELECT COUNT(1) FROM issues WHERE closed_at IS NULL AND status = 'needs_admin'),
+		(SELECT COUNT(1) FROM agent_actions a JOIN issues i ON i.id = a.issue_id
+		   WHERE a.status = 'proposed' AND i.closed_at IS NULL AND i.status = 'awaiting_approval'),
+		(SELECT COUNT(1) FROM agent_approval_rules WHERE status = 'paused')`,
+		cutoff, ResolutionReporterConfirmed,
+	)
+	if err := row.Scan(&d.IssuesOpened, &d.IssuesResolved, &d.ZeroTouch, &d.ActionsExecuted,
+		&d.RuleApproved, &d.ReporterClosed, &d.TokensIn, &d.TokensOut,
+		&d.NeedsAdminOpen, &d.PendingProposals, &d.PausedRules); err != nil {
+		return nil, fmt.Errorf("compute agent digest: %w", err)
+	}
+
+	rows, err := s.db.Query(`
+		SELECT r.problem_kind, r.action_kind, r.action_facet, COUNT(1)
+		FROM agent_actions a
+		JOIN agent_approval_rules r ON r.id = a.auto_rule_id
+		WHERE a.executed_at >= datetime('now', ?) AND a.status = 'executed'
+		GROUP BY r.id ORDER BY COUNT(1) DESC LIMIT 10`, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("compute digest rule counts: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var problem, kind, facet string
+		var count int64
+		if err := rows.Scan(&problem, &kind, &facet, &count); err != nil {
+			return nil, err
+		}
+		d.RuleCounts = append(d.RuleCounts, DigestRuleCount{
+			Label: approvalRuleLabel(problem, ActionKind(kind), facet),
+			Count: count,
+		})
+	}
+	return d, rows.Err()
+}

--- a/server/internal/remediation/handler.go
+++ b/server/internal/remediation/handler.go
@@ -75,6 +75,20 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// Digest handles GET /api/admin/agent-digest?days=7 — the agent scoreboard.
+func (h *Handler) Digest(w http.ResponseWriter, r *http.Request) {
+	days := 7
+	if v, err := strconv.Atoi(r.URL.Query().Get("days")); err == nil && v > 0 {
+		days = v
+	}
+	digest, err := h.service.Digest(days)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, digest)
+}
+
 // ListMine handles GET /api/issues — the reporter inbox: the caller's OWN
 // reports, newest first. Reporter-visible copy only: the requester-copy
 // boundary rewrites admin-facing resolution text before it leaves the server.


### PR DESCRIPTION
Wave 4.3a (follows #386/#387). The system deliberately never pages on success — so an admin's felt experience of a well-tuned agent was silence punctuated by pause alerts, the exact shape that gets a feature switched off.

- **`GET /api/admin/agent-digest?days=N`**: the rolling scoreboard, computed live — issues opened/resolved, **zero-touch** resolutions (no human decided any action: the earned-autonomy lane end to end), executions, rule-approved counts with the rules *named*, reporter closes, token spend, and what currently needs a human (needs_admin / pending proposals / paused rules).
- **The Agent fixes screen** renders it as one line above the tabs: *"Last 7 days: 5 resolved · 3 zero-touch · 2 by your rules · 1 needs you."*

Pinned by test (zero-touch semantics + named rule counts). `go vet`/`go test ./...` green; `flutter analyze` clean; 941 Flutter tests pass. Route documented.

Remaining wave-4 oddments (weekly digest push + its pref column, badge/discoverability tweaks, setup-status rows, the override editor) queue as 4.3b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1