### PR TITLE
feat(auth): fall back to http when a bare server address has no https

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -133,7 +133,7 @@ The shared design foundation also owns typography, spacing, shape, and motion to
 
 ### Auth
 - **Connect links** -- open one and the account connects instantly (`cantinarr://connect` deep links on iOS); passwordless by default with a long-lived, auto-refreshing session.
-- **First-run setup** -- the auth screen walks through server URL → admin account creation → an optional passkey offer.
+- **First-run setup** -- the auth screen walks through server URL → admin account creation → an optional passkey offer. The scheme is optional: a bare address is probed over https first and falls back to http only when https is unreachable (a typed scheme is always respected).
 - **Passkeys & passwords** -- native passkey sign-in on associated deployments (iOS/Android/Windows platform plugins, browser fallback), password login where enabled.
 - **Session resilience** -- the session survives transport failures and VPN flaps; only a genuine 401 clears it. There is deliberately no logout button -- admins revoke devices server-side.
 - **Separate OAuth directions** -- ChatGPT device authorization is an explicit outbound sign-in that lets Cantinarr use a personal or admin-shared Codex allowance. Cantinarr's MCP OAuth is a different inbound login that lets an external client access Cantinarr.

--- a/app/lib/features/auth/logic/auth_provider.dart
+++ b/app/lib/features/auth/logic/auth_provider.dart
@@ -420,9 +420,48 @@ class AuthNotifier extends AsyncNotifier<AuthState> {
   }
 
   /// Check server status (needs setup, webauthn available).
