### PR TITLE
fix(agents): don't report the self-clear count either — it's ordinary *arr life

### DIFF
--- a/app/lib/features/issues/ui/pending_agent_actions_screen.dart
+++ b/app/lib/features/issues/ui/pending_agent_actions_screen.dart
@@ -142,17 +142,15 @@ class _PendingAgentActionsScreenState
     final resolved = n('issues_resolved');
     final zeroTouch = n('zero_touch');
     final byRules = n('rule_approved');
-    final selfCleared = n('self_cleared');
     final needsAdmin = n('needs_admin_open');
     final paused = n('paused_rules');
+    // Incidents that cleared before promotion are deliberately absent from this
+    // card. That is ordinary *arr life — an archive mid-extract, an import that
+    // lands a minute later — and the server does not report the count at all.
     final parts = <String>[
       '$resolved resolved',
       if (zeroTouch > 0) '$zeroTouch zero-touch',
       if (byRules > 0) '$byRules by your rules',
-      // Kept visibly apart from the agent's own numbers: these never reached a
-      // human or the agent, they came right on their own. Informative about the
-      // stack, but claiming them as fixes is what made this card read as 680.
-      if (selfCleared > 0) '$selfCleared cleared on their own',
       if (needsAdmin > 0) '$needsAdmin need you',
       if (paused > 0) '$paused rule(s) paused',
     ];

--- a/server/README.md
+++ b/server/README.md
@@ -216,7 +216,7 @@ Request statuses: `unavailable`, `requested`, `pending` (awaiting approval), `de
 ```
 POST   /api/issues                         # user: report a problem; requires instance_id plus media scope — tmdb/tvdb ids
 GET    /api/issues                         # reporter inbox: the caller's OWN reports, newest first, requester copy applied
-GET    /api/admin/agent-digest             # the agent scoreboard: rolling window of resolved/zero-touch/rule-approved/self-cleared counts, tokens, and what needs a human
+GET    /api/admin/agent-digest             # the agent scoreboard: rolling window of resolved/zero-touch/rule-approved counts, tokens, and what needs a human; incidents that cleared before promotion are excluded, not reported
 GET    /api/admin/agent-approval-rules/candidates  # triples the admin has hand-approved and could automate (grounded; active-ruled triples excluded)
 POST   /api/admin/agent-approval-rules     # arm a rule from the catalog — server re-checks the triple was actually hand-approved
                                            #   for movie/tv, foreign_id (+book_format when both formats exist) for book

