### PR TITLE
fix(setup): problem-detection checklist row deep-links to Settings > AI Remediation

### DIFF
--- a/app/lib/features/setup_wizard/ui/setup_wizard_screen.dart
+++ b/app/lib/features/setup_wizard/ui/setup_wizard_screen.dart
@@ -50,6 +50,8 @@ class _SetupWizardScreenState extends ConsumerState<SetupWizardScreen> {
         return '/settings/discovery';
       case 'plex_invites':
         return '/settings/plex';
+      case 'remediation':
+        return '/settings/ai-remediation';
       default:
         return null; // push = server env var; unknown keys = newer server
     }
@@ -81,6 +83,8 @@ class _SetupWizardScreenState extends ConsumerState<SetupWizardScreen> {
         return Icons.menu_book;
       case 'ai':
         return Icons.smart_toy_outlined;
+      case 'remediation':
+        return Icons.auto_fix_high_outlined;
       default:
         return Icons.tune;
     }

--- a/app/test/setup_wizard/setup_wizard_screen_test.dart
+++ b/app/test/setup_wizard/setup_wizard_screen_test.dart
@@ -136,6 +136,23 @@ void _rowEmphasisTests() {
     expect(_pillOn(tester, 'trakt').color, AppTheme.accent);
   });
 
+  testWidgets('the problem-detection row deep-links like any other',
+      (tester) async {
+    await _pumpWizard(tester, [
+      ('tmdb', true, false),
+      ('remediation', false, true),
+    ]);
+
+    // 'remediation' has a real destination (Settings > AI Remediation), so it
+    // carries the action chip and a tap handler — it is not another push.
+    expect(_pillOn(tester, 'remediation').text, 'Set up');
+    final tile = tester.widget<ListTile>(
+      find.ancestor(
+          of: find.text('remediation'), matching: find.byType(ListTile)),
+    );
+    expect(tile.onTap, isNotNull);
+  });
+
   testWidgets('a row with nowhere to go offers no action', (tester) async {
     await _pumpWizard(tester, [
       ('tmdb', true, false),


### PR DESCRIPTION
## What

The **Automatic problem detection** row on the Setup Checklist rendered with no "Set up" chip and no tap handler — `_routeFor` had no case for the `remediation` key, so the row fell into the same "nowhere to send you" bucket as `push`. That bucket is for rows with genuinely no destination; this one has a real screen at `/settings/ai-remediation`. Adds the route mapping (and the Settings tile's `auto_fix_high` icon in place of the generic fallback), so the row now behaves like every other actionable item: full-strength copy, "Set up" chip, tap opens the decision screen. Its clickability was never meant to depend on AI being configured, and still doesn't.

## Verification

- app: `flutter analyze --no-fatal-infos` — no issues; `flutter test` — 974 passed (new widget test pins the chip + tap handler on the remediation row; the existing "nowhere to go" test keeps `push` chip-less)
- server: untouched

## Docs

Docs are part of the change, not a follow-up. Tick what you updated, or tick the last box and say why nothing needed it:

- [ ] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [x] No docs impact — explained above: app/README documents the checklist's philosophy (rows deep-link; only `push` has nowhere to go) and this change makes behavior match that existing description rather than changing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjR3GAa7xpwUE6m3jbT928