### PR TITLE
feat(agents): remediation joins the setup checklist

### DIFF
--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -167,7 +167,7 @@ func NewRouter(
 
 			// Setup checklist: which features are configured, derived live on
 			// every request (drives the app's setup wizard + reminders).
-			r.With(auth.RequirePermission(auth.PermissionInstancesManage)).Get("/setup-status", setupStatusHandler(cfg, instanceStore, creds, aiHandler, plexService, serverSettings))
+			r.With(auth.RequirePermission(auth.PermissionInstancesManage)).Get("/setup-status", setupStatusHandler(cfg, instanceStore, creds, aiHandler, plexService, serverSettings, remediationService))
 
 			// Update availability + the admin-configured management-portal URL that
 			// backs the "update available" banner. GET returns both; PUT sets the

--- a/server/internal/api/setup_status.go
+++ b/server/internal/api/setup_status.go
@@ -10,6 +10,7 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/instance"
 	"github.com/windoze95/cantinarr-server/internal/plex"
 	"github.com/windoze95/cantinarr-server/internal/serversettings"
+	"github.com/windoze95/cantinarr-server/internal/remediation"
 )
 
 // setupItem is one entry in the admin setup checklist. The list is DERIVED
@@ -41,6 +42,13 @@ type setupFacts struct {
 	AI                bool
 	Push              bool
 	PlexInvites       bool
+	// RemediationDecided is whether an admin has ever saved remediation
+	// settings; like discovery, on and off are both correct answers and the
+	// checklist only asks that the decision was made.
+	RemediationDecided bool
+	// RemediationEnabled + AI together surface the one genuinely broken shape:
+	// detection switched on with no shared provider to investigate.
+	RemediationEnabled bool
 	// DiscoveryChosen is whether an admin has ever saved a discovery
 	// preference. Unlike the rest of the checklist there is no "correct"
 	// answer to grade against — every source and either language setting is
@@ -49,6 +57,16 @@ type setupFacts struct {
 	// DiscoverySource is the feed currently backing the headline rows, used
 	// only to describe the state back to the admin.
 	DiscoverySource string
+}
+
+// remediationDescription grades the decision, then calls out the one
+// genuinely broken shape: detection switched on with nothing configured to
+// investigate — the issues it opens would only ever wait.
+func remediationDescription(f setupFacts) string {
+	if f.RemediationEnabled && !f.AI {
+		return "Remediation is ON but no shared AI provider is configured — detected problems wait instead of being investigated. Add a provider under Providers & Credentials."
+	}
+	return "Decide whether Cantinarr should detect and investigate stuck downloads on its own. On or off — deciding is the step."
 }
 
 // discoveryDescription explains the discovery-rows step in terms of what is
@@ -149,12 +167,19 @@ func buildSetupItems(f setupFacts) []setupItem {
 			Configured:  f.AI,
 			Optional:    true,
 		},
+		{
+			Key:         "remediation",
+			Title:       "Automatic problem detection",
+			Description: remediationDescription(f),
+			Configured:  f.RemediationDecided,
+			Optional:    true,
+		},
 	}
 }
 
 // setupStatusHandler answers the admin setup checklist: which features are
 // configured right now. Everything is re-derived per request.
-func setupStatusHandler(cfg *config.Config, store *instance.Store, creds *credentials.Registry, aiHandler *ai.Handler, plexService *plex.Service, serverSettings *serversettings.Service) http.HandlerFunc {
+func setupStatusHandler(cfg *config.Config, store *instance.Store, creds *credentials.Registry, aiHandler *ai.Handler, plexService *plex.Service, serverSettings *serversettings.Service, remediationSvc *remediation.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var facts setupFacts
 		if instances, err := store.ListAll(); err == nil {
@@ -179,6 +204,10 @@ func setupStatusHandler(cfg *config.Config, store *instance.Store, creds *creden
 		facts.TMDB = creds.IsConfigured(credentials.KeyTMDBAccessToken)
 		facts.Trakt = creds.IsConfigured(credentials.KeyTraktClientID)
 		facts.AI = creds.IsAIConfigured()
+		if remediationSvc != nil {
+			facts.RemediationDecided = remediationSvc.SettingsDecided()
+			facts.RemediationEnabled = remediationSvc.Settings().Enabled
+		}
 		if aiHandler != nil {
 			facts.AI = aiHandler.ProviderConfigured()
 		}

--- a/server/internal/api/setup_status_test.go
+++ b/server/internal/api/setup_status_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestBuildSetupItemsNothingConfigured(t *testing.T) {
 	items := buildSetupItems(setupFacts{})
-	if len(items) != 12 {
-		t.Fatalf("items = %d, want 12", len(items))
+	if len(items) != 13 {
+		t.Fatalf("items = %d, want 13", len(items))
 	}
 	for _, item := range items {
 		if item.Configured {
@@ -158,5 +158,18 @@ func TestAdoptedTraktLeavesTheStepUnfinished(t *testing.T) {
 		if item.Key == "discovery_prefs" && item.Configured {
 			t.Error("discovery_prefs configured by an auto-adopted Trakt source, want it still open")
 		}
+	}
+}
+
+// The one genuinely broken remediation shape gets called out in the item copy:
+// detection on, nothing configured to investigate.
+func TestRemediationSetupItemWarnsWhenProviderless(t *testing.T) {
+	broken := remediationDescription(setupFacts{RemediationEnabled: true, AI: false})
+	if !strings.Contains(broken, "no shared AI provider") {
+		t.Fatalf("providerless copy = %q, want the warning", broken)
+	}
+	fine := remediationDescription(setupFacts{RemediationEnabled: true, AI: true})
+	if strings.Contains(fine, "no shared AI provider") {
+		t.Fatalf("healthy copy still warns: %q", fine)
 	}
 }

--- a/server/internal/remediation/settings.go
+++ b/server/internal/remediation/settings.go
@@ -233,6 +233,14 @@ func (s *Service) Settings() Settings {
 	return g
 }
 
+// SettingsDecided reports whether an admin has ever SAVED remediation
+// settings — the setup checklist grades "did you decide", never which answer.
+func (s *Service) SettingsDecided() bool {
+	var one int
+	err := s.db.QueryRow("SELECT 1 FROM settings WHERE key = ?", remediationSettingsKey).Scan(&one)
+	return err == nil
+}
+
 // SetSettings persists the global remediation settings (written exactly like
 // request.SetGlobalSettings) and returns the normalized value that was stored.
 func (s *Service) SetSettings(g Settings) (Settings, error) {


### PR DESCRIPTION
Wave 4.3b (follows #388). One derived setup-status item exposes the feature everywhere the checklist already surfaces (wizard, Settings progress, drawer reminder):

- **"Automatic problem detection"** — preference-shaped like the discovery step: it grades whether the decision was ever *saved* (new `SettingsDecided` probe), never which answer.
- The one genuinely broken shape gets dedicated copy: remediation ON with no shared AI provider — detected problems would only ever wait — names the fix and where it lives.
- Item-count pin updated (12 → 13) plus a copy-shape test.

**Deliberately not changed** after reading the code: the hamburger dot's agent-fix exclusion is documented double-count avoidance, and hide-when-empty is the settled Focused-attention-menu design — the review's discoverability worries were already answered by design.

`go vet`/`go test ./...` green. Remaining wave-4 queue: weekly digest push, the override editor, and the claimResume re-promotion fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1