### PR TITLE
fix(ios): forward the full notification tap payload to Dart

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -194,13 +194,17 @@ import UserNotifications
     completionHandler()
   }
 
-  /// Extracts the tap-routing fields the Dart side understands from an APNs
-  /// `userInfo` dict. Custom keys are delivered as siblings of `aps`.
+  /// Extracts the tap-routing payload from an APNs `userInfo` dict. Custom keys
+  /// are delivered as siblings of the reserved `aps` dictionary; forward every
+  /// one of them — Dart's router consumes more keys than just type/media_type/
+  /// tmdb_id (issue_id, foreign_id, title, instance_id), and a whitelist here
+  /// silently breaks deep links whenever the server grows the payload.
   private func routingPayload(from userInfo: [AnyHashable: Any]) -> [String: Any] {
     var payload: [String: Any] = [:]
-    if let type = userInfo["type"] as? String { payload["type"] = type }
-    if let mediaType = userInfo["media_type"] as? String { payload["media_type"] = mediaType }
-    if let tmdbID = userInfo["tmdb_id"] { payload["tmdb_id"] = tmdbID }
+    for (key, value) in userInfo {
+      guard let key = key as? String, key != "aps" else { continue }
+      payload[key] = value
+    }
     return payload
   }
 }


### PR DESCRIPTION
## What

`AppDelegate.routingPayload` whitelisted only `type`/`media_type`/`tmdb_id`, while `PushService._routeNotification` also reads `issue_id`, `foreign_id`, `title`, and `instance_id`. Live impact today:

- Tapping an **issue** notification (`issue_created`, `issue_updated`, `agent_action_decided`, …) opens the app but never navigates — `issue_id` is null so the router returns without pushing the thread.
- Tapping a **book** decision/`new_book` notification loses `foreign_id`/`title`/`instance_id` and degrades from the book detail deep link to the Books tab fallback.

## Fix

Forward every custom `userInfo` key (everything except the reserved `aps` dictionary) instead of maintaining a second copy of the routing contract in Swift. Dart already ignores keys it doesn't consume, so the whitelist bought nothing and silently broke deep links each time the server grew the payload. This also freezes the payload contract the upcoming Android integration mirrors (its native side forwards all data keys the same way).

## Verification

- `swiftc -parse` clean (no local Xcode/Flutter toolchain — the TestFlight workflow proves the real build, per AGENTS.md)
- `flutter analyze --no-fatal-infos` — no issues
- `flutter test` — 948/948 green

No docs change: behavior fix inside an already-documented surface. Merge auto-deploys to TestFlight (`app/ios/**` path), shipping the fixed deep links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoWzaBWHUb795CKpkdAqh1