### PR TITLE
fix(agents): the scoreboard stops taking credit for the queue's own recoveries

### DIFF
--- a/app/lib/features/issues/ui/pending_agent_actions_screen.dart
+++ b/app/lib/features/issues/ui/pending_agent_actions_screen.dart
@@ -142,12 +142,17 @@ class _PendingAgentActionsScreenState
     final resolved = n('issues_resolved');
     final zeroTouch = n('zero_touch');
     final byRules = n('rule_approved');
+    final selfCleared = n('self_cleared');
     final needsAdmin = n('needs_admin_open');
     final paused = n('paused_rules');
     final parts = <String>[
       '$resolved resolved',
       if (zeroTouch > 0) '$zeroTouch zero-touch',
       if (byRules > 0) '$byRules by your rules',
+      // Kept visibly apart from the agent's own numbers: these never reached a
+      // human or the agent, they came right on their own. Informative about the
+      // stack, but claiming them as fixes is what made this card read as 680.
+      if (selfCleared > 0) '$selfCleared cleared on their own',
       if (needsAdmin > 0) '$needsAdmin need you',
       if (paused > 0) '$paused rule(s) paused',
     ];

--- a/server/README.md
+++ b/server/README.md
@@ -216,7 +216,7 @@ Request statuses: `unavailable`, `requested`, `pending` (awaiting approval), `de
 ```
 POST   /api/issues                         # user: report a problem; requires instance_id plus media scope — tmdb/tvdb ids
 GET    /api/issues                         # reporter inbox: the caller's OWN reports, newest first, requester copy applied
-GET    /api/admin/agent-digest             # the agent scoreboard: rolling window of resolved/zero-touch/rule-approved counts, tokens, and what needs a human
+GET    /api/admin/agent-digest             # the agent scoreboard: rolling window of resolved/zero-touch/rule-approved/self-cleared counts, tokens, and what needs a human
 GET    /api/admin/agent-approval-rules/candidates  # triples the admin has hand-approved and could automate (grounded; active-ruled triples excluded)
 POST   /api/admin/agent-approval-rules     # arm a rule from the catalog — server re-checks the triple was actually hand-approved
                                            #   for movie/tv, foreign_id (+book_format when both formats exist) for book

--- a/server/internal/remediation/attempts_test.go
+++ b/server/internal/remediation/attempts_test.go
@@ -517,6 +517,64 @@ func TestAgentDigestCountsZeroTouch(t *testing.T) {
 	}
 }
 
+// The scoreboard must not count the queue's own churn as agent work. An auto
+// incident that never promoted cleared before anyone was asked to look, and it
+// closed silently by design — so it belongs in self_cleared, never in the
+// "resolved"/"zero-touch" headline. Regression pin: a live instance showed
+// "680 resolved · 667 zero-touch · 1 by your rules", which is the shape of a
+// number counting observation noise. A reporter's own issue can also carry an
+// unpromoted observation row, so the filter is scoped to auto issues.
+func TestAgentDigestExcludesNeverPromotedNoise(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	if _, err := svc.db.Exec("INSERT INTO users (id, username, password_hash, role) VALUES (9, 'boss', '', 'admin')"); err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+	if _, err := svc.db.Exec(
+		`INSERT INTO issues (id, source, status, media_type, tmdb_id, title, detail, resolution_kind, closed_at)
+		 VALUES (201, 'auto', 'resolved', 'movie', 1, 'noise',    'd', 'arr_state_cleared', CURRENT_TIMESTAMP),
+		        (202, 'auto', 'resolved', 'movie', 2, 'realfix',  'd', 'agent_concluded',   CURRENT_TIMESTAMP),
+		        (203, 'auto', 'resolved', 'movie', 3, 'watched',  'd', 'arr_state_cleared', CURRENT_TIMESTAMP),
+		        (204, 'user', 'resolved', 'movie', 4, 'reported', 'd', 'agent_concluded',   CURRENT_TIMESTAMP)`,
+	); err != nil {
+		t.Fatalf("seed issues: %v", err)
+	}
+	// 201 never promoted (pure noise). 202/203 promoted (real incidents).
+	// 204 is a user report that picked up an unpromoted observation row the way
+	// cancelExecutingForRecovery leaves one — it must still count as real work.
+	if _, err := svc.db.Exec(
+		`INSERT INTO issue_observations (issue_id, service_type, scope_key, promoted_at) VALUES
+		 (201, 'radarr', 'k1', NULL),
+		 (202, 'radarr', 'k2', CURRENT_TIMESTAMP),
+		 (203, 'radarr', 'k3', CURRENT_TIMESTAMP),
+		 (204, 'radarr', 'k4', NULL)`,
+	); err != nil {
+		t.Fatalf("seed observations: %v", err)
+	}
+	// Only 202 and 204 had a fix actually execute; 203 recovered on its own
+	// after promotion, so it is a real resolved incident but not zero-touch.
+	if _, err := svc.db.Exec(
+		`INSERT INTO agent_actions (issue_id, kind, params, rationale, risk, status, executed_at, auto_rule_id, decided_by, fingerprint, tool_use_id)
+		 VALUES (202, 'remediate_queue', '{}', 'r', 'mutating', 'executed', CURRENT_TIMESTAMP, NULL, NULL, 'fp-a', 'tu-a'),
+		        (204, 'remediate_queue', '{}', 'r', 'mutating', 'executed', CURRENT_TIMESTAMP, NULL, NULL, 'fp-b', 'tu-b')`,
+	); err != nil {
+		t.Fatalf("seed actions: %v", err)
+	}
+
+	d, err := svc.Digest(7)
+	if err != nil {
+		t.Fatalf("Digest: %v", err)
+	}
+	if d.SelfCleared != 1 {
+		t.Fatalf("selfCleared = %d, want the 1 never-promoted auto incident", d.SelfCleared)
+	}
+	if d.IssuesResolved != 3 {
+		t.Fatalf("resolved = %d, want 3 (two promoted + the user report), not the noise", d.IssuesResolved)
+	}
+	if d.ZeroTouch != 2 {
+		t.Fatalf("zeroTouch = %d, want 2 — only issues where a fix actually executed", d.ZeroTouch)
+	}
+}
+
 // The weekly scoreboard pages once a week, only when the week has something
 // to say — and a quiet week advances the window silently.
 func TestWeeklyDigestPushPacing(t *testing.T) {

--- a/server/internal/remediation/digest.go
+++ b/server/internal/remediation/digest.go
@@ -14,10 +14,23 @@ import (
 type AgentDigest struct {
 	Days int `json:"days"`
 
-	IssuesOpened   int64 `json:"issues_opened"`
+	IssuesOpened int64 `json:"issues_opened"`
+	// IssuesResolved counts resolved issues that were ever real work. An auto
+	// incident that never promoted is deliberately NOT in this population: it
+	// was observed, it cleared on its own before anyone was asked to look, and
+	// it closed silently by design (closeObservedRecovery passes
+	// silentNotifications for exactly these). Counting them made a busy queue
+	// read as agent accomplishment — a live instance reported 680 "resolved"
+	// against a single rule-approved fix.
 	IssuesResolved int64 `json:"issues_resolved"`
-	// ZeroTouch counts resolved issues in the window where no human made any
-	// action decision — the earned-autonomy lane doing its job end to end.
+	// SelfCleared is that excluded population, named rather than hidden: auto
+	// incidents whose arr state came right on its own. Real information about a
+	// stack that heals itself, but it is not something the agent did.
+	SelfCleared int64 `json:"self_cleared"`
+	// ZeroTouch counts resolved issues where automation carried the whole way:
+	// at least one action actually EXECUTED and no human decided any of them.
+	// The executed requirement is what keeps "earned autonomy doing its job end
+	// to end" from silently absorbing every incident that fixed itself.
 	ZeroTouch        int64 `json:"zero_touch"`
 	ActionsExecuted  int64 `json:"actions_executed"`
 	RuleApproved     int64 `json:"rule_approved"`
@@ -52,10 +65,23 @@ func (s *Service) Digest(days int) (*AgentDigest, error) {
 	cutoff := fmt.Sprintf("-%d days", days)
 	d := &AgentDigest{Days: days, GeneratedAt: time.Now().UTC()}
 
+	// A never-promoted auto incident is observation noise, not work: it cleared
+	// before promotion ever asked for an agent or a human. The source guard
+	// matters — a USER-reported issue can also carry an observation row (see
+	// cancelExecutingForRecovery), and a reporter's issue is real work by
+	// definition, so it must never be filtered out by this clause.
+	const selfCleared = `EXISTS (SELECT 1 FROM issue_observations o
+		WHERE o.issue_id = i.id AND o.promoted_at IS NULL) AND i.source = ?3`
+
 	row := s.db.QueryRow(`SELECT
 		(SELECT COUNT(1) FROM issues WHERE created_at >= datetime('now', ?1)),
-		(SELECT COUNT(1) FROM issues WHERE closed_at >= datetime('now', ?1) AND status = 'resolved'),
 		(SELECT COUNT(1) FROM issues i WHERE i.closed_at >= datetime('now', ?1) AND i.status = 'resolved'
+		   AND NOT (`+selfCleared+`)),
+		(SELECT COUNT(1) FROM issues i WHERE i.closed_at >= datetime('now', ?1) AND i.status = 'resolved'
+		   AND `+selfCleared+`),
+		(SELECT COUNT(1) FROM issues i WHERE i.closed_at >= datetime('now', ?1) AND i.status = 'resolved'
+		   AND NOT (`+selfCleared+`)
+		   AND EXISTS (SELECT 1 FROM agent_actions a WHERE a.issue_id = i.id AND a.status = 'executed')
 		   AND NOT EXISTS (SELECT 1 FROM agent_actions a WHERE a.issue_id = i.id AND a.decided_by IS NOT NULL)),
 		(SELECT COUNT(1) FROM agent_actions WHERE executed_at >= datetime('now', ?1) AND status = 'executed'),
 		(SELECT COUNT(1) FROM agent_actions WHERE executed_at >= datetime('now', ?1) AND status = 'executed' AND auto_rule_id IS NOT NULL AND decided_by IS NULL),
@@ -66,9 +92,9 @@ func (s *Service) Digest(days int) (*AgentDigest, error) {
 		(SELECT COUNT(1) FROM agent_actions a JOIN issues i ON i.id = a.issue_id
 		   WHERE a.status = 'proposed' AND i.closed_at IS NULL AND i.status = 'awaiting_approval'),
 		(SELECT COUNT(1) FROM agent_approval_rules WHERE status = 'paused')`,
-		cutoff, ResolutionReporterConfirmed,
+		cutoff, ResolutionReporterConfirmed, SourceAuto,
 	)
-	if err := row.Scan(&d.IssuesOpened, &d.IssuesResolved, &d.ZeroTouch, &d.ActionsExecuted,
+	if err := row.Scan(&d.IssuesOpened, &d.IssuesResolved, &d.SelfCleared, &d.ZeroTouch, &d.ActionsExecuted,
 		&d.RuleApproved, &d.ReporterClosed, &d.TokensIn, &d.TokensOut,
 		&d.NeedsAdminOpen, &d.PendingProposals, &d.PausedRules); err != nil {
 		return nil, fmt.Errorf("compute agent digest: %w", err)


### PR DESCRIPTION
## The report

A live instance showed:

> Last 7 days: **680 resolved · 667 zero-touch** · 1 by your rules · 1 rule(s) paused

One rule-approved fix cannot sit behind 667 zero-touch resolutions. The shape is the tell: the digest was counting observation noise as agent work.

## What was actually happening

Auto incidents are created whenever the queue looks wrong and closed again when the arr state clears. **Most never promote** — they resolve before promotion ever asks for an agent or a human. The pipeline already knows they aren't real: `closeObservedRecovery` passes `silentNotifications: !wasPromoted` for exactly this population, and its comment calls them "a never-promoted incident quietly resolved".

They were still counted twice over:

- in `issues_resolved`, because the query was a bare `COUNT(1) ... WHERE status = 'resolved'`;
- in `zero_touch`, because "no human decided any action" is trivially true for an incident no human ever saw. That's the metric whose own doc-comment claims it is "the earned-autonomy lane doing its job end to end".

## The fix

| field | now counts |
|---|---|
| `issues_resolved` | resolved issues that were real work — everything except never-promoted **auto** incidents |
| `zero_touch` | resolved **and at least one action executed** and no human decided any of them |
| `self_cleared` | the excluded population, named rather than hidden |

The card renders `self_cleared` visibly apart from the agent's own numbers ("N cleared on their own"). A stack that heals itself is worth knowing about — it just isn't a fix, and the section is titled *Agent fixes*.

## The regression that nearly shipped inside the fix

Scoping matters: a **user-reported** issue can also carry an unpromoted `issue_observations` row, because `cancelExecutingForRecovery` calls `ensureIssueObservation` for any issue. A reporter's issue is real work by definition. A naive `promoted_at IS NULL` filter would have silently erased real user reports from the scoreboard, so the clause is scoped to `i.source = 'auto'` and the test pins that case beside the noise case.

## Proof

The digest had **no test file of its own** — that is how it shipped. The new test seeds four resolved issues (noise / promoted-with-fix / promoted-self-recovered / user report) and pins 3 resolved, 2 zero-touch, 1 self-cleared. Run against the pre-fix query, the same data reports `resolved=4 zeroTouch=4`.

Existing `TestAgentDigestCountsZeroTouch` still passes unchanged: its issues have no observation rows and both have executed actions, so its 2/1/2/1 expectation is unaffected.

## Verification

`go vet ./...` clean, `go test ./...` all pass, `flutter analyze --no-fatal-infos` clean, `flutter test` 942 pass.

## Docs

`server/README.md` route line updated for the new field. The `agent_digest` push copy is unchanged — it reads the same fields, so its numbers become honest without a copy change.