### PR TITLE
feat(agents): the writable prevention cause points at the existing apply flow

### DIFF
--- a/server/internal/arr/prevention.go
+++ b/server/internal/arr/prevention.go
@@ -150,6 +150,12 @@ var preventionCatalog = map[string]Prevention{
 		Steps: []string{
 			"Settings > Indexers — identify the source and lower its priority, or remove it.",
 			"Settings > Profiles — a minimum size on the quality profile rejects a sample before it is ever grabbed.",
+			// The one cause in this catalog Cantinarr can already change — through
+			// the assistant's existing previewed, one-turn, restorable apply flow.
+			// Deliberately a pointer rather than a second apply mechanism: the
+			// profile write's one-use handoff depends on authenticated in-app
+			// chat-turn provenance, and that boundary is not forked for a notice.
+			"Or ask the in-app AI assistant to raise that profile's minimum size — it previews the exact change and applies it in the same turn, recorded in Configuration history with a one-time restore.",
 		},
 	},
 	ProblemPreAirSeasonFill: {


### PR DESCRIPTION
Wave 7.2, deliberately scoped down from the plan's apply-card sketch. The sample-clip entry is the catalog's one writable cause (quality-profile minimum size), and routing a profile write through approval cards would fork the **one-use apply handoff** — a boundary whose safety deliberately depends on authenticated in-app chat-turn provenance — for a single entry.

Instead, the notice teaches the path that already exists: *ask the assistant — it previews the exact change, applies it in the same turn, and records it in Configuration history with a one-time restore.* If practice shows the pointer isn't enough, the full apply-card gets designed as its own provenance review, not as a notice side effect.

One catalog string + rationale comment. `go vet`/`go test` green. With #395, wave 7 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1