### PR TITLE
fix(agents): a fix's success no longer burns its own resume

### DIFF
--- a/server/internal/remediation/observation.go
+++ b/server/internal/remediation/observation.go
@@ -1140,10 +1140,17 @@ func (s *Service) suspendIssueForRecovery(issueID int64, item arr.QueueObservati
 		return false, err
 	}
 	superseded, _ := actionRes.RowsAffected()
+	// resume_pending deliberately SURVIVES suspension: it is a decision already
+	// made (approved and executed, or denied) whose continuation is pure
+	// follow-up, and the commonest trigger for this suspend is the fix's OWN
+	// success emptying the queue — aborting the very handoff that success just
+	// staged burned its transcript and forced a second fresh run. Live agent
+	// states are still cancelled; the surviving handoff is consumed when the
+	// issue re-promotes (claimResume accepts open) or finalized if it closes.
 	if _, err := tx.Exec(
 		`UPDATE agent_runs SET status='aborted', stop_reason='arr_recovery_in_flight',
 		 deadline_at=NULL, finished_at=COALESCE(finished_at, ?)
-		 WHERE issue_id=? AND status IN ('running','waiting_user','waiting_approval','resume_pending')`,
+		 WHERE issue_id=? AND status IN ('running','waiting_user','waiting_approval')`,
 		now, issueID,
 	); err != nil {
 		return false, err

--- a/server/internal/remediation/pipeline_harness_test.go
+++ b/server/internal/remediation/pipeline_harness_test.go
@@ -216,20 +216,14 @@ func TestPipelineStalledUpgradeFullLoop(t *testing.T) {
 		t.Fatalf("issue after settled absence = %q, want re-promoted %q", mid.Status, IssueOpen)
 	}
 
-	// Current production truth, surfaced by this harness: the staged resume is
-	// ORPHANED here. Its claim requires the issue at `investigating`, but the
-	// settle dance above re-promoted it to `open`, so the close arrives via a
-	// FRESH run that recoverWork enqueues for the open issue — reading the same
-	// script continuation (scoped read, then conclude). upgradeAbandonProven
-	// supplies the server-side proof: the library file is unchanged and the
-	// server itself dispatched blocklist_only. (A later wave may teach the
-	// resume claim to accept a re-promoted issue; this assertion is the pin
-	// that documents today's two-run shape until then.)
+	// The staged resume survives its own fix's success: re-promotion lands the
+	// issue at `open`, and the resume claim accepts it — the preserved
+	// transcript continues (scoped read, then conclude), and
+	// upgradeAbandonProven supplies the server-side proof: the library file is
+	// unchanged and the server itself dispatched blocklist_only. One incident,
+	// one approval, ONE run.
 	if err := r.Resume(context.Background(), issue.ID); err != nil {
-		t.Fatalf("orphaned Resume attempt errored (want quiet no-op): %v", err)
-	}
-	if err := r.Run(context.Background(), issue.ID); err != nil {
-		t.Fatalf("fresh Run after settle: %v", err)
+		t.Fatalf("Resume after settle: %v", err)
 	}
 
 	final := soleIssue(t, h.svc)
@@ -238,8 +232,8 @@ func TestPipelineStalledUpgradeFullLoop(t *testing.T) {
 			final.Status, final.ResolutionKind, IssueResolved, ResolutionArrStateCleared)
 	}
 	count, runStatus := agentRunRows(t, h.svc, issue.ID)
-	if count != 2 || runStatus != "succeeded" {
-		t.Fatalf("agent_runs = %d rows (last %q), want the orphaned-resume + succeeded fresh-run pair", count, runStatus)
+	if count != 1 || runStatus != "succeeded" {
+		t.Fatalf("agent_runs = %d rows (last %q), want the ONE resumed, succeeded run", count, runStatus)
 	}
 }
 

--- a/server/internal/remediation/runner.go
+++ b/server/internal/remediation/runner.go
@@ -311,7 +311,16 @@ func (r *Runner) Resume(ctx context.Context, issueID int64) error {
 		return fmt.Errorf("load issue %d: %w", issueID, err)
 	}
 	if isTerminalStatus(issue.Status) {
-		return nil // already closed (e.g. admin dismissed while parked).
+		// Already closed (e.g. admin dismissed while parked). The staged
+		// handoff can never be consumed now — finalize it, or recoverWork
+		// re-enqueues a resume nothing will ever claim, every minute, forever.
+		r.db.Exec(
+			`UPDATE agent_runs SET status = 'aborted', stop_reason = 'issue_closed',
+			 finished_at = COALESCE(finished_at, CURRENT_TIMESTAMP)
+			 WHERE issue_id = ? AND status = ?`,
+			issueID, runStatusResumePending,
+		)
+		return nil
 	}
 	if issue.Status == IssueObserving || issue.Status == IssueRecovering {
 		return nil
@@ -1468,10 +1477,16 @@ func (r *Runner) claimResume(issueID int64) (resumeState, bool, error) {
 		}
 		return resumeState{}, false, err
 	}
+	// `open` is accepted beside `investigating` on purpose: a fix's own
+	// success empties the queue, the preflight suspends the issue for the
+	// absence settle, and re-promotion lands it at open — which used to orphan
+	// this handoff and burn its transcript, closing the issue via a second
+	// fresh run instead. active_run_id is the mutual exclusion either way: a
+	// fresh Run that claims first blocks this CAS, and vice versa.
 	issueRes, err := tx.Exec(
 		`UPDATE issues SET status = ?, active_run_id = ?, updated_at = CURRENT_TIMESTAMP
-		 WHERE id = ? AND status = ? AND active_run_id IS NULL AND closed_at IS NULL`,
-		IssueInvestigating, state.runID, issueID, IssueInvestigating,
+		 WHERE id = ? AND status IN (?, ?) AND active_run_id IS NULL AND closed_at IS NULL`,
+		IssueInvestigating, state.runID, issueID, IssueInvestigating, IssueOpen,
 	)
 	if err != nil {
 		return resumeState{}, false, err


### PR DESCRIPTION
Finishing pass 1/3 (the decision: complete without regressing). Every post-fix resume was orphaned — `suspendIssueForRecovery` aborted even the `resume_pending` handoff that the fix's own success had just staged, burning the transcript and forcing a second fresh run.

- **Handoffs survive suspension**: a staged resume is a decision already made; recovery doesn't invalidate its continuation. Live states still cancel; the pre-dispatch cancel path still aborts handoffs (stale there by definition).
- **`claimResume` accepts a re-promoted `open` issue**; `active_run_id` remains the mutual exclusion against a racing fresh Run.
- **Terminal issues finalize their handoff** (`aborted`/`issue_closed`) so recoverWork stops re-enqueueing a resume nothing will claim, every minute, forever.

The harness pin flips from the documented two-run shape to the truth it held the door open for: **one incident, one approval, one run**, closed through the preserved transcript with the same typed proof. `go vet`/`go test ./...` green.

Next in the pass: the weekly digest push, then the delete-card episode selector + prevention bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1