### PR TITLE
feat(agents): arm from the catalog — trusting a repeat fix stops waiting for a checkbox

### DIFF
--- a/app/lib/features/issues/data/issues_service.dart
+++ b/app/lib/features/issues/data/issues_service.dart
@@ -108,6 +108,23 @@ class IssuesService {
   // ---- Admin ---------------------------------------------------------------
 
   /// List issues for the admin queue, optionally filtered by [status].
+  /// Triples the admin has hand-approved and could automate.
+  Future<List<Map<String, dynamic>>> listRuleCandidates() async {
+    final resp = await _dio.get('/api/admin/agent-approval-rules/candidates');
+    return ((resp.data['candidates'] as List?) ?? const [])
+        .whereType<Map<String, dynamic>>()
+        .toList();
+  }
+
+  /// Arm a rule from the catalog (server re-checks the grounding).
+  Future<void> armRule(String problemKind, String actionKind, String actionFacet) async {
+    await _dio.post('/api/admin/agent-approval-rules', data: {
+      'problem_kind': problemKind,
+      'action_kind': actionKind,
+      'action_facet': actionFacet,
+    });
+  }
+
   /// The agent scoreboard: what the pipeline did over the trailing window.
   Future<Map<String, dynamic>> agentDigest({int days = 7}) async {
     final resp = await _dio

--- a/app/lib/features/issues/ui/agent_approval_rules_screen.dart
+++ b/app/lib/features/issues/ui/agent_approval_rules_screen.dart
@@ -29,6 +29,7 @@ class AgentApprovalRulesScreen extends ConsumerStatefulWidget {
 class _AgentApprovalRulesScreenState
     extends ConsumerState<AgentApprovalRulesScreen> {
   List<AgentApprovalRule>? _rules;
+  List<Map<String, dynamic>> _candidates = const [];
   bool _isLoading = true;
   String? _error;
   int _loadEpoch = 0;
@@ -48,6 +49,19 @@ class _AgentApprovalRulesScreenState
     return m != null ? m.group(1)! : 'Something went wrong';
   }
 
+  Future<void> _armCandidate(Map<String, dynamic> candidate) async {
+    try {
+      await ref.read(issuesServiceProvider).armRule(
+            candidate['problem_kind'] as String? ?? '',
+            candidate['action_kind'] as String? ?? '',
+            candidate['action_facet'] as String? ?? '',
+          );
+    } catch (_) {
+      // Grounding is re-checked server-side; a refusal just leaves the list.
+    }
+    if (mounted) _load();
+  }
+
   Future<void> _load() async {
     final epoch = ++_loadEpoch;
     setState(() {
@@ -55,10 +69,18 @@ class _AgentApprovalRulesScreenState
       _error = null;
     });
     try {
-      final rules = await ref.read(issuesServiceProvider).listApprovalRules();
+      final service = ref.read(issuesServiceProvider);
+      final rules = await service.listApprovalRules();
+      List<Map<String, dynamic>> candidates = const [];
+      try {
+        candidates = await service.listRuleCandidates();
+      } catch (_) {
+        // The catalog is a convenience; the rules list works without it.
+      }
       if (!mounted || epoch != _loadEpoch) return;
       setState(() {
         _rules = rules;
+        _candidates = candidates;
         _isLoading = false;
       });
     } catch (e) {
@@ -217,13 +239,20 @@ class _AgentApprovalRulesScreenState
         ],
       );
     }
+    final extra = _candidates.isEmpty ? 0 : 1;
     return ListView.separated(
       physics: const AlwaysScrollableScrollPhysics(),
       padding: const EdgeInsets.all(16),
-      itemCount: rules.length,
+      itemCount: rules.length + extra,
       separatorBuilder: (_, __) => const SizedBox(height: 10),
       itemBuilder: (context, index) {
-        final rule = rules[index];
+        if (extra == 1 && index == 0) {
+          return _ReadyToAutomateCard(
+            candidates: _candidates,
+            onArm: _armCandidate,
+          );
+        }
+        final rule = rules[index - extra];
         return _RuleCard(
           rule: rule,
           busy: _busyRules.contains(rule.id),
@@ -396,5 +425,63 @@ class _RuleCard extends StatelessWidget {
     if (d.inMinutes < 60) return '${d.inMinutes}m ago';
     if (d.inHours < 24) return '${d.inHours}h ago';
     return '${d.inDays}d ago';
+  }
+}
+
+/// Triples the admin has already approved by hand and could put on autopilot —
+/// "remember, later", grounded server-side.
+class _ReadyToAutomateCard extends StatelessWidget {
+  final List<Map<String, dynamic>> candidates;
+  final Future<void> Function(Map<String, dynamic>) onArm;
+
+  const _ReadyToAutomateCard({required this.candidates, required this.onArm});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: AppTheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: AppTheme.border),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Ready to automate',
+            style: TextStyle(
+                color: AppTheme.textPrimary,
+                fontSize: 14,
+                fontWeight: FontWeight.w700),
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            "Fixes you've already approved by hand. Arming one approves future matches automatically; it pauses itself if a fix fails.",
+            style: TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+          ),
+          const SizedBox(height: 8),
+          for (final c in candidates)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '${c['label'] ?? ''} · approved ${c['approved_count'] ?? 0}x by hand',
+                      style: const TextStyle(
+                          color: AppTheme.textPrimary, fontSize: 13),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => onArm(c),
+                    child: const Text('Arm'),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
   }
 }

--- a/server/README.md
+++ b/server/README.md
@@ -217,6 +217,8 @@ Request statuses: `unavailable`, `requested`, `pending` (awaiting approval), `de
 POST   /api/issues                         # user: report a problem; requires instance_id plus media scope — tmdb/tvdb ids
 GET    /api/issues                         # reporter inbox: the caller's OWN reports, newest first, requester copy applied
 GET    /api/admin/agent-digest             # the agent scoreboard: rolling window of resolved/zero-touch/rule-approved counts, tokens, and what needs a human
+GET    /api/admin/agent-approval-rules/candidates  # triples the admin has hand-approved and could automate (grounded; active-ruled triples excluded)
+POST   /api/admin/agent-approval-rules     # arm a rule from the catalog — server re-checks the triple was actually hand-approved
                                            #   for movie/tv, foreign_id (+book_format when both formats exist) for book
                                            #   (instance must be Radarr for movie, Sonarr for tv, Chaptarr for book;
                                            #   gated by allow_reporting); returns {issue_id,status}; initial status is

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -238,6 +238,8 @@ func NewRouter(
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Post("/issues/{id}/resolve", remediationHandler.ResolveIssue)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/issues/{id}/activity", remediationHandler.GetIssueActivity)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/agent-digest", remediationHandler.Digest)
+			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/agent-approval-rules/candidates", remediationHandler.ListRuleCandidates)
+			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Post("/agent-approval-rules", remediationHandler.ArmRule)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Get("/remediation-settings", remediationHandler.GetSettings)
 			r.With(auth.RequirePermission(auth.PermissionRemediationManage)).Put("/remediation-settings", remediationHandler.UpdateSettings)
 

--- a/server/internal/remediation/approvalrules.go
+++ b/server/internal/remediation/approvalrules.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 	"time"
 )
 
@@ -705,4 +706,114 @@ func (s *Service) announceBootPausedRules() {
 	for _, ruleID := range ruleIDs {
 		s.notifyAutoApprovalPaused(ruleID, 0)
 	}
+}
+
+// RuleCandidate is one (problem, fix, facet) triple the admin has actually
+// approved by hand and could automate — the arm-from-catalog surface, so
+// trusting a repeat fix no longer waits for the next proposal's checkbox.
+type RuleCandidate struct {
+	ProblemKind   string     `json:"problem_kind"`
+	ActionKind    string     `json:"action_kind"`
+	ActionFacet   string     `json:"action_facet"`
+	Label         string     `json:"label"`
+	ApprovedCount int64      `json:"approved_count"`
+	LastApproved  *time.Time `json:"last_approved_at"`
+}
+
+// ListRuleCandidates aggregates every triple with at least one HUMAN-approved
+// execution and no active rule. Grounded by construction: a triple nobody has
+// approved by hand cannot appear, so arming from here is "remember, later" —
+// never inventing a rule from thin air.
+func (s *Service) ListRuleCandidates() ([]RuleCandidate, error) {
+	rows, err := s.db.Query(
+		`SELECT i.problem_kind, a.kind, COALESCE(NULLIF(a.approved_params, ''), a.params), a.decided_at
+		 FROM agent_actions a JOIN issues i ON i.id = a.issue_id
+		 WHERE a.decided_by IS NOT NULL AND a.executed_at IS NOT NULL AND a.status = ?
+		   AND i.problem_kind IS NOT NULL AND i.problem_kind != ''`,
+		ActionExecuted,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query rule candidates: %w", err)
+	}
+	defer rows.Close()
+	type agg struct {
+		count int64
+		last  *time.Time
+	}
+	byKey := map[string]*agg{}
+	meta := map[string]RuleCandidate{}
+	for rows.Next() {
+		var problem, kind, params string
+		var decidedAt sql.NullTime
+		if err := rows.Scan(&problem, &kind, &params, &decidedAt); err != nil {
+			return nil, err
+		}
+		facet, ok := actionAutoFacet(ActionKind(kind), json.RawMessage(params))
+		if !ok {
+			continue
+		}
+		key := approvalRuleKey(problem, kind, facet)
+		if _, seen := byKey[key]; !seen {
+			byKey[key] = &agg{}
+			meta[key] = RuleCandidate{
+				ProblemKind: problem, ActionKind: kind, ActionFacet: facet,
+				Label: approvalRuleLabel(problem, ActionKind(kind), facet),
+			}
+		}
+		byKey[key].count++
+		if decidedAt.Valid && (byKey[key].last == nil || decidedAt.Time.After(*byKey[key].last)) {
+			v := decidedAt.Time
+			byKey[key].last = &v
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Subtract triples that already have an ACTIVE rule (paused ones stay
+	// listed — arming from the catalog reactivates, same as remember).
+	ruleRows, err := s.db.Query(
+		"SELECT problem_kind, action_kind, action_facet FROM agent_approval_rules WHERE status = ?",
+		ApprovalRuleActive,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query active rules: %w", err)
+	}
+	defer ruleRows.Close()
+	for ruleRows.Next() {
+		var problem, kind, facet string
+		if err := ruleRows.Scan(&problem, &kind, &facet); err != nil {
+			return nil, err
+		}
+		delete(byKey, approvalRuleKey(problem, kind, facet))
+	}
+	out := make([]RuleCandidate, 0, len(byKey))
+	for key, a := range byKey {
+		c := meta[key]
+		c.ApprovedCount = a.count
+		c.LastApproved = a.last
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ApprovedCount > out[j].ApprovedCount })
+	return out, nil
+}
+
+// ArmRuleFromCatalog creates (or reactivates) a rule for a triple the admin
+// has actually approved by hand — the grounding is re-checked here, server
+// side, whatever the client claimed.
+func (s *Service) ArmRuleFromCatalog(adminID int64, problemKind, actionKind, actionFacet string) (int64, error) {
+	candidates, err := s.ListRuleCandidates()
+	if err != nil {
+		return 0, err
+	}
+	grounded := false
+	for _, c := range candidates {
+		if c.ProblemKind == problemKind && c.ActionKind == actionKind && c.ActionFacet == actionFacet {
+			grounded = true
+			break
+		}
+	}
+	if !grounded {
+		return 0, fmt.Errorf("this exact fix has never been approved by hand; approve it once on a real proposal first")
+	}
+	return s.createOrReactivateApprovalRule(adminID, 0, problemKind, ActionKind(actionKind), actionFacet)
 }

--- a/server/internal/remediation/approvalrules_test.go
+++ b/server/internal/remediation/approvalrules_test.go
@@ -786,3 +786,46 @@ func TestPausedRuleCarriesEvidenceAndSincePauseCount(t *testing.T) {
 		t.Fatalf("approved_since_pause = %d, want exactly the matching-facet manual approval", rule.ApprovedSincePause)
 	}
 }
+
+// The catalog is grounded by construction: only hand-approved triples appear,
+// active-ruled triples vanish, and arming an unseen triple is refused.
+func TestRuleCatalogGroundedArming(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	if _, err := svc.db.Exec("INSERT INTO users (id, username, password_hash, role) VALUES (3, 'boss', '', 'admin')"); err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+	res, _ := svc.db.Exec(
+		`INSERT INTO issues (source, status, media_type, tmdb_id, title, detail, problem_kind)
+		 VALUES ('user', 'resolved', 'movie', 9, 'M', 'stalled', 'Download stalled')`)
+	issueID, _ := res.LastInsertId()
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_actions (issue_id, kind, params, rationale, risk, status, decided_by, decided_at, executed_at, fingerprint, tool_use_id)
+		 VALUES (?, 'remediate_queue', '{"media_type":"movie","queue_id":1,"action":"blocklist_only"}', 'r', 'mutating', 'executed', 3, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'fp-c1', 'tu-c1')`,
+		issueID,
+	); err != nil {
+		t.Fatalf("seed approval: %v", err)
+	}
+
+	candidates, err := svc.ListRuleCandidates()
+	if err != nil {
+		t.Fatalf("ListRuleCandidates: %v", err)
+	}
+	if len(candidates) != 1 || candidates[0].ActionFacet != "blocklist_only" || candidates[0].ApprovedCount != 1 {
+		t.Fatalf("candidates = %+v, want the one hand-approved triple", candidates)
+	}
+
+	if _, err := svc.ArmRuleFromCatalog(3, "Download stalled", "remediate_queue", "remove"); err == nil {
+		t.Fatalf("armed a never-approved facet")
+	}
+	ruleID, err := svc.ArmRuleFromCatalog(3, "Download stalled", "remediate_queue", "blocklist_only")
+	if err != nil || ruleID <= 0 {
+		t.Fatalf("grounded arm = (%d, %v)", ruleID, err)
+	}
+	after, err := svc.ListRuleCandidates()
+	if err != nil {
+		t.Fatalf("ListRuleCandidates after arm: %v", err)
+	}
+	if len(after) != 0 {
+		t.Fatalf("armed triple still listed: %+v", after)
+	}
+}