-  Future<ServerStatus> checkServer(String serverUrl) async {
+  ///
+  /// A bare address (no scheme) is probed over https first; when https is
+  /// unreachable at the transport level the probe retries over http. Returns
+  /// the status together with the URL that actually answered so callers keep
+  /// using that exact scheme. An explicit scheme is never second-guessed.
+  Future<({String serverUrl, ServerStatus status})> checkServer(
+      String serverUrl) async {
+    final schemeProbe = serverUrl.trim().toLowerCase();
+    final hasScheme = schemeProbe.startsWith('http://') ||
+        schemeProbe.startsWith('https://');
     final normalizedUrl = _normalizeUrl(serverUrl);
-    return _authService.getServerStatus(normalizedUrl);
+    try {
+      final status = await _authService.getServerStatus(normalizedUrl);
+      return (serverUrl: normalizedUrl, status: status);
+    } on DioException catch (e) {
+      if (hasScheme || !_httpsUnreachable(e)) rethrow;
+      final httpUrl = 'http://${normalizedUrl.substring('https://'.length)}';
+      final status = await _authService.getServerStatus(httpUrl);
+      return (serverUrl: httpUrl, status: status);
+    }
+  }
+
+  /// True when the https probe failed before any HTTP exchange happened —
+  /// connection refused/timeout, a TLS handshake against a plaintext port, or
+  /// a certificate failure. An answer with any status code means https IS
+  /// available and the real error must surface instead of an http retry.
+  bool _httpsUnreachable(DioException e) {
+    switch (e.type) {
+      case DioExceptionType.connectionError:
+      case DioExceptionType.connectionTimeout:
+      case DioExceptionType.badCertificate:
+        return true;
+      case DioExceptionType.unknown:
+        // dart:io surfaces TLS/socket failures as `unknown`; match by name
+        // because dart:io types can't be imported in web-compatible code.
+        final err = e.error?.toString() ?? '';
+        return err.contains('HandshakeException') ||
+            err.contains('SocketException') ||
+            err.contains('CERTIFICATE');
+      default:
+        return false;
+    }
   }
 
   /// Create admin account during first-run setup.

--- a/app/lib/features/auth/ui/auth_screen.dart
+++ b/app/lib/features/auth/ui/auth_screen.dart
@@ -63,12 +63,16 @@ class _AuthScreenState extends ConsumerState<AuthScreen> {
     });
 
     try {
-      final status =
+      final result =
           await ref.read(authProvider.notifier).checkServer(serverUrl);
+      // Reflect the URL that actually answered (scheme included) back into
+      // the field — the setup/login views read it from here, so they reuse
+      // exactly the scheme the probe settled on.
+      _serverUrlController.text = result.serverUrl;
       setState(() {
-        _serverStatus = status;
+        _serverStatus = result.status;
         _isCheckingServer = false;
-        _view = status.needsSetup ? _AuthView.setup : _AuthView.login;
+        _view = result.status.needsSetup ? _AuthView.setup : _AuthView.login;
       });
     } catch (e) {
       setState(() {
@@ -395,7 +399,7 @@ class _ServerUrlView extends StatelessWidget {
           controller: controller,
           decoration: const InputDecoration(
             labelText: 'Server URL',
-            hintText: 'https://cantinarr.example.com',
+            hintText: 'cantinarr.example.com',
             prefixIcon: Icon(Icons.dns_outlined),
           ),
           keyboardType: TextInputType.url,

--- a/app/lib/features/auth/ui/passkey_create_screen.dart
+++ b/app/lib/features/auth/ui/passkey_create_screen.dart
@@ -40,8 +40,10 @@ class _PasskeyCreateScreenState extends ConsumerState<PasskeyCreateScreen> {
     final conn = ref.read(authProvider).valueOrNull?.connection;
     if (conn != null) {
       try {
-        final status =
-            await ref.read(authProvider.notifier).checkServer(conn.serverUrl);
+        final status = (await ref
+                .read(authProvider.notifier)
+                .checkServer(conn.serverUrl))
+            .status;
         serverNativeReady =
             status.supportsPasskeyPlatform(PasskeyService.platformKind());
         browserFallbackAvailable = status.webAuthnAvailable;

--- a/app/test/app_deep_links_test.dart
+++ b/app/test/app_deep_links_test.dart
@@ -389,8 +389,9 @@ class _FakeAuthNotifier extends AuthNotifier {
   }
 
   @override
-  Future<ServerStatus> checkServer(String serverUrl) async =>
-      const ServerStatus(needsSetup: false);
+  Future<({String serverUrl, ServerStatus status})> checkServer(
+          String serverUrl) async =>
+      (serverUrl: serverUrl, status: const ServerStatus(needsSetup: false));
 }
 
 Dio _fakeDio() {

--- a/app/test/auth/server_url_entry_test.dart
+++ b/app/test/auth/server_url_entry_test.dart
@@ -15,6 +15,11 @@ import 'package:flutter_test/flutter_test.dart';
 /// already covered by test/app_deep_links_test.dart (PR #224). The entry
 /// path differs: it never lowercases (the URL is used verbatim as the base
 /// URL) and it strips at most ONE trailing slash.
+///
+/// Also covers the scheme fallback in `checkServer`: a bare address is probed
+/// over https first and retried over http only when https failed at the
+/// transport level (refused / timeout / TLS handshake) — never when https
+/// answered with an HTTP status, and never when the user typed a scheme.
 void main() {
   Future<_Harness> harness() async {
     final service = _RecordingAuthService();
@@ -120,6 +125,93 @@ void main() {
     expect(h.service.redeemUrls, ['https://media.example.com'],
         reason: 'checkServer and the credential flows share _normalizeUrl');
   });
+
+  group('scheme fallback', () {
+    DioException probeFailure(DioExceptionType type, [Object? error]) =>
+        DioException(
+          requestOptions: RequestOptions(path: '/api/auth/status'),
+          type: type,
+          error: error,
+        );
+
+    test('a bare address falls back to http when https is refused', () async {
+      final h = await harness();
+      h.service.statusFailure = (url) => url.startsWith('https://')
+          ? probeFailure(DioExceptionType.connectionError)
+          : null;
+      final result = await h.container
+          .read(authProvider.notifier)
+          .checkServer('192.168.1.20:8585');
+      expect(h.service.statusUrls,
+          ['https://192.168.1.20:8585', 'http://192.168.1.20:8585']);
+      expect(result.serverUrl, 'http://192.168.1.20:8585',
+          reason: 'the answering URL flows back so login/setup reuse http');
+    });
+
+    test('a TLS handshake against a plaintext port also falls back', () async {
+      // dart:io surfaces this as an unknown-type DioException wrapping a
+      // HandshakeException; the notifier matches it by name (web-safe).
+      final h = await harness();
+      h.service.statusFailure = (url) => url.startsWith('https://')
+          ? probeFailure(
+              DioExceptionType.unknown,
+              Exception('HandshakeException: wrong version number'),
+            )
+          : null;
+      final result = await h.container
+          .read(authProvider.notifier)
+          .checkServer('cantinarr.local:8585');
+      expect(result.serverUrl, 'http://cantinarr.local:8585');
+    });
+
+    test('an https answer with an HTTP status blocks the fallback', () async {
+      // A 404 means https IS available — the URL is wrong, and retrying over
+      // http would mask the real error.
+      final h = await harness();
+      h.service.statusFailure =
+          (url) => probeFailure(DioExceptionType.badResponse);
+      await expectLater(
+        h.container.read(authProvider.notifier).checkServer('media.example.com'),
+        throwsA(isA<DioException>()),
+      );
+      expect(h.service.statusUrls, ['https://media.example.com']);
+    });
+
+    test('an explicit https:// never falls back to http', () async {
+      final h = await harness();
+      h.service.statusFailure =
+          (url) => probeFailure(DioExceptionType.connectionError);
+      await expectLater(
+        h.container
+            .read(authProvider.notifier)
+            .checkServer('https://media.example.com'),
+        throwsA(isA<DioException>()),
+      );
+      expect(h.service.statusUrls, ['https://media.example.com'],
+          reason: 'a typed scheme is respected verbatim');
+    });
+
+    test('when both schemes are unreachable the error surfaces', () async {
+      final h = await harness();
+      h.service.statusFailure =
+          (url) => probeFailure(DioExceptionType.connectionError);
+      await expectLater(
+        h.container.read(authProvider.notifier).checkServer('192.168.1.20'),
+        throwsA(isA<DioException>()),
+      );
+      expect(h.service.statusUrls,
+          ['https://192.168.1.20', 'http://192.168.1.20']);
+    });
+
+    test('a reachable https server keeps https and probes once', () async {
+      final h = await harness();
+      final result = await h.container
+          .read(authProvider.notifier)
+          .checkServer('media.example.com');
+      expect(result.serverUrl, 'https://media.example.com');
+      expect(h.service.statusUrls, ['https://media.example.com']);
+    });
+  });
 }
 
 typedef _Harness = ({ProviderContainer container, _RecordingAuthService service});
@@ -131,9 +223,14 @@ class _RecordingAuthService extends AuthService {
   final List<String> statusUrls = [];
   final List<String> redeemUrls = [];
 
+  /// When set, a non-null return makes the status probe for that URL fail.
+  DioException? Function(String url)? statusFailure;
+
   @override
   Future<ServerStatus> getServerStatus(String serverUrl) async {
     statusUrls.add(serverUrl);
+    final failure = statusFailure?.call(serverUrl);
+    if (failure != null) throw failure;
     return const ServerStatus(needsSetup: false);
   }
 


### PR DESCRIPTION
## Summary
Entering a scheme-less server address on first launch (a LAN IP like `192.168.1.20:8585`, a `.local` host) used to fail outright: the URL was silently prefixed with `https://` and the TLS handshake against a plaintext server died with "Could not connect to server". Users had to know to type `http://` themselves.

- `checkServer` now probes https first and retries over http **only** when https failed at the transport level (connection refused/timeout, TLS handshake against a plaintext port, certificate failure). Any answered HTTP status means https exists — the real error surfaces instead of a misleading http retry.
- A typed scheme (`http://` or `https://`) is never second-guessed.
- The URL that actually answered is returned and written back into the entry field, so the setup/login/passkey flows all reuse the exact scheme the probe settled on.
- TLS failures are matched by error-name string in the `unknown` Dio bucket because `dart:io` types can't be imported in web-compatible code.
- Server URL hint no longer shows a scheme (`cantinarr.example.com`).

## Testing
- `flutter analyze --no-fatal-infos` — clean
- `flutter test` — 956 passed; new fallback coverage in `test/auth/server_url_entry_test.dart` (falls back on refused + handshake, blocked on answered status, explicit scheme respected, both-fail surfaces error, https kept when reachable)

## Docs
- `app/README.md` First-run setup bullet updated to describe the optional scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAXxRRvak7LYQHK3rgiuLp