### PR TITLE
docs(server): the package tree learns to count — 38 tools, 36 shared

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -660,7 +660,7 @@ server/
 │   ├── discover/             # TMDB/Trakt discovery + media detail proxy handlers
 │   ├── downloads/            # Unified download-client queue API across all four clients
 │   ├── instance/             # Instance registry, defaults invariant, per-user pins, safe webhook rotation
-│   ├── mcp/                  # 35 registered tools, toggles, tool server (33 also exposed through external MCP)
+│   ├── mcp/                  # 38 registered tools, toggles, tool server (36 also exposed through external MCP)
 │   ├── mcpserver/            # MCP Streamable HTTP endpoint, prompts, agent guide (mcp-go)
 │   ├── mediafiles/           # Ticketed, instance-mapped + root-confined media streaming
 │   ├── mediapath/            # Cross-platform arr-path validation and local translation


### PR DESCRIPTION
## What

`server/README.md`'s package tree still said `35 registered tools ... (33 also exposed through external MCP)`. The prose everywhere else — both READMEs' feature bullets, the diagram, the tool-table preamble — was swept to 38/36 during the agent-systems initiative; the ASCII tree line was the one that got missed.

## Why those numbers

Verified against code, not against the other docs:

- `internal/mcpserver/tool_annotations.go` holds **38** map entries, and `TestMCPToolAnnotationsCoverRegistry` pins that map equal to the registry — so 38 registered.
- Exactly **two** tools carry `InAppChatOnly: true` (`preview_profile_change`, `apply_profile_change` in `arr_profile_tools.go`), and `ToolListFilter` is what drops them from `/mcp` — so **36** exposed.
- The tool table in `server/README.md` already lists exactly 38 rows, one per registry name.

## How it surfaced

Tracing the failed GHCR publish on `490acdd`. `docker/metadata-action` copies the GitHub repo description verbatim into `org.opencontainers.image.description`, so the build log printed the blurb — which still claimed 34 tools. That blurb lives outside the tree (fixed separately on the repo's About field), but checking it turned up this in-tree sibling.

## Docs

Docs-only change; `AGENTS.md`'s docs map is unaffected. No route, tool, env var, table, or screen changed.