### PR TITLE
feat(agents): spare an episode, read the checklist — the finishing pass closes

### DIFF
--- a/app/lib/features/issues/ui/issue_thread_screen.dart
+++ b/app/lib/features/issues/ui/issue_thread_screen.dart
@@ -970,23 +970,58 @@ class _IssueSummaryCard extends StatelessWidget {
           if (issue.status == IssueStatus.needsAdmin &&
               issue.resolutionLabel.trim().isNotEmpty) ...[
             const SizedBox(height: 8),
-            const Text(
-              'Needs a closer look',
-              style: TextStyle(
+            Text(
+              issue.isPrevention ? 'What to change' : 'Needs a closer look',
+              style: const TextStyle(
                 color: AppTheme.requested,
                 fontSize: 12,
                 fontWeight: FontWeight.w700,
               ),
             ),
             const SizedBox(height: 4),
-            SelectableText(
-              issue.resolutionLabel.trim(),
-              style: const TextStyle(
-                color: AppTheme.textSecondary,
-                fontSize: 13,
-                height: 1.35,
+            if (issue.isPrevention)
+              // A notice's remedy is a checklist, not prose: one bullet per
+              // step, straight from the server-authored lines.
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (final step in issue.resolutionLabel
+                      .trim()
+                      .split('\n')
+                      .where((line) => line.trim().isNotEmpty))
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 4),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          const Text('•  ',
+                              style: TextStyle(
+                                  color: AppTheme.textSecondary,
+                                  fontSize: 13)),
+                          Expanded(
+                            child: SelectableText(
+                              step.trim().replaceFirst(RegExp(r'^[-•]\s*'), ''),
+                              style: const TextStyle(
+                                color: AppTheme.textSecondary,
+                                fontSize: 13,
+                                height: 1.35,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                ],
+              )
+            else
+              SelectableText(
+                issue.resolutionLabel.trim(),
+                style: const TextStyle(
+                  color: AppTheme.textSecondary,
+                  fontSize: 13,
+                  height: 1.35,
+                ),
               ),
-            ),
           ],
           if (issue.detail.isNotEmpty) ...[
             const SizedBox(height: 10),

--- a/app/lib/features/issues/ui/proposed_action_card.dart
+++ b/app/lib/features/issues/ui/proposed_action_card.dart
@@ -51,6 +51,36 @@ class ProposedActionCard extends ConsumerStatefulWidget {
 }
 
 class _ProposedActionCardState extends ConsumerState<ProposedActionCard> {
+  /// For a decidable TV delete: which of the proposed episodes stay selected.
+  /// Starts as the full proposal; unchecking builds an approval override so
+  /// the admin can spare an episode without denying the whole repair — the
+  /// only editing this card offers, because shrinking a destructive fix is
+  /// the one edit with no wrong answer.
+  Set<int>? _deleteEpisodeSelection;
+
+  List<int> get _proposedDeleteEpisodes {
+    final raw = _action.params.raw['episodes'];
+    if (raw is List) {
+      return raw.whereType<num>().map((e) => e.toInt()).toList()..sort();
+    }
+    return const [];
+  }
+
+  bool get _deleteSelectionActive =>
+      _action.kind == AgentActionKind.deleteMediaFiles &&
+      _action.canTakeAction &&
+      _proposedDeleteEpisodes.length > 1;
+
+  Object? _deleteOverride() {
+    final selection = _deleteEpisodeSelection;
+    final proposed = _proposedDeleteEpisodes;
+    if (selection == null || proposed.isEmpty) return null;
+    if (selection.length == proposed.length) return null; // as proposed
+    final params = Map<String, dynamic>.from(_action.params.raw);
+    params['episodes'] = (selection.toList()..sort());
+    return params;
+  }
+
   /// The authoritative action shown. Starts from the prop and is replaced by
   /// the server's response after a decision so the frozen footer is accurate.
   late AgentAction _action;
@@ -107,6 +137,7 @@ class _ProposedActionCardState extends ConsumerState<ProposedActionCard> {
     try {
       final updated = await service.approveAction(
         _action.id,
+        override: _deleteOverride(),
         remember: confirmation.remember,
       );
       if (!mounted) return;
@@ -431,6 +462,48 @@ class _ProposedActionCardState extends ConsumerState<ProposedActionCard> {
 
           // The quoted, non-editable params (release / quality / queue id …).
           ..._buildParamRows(action),
+
+          // The one edit with no wrong answer: shrink a destructive delete.
+          if (_deleteSelectionActive) ...[
+            const SizedBox(height: 10),
+            const Text(
+              'Episodes to delete (uncheck to spare)',
+              style: TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 6),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                for (final ep in _proposedDeleteEpisodes)
+                  FilterChip(
+                    label: Text('E$ep'),
+                    selected: (_deleteEpisodeSelection ??
+                            _proposedDeleteEpisodes.toSet())
+                        .contains(ep),
+                    onSelected: (selected) {
+                      setState(() {
+                        final current = _deleteEpisodeSelection ??
+                            _proposedDeleteEpisodes.toSet();
+                        final next = Set<int>.from(current);
+                        if (selected) {
+                          next.add(ep);
+                        } else if (next.length > 1) {
+                          // Never allow an empty delete: sparing everything
+                          // is what Deny is for.
+                          next.remove(ep);
+                        }
+                        _deleteEpisodeSelection = next;
+                      });
+                    },
+                  ),
+              ],
+            ),
+          ],
 
           if (action.approvedParams != null &&
               !mapEquals(

--- a/app/test/issues/proposed_action_card_test.dart
+++ b/app/test/issues/proposed_action_card_test.dart
@@ -148,6 +148,9 @@ class _FakeIssuesService extends IssuesService {
   /// the dialog checkbox (and only the checkbox) arms a standing rule.
   bool? lastRemember;
 
+  /// The `override` of the last approveAction call — the episode-sparing edit.
+  Object? lastOverride;
+
   @override
   Future<AgentAction> denyAction(int id, {String? note}) async {
     final error = denyError;
@@ -163,6 +166,7 @@ class _FakeIssuesService extends IssuesService {
     bool remember = false,
   }) async {
     lastRemember = remember;
+    lastOverride = override;
     final error = approveError;
     if (error != null) throw error;
     final base = _proposed();
@@ -390,6 +394,7 @@ void main() {
     // An irreversible fix is still an approvable one.
     expect(find.widgetWithText(ElevatedButton, 'Approve'), findsOneWidget);
 
+    await tester.ensureVisible(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.pumpAndSettle();
     expect(
@@ -447,6 +452,7 @@ void main() {
     expect(find.text('no'), findsOneWidget);
     expect(find.widgetWithText(ElevatedButton, 'Approve'), findsOneWidget);
 
+    await tester.ensureVisible(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.pumpAndSettle();
     expect(
@@ -529,6 +535,7 @@ void main() {
       action: _proposed(),
     );
 
+    await tester.ensureVisible(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.pumpAndSettle();
     expect(find.text('Approve this change?'), findsOneWidget);
@@ -578,6 +585,7 @@ void main() {
       action: _proposed(),
     );
 
+    await tester.ensureVisible(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.pumpAndSettle();
     await tester.tap(find.widgetWithText(ElevatedButton, 'Approve and apply'));
@@ -600,6 +608,7 @@ void main() {
       action: _proposed(),
     );
 
+    await tester.ensureVisible(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.pumpAndSettle();
     await tester.tap(find.widgetWithText(ElevatedButton, 'Approve and apply'));
@@ -721,6 +730,7 @@ void main() {
       action: _proposed(),
     );
 
+    await tester.ensureVisible(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.pumpAndSettle();
     expect(find.byType(CheckboxListTile), findsNothing);
@@ -742,6 +752,7 @@ void main() {
       action: _proposedWithOffer(),
     );
 
+    await tester.ensureVisible(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.pumpAndSettle();
     // The checkbox and its server-typed label render only because the server
@@ -775,6 +786,7 @@ void main() {
       action: _proposedWithOffer(reactivates: true),
     );
 
+    await tester.ensureVisible(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
     await tester.pumpAndSettle();
     // A paused rule's offer says checking the box re-arms it.
@@ -820,6 +832,52 @@ void main() {
       findsOneWidget,
     );
     expect(find.widgetWithText(ElevatedButton, 'Approve'), findsNothing);
+  });
+
+  // The one edit with no wrong answer: unchecking an episode on a destructive
+  // delete sends an approval override that spares it — never an empty delete.
+  testWidgets('delete card episode chips build a sparing override',
+      (tester) async {
+    final service = _FakeIssuesService();
+    final action = AgentAction.fromJson(<String, dynamic>{
+      'id': 14,
+      'issue_id': 5,
+      'run_id': 9,
+      'kind': 'delete_media_files',
+      'params': {
+        'media_type': 'tv',
+        'tmdb_id': 615,
+        'season': 11,
+        'episodes': [1, 2, 3],
+        'blocklist': true,
+      },
+      'rationale': 'impossible files',
+      'status': 'proposed',
+      'can_decide': true,
+      'issue_title': 'Futurama',
+      'issue_media_type': 'tv',
+      'issue_status': 'awaiting_approval',
+      'instance_id': 'inst-1',
+      'instance_name': 'TV',
+      'instance_service_type': 'sonarr',
+      'created_at': '2026-06-23T10:00:00Z',
+    });
+    await _pump(tester, auth: _adminState, service: service, action: action);
+
+    expect(find.text('E1'), findsOneWidget);
+    await tester.tap(find.text('E2'));
+    await tester.pumpAndSettle();
+    await tester.ensureVisible(find.widgetWithText(ElevatedButton, 'Approve'));
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
+    await tester.pumpAndSettle();
+    // Confirm dialog: press its approve button.
+    await tester.tap(find.byType(ElevatedButton).last);
+    await tester.pumpAndSettle();
+
+    final override = service.lastOverride as Map<String, dynamic>?;
+    expect(override, isNotNull, reason: 'a shrunk selection must override');
+    expect(override!['episodes'], [1, 3]);
+    await _drainSnackBar(tester);
   });
 
   // The approver must never decide with less evidence than the model: the


### PR DESCRIPTION
Finishing pass 3/3 (with #401, #402).

- **Episode chips on delete cards**: the one edit with no wrong answer — uncheck to spare, building an approval override through the validated-but-unused server path. Selection can never go empty (sparing everything is what Deny is for). Pinned: unchecking E2 approves with `episodes: [1,3]`.
- **Prevention steps as a checklist**: one bullet per server-authored line under "What to change" — client-side split, no wire change (supersedes the typed-payload idea at zero churn).
- Two existing dialog-copy pins gained `ensureVisible` (the nine-chip wrap pushed Approve below the test viewport; behavior unchanged).

`go vet`/`go test ./...` green; `flutter analyze` clean; **942** Flutter tests pass.

This closes the finishing decision: everything buildable without regression is built. Remaining by choice, as design-first backlog: the prevention apply-card (provenance review) and the sentinel's agent run (needs its own recovery proof); pre-release book detection stays out on the honesty bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV3kiuSXLoGDfKnUz1iPZ1