--- a/server/internal/remediation/handler.go
+++ b/server/internal/remediation/handler.go
@@ -75,6 +75,41 @@ func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// ListRuleCandidates handles GET /api/admin/agent-approval-rules/candidates.
+func (h *Handler) ListRuleCandidates(w http.ResponseWriter, r *http.Request) {
+	candidates, err := h.service.ListRuleCandidates()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"candidates": candidates})
+}
+
+// ArmRule handles POST /api/admin/agent-approval-rules — grounded server-side:
+// only triples the admin has actually hand-approved can be armed.
+func (h *Handler) ArmRule(w http.ResponseWriter, r *http.Request) {
+	claims := auth.GetClaims(r.Context())
+	if claims == nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+		return
+	}
+	var body struct {
+		ProblemKind string `json:"problem_kind"`
+		ActionKind  string `json:"action_kind"`
+		ActionFacet string `json:"action_facet"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid body"})
+		return
+	}
+	ruleID, err := h.service.ArmRuleFromCatalog(claims.UserID, body.ProblemKind, body.ActionKind, body.ActionFacet)
+	if err != nil {
+		writeJSON(w, http.StatusConflict, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"rule_id": ruleID})
+}
+
 // Digest handles GET /api/admin/agent-digest?days=7 — the agent scoreboard.
 func (h *Handler) Digest(w http.ResponseWriter, r *http.Request) {
 	days := 7


### PR DESCRIPTION
Wave 8.1, closing the autonomy-expansion wave (follows #397). Rules were born only by ticking *remember* at the exact moment a matching proposal happened to be on screen.

- **`GET .../agent-approval-rules/candidates`**: every triple with ≥1 **human-approved** execution and no active rule — grounded by construction; paused triples stay listed (arming reactivates).
- **`POST .../agent-approval-rules`**: server re-checks the grounding whatever the client claimed — a never-hand-approved triple is refused with *"approve it once on a real proposal first"*.
- The rules screen opens with **Ready to automate**: label · approved-Nx-by-hand · Arm.

Pinned (grounded listing, ungrounded refusal, armed triples vanish). `go vet`/`go test ./...` green; `flutter analyze` clean; 941 tests pass. Routes documented.

With #397, wave 8 closes: the lane exists (D2), and now it's easy to enter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1