--- a/server/internal/remediation/attempts_test.go
+++ b/server/internal/remediation/attempts_test.go
@@ -519,8 +519,8 @@ func TestAgentDigestCountsZeroTouch(t *testing.T) {
 
 // The scoreboard must not count the queue's own churn as agent work. An auto
 // incident that never promoted cleared before anyone was asked to look, and it
-// closed silently by design — so it belongs in self_cleared, never in the
-// "resolved"/"zero-touch" headline. Regression pin: a live instance showed
+// closed silently by design — ordinary *arr life, reported nowhere, and never
+// part of the "resolved"/"zero-touch" headline. Regression pin: a live instance showed
 // "680 resolved · 667 zero-touch · 1 by your rules", which is the shape of a
 // number counting observation noise. A reporter's own issue can also carry an
 // unpromoted observation row, so the filter is scoped to auto issues.
@@ -563,9 +563,6 @@ func TestAgentDigestExcludesNeverPromotedNoise(t *testing.T) {
 	d, err := svc.Digest(7)
 	if err != nil {
 		t.Fatalf("Digest: %v", err)
-	}
-	if d.SelfCleared != 1 {
-		t.Fatalf("selfCleared = %d, want the 1 never-promoted auto incident", d.SelfCleared)
 	}
 	if d.IssuesResolved != 3 {
 		t.Fatalf("resolved = %d, want 3 (two promoted + the user report), not the noise", d.IssuesResolved)

--- a/server/internal/remediation/digest.go
+++ b/server/internal/remediation/digest.go
@@ -22,11 +22,14 @@ type AgentDigest struct {
 	// silentNotifications for exactly these). Counting them made a busy queue
 	// read as agent accomplishment — a live instance reported 680 "resolved"
 	// against a single rule-approved fix.
+	//
+	// That excluded population is not reported anywhere, on purpose. It is
+	// ordinary *arr life: an archive still extracting, an import that lands a
+	// minute later, a download the client resumes. Some of it is the arr's own
+	// retry machinery working, and some was never a problem at all — the sweep
+	// simply looked mid-flight. Neither is something the agent did, and a large
+	// number sitting next to a small honest one is read as the big number.
 	IssuesResolved int64 `json:"issues_resolved"`
-	// SelfCleared is that excluded population, named rather than hidden: auto
-	// incidents whose arr state came right on its own. Real information about a
-	// stack that heals itself, but it is not something the agent did.
-	SelfCleared int64 `json:"self_cleared"`
 	// ZeroTouch counts resolved issues where automation carried the whole way:
 	// at least one action actually EXECUTED and no human decided any of them.
 	// The executed requirement is what keeps "earned autonomy doing its job end
@@ -70,17 +73,15 @@ func (s *Service) Digest(days int) (*AgentDigest, error) {
 	// matters — a USER-reported issue can also carry an observation row (see
 	// cancelExecutingForRecovery), and a reporter's issue is real work by
 	// definition, so it must never be filtered out by this clause.
-	const selfCleared = `EXISTS (SELECT 1 FROM issue_observations o
+	const observationNoise = `EXISTS (SELECT 1 FROM issue_observations o
 		WHERE o.issue_id = i.id AND o.promoted_at IS NULL) AND i.source = ?3`
 
 	row := s.db.QueryRow(`SELECT
 		(SELECT COUNT(1) FROM issues WHERE created_at >= datetime('now', ?1)),
 		(SELECT COUNT(1) FROM issues i WHERE i.closed_at >= datetime('now', ?1) AND i.status = 'resolved'
-		   AND NOT (`+selfCleared+`)),
+		   AND NOT (`+observationNoise+`)),
 		(SELECT COUNT(1) FROM issues i WHERE i.closed_at >= datetime('now', ?1) AND i.status = 'resolved'
-		   AND `+selfCleared+`),
-		(SELECT COUNT(1) FROM issues i WHERE i.closed_at >= datetime('now', ?1) AND i.status = 'resolved'
-		   AND NOT (`+selfCleared+`)
+		   AND NOT (`+observationNoise+`)
 		   AND EXISTS (SELECT 1 FROM agent_actions a WHERE a.issue_id = i.id AND a.status = 'executed')
 		   AND NOT EXISTS (SELECT 1 FROM agent_actions a WHERE a.issue_id = i.id AND a.decided_by IS NOT NULL)),
 		(SELECT COUNT(1) FROM agent_actions WHERE executed_at >= datetime('now', ?1) AND status = 'executed'),
@@ -94,7 +95,7 @@ func (s *Service) Digest(days int) (*AgentDigest, error) {
 		(SELECT COUNT(1) FROM agent_approval_rules WHERE status = 'paused')`,
 		cutoff, ResolutionReporterConfirmed, SourceAuto,
 	)
-	if err := row.Scan(&d.IssuesOpened, &d.IssuesResolved, &d.SelfCleared, &d.ZeroTouch, &d.ActionsExecuted,
+	if err := row.Scan(&d.IssuesOpened, &d.IssuesResolved, &d.ZeroTouch, &d.ActionsExecuted,
 		&d.RuleApproved, &d.ReporterClosed, &d.TokensIn, &d.TokensOut,
 		&d.NeedsAdminOpen, &d.PendingProposals, &d.PausedRules); err != nil {
 		return nil, fmt.Errorf("compute agent digest: %w", err)


### PR DESCRIPTION
## Why

#405 stopped counting never-promoted incidents as agent work, but still named the excluded population on the card ("N cleared on their own"). Julian pushed back: that's business as usual for an *arr stack. He's right, and the argument that decides it is the one #405 was built on — **667 sitting next to 13 is read as 667**. Keeping the number was the same misread, one line lower, on a card titled *Agent fixes*.

## What that population actually is

The gate is `groupHasProblemSignal`: Import Doctor severity **warning or error** only, so `ProblemNotAnUpgrade` (info) never creates one. What then clears inside the observation window is an archive that finished extracting, an import that landed a minute later, a download the client resumed, an item that left the queue.

Worth being precise about, because it cuts against reporting it: some of those are the arr's own retry machinery doing its job, and some **were never a problem at all** — the sweep looked mid-flight. A single count that mixes "the arr self-healed" with "we mis-timed a snapshot" isn't a signal anyone can act on.

## Change

- `self_cleared` removed from `AgentDigest` and from the digest card.
- The **exclusion stays** — it is what makes `issues_resolved` and `zero_touch` honest — and the reasoning moves into the code comment (`observationNoise`), where it documents the query instead of decorating the UI.
- The regression test still seeds the never-promoted incident and pins that it stays out of both headline numbers; only the `SelfCleared` assertion is gone.

## Verification

`go vet ./...` clean, `go test ./...` all pass, `flutter analyze --no-fatal-infos` clean, `flutter test` 942 pass.

## Docs

`server/README.md` route line now says the excluded incidents are not reported, rather than listing a field that no longer exists.