### PR TITLE
fix(agents): the digest stats agree with their own counts

### DIFF
--- a/app/lib/features/issues/ui/issues_list_screen.dart
+++ b/app/lib/features/issues/ui/issues_list_screen.dart
@@ -171,9 +171,10 @@ class _IssuesListScreenState extends ConsumerState<IssuesListScreen>
       '$resolved resolved',
       if (zeroTouch > 0) '$zeroTouch zero-touch',
       if (byRules > 0) '$byRules by your rules',
-      if (selfCleared > 0) '$selfCleared cleared on their own',
-      if (needsAdmin > 0) '$needsAdmin need you',
-      if (paused > 0) '$paused rule(s) paused',
+      if (selfCleared > 0)
+        '$selfCleared cleared on ${selfCleared == 1 ? 'its' : 'their'} own',
+      if (needsAdmin > 0) '$needsAdmin need${needsAdmin == 1 ? 's' : ''} you',
+      if (paused > 0) '$paused rule${paused == 1 ? '' : 's'} paused',
     ].map(_glueStat).toList();
     return Container(
       margin: const EdgeInsets.fromLTRB(12, 10, 12, 0),

--- a/app/test/issues/issues_digest_card_test.dart
+++ b/app/test/issues/issues_digest_card_test.dart
@@ -41,11 +41,37 @@ void main() {
     // non-breaking hyphen so it cannot split either.
     expect(line, contains('13\u00A0resolved'));
     expect(line, contains('667\u00A0cleared\u00A0on\u00A0their\u00A0own'));
+    expect(line, contains('2\u00A0need\u00A0you'));
     expect(line, contains('4\u00A0zero\u2011touch'));
     // The delimiter leads the next line: breakable space BEFORE the dot, glued
     // space after it.
     expect(line, contains(' ·\u00A0'));
     expect(line, isNot(contains('· ')));
+    // One paused rule reads "rule", not "rule(s)".
+    expect(line, contains('1\u00A0rule\u00A0paused'));
+  });
+
+  testWidgets('paused-rule stat pluralises with the count', (tester) async {
+    final service = _FakeIssuesService(
+      issues: [_issue(1, 'needs_admin')],
+      digest: const {
+        'issues_resolved': 2,
+        'paused_rules': 3,
+        'needs_admin_open': 1,
+        'self_cleared': 1,
+      },
+    );
+    await _pump(tester, service);
+
+    final line = tester
+        .widgetList<Text>(find.byType(Text))
+        .map((t) => t.data ?? '')
+        .firstWhere((d) => d.contains('Last'), orElse: () => '');
+    expect(line, contains('3\u00A0rules\u00A0paused'));
+    // "1 needs you", not "1 need you".
+    expect(line, contains('1\u00A0needs\u00A0you'));
+    // A lone self-cleared incident cleared on ITS own.
+    expect(line, contains('1\u00A0cleared\u00A0on\u00A0its\u00A0own'));
   });
 
   testWidgets('closed tab says how much history it is not showing',


### PR DESCRIPTION
`1 rule(s) paused` was the visible one, but the same card also read `1 need you` and `1 cleared on their own`. Each stat now agrees with its count:

| count | before | after |
|---|---|---|
| 1 | `1 rule(s) paused` | `1 rule paused` |
| 3 | `3 rule(s) paused` | `3 rules paused` |
| 1 | `1 need you` | `1 need**s** you` |
| 2 | `2 need you` | `2 need you` |
| 1 | `1 cleared on their own` | `1 cleared on **its** own` |
| 667 | `667 cleared on their own` | unchanged |

`needs you` is verb agreement rather than a plural, which is why it inverts relative to the others.

**Left alone on purpose:** `N resolved` and `N zero-touch` carry no noun to agree with, and `N by your rules` names the mechanism rather than counting rules — "1 by your rule" would assert something the number doesn't say (that number counts fixes, not rules).

Inline ternaries follow the existing house idiom (`instance_edit_screen.dart`, `app_shell.dart`); there was no shared pluralisation helper to reuse, and this card was the last `(s)` copy in `app/lib`.

## Tests

`issues_digest_card_test.dart` pins both halves of every pair — singular via a 1-count fixture, plural via the existing many-count one — so a later edit can't quietly reintroduce `(s)`. The assertions match the non-breaking-space glue, so they also keep proving the stats stay unbreakable.

## Verification

`flutter analyze --no-fatal-infos` clean, `flutter test` 946 pass. No server change.