### PR TITLE
feat(agents): prevention is recognizably first-class — and the mute has a price tag

### DIFF
--- a/app/lib/features/issues/data/issue_models.dart
+++ b/app/lib/features/issues/data/issue_models.dart
@@ -149,6 +149,7 @@ class Issue {
   /// executing), and it deliberately stays false on list reads — only the
   /// single-issue fetch that renders the control computes it.
   final bool canConfirmFixed;
+  final bool isPrevention;
 
   const Issue({
     required this.id,
@@ -172,6 +173,7 @@ class Issue {
     required this.updatedAt,
     required this.closedAt,
     required this.canConfirmFixed,
+    this.isPrevention = false,
   });
 
   bool get isTv => mediaType == 'tv';
@@ -189,6 +191,7 @@ class Issue {
   /// A short scope label for list/thread subtitles:
   /// "S2·E4" / "Season 2" / "Movie".
   String get scopeLabel {
+    if (isPrevention) return 'Prevention';
     if (isTv) {
       // A positive episode disambiguates Sonarr Specials (season zero) from
       // the season=0/episode=0 whole-series sentinel.
@@ -238,6 +241,7 @@ class Issue {
         // missing field never offers an irreversible close the server would
         // refuse.
         canConfirmFixed: json['can_confirm_fixed'] as bool? ?? false,
+        isPrevention: json['is_prevention'] as bool? ?? false,
       );
 }
 

--- a/app/lib/features/issues/ui/issue_thread_screen.dart
+++ b/app/lib/features/issues/ui/issue_thread_screen.dart
@@ -269,13 +269,15 @@ class _IssueThreadScreenState extends ConsumerState<IssueThreadScreen>
       context: context,
       builder: (dialogContext) => AlertDialog(
         backgroundColor: AppTheme.surface,
-        title: const Text(
-          'Dismiss this issue?',
-          style: TextStyle(color: AppTheme.textPrimary),
+        title: Text(
+          issue.isPrevention ? 'Dismiss this notice?' : 'Dismiss this issue?',
+          style: const TextStyle(color: AppTheme.textPrimary),
         ),
-        content: const Text(
-          'This closes the issue without applying any pending fixes. Pending fixes will no longer be available for approval.',
-          style: TextStyle(color: AppTheme.textSecondary),
+        content: Text(
+          issue.isPrevention
+              ? 'Dismissing silences this notice for about 6 months. It only returns if the problem re-forms from newer incidents.'
+              : 'This closes the issue without applying any pending fixes. Pending fixes will no longer be available for approval.',
+          style: const TextStyle(color: AppTheme.textSecondary),
         ),
         actions: [
           TextButton(
@@ -328,6 +330,7 @@ class _IssueThreadScreenState extends ConsumerState<IssueThreadScreen>
       builder: (_) => _AdminResolutionDialog(
         disposition: disposition,
         needsVerification: issue.status == IssueStatus.needsAdmin,
+        isPrevention: issue.isPrevention,
       ),
     );
     if (note == null || !mounted) return;
@@ -796,10 +799,12 @@ class _AdminCompletionPanel extends StatelessWidget {
 class _AdminResolutionDialog extends StatefulWidget {
   final AdminIssueDisposition disposition;
   final bool needsVerification;
+  final bool isPrevention;
 
   const _AdminResolutionDialog({
     required this.disposition,
     required this.needsVerification,
+    this.isPrevention = false,
   });
 
   @override
@@ -840,6 +845,20 @@ class _AdminResolutionDialogState extends State<_AdminResolutionDialog> {
                 height: 1.35,
               ),
             ),
+            if (widget.isPrevention) ...[
+              const SizedBox(height: 8),
+              Text(
+                resolved
+                    ? 'Closing a notice this way silences it for about 2 months; it returns only if the problem re-forms from newer incidents.'
+                    : 'Closing without a fix tells Cantinarr you are not going to change this — the notice stays silent for 12 months unless the problem re-forms.',
+                style: const TextStyle(
+                  color: AppTheme.requested,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                  height: 1.35,
+                ),
+              ),
+            ],
             if (widget.needsVerification) ...[
               const SizedBox(height: 8),
               const Text(

--- a/server/internal/remediation/models.go
+++ b/server/internal/remediation/models.go
@@ -180,6 +180,13 @@ type Issue struct {
 	// per-row query for a control no list renders.
 	CanConfirmFixed bool `json:"can_confirm_fixed"`
 
+	// IsPrevention marks a recurrence notice — advice about a setting, not an
+	// incident. Computed at read from the dedupe namespace so clients render
+	// the dedicated tile and disclose the closure verbs' mute durations
+	// (resolve 60d / dismiss 180d / close-without-fix 365d) at the point of
+	// decision instead of hiding a 12-month choice behind a generic button.
+	IsPrevention bool `json:"is_prevention"`
+
 	InstanceID string `json:"instance_id"`
 	DownloadID string `json:"-"`
 	ArrQueueID int    `json:"-"`

--- a/server/internal/remediation/prevention_test.go
+++ b/server/internal/remediation/prevention_test.go
@@ -982,3 +982,33 @@ func TestPreventionNoticeQuotesLiveValuesAndSelfResolves(t *testing.T) {
 		t.Fatalf("after the setting changed: closed %v kind %q, want auto-resolved %q", closed, kind, ResolutionPreventionSettingChanged)
 	}
 }
+
+// The wire flag that makes prevention recognizably first-class client-side.
+func TestIsPreventionFlagOnWire(t *testing.T) {
+	svc, _, fake := setupPreAirService(t)
+	fake.setIndexers(nil)
+	advice, _ := arr.PreventionFor(arr.ProblemDownloadStalled)
+	noticeID, err := svc.openPreventionIssue(preventionCandidate{
+		instanceID: preAirSonarrID, problemKind: arr.ProblemDownloadStalled,
+		issueCount: 3, distinctMedia: 2, distinctDays: 3,
+	}, advice, "TV", time.Now().UTC())
+	if err != nil {
+		t.Fatalf("open notice: %v", err)
+	}
+	notice, err := svc.GetIssue(noticeID)
+	if err != nil {
+		t.Fatalf("load notice: %v", err)
+	}
+	if !notice.IsPrevention {
+		t.Fatalf("prevention notice not flagged on the wire")
+	}
+	res, _ := svc.db.Exec(`INSERT INTO issues (source, status, media_type, tmdb_id, title, detail) VALUES ('auto','open','movie',1,'M','d')`)
+	plainID, _ := res.LastInsertId()
+	plain, err := svc.GetIssue(plainID)
+	if err != nil {
+		t.Fatalf("load plain issue: %v", err)
+	}
+	if plain.IsPrevention {
+		t.Fatalf("ordinary issue flagged as prevention")
+	}
+}

--- a/server/internal/remediation/service.go
+++ b/server/internal/remediation/service.go
@@ -551,7 +551,8 @@ func (s *Service) GetIssue(issueID int64) (*Issue, error) {
 		        i.tmdb_id, i.tvdb_id, i.media_type, i.title, i.season_number, i.episode_number,
 		        i.detail, i.occurrences, i.read, i.resolution, i.resolution_kind,
 		        i.created_at, i.updated_at, i.closed_at,
-		        i.instance_id, i.download_id, i.arr_queue_id, i.author_id, i.book_id
+		        i.instance_id, i.download_id, i.arr_queue_id, i.author_id, i.book_id,
+		        COALESCE(i.dedupe_key, '') LIKE 'system:prevention:%'
 		 FROM issues i LEFT JOIN users u ON u.id = i.reporter_id
 		 WHERE i.id = ?`,
 		issueID,
@@ -987,7 +988,8 @@ func (s *Service) ListIssuesForReporter(reporterID int64) ([]Issue, error) {
 	                 i.tmdb_id, i.tvdb_id, i.media_type, i.title, i.season_number, i.episode_number,
 	                 i.detail, i.occurrences, i.read, i.resolution, i.resolution_kind,
 	                 i.created_at, i.updated_at, i.closed_at,
-	                 i.instance_id, i.download_id, i.arr_queue_id, i.author_id, i.book_id
+	                 i.instance_id, i.download_id, i.arr_queue_id, i.author_id, i.book_id,
+	                 COALESCE(i.dedupe_key, '') LIKE 'system:prevention:%'
 	          FROM issues i LEFT JOIN users u ON u.id = i.reporter_id
 	          WHERE i.reporter_id = ? ORDER BY i.updated_at DESC, i.id DESC`, reporterID)
 	if err != nil {
@@ -1010,7 +1012,8 @@ func (s *Service) ListIssues(status string) ([]Issue, error) {
 	                 i.tmdb_id, i.tvdb_id, i.media_type, i.title, i.season_number, i.episode_number,
 	                 i.detail, i.occurrences, i.read, i.resolution, i.resolution_kind,
 	                 i.created_at, i.updated_at, i.closed_at,
-	                 i.instance_id, i.download_id, i.arr_queue_id, i.author_id, i.book_id
+	                 i.instance_id, i.download_id, i.arr_queue_id, i.author_id, i.book_id,
+	                 COALESCE(i.dedupe_key, '') LIKE 'system:prevention:%'
 	          FROM issues i LEFT JOIN users u ON u.id = i.reporter_id`
 	var (
 		rows *sql.Rows
@@ -1101,6 +1104,7 @@ func scanIssue(row rowScanner) (*Issue, error) {
 		&iss.TmdbID, &tvdbID, &iss.MediaType, &iss.Title, &iss.SeasonNumber, &iss.EpisodeNumber,
 		&iss.Detail, &iss.Occurrences, &iss.Read, &resolution, &resolutionKind,
 		&iss.CreatedAt, &iss.UpdatedAt, &closedAt, &instanceID, &downloadID, &arrQueueID, &authorID, &bookID,
+		&iss.IsPrevention,
 	); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Wave 7.1 (follows the eyes wave; pairs with #392's live-value quoting). A recurrence notice rendered as an ordinary system issue, and its closure verbs were *silently* a 60/180/365-day mute — a 12-month decision hidden behind the most convenient button.

- **`is_prevention`** on the issue wire (computed at read from the dedupe namespace; `COALESCE` because `NULL LIKE` is NULL).
- The list chip reads **Prevention** instead of masquerading as a generic System row.
- **Every closure verb discloses its cost** on the notice: resolved ≈ 2 months of silence, dismiss ≈ 6, close-without-fix = 12 ("you are telling Cantinarr you are not going to change this") — and all three say it returns only if the problem re-forms from newer incidents.

Typed steps payload stays deferred — the disclosure and tile were the real debt. Pinned (flag true on a notice, false on an ordinary issue). `go vet`/`go test ./...` green; `flutter analyze` clean; 941 tests pass.

Next: 7.2 — the writable-subset apply card (D3) through the preview/apply/config-history machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1