### PR TITLE
feat(app): scroll-to-and-highlight deep links for settings screens

### DIFF
--- a/app/lib/core/widgets/settings_highlight.dart
+++ b/app/lib/core/widgets/settings_highlight.dart
@@ -1,0 +1,163 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../theme/app_theme.dart';
+
+/// Scrolls its child into view and flashes a fading accent ring when a
+/// settings-search deep link (`?highlight=<anchorId>`) targets it.
+///
+/// Wrap an anchorable control (a `SwitchListTile`, `ListTile`, or section
+/// widget that is a direct child of the screen's `ListView`) and pass the
+/// screen's active `highlightId`. When the two match, the wrapper waits for
+/// its first frame, calls [Scrollable.ensureVisible] on itself, and plays a
+/// one-shot highlight that decays over ~1.6s. With animations disabled it
+/// jumps instead and shows the ring statically for two seconds.
+///
+/// When inactive the wrapper paints nothing and adds no layout — a wrapped
+/// child is pixel-identical to a bare one.
+///
+/// The trigger runs when this widget mounts, so on screens that load content
+/// asynchronously it fires whenever the body actually appears. Anchors must
+/// only be placed below content that is present at body-mount; a section that
+/// streams in later would shift an already-performed scroll.
+///
+/// A `ListView` inflates children lazily, so an anchor far below the fold
+/// would never mount and never fire. Screens make the anchored child real on
+/// arrival by widening the list's cache extent while a highlight is
+/// requested:
+///
+/// ```dart
+/// ListView(
+///   cacheExtent: SettingsHighlight.cacheExtentFor(widget.highlightId),
+///   ...
+/// )
+/// ```
+class SettingsHighlight extends StatefulWidget {
+  /// Stable anchor id for the wrapped control (see `SettingsAnchors`).
+  final String anchorId;
+
+  /// The screen's active deep-link target, usually from `?highlight=`.
+  /// `null` (or any other id) leaves this wrapper inert.
+  final String? highlightId;
+
+  final Widget child;
+
+  const SettingsHighlight({
+    super.key,
+    required this.anchorId,
+    required this.highlightId,
+    required this.child,
+  });
+
+  /// Far beyond any settings list, but finite: an infinite cache extent
+  /// produces non-finite semantics geometry.
+  static const double _buildAllCacheExtent = 100000;
+
+  /// Cache extent for a settings list that hosts anchors: wide enough to
+  /// build every child while [highlightId] is active (so the anchored
+  /// control mounts and can fire), the framework default otherwise.
+  static double? cacheExtentFor(String? highlightId) =>
+      highlightId != null ? _buildAllCacheExtent : null;
+
+  @override
+  State<SettingsHighlight> createState() => _SettingsHighlightState();
+}
+
+class _SettingsHighlightState extends State<SettingsHighlight>
+    with SingleTickerProviderStateMixin {
+  // At rest the controller sits fully faded out (strength 0), so the first
+  // build paints nothing without any status juggling.
+  late final AnimationController _fade = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1600),
+    value: 1.0,
+  );
+
+  /// One-shot latch: in-page rebuilds never re-trigger. A genuine new target
+  /// (didUpdateWidget with a different highlightId) re-arms it.
+  bool _fired = false;
+  Timer? _clearTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _armIfMatched();
+  }
+
+  @override
+  void didUpdateWidget(SettingsHighlight oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.highlightId != widget.highlightId) {
+      _fired = false;
+      _armIfMatched();
+    }
+  }
+
+  void _armIfMatched() {
+    if (_fired ||
+        widget.highlightId == null ||
+        widget.highlightId != widget.anchorId) {
+      return;
+    }
+    _fired = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) => _trigger());
+  }
+
+  void _trigger() {
+    if (!mounted) return;
+    final reduceMotion = MediaQuery.disableAnimationsOf(context);
+    Scrollable.ensureVisible(
+      context,
+      duration: reduceMotion ? Duration.zero : AppTheme.motionSlow,
+      curve: Curves.easeInOut,
+      alignment: 0.1,
+    );
+    if (reduceMotion) {
+      // The ring is informative, not decorative: show it statically and
+      // clear it after a beat instead of animating.
+      _fade.value = 0.0;
+      _clearTimer?.cancel();
+      _clearTimer = Timer(const Duration(seconds: 2), () {
+        if (mounted) _fade.value = 1.0;
+      });
+    } else {
+      _fade.forward(from: 0.0);
+    }
+  }
+
+  @override
+  void dispose() {
+    _clearTimer?.cancel();
+    _fade.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _fade,
+      child: widget.child,
+      builder: (context, child) {
+        // Bright arrival, gentle decay: full strength the instant the flash
+        // starts, easing out to nothing.
+        final strength =
+            (1.0 - Curves.easeOutCubic.transform(_fade.value)).clamp(0.0, 1.0);
+        return DecoratedBox(
+          position: DecorationPosition.foreground,
+          decoration: strength == 0
+              ? const BoxDecoration()
+              : BoxDecoration(
+                  color: AppTheme.accent.withValues(alpha: 0.08 * strength),
+                  borderRadius: BorderRadius.circular(AppTheme.radiusMd),
+                  border: Border.all(
+                    color: AppTheme.accent.withValues(alpha: 0.9 * strength),
+                    width: 1.5,
+                  ),
+                ),
+          child: child!,
+        );
+      },
+    );
+  }
+}

--- a/app/lib/features/ai_assistant/ui/ai_access_screen.dart
+++ b/app/lib/features/ai_assistant/ui/ai_access_screen.dart
@@ -6,7 +6,9 @@ import 'package:go_router/go_router.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_panel.dart';
+import '../../../core/widgets/settings_highlight.dart';
 import '../../auth/logic/auth_provider.dart';
+import '../../settings/settings_anchors.dart';
 import '../data/ai_settings_service.dart';
 import '../data/codex_oauth_service.dart';
 
@@ -16,7 +18,10 @@ import '../data/codex_oauth_service.dart';
 /// provider. A selected but broken personal provider fails closed; this screen
 /// makes switching back to included access an explicit action.
 class AiAccessScreen extends ConsumerStatefulWidget {
-  const AiAccessScreen({super.key});
+  /// Settings-search anchor to scroll to and flash on arrival.
+  final String? highlightId;
+
+  const AiAccessScreen({super.key, this.highlightId});
 
   @override
   ConsumerState<AiAccessScreen> createState() => _AiAccessScreenState();
@@ -238,34 +243,46 @@ class _AiAccessScreenState extends ConsumerState<AiAccessScreen> {
         settings.effective.source == AiAccessSource.shared &&
             settings.effective.available;
     return ListView(
+      // Build every child while a settings-search highlight needs to find
+      // its anchor (see SettingsHighlight).
+      cacheExtent: SettingsHighlight.cacheExtentFor(widget.highlightId),
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
       children: [
         _EffectiveSourcePanel(settings: settings),
         const SizedBox(height: 22),
-        _IncludedSourcePanel(
-          settings: settings,
-          clearing: _clearing,
-          onUseIncluded: _useIncluded,
+        SettingsHighlight(
+          anchorId: SettingsAnchors.aiAccessIncluded,
+          highlightId: widget.highlightId,
+          child: _IncludedSourcePanel(
+            settings: settings,
+            clearing: _clearing,
+            onUseIncluded: _useIncluded,
+          ),
         ),
         const SizedBox(height: 16),
-        _PersonalSourcePanel(
-          settings: settings,
-          provider: _provider,
-          model: _model,
-          customModelValue: _customModel,
-          customModelController: _customModelController,
-          apiKeyController: _apiKeyController,
-          saving: _saving,
-          collapsed: includedActive && !_personalExpanded,
-          onToggleCollapsed: includedActive
-              ? () => setState(() => _personalExpanded = !_personalExpanded)
-              : null,
-          onProviderSelected: (provider) => _selectProvider(settings, provider),
-          onModelSelected: (model) => setState(() => _model = model),
-          onSaveKeyAndUse: () => _saveAndUse(settings, saveKey: true),
-          onUseConfigured: () => _saveAndUse(settings),
-          onDeleteKey: (provider) => _deleteKey(settings, provider),
-          onOpenChatGPT: _openOpenAIOAuth,
+        SettingsHighlight(
+          anchorId: SettingsAnchors.aiAccessPersonal,
+          highlightId: widget.highlightId,
+          child: _PersonalSourcePanel(
+            settings: settings,
+            provider: _provider,
+            model: _model,
+            customModelValue: _customModel,
+            customModelController: _customModelController,
+            apiKeyController: _apiKeyController,
+            saving: _saving,
+            collapsed: includedActive && !_personalExpanded,
+            onToggleCollapsed: includedActive
+                ? () => setState(() => _personalExpanded = !_personalExpanded)
+                : null,
+            onProviderSelected: (provider) =>
+                _selectProvider(settings, provider),
+            onModelSelected: (model) => setState(() => _model = model),
+            onSaveKeyAndUse: () => _saveAndUse(settings, saveKey: true),
+            onUseConfigured: () => _saveAndUse(settings),
+            onDeleteKey: (provider) => _deleteKey(settings, provider),
+            onOpenChatGPT: _openOpenAIOAuth,
+          ),
         ),
       ],
     );

--- a/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
+++ b/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
@@ -6,7 +6,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/settings_highlight.dart';
 import '../../settings/data/credentials_service.dart';
+import '../../settings/settings_anchors.dart';
 import '../data/issue_models.dart';
 import '../logic/issues_provider.dart';
 
@@ -14,7 +16,10 @@ import '../logic/issues_provider.dart';
 /// `RequestSettingsScreen`'s load → edit → Save shape: a master Enabled
 /// switch, sub-toggles, a remediation-mode dropdown, and numeric bound fields.
 class AiRemediationSettingsScreen extends ConsumerStatefulWidget {
-  const AiRemediationSettingsScreen({super.key});
+  /// Settings-search anchor to scroll to and flash on arrival.
+  final String? highlightId;
+
+  const AiRemediationSettingsScreen({super.key, this.highlightId});
 
   @override
   ConsumerState<AiRemediationSettingsScreen> createState() =>
@@ -187,8 +192,18 @@ class _AiRemediationSettingsScreenState
     );
   }
 
+  /// Wraps [child] with the settings-search highlight for [anchorId].
+  Widget _anchor(String anchorId, Widget child) => SettingsHighlight(
+        anchorId: anchorId,
+        highlightId: widget.highlightId,
+        child: child,
+      );
+
   Widget _buildBody(RemediationSettings s) {
     return ListView(
+      // Build every child while a settings-search highlight needs to find
+      // its anchor (see SettingsHighlight).
+      cacheExtent: SettingsHighlight.cacheExtentFor(widget.highlightId),
       padding: const EdgeInsets.symmetric(vertical: 8),
       children: [
         const Padding(
@@ -206,116 +221,137 @@ class _AiRemediationSettingsScreenState
         // The pipeline's other two surfaces, one tap away — the queue, its
         // governing rules, and this config are one system, not three
         // destinations an admin must already know about.
-        ListTile(
-          leading:
-              const Icon(Icons.rule_folder_outlined, color: AppTheme.accent),
-          title: const Text('Standing auto-approvals',
-              style: TextStyle(color: AppTheme.textPrimary)),
-          subtitle: const Text('The fixes approved without paging you',
-              style: TextStyle(color: AppTheme.textSecondary, fontSize: 12)),
-          trailing: const Icon(Icons.chevron_right,
-              color: AppTheme.textSecondary, size: 18),
-          onTap: () => context.push('/settings/agent-approval-rules'),
+        _anchor(
+          SettingsAnchors.remediationRules,
+          ListTile(
+            leading:
+                const Icon(Icons.rule_folder_outlined, color: AppTheme.accent),
+            title: const Text('Standing auto-approvals',
+                style: TextStyle(color: AppTheme.textPrimary)),
+            subtitle: const Text('The fixes approved without paging you',
+                style: TextStyle(color: AppTheme.textSecondary, fontSize: 12)),
+            trailing: const Icon(Icons.chevron_right,
+                color: AppTheme.textSecondary, size: 18),
+            onTap: () => context.push('/settings/agent-approval-rules'),
+          ),
         ),
-        ListTile(
-          leading: const Icon(Icons.build_circle_outlined,
-              color: AppTheme.accent),
-          title: const Text('Agent fixes',
-              style: TextStyle(color: AppTheme.textPrimary)),
-          subtitle: const Text('Awaiting review, and everything already done',
-              style: TextStyle(color: AppTheme.textSecondary, fontSize: 12)),
-          trailing: const Icon(Icons.chevron_right,
-              color: AppTheme.textSecondary, size: 18),
-          onTap: () => context.push('/agent-actions'),
+        _anchor(
+          SettingsAnchors.remediationFixes,
+          ListTile(
+            leading: const Icon(Icons.build_circle_outlined,
+                color: AppTheme.accent),
+            title: const Text('Agent fixes',
+                style: TextStyle(color: AppTheme.textPrimary)),
+            subtitle: const Text('Awaiting review, and everything already done',
+                style: TextStyle(color: AppTheme.textSecondary, fontSize: 12)),
+            trailing: const Icon(Icons.chevron_right,
+                color: AppTheme.textSecondary, size: 18),
+            onTap: () => context.push('/agent-actions'),
+          ),
         ),
         const _SectionLabel('General'),
-        SwitchListTile(
-          value: s.enabled,
-          activeThumbColor: AppTheme.accent,
-          onChanged: (v) => setState(() => _edited = s.copyWith(enabled: v)),
-          title: const Text(
-            'Enabled',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
-          ),
-          subtitle: const Text(
-            'Master switch for the remediation assistant.',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
-          ),
-        ),
-        SwitchListTile(
-          value: s.autoDispatch,
-          activeThumbColor: AppTheme.accent,
-          onChanged: (v) =>
-              setState(() => _edited = s.copyWith(autoDispatch: v)),
-          title: const Text(
-            'Auto-dispatch on detected problems',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
-          ),
-          subtitle: const Text(
-            'Track detected problems quietly while Radarr or Sonarr retries, '
-            'then investigate only after the observation window.',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        _anchor(
+          SettingsAnchors.remediationEnabled,
+          SwitchListTile(
+            value: s.enabled,
+            activeThumbColor: AppTheme.accent,
+            onChanged: (v) => setState(() => _edited = s.copyWith(enabled: v)),
+            title: const Text(
+              'Enabled',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+            ),
+            subtitle: const Text(
+              'Master switch for the remediation assistant.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
           ),
         ),
-        SwitchListTile(
-          value: s.allowReporting,
-          activeThumbColor: AppTheme.accent,
-          onChanged: (v) =>
-              setState(() => _edited = s.copyWith(allowReporting: v)),
-          title: const Text(
-            'Allow problem reporting',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
-          ),
-          subtitle: const Text(
-            'Show a "Report a problem" button to users on media screens.',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
-          ),
-        ),
-        SwitchListTile(
-          value: s.markResolvedAsRead,
-          activeThumbColor: AppTheme.accent,
-          onChanged: (v) =>
-              setState(() => _edited = s.copyWith(markResolvedAsRead: v)),
-          title: const Text(
-            'Mark resolved issues as read',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
-          ),
-          subtitle: const Text(
-            'Clear the unread dot when an issue resolves, instead of re-flagging '
-            'it for another look.',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        _anchor(
+          SettingsAnchors.remediationAutoDispatch,
+          SwitchListTile(
+            value: s.autoDispatch,
+            activeThumbColor: AppTheme.accent,
+            onChanged: (v) =>
+                setState(() => _edited = s.copyWith(autoDispatch: v)),
+            title: const Text(
+              'Auto-dispatch on detected problems',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+            ),
+            subtitle: const Text(
+              'Track detected problems quietly while Radarr or Sonarr retries, '
+              'then investigate only after the observation window.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
           ),
         ),
-        ListTile(
-          title: const Text(
-            'Mode',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+        _anchor(
+          SettingsAnchors.remediationAllowReporting,
+          SwitchListTile(
+            value: s.allowReporting,
+            activeThumbColor: AppTheme.accent,
+            onChanged: (v) =>
+                setState(() => _edited = s.copyWith(allowReporting: v)),
+            title: const Text(
+              'Allow problem reporting',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+            ),
+            subtitle: const Text(
+              'Show a "Report a problem" button to users on media screens.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
           ),
-          subtitle: const Text(
-            'Whether the assistant may prepare a fix for an admin to review.',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        ),
+        _anchor(
+          SettingsAnchors.remediationMarkResolvedRead,
+          SwitchListTile(
+            value: s.markResolvedAsRead,
+            activeThumbColor: AppTheme.accent,
+            onChanged: (v) =>
+                setState(() => _edited = s.copyWith(markResolvedAsRead: v)),
+            title: const Text(
+              'Mark resolved issues as read',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+            ),
+            subtitle: const Text(
+              'Clear the unread dot when an issue resolves, instead of re-flagging '
+              'it for another look.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
           ),
-          trailing: DropdownButton<RemediationMode>(
-            value: s.mode,
-            dropdownColor: AppTheme.surface,
-            underline: const SizedBox.shrink(),
-            style: const TextStyle(color: AppTheme.textPrimary, fontSize: 14),
-            items: [
-              for (final a in RemediationMode.values)
-                DropdownMenuItem<RemediationMode>(
-                  value: a,
-                  child: Text(a.label),
-                ),
-            ],
-            onChanged: (v) {
-              if (v == null) return;
-              setState(() => _edited = s.copyWith(mode: v));
-            },
+        ),
+        _anchor(
+          SettingsAnchors.remediationMode,
+          ListTile(
+            title: const Text(
+              'Mode',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+            ),
+            subtitle: const Text(
+              'Whether the assistant may prepare a fix for an admin to review.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
+            trailing: DropdownButton<RemediationMode>(
+              value: s.mode,
+              dropdownColor: AppTheme.surface,
+              underline: const SizedBox.shrink(),
+              style: const TextStyle(color: AppTheme.textPrimary, fontSize: 14),
+              items: [
+                for (final a in RemediationMode.values)
+                  DropdownMenuItem<RemediationMode>(
+                    value: a,
+                    child: Text(a.label),
+                  ),
+              ],
+              onChanged: (v) {
+                if (v == null) return;
+                setState(() => _edited = s.copyWith(mode: v));
+              },
+            ),
           ),
         ),
         const _SectionLabel('Automatic recovery'),
@@ -332,31 +368,40 @@ class _AiRemediationSettingsScreenState
             ),
           ),
         ),
-        _NumberTile(
-          label: 'Minimum watch time (minutes)',
-          help: 'Wait at least this long before any agent work, proposal, or '
-              'admin alert can begin.',
-          value: s.observationMinMinutes,
-          onChanged: (v) => setState(
-            () => _edited = s.copyWith(observationMinMinutes: v),
+        _anchor(
+          SettingsAnchors.remediationWatchTime,
+          _NumberTile(
+            label: 'Minimum watch time (minutes)',
+            help: 'Wait at least this long before any agent work, proposal, or '
+                'admin alert can begin.',
+            value: s.observationMinMinutes,
+            onChanged: (v) => setState(
+              () => _edited = s.copyWith(observationMinMinutes: v),
+            ),
           ),
         ),
-        _NumberTile(
-          label: 'Quiet time after arr activity (minutes)',
-          help: 'Keep waiting while Radarr or Sonarr is retrying. Escalation '
-              'starts only after no new recovery activity for this long.',
-          value: s.observationQuietMinutes,
-          onChanged: (v) => setState(
-            () => _edited = s.copyWith(observationQuietMinutes: v),
+        _anchor(
+          SettingsAnchors.remediationQuietTime,
+          _NumberTile(
+            label: 'Quiet time after arr activity (minutes)',
+            help: 'Keep waiting while Radarr or Sonarr is retrying. Escalation '
+                'starts only after no new recovery activity for this long.',
+            value: s.observationQuietMinutes,
+            onChanged: (v) => setState(
+              () => _edited = s.copyWith(observationQuietMinutes: v),
+            ),
           ),
         ),
-        _NumberTile(
-          label: 'Recovery settle time (minutes)',
-          help: 'When the failed queue item clears, allow imports and library '
-              'state this long to settle before deciding the outcome.',
-          value: s.observationSettleMinutes,
-          onChanged: (v) => setState(
-            () => _edited = s.copyWith(observationSettleMinutes: v),
+        _anchor(
+          SettingsAnchors.remediationSettleTime,
+          _NumberTile(
+            label: 'Recovery settle time (minutes)',
+            help: 'When the failed queue item clears, allow imports and library '
+                'state this long to settle before deciding the outcome.',
+            value: s.observationSettleMinutes,
+            onChanged: (v) => setState(
+              () => _edited = s.copyWith(observationSettleMinutes: v),
+            ),
           ),
         ),
         const _SectionLabel('Shared AI'),
@@ -374,39 +419,42 @@ class _AiRemediationSettingsScreenState
             ),
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
-          child: DropdownButtonFormField<String>(
-            key: ValueKey(
-              'remediation-model-${_credentials!.ai.provider}-$_modelSelection',
-            ),
-            initialValue: _modelSelection,
-            isExpanded: true,
-            decoration: const InputDecoration(
-              labelText: 'Remediation model',
-              isDense: true,
-            ),
-            items: [
-              DropdownMenuItem(
-                value: _sharedModel,
-                child: Text('Use shared model (${_credentials!.ai.model})'),
+        _anchor(
+          SettingsAnchors.remediationModel,
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+            child: DropdownButtonFormField<String>(
+              key: ValueKey(
+                'remediation-model-${_credentials!.ai.provider}-$_modelSelection',
               ),
-              ...?_providerOption(_credentials!)?.models.map(
-                    (model) => DropdownMenuItem(
-                      value: model.id,
-                      child: Text(model.label),
+              initialValue: _modelSelection,
+              isExpanded: true,
+              decoration: const InputDecoration(
+                labelText: 'Remediation model',
+                isDense: true,
+              ),
+              items: [
+                DropdownMenuItem(
+                  value: _sharedModel,
+                  child: Text('Use shared model (${_credentials!.ai.model})'),
+                ),
+                ...?_providerOption(_credentials!)?.models.map(
+                      (model) => DropdownMenuItem(
+                        value: model.id,
+                        child: Text(model.label),
+                      ),
                     ),
-                  ),
-              const DropdownMenuItem(
-                value: _customModel,
-                child: Text('Custom model ID'),
-              ),
-            ],
-            onChanged: (value) {
-              if (value != null) {
-                setState(() => _modelSelection = value);
-              }
-            },
+                const DropdownMenuItem(
+                  value: _customModel,
+                  child: Text('Custom model ID'),
+                ),
+              ],
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() => _modelSelection = value);
+                }
+              },
+            ),
           ),
         ),
         if (_modelSelection == _customModel)
@@ -435,45 +483,63 @@ class _AiRemediationSettingsScreenState
           ),
         ),
         const _SectionLabel('Limits'),
-        _NumberTile(
-          label: 'Max steps per run',
-          value: s.maxSteps,
-          onChanged: (v) => setState(() => _edited = s.copyWith(maxSteps: v)),
+        _anchor(
+          SettingsAnchors.remediationMaxSteps,
+          _NumberTile(
+            label: 'Max steps per run',
+            value: s.maxSteps,
+            onChanged: (v) => setState(() => _edited = s.copyWith(maxSteps: v)),
+          ),
         ),
-        _NumberTile(
-          label: 'Max output tokens per turn',
-          help: 'API-key providers receive this as a request cap. For shared '
-              'OpenAI OAuth, Cantinarr watches Codex usage reports and interrupts '
-              'the turn when reported output reaches the limit. Reports are '
-              'best-effort rather than a request-side hard cap and can arrive '
-              'after the model has already exceeded the boundary.',
-          value: s.maxTurnTokens,
-          onChanged: (v) =>
-              setState(() => _edited = s.copyWith(maxTurnTokens: v)),
+        _anchor(
+          SettingsAnchors.remediationMaxTurnTokens,
+          _NumberTile(
+            label: 'Max output tokens per turn',
+            help: 'API-key providers receive this as a request cap. For shared '
+                'OpenAI OAuth, Cantinarr watches Codex usage reports and interrupts '
+                'the turn when reported output reaches the limit. Reports are '
+                'best-effort rather than a request-side hard cap and can arrive '
+                'after the model has already exceeded the boundary.',
+            value: s.maxTurnTokens,
+            onChanged: (v) =>
+                setState(() => _edited = s.copyWith(maxTurnTokens: v)),
+          ),
         ),
-        _NumberTile(
-          label: 'Max wall-clock (seconds)',
-          value: s.maxWallClockSecs,
-          onChanged: (v) =>
-              setState(() => _edited = s.copyWith(maxWallClockSecs: v)),
+        _anchor(
+          SettingsAnchors.remediationMaxWallClock,
+          _NumberTile(
+            label: 'Max wall-clock (seconds)',
+            value: s.maxWallClockSecs,
+            onChanged: (v) =>
+                setState(() => _edited = s.copyWith(maxWallClockSecs: v)),
+          ),
         ),
-        _NumberTile(
-          label: 'Daily run cap',
-          value: s.dailyRunCap,
-          onChanged: (v) =>
-              setState(() => _edited = s.copyWith(dailyRunCap: v)),
+        _anchor(
+          SettingsAnchors.remediationDailyCap,
+          _NumberTile(
+            label: 'Daily run cap',
+            value: s.dailyRunCap,
+            onChanged: (v) =>
+                setState(() => _edited = s.copyWith(dailyRunCap: v)),
+          ),
         ),
-        _NumberTile(
-          label: 'Wait for a user reply (hours)',
-          value: s.maxUserWaitHours,
-          onChanged: (v) =>
-              setState(() => _edited = s.copyWith(maxUserWaitHours: v)),
+        _anchor(
+          SettingsAnchors.remediationUserWait,
+          _NumberTile(
+            label: 'Wait for a user reply (hours)',
+            value: s.maxUserWaitHours,
+            onChanged: (v) =>
+                setState(() => _edited = s.copyWith(maxUserWaitHours: v)),
+          ),
         ),
-        _NumberTile(
-          label: 'Failed auto investigations before pausing',
-          value: s.circuitBreakerGiveups,
-          onChanged: (v) =>
-              setState(() => _edited = s.copyWith(circuitBreakerGiveups: v)),
+        _anchor(
+          SettingsAnchors.remediationBreakerGiveups,
+          _NumberTile(
+            label: 'Failed auto investigations before pausing',
+            value: s.circuitBreakerGiveups,
+            onChanged: (v) =>
+                setState(() => _edited = s.copyWith(circuitBreakerGiveups: v)),
+          ),
         ),
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),

--- a/app/lib/features/notifications/ui/notification_preferences_screen.dart
+++ b/app/lib/features/notifications/ui/notification_preferences_screen.dart
@@ -5,7 +5,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/settings_highlight.dart';
 import '../../auth/logic/auth_provider.dart';
+import '../../settings/settings_anchors.dart';
 import '../notification_prefs.dart';
 import '../notification_prefs_service.dart';
 import '../push_service.dart';
@@ -14,7 +16,10 @@ import '../push_service.dart';
 /// the saved preferences on open and persists each toggle immediately,
 /// reverting the switch if the server rejects the change.
 class NotificationPreferencesScreen extends ConsumerStatefulWidget {
-  const NotificationPreferencesScreen({super.key});
+  /// Settings-search anchor to scroll to and flash on arrival.
+  final String? highlightId;
+
+  const NotificationPreferencesScreen({super.key, this.highlightId});
 
   @override
   ConsumerState<NotificationPreferencesScreen> createState() =>
@@ -180,6 +185,9 @@ class _NotificationPreferencesScreenState
     final showBooks = auth?.connection?.services.chaptarr ?? false;
 
     return ListView(
+      // Build every child while a settings-search highlight needs to find
+      // its anchor (see SettingsHighlight).
+      cacheExtent: SettingsHighlight.cacheExtentFor(widget.highlightId),
       padding: const EdgeInsets.symmetric(vertical: 8),
       children: [
         if (_pushSupported) ..._buildStatusSection(),
@@ -195,6 +203,7 @@ class _NotificationPreferencesScreenState
           subtitle: 'When your request is approved or denied',
           value: prefs.requestDecision,
           onChanged: (v) => _save(prefs.copyWith(requestDecision: v), prefs),
+          anchor: SettingsAnchors.notificationsRequestDecision,
         ),
         if (isAdmin) ...[
           _toggle(
@@ -202,12 +211,14 @@ class _NotificationPreferencesScreenState
             subtitle: 'When someone submits a request needing approval',
             value: prefs.requestPending,
             onChanged: (v) => _save(prefs.copyWith(requestPending: v), prefs),
+            anchor: SettingsAnchors.notificationsRequestPending,
           ),
           _toggle(
             title: 'Problem reports',
             subtitle: 'When someone reports a problem with their media',
             value: prefs.issueCreated,
             onChanged: (v) => _save(prefs.copyWith(issueCreated: v), prefs),
+            anchor: SettingsAnchors.notificationsProblemReports,
           ),
           _toggle(
             title: 'Fixes awaiting approval',
@@ -215,6 +226,7 @@ class _NotificationPreferencesScreenState
             value: prefs.agentActionPending,
             onChanged: (v) =>
                 _save(prefs.copyWith(agentActionPending: v), prefs),
+            anchor: SettingsAnchors.notificationsAgentFixes,
           ),
           _toggle(
             title: 'Weekly agent summary',
@@ -222,6 +234,7 @@ class _NotificationPreferencesScreenState
                 'One line a week: what resolved itself, what your rules handled, what needs you',
             value: prefs.agentDigest,
             onChanged: (v) => _save(prefs.copyWith(agentDigest: v), prefs),
+            anchor: SettingsAnchors.notificationsAgentDigest,
           ),
           _toggle(
             title: 'Plex access requests',
@@ -229,6 +242,7 @@ class _NotificationPreferencesScreenState
             value: prefs.plexAccessRequest,
             onChanged: (v) =>
                 _save(prefs.copyWith(plexAccessRequest: v), prefs),
+            anchor: SettingsAnchors.notificationsPlexAccessRequests,
           ),
           _toggle(
             title: 'Quality upgrades',
@@ -236,6 +250,7 @@ class _NotificationPreferencesScreenState
                 'When an existing movie, episode, or book is replaced with a better version',
             value: prefs.contentUpgraded,
             onChanged: (v) => _save(prefs.copyWith(contentUpgraded: v), prefs),
+            anchor: SettingsAnchors.notificationsQualityUpgrades,
           ),
         ],
         _toggle(
@@ -243,12 +258,14 @@ class _NotificationPreferencesScreenState
           subtitle: 'When a movie finishes downloading',
           value: prefs.newMovie,
           onChanged: (v) => _save(prefs.copyWith(newMovie: v), prefs),
+          anchor: SettingsAnchors.notificationsNewMovie,
         ),
         _toggle(
           title: 'New episode available',
           subtitle: 'When a new episode is available',
           value: prefs.newEpisode,
           onChanged: (v) => _save(prefs.copyWith(newEpisode: v), prefs),
+          anchor: SettingsAnchors.notificationsNewEpisode,
         ),
         if (showBooks)
           _toggle(
@@ -256,12 +273,14 @@ class _NotificationPreferencesScreenState
             subtitle: 'When a book finishes downloading',
             value: prefs.newBook,
             onChanged: (v) => _save(prefs.copyWith(newBook: v), prefs),
+            anchor: SettingsAnchors.notificationsNewBook,
           ),
         _toggle(
           title: 'Plex invite sent',
           subtitle: 'When your Plex invite email goes out',
           value: prefs.plexInviteSent,
           onChanged: (v) => _save(prefs.copyWith(plexInviteSent: v), prefs),
+          anchor: SettingsAnchors.notificationsPlexInviteSent,
         ),
         _toggle(
           title: 'My report updates',
@@ -269,6 +288,7 @@ class _NotificationPreferencesScreenState
               'When the assistant has a question about your report, a fix is ready to confirm, or your report closes',
           value: prefs.issueReportUpdate,
           onChanged: (v) => _save(prefs.copyWith(issueReportUpdate: v), prefs),
+          anchor: SettingsAnchors.notificationsReportUpdates,
         ),
         const SizedBox(height: 32),
       ],
@@ -379,8 +399,9 @@ class _NotificationPreferencesScreenState
     required String subtitle,
     required bool value,
     required ValueChanged<bool> onChanged,
+    String? anchor,
   }) {
-    return SwitchListTile(
+    final tile = SwitchListTile(
       value: value,
       onChanged: onChanged,
       activeThumbColor: AppTheme.accent,
@@ -389,6 +410,12 @@ class _NotificationPreferencesScreenState
               color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
       subtitle: Text(subtitle,
           style: const TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+    );
+    if (anchor == null) return tile;
+    return SettingsHighlight(
+      anchorId: anchor,
+      highlightId: widget.highlightId,
+      child: tile,
     );
   }
 }

--- a/app/lib/features/settings/settings_anchors.dart
+++ b/app/lib/features/settings/settings_anchors.dart
@@ -1,0 +1,85 @@
+/// Stable anchor ids for settings-search deep links.
+///
+/// A settings screen wraps each anchorable control in a `SettingsHighlight`
+/// carrying one of these ids, and the settings-search index navigates with
+/// `?highlight=<id>` to scroll to and flash that control on arrival. Ids are
+/// kebab-case, dot-scoped by screen, and restricted to `[a-z0-9.-]` so they
+/// never need URL encoding.
+///
+/// Never rename a value: ids travel in shareable URLs. Add, don't repurpose.
+abstract final class SettingsAnchors {
+  // /settings (root)
+  static const rootStatus = 'root.status';
+  static const rootAiAssistant = 'root.ai-assistant';
+  static const rootRequestUpdates = 'root.request-updates';
+  static const rootShowPlexGuide = 'root.show-plex-guide';
+  static const rootAttentionApprovals = 'root.attention-approvals';
+  static const rootAttentionIssues = 'root.attention-issues';
+  static const rootAttentionAgentFixes = 'root.attention-agent-fixes';
+  static const rootAttentionProfileApprovals =
+      'root.attention-profile-approvals';
+
+  // /settings/request-settings
+  static const requestsRequireApproval = 'requests.require-approval';
+  static const requestsSeasonChoice = 'requests.season-choice';
+  static const requestsSeasonScope = 'requests.season-scope';
+  static const requestsQualityChoice = 'requests.quality-choice';
+  static const requestsQualityRadarr = 'requests.quality-radarr';
+  static const requestsQualitySonarr = 'requests.quality-sonarr';
+
+  // /settings/notifications
+  static const notificationsRequestDecision = 'notifications.request-decision';
+  static const notificationsRequestPending = 'notifications.request-pending';
+  static const notificationsProblemReports = 'notifications.problem-reports';
+  static const notificationsAgentFixes = 'notifications.agent-fixes';
+  static const notificationsAgentDigest = 'notifications.agent-digest';
+  static const notificationsPlexAccessRequests =
+      'notifications.plex-access-requests';
+  static const notificationsQualityUpgrades = 'notifications.quality-upgrades';
+  static const notificationsNewMovie = 'notifications.new-movie';
+  static const notificationsNewEpisode = 'notifications.new-episode';
+  static const notificationsNewBook = 'notifications.new-book';
+  static const notificationsPlexInviteSent = 'notifications.plex-invite-sent';
+  static const notificationsReportUpdates = 'notifications.report-updates';
+
+  // /settings/ai-remediation
+  static const remediationRules = 'remediation.rules';
+  static const remediationFixes = 'remediation.fixes';
+  static const remediationEnabled = 'remediation.enabled';
+  static const remediationAutoDispatch = 'remediation.auto-dispatch';
+  static const remediationAllowReporting = 'remediation.allow-reporting';
+  static const remediationMarkResolvedRead = 'remediation.mark-resolved-read';
+  static const remediationMode = 'remediation.mode';
+  static const remediationWatchTime = 'remediation.watch-time';
+  static const remediationQuietTime = 'remediation.quiet-time';
+  static const remediationSettleTime = 'remediation.settle-time';
+  static const remediationModel = 'remediation.model';
+  static const remediationMaxSteps = 'remediation.max-steps';
+  static const remediationMaxTurnTokens = 'remediation.max-turn-tokens';
+  static const remediationMaxWallClock = 'remediation.max-wall-clock';
+  static const remediationDailyCap = 'remediation.daily-cap';
+  static const remediationUserWait = 'remediation.user-wait';
+  static const remediationBreakerGiveups = 'remediation.breaker-giveups';
+
+  // /settings/plex
+  static const plexAutoInvite = 'plex.auto-invite';
+
+  // /settings/credentials
+  static const credentialsAiModel = 'credentials.ai-model';
+  static const credentialsHealthCheck = 'credentials.health-check';
+  static const credentialsTmdb = 'credentials.tmdb';
+  static const credentialsAnthropic = 'credentials.anthropic';
+  static const credentialsOpenAi = 'credentials.openai';
+  static const credentialsGemini = 'credentials.gemini';
+  static const credentialsTrakt = 'credentials.trakt';
+
+  // /settings/discovery
+  static const discoveryEnglishOnly = 'discovery.english-only';
+
+  // /settings/ai-tools
+  static const aiToolsDebugLogging = 'ai-tools.debug-logging';
+
+  // /settings/ai
+  static const aiAccessIncluded = 'ai-access.included';
+  static const aiAccessPersonal = 'ai-access.personal';
+}

--- a/app/lib/features/settings/ui/ai_tools_screen.dart
+++ b/app/lib/features/settings/ui/ai_tools_screen.dart
@@ -3,11 +3,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/settings_highlight.dart';
 import '../data/ai_tools_service.dart';
+import '../settings_anchors.dart';
 
 /// Admin screen for enabling/disabling AI assistant tools.
 class AiToolsScreen extends ConsumerStatefulWidget {
-  const AiToolsScreen({super.key});
+  /// Settings-search anchor to scroll to and flash on arrival.
+  final String? highlightId;
+
+  const AiToolsScreen({super.key, this.highlightId});
 
   @override
   ConsumerState<AiToolsScreen> createState() => _AiToolsScreenState();
@@ -141,6 +146,10 @@ class _AiToolsScreenState extends ConsumerState<AiToolsScreen> {
                       onRefresh: _loadTools,
                       child: ListView(
                         physics: const AlwaysScrollableScrollPhysics(),
+                        // Build every child while a settings-search highlight
+                        // needs to find its anchor (see SettingsHighlight).
+                        cacheExtent:
+                            SettingsHighlight.cacheExtentFor(widget.highlightId),
                         padding: const EdgeInsets.symmetric(vertical: 8),
                         children: [
                           const Padding(
@@ -151,11 +160,15 @@ class _AiToolsScreenState extends ConsumerState<AiToolsScreen> {
                                   color: AppTheme.textSecondary, fontSize: 13),
                             ),
                           ),
-                          _DebugLoggingTile(
-                            status: _debug,
-                            pending: _debugPending,
-                            onToggle: (enabled) => _setDebug(enabled),
-                            onExtend: () => _setDebug(true),
+                          SettingsHighlight(
+                            anchorId: SettingsAnchors.aiToolsDebugLogging,
+                            highlightId: widget.highlightId,
+                            child: _DebugLoggingTile(
+                              status: _debug,
+                              pending: _debugPending,
+                              onToggle: (enabled) => _setDebug(enabled),
+                              onExtend: () => _setDebug(true),
+                            ),
                           ),
                           const Divider(color: AppTheme.border),
                           if (_tools?.isEmpty ?? false)

--- a/app/lib/features/settings/ui/credentials_screen.dart
+++ b/app/lib/features/settings/ui/credentials_screen.dart
@@ -6,14 +6,19 @@ import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_panel.dart';
+import '../../../core/widgets/settings_highlight.dart';
 import '../../ai_assistant/data/codex_oauth_service.dart';
 import '../../ai_assistant/data/ai_settings_service.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../data/credentials_service.dart';
+import '../settings_anchors.dart';
 
 /// Admin screen for managing API credentials (write-only).
 class CredentialsScreen extends ConsumerStatefulWidget {
-  const CredentialsScreen({super.key});
+  /// Settings-search anchor to scroll to and flash on arrival.
+  final String? highlightId;
+
+  const CredentialsScreen({super.key, this.highlightId});
 
   @override
   ConsumerState<CredentialsScreen> createState() => _CredentialsScreenState();
@@ -266,6 +271,13 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
     });
   }
 
+  /// Wraps [child] with the settings-search highlight for [anchorId].
+  Widget _anchor(String anchorId, Widget child) => SettingsHighlight(
+        anchorId: anchorId,
+        highlightId: widget.highlightId,
+        child: child,
+      );
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -289,6 +301,10 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
                       ),
                     )
                   : ListView(
+                      // Build every child while a settings-search highlight
+                      // needs to find its anchor (see SettingsHighlight).
+                      cacheExtent:
+                          SettingsHighlight.cacheExtentFor(widget.highlightId),
                       padding: const EdgeInsets.all(16),
                       children: [
                         const Text(
@@ -299,40 +315,46 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
                               color: AppTheme.textSecondary, fontSize: 13),
                         ),
                         const SizedBox(height: 24),
-                        _AISelectionSection(
-                          providers: _status?.ai.providers ?? const [],
-                          selectedProvider: _selectedProvider,
-                          selectedModel: _selectedModel,
-                          customModelValue: _customModelValue,
-                          customModelController: _customModelController,
-                          isSelectedProviderConfigured: _status?.isConfigured(
-                                _providerFor(
-                                      _selectedProvider,
-                                      _status?.ai.providers ?? const [],
-                                    )?.credentialKey ??
-                                    'anthropic_key',
-                              ) ??
-                              false,
-                          selectedProviderAuthType: _providerFor(
-                                _selectedProvider,
-                                _status?.ai.providers ?? const [],
-                              )?.authType ??
-                              'api_key',
-                          onProviderChanged: _selectProvider,
-                          onModelChanged: (value) =>
-                              setState(() => _selectedModel = value),
+                        _anchor(
+                          SettingsAnchors.credentialsAiModel,
+                          _AISelectionSection(
+                            providers: _status?.ai.providers ?? const [],
+                            selectedProvider: _selectedProvider,
+                            selectedModel: _selectedModel,
+                            customModelValue: _customModelValue,
+                            customModelController: _customModelController,
+                            isSelectedProviderConfigured: _status?.isConfigured(
+                                  _providerFor(
+                                        _selectedProvider,
+                                        _status?.ai.providers ?? const [],
+                                      )?.credentialKey ??
+                                      'anthropic_key',
+                                ) ??
+                                false,
+                            selectedProviderAuthType: _providerFor(
+                                  _selectedProvider,
+                                  _status?.ai.providers ?? const [],
+                                )?.authType ??
+                                'api_key',
+                            onProviderChanged: _selectProvider,
+                            onModelChanged: (value) =>
+                                setState(() => _selectedModel = value),
+                          ),
                         ),
                         const SizedBox(height: 14),
-                        _AIHealthCheckSection(
-                          enabled: _healthCheckEnabled,
-                          intervalHours:
-                              _status?.ai.healthCheckIntervalHours ?? 24,
-                          lastCheckedAt: _status?.ai.healthLastCheckedAt,
-                          onChanged: _isSaving
-                              ? null
-                              : (value) => setState(
-                                    () => _healthCheckEnabled = value,
-                                  ),
+                        _anchor(
+                          SettingsAnchors.credentialsHealthCheck,
+                          _AIHealthCheckSection(
+                            enabled: _healthCheckEnabled,
+                            intervalHours:
+                                _status?.ai.healthCheckIntervalHours ?? 24,
+                            lastCheckedAt: _status?.ai.healthLastCheckedAt,
+                            onChanged: _isSaving
+                                ? null
+                                : (value) => setState(
+                                      () => _healthCheckEnabled = value,
+                                    ),
+                          ),
                         ),
                         const SizedBox(height: 14),
                         if (_selectedProvider == 'codex')
@@ -364,74 +386,90 @@ class _CredentialsScreenState extends ConsumerState<CredentialsScreen> {
                                 _selectedProvider,
                           ),
                         const SizedBox(height: 24),
-                        _CredentialSection(
-                          title: 'TMDB',
-                          description:
-                              'Discovery and search run on Cantinarr\'s '
-                              'built-in key out of the box. Add your own '
-                              'access token to use your TMDB account instead.',
-                          isConfigured:
-                              _status?.isConfigured('tmdb_access_token') ??
-                                  false,
-                          builtinActive: _status?.tmdbUsingBuiltin ?? false,
-                          controller: _tmdbController,
-                          hint: 'TMDB access token',
-                          onDelete: () => _deleteCredential(
-                            'tmdb_access_token',
-                            'TMDB',
-                            message: 'Your token will be removed and '
-                                'Cantinarr\'s built-in key takes over.',
+                        _anchor(
+                          SettingsAnchors.credentialsTmdb,
+                          _CredentialSection(
+                            title: 'TMDB',
+                            description:
+                                'Discovery and search run on Cantinarr\'s '
+                                'built-in key out of the box. Add your own '
+                                'access token to use your TMDB account instead.',
+                            isConfigured:
+                                _status?.isConfigured('tmdb_access_token') ??
+                                    false,
+                            builtinActive: _status?.tmdbUsingBuiltin ?? false,
+                            controller: _tmdbController,
+                            hint: 'TMDB access token',
+                            onDelete: () => _deleteCredential(
+                              'tmdb_access_token',
+                              'TMDB',
+                              message: 'Your token will be removed and '
+                                  'Cantinarr\'s built-in key takes over.',
+                            ),
                           ),
                         ),
                         const SizedBox(height: 20),
-                        _CredentialSection(
-                          title: 'Anthropic (AI)',
-                          description:
-                              'Shared Claude API key for included AI usage',
-                          isConfigured:
-                              _status?.isConfigured('anthropic_key') ?? false,
-                          controller: _anthropicController,
-                          hint: 'Anthropic API key',
-                          onDelete: () =>
-                              _deleteCredential('anthropic_key', 'Anthropic'),
+                        _anchor(
+                          SettingsAnchors.credentialsAnthropic,
+                          _CredentialSection(
+                            title: 'Anthropic (AI)',
+                            description:
+                                'Shared Claude API key for included AI usage',
+                            isConfigured:
+                                _status?.isConfigured('anthropic_key') ?? false,
+                            controller: _anthropicController,
+                            hint: 'Anthropic API key',
+                            onDelete: () =>
+                                _deleteCredential('anthropic_key', 'Anthropic'),
+                          ),
                         ),
                         if (_status?.ai.providers.isNotEmpty ?? false) ...[
                           const SizedBox(height: 20),
-                          _CredentialSection(
-                            title: 'OpenAI (AI)',
-                            description:
-                                'Shared OpenAI API key for included AI usage',
-                            isConfigured:
-                                _status?.isConfigured('openai_key') ?? false,
-                            controller: _openAIController,
-                            hint: 'OpenAI API key',
-                            onDelete: () =>
-                                _deleteCredential('openai_key', 'OpenAI'),
+                          _anchor(
+                            SettingsAnchors.credentialsOpenAi,
+                            _CredentialSection(
+                              title: 'OpenAI (AI)',
+                              description:
+                                  'Shared OpenAI API key for included AI usage',
+                              isConfigured:
+                                  _status?.isConfigured('openai_key') ?? false,
+                              controller: _openAIController,
+                              hint: 'OpenAI API key',
+                              onDelete: () =>
+                                  _deleteCredential('openai_key', 'OpenAI'),
+                            ),
                           ),
                           const SizedBox(height: 20),
-                          _CredentialSection(
-                            title: 'Google Gemini (AI)',
-                            description:
-                                'Shared Gemini API key for included AI usage',
-                            isConfigured:
-                                _status?.isConfigured('gemini_key') ?? false,
-                            controller: _geminiController,
-                            hint: 'Gemini API key',
-                            onDelete: () => _deleteCredential(
-                                'gemini_key', 'Google Gemini'),
+                          _anchor(
+                            SettingsAnchors.credentialsGemini,
+                            _CredentialSection(
+                              title: 'Google Gemini (AI)',
+                              description:
+                                  'Shared Gemini API key for included AI usage',
+                              isConfigured:
+                                  _status?.isConfigured('gemini_key') ?? false,
+                              controller: _geminiController,
+                              hint: 'Gemini API key',
+                              onDelete: () => _deleteCredential(
+                                  'gemini_key', 'Google Gemini'),
+                            ),
                           ),
                         ],
                         const SizedBox(height: 20),
-                        _CredentialSection(
-                          title: 'Trakt',
-                          description:
-                              'Enhances discovery with trending and popular lists',
-                          isConfigured:
-                              _status?.isConfigured('trakt_client_id') ?? false,
-                          controller: _traktIdController,
-                          hint: 'Trakt client ID',
-                          onDelete: () =>
-                              _deleteCredential('trakt_client_id', 'Trakt'),
+                        _anchor(
+                          SettingsAnchors.credentialsTrakt,
+                          _CredentialSection(
+                            title: 'Trakt',
+                            description:
+                                'Enhances discovery with trending and popular lists',
+                            isConfigured:
+                                _status?.isConfigured('trakt_client_id') ??
+                                    false,
+                            controller: _traktIdController,
+                            hint: 'Trakt client ID',
+                            onDelete: () =>
+                                _deleteCredential('trakt_client_id', 'Trakt'),
+                          ),
                         ),
                         const SizedBox(height: 32),
                         SizedBox(

--- a/app/lib/features/settings/ui/discovery_settings_screen.dart
+++ b/app/lib/features/settings/ui/discovery_settings_screen.dart
@@ -3,13 +3,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/settings_highlight.dart';
 import '../../../core/widgets/status_pill.dart';
 import '../data/discovery_settings_service.dart';
+import '../settings_anchors.dart';
 
 /// Admin screen for choosing which feed backs the headline discovery rows and
 /// whether those rows drop non-English titles.
 class DiscoverySettingsScreen extends ConsumerStatefulWidget {
-  const DiscoverySettingsScreen({super.key});
+  /// Settings-search anchor to scroll to and flash on arrival.
+  final String? highlightId;
+
+  const DiscoverySettingsScreen({super.key, this.highlightId});
 
   @override
   ConsumerState<DiscoverySettingsScreen> createState() =>
@@ -169,6 +174,9 @@ class _DiscoverySettingsScreenState
 
   Widget _buildBody(DiscoverySettings edited) {
     return ListView(
+      // Build every child while a settings-search highlight needs to find
+      // its anchor (see SettingsHighlight).
+      cacheExtent: SettingsHighlight.cacheExtentFor(widget.highlightId),
       padding: const EdgeInsets.symmetric(vertical: 8),
       children: [
         const Padding(
@@ -184,20 +192,24 @@ class _DiscoverySettingsScreenState
         for (final source in edited.sources)
           _sourceTile(edited, source),
         const _SectionLabel('Language'),
-        SwitchListTile(
-          value: edited.englishOnly,
-          activeThumbColor: AppTheme.accent,
-          onChanged: (v) =>
-              setState(() => _edited = edited.copyWith(englishOnly: v)),
-          title: const Text(
-            'Only show English-language titles',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
-          ),
-          subtitle: const Text(
-            'Hides titles whose original language is not English from the '
-            'discovery and recommendation rows. Search still finds everything.',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        SettingsHighlight(
+          anchorId: SettingsAnchors.discoveryEnglishOnly,
+          highlightId: widget.highlightId,
+          child: SwitchListTile(
+            value: edited.englishOnly,
+            activeThumbColor: AppTheme.accent,
+            onChanged: (v) =>
+                setState(() => _edited = edited.copyWith(englishOnly: v)),
+            title: const Text(
+              'Only show English-language titles',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+            ),
+            subtitle: const Text(
+              'Hides titles whose original language is not English from the '
+              'discovery and recommendation rows. Search still finds everything.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
           ),
         ),
         Padding(

--- a/app/lib/features/settings/ui/plex_settings_screen.dart
+++ b/app/lib/features/settings/ui/plex_settings_screen.dart
@@ -5,13 +5,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/settings_highlight.dart';
 import '../data/plex_admin_service.dart';
+import '../settings_anchors.dart';
 
 /// Admin screen for the Plex integration: link a Plex account (PIN flow),
 /// pick the server and libraries invites share, and turn on auto-invite so a
 /// user sharing their Plex email gets invited with zero admin taps.
 class PlexSettingsScreen extends ConsumerStatefulWidget {
-  const PlexSettingsScreen({super.key});
+  /// Settings-search anchor to scroll to and flash on arrival.
+  final String? highlightId;
+
+  const PlexSettingsScreen({super.key, this.highlightId});
 
   @override
   ConsumerState<PlexSettingsScreen> createState() => _PlexSettingsScreenState();
@@ -262,6 +267,9 @@ class _PlexSettingsScreenState extends ConsumerState<PlexSettingsScreen> {
   Widget _buildBody() {
     final status = _status!;
     return ListView(
+      // Build every child while a settings-search highlight needs to find
+      // its anchor (see SettingsHighlight).
+      cacheExtent: SettingsHighlight.cacheExtentFor(widget.highlightId),
       padding: const EdgeInsets.symmetric(vertical: 8),
       children: [
         const Padding(
@@ -429,16 +437,20 @@ class _PlexSettingsScreenState extends ConsumerState<PlexSettingsScreen> {
       ],
       const SizedBox(height: 8),
       const _SectionHeader(title: 'Invites'),
-      SwitchListTile(
-        value: _autoInvite,
-        onChanged: (v) => setState(() => _autoInvite = v),
-        activeThumbColor: AppTheme.accent,
-        title: const Text('Auto-invite',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
-        subtitle: const Text(
-            'Send the invite automatically when someone shares their Plex email',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+      SettingsHighlight(
+        anchorId: SettingsAnchors.plexAutoInvite,
+        highlightId: widget.highlightId,
+        child: SwitchListTile(
+          value: _autoInvite,
+          onChanged: (v) => setState(() => _autoInvite = v),
+          activeThumbColor: AppTheme.accent,
+          title: const Text('Auto-invite',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
+          subtitle: const Text(
+              'Send the invite automatically when someone shares their Plex email',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+        ),
       ),
       Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/app/lib/features/settings/ui/request_settings_screen.dart
+++ b/app/lib/features/settings/ui/request_settings_screen.dart
@@ -3,12 +3,17 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/settings_highlight.dart';
 import '../data/request_settings_service.dart';
+import '../settings_anchors.dart';
 import '../../request/data/request_service.dart';
 
 /// Admin screen for editing the global media-request defaults.
 class RequestSettingsScreen extends ConsumerStatefulWidget {
-  const RequestSettingsScreen({super.key});
+  /// Settings-search anchor to scroll to and flash on arrival.
+  final String? highlightId;
+
+  const RequestSettingsScreen({super.key, this.highlightId});
 
   @override
   ConsumerState<RequestSettingsScreen> createState() =>
@@ -117,6 +122,9 @@ class _RequestSettingsScreenState extends ConsumerState<RequestSettingsScreen> {
 
   Widget _buildBody(AdminRequestSettings admin, GlobalRequestSettings edited) {
     return ListView(
+      // Build every child while a settings-search highlight needs to find
+      // its anchor (see SettingsHighlight).
+      cacheExtent: SettingsHighlight.cacheExtentFor(widget.highlightId),
       padding: const EdgeInsets.symmetric(vertical: 8),
       children: [
         const Padding(
@@ -128,90 +136,115 @@ class _RequestSettingsScreenState extends ConsumerState<RequestSettingsScreen> {
           ),
         ),
         const _SectionLabel('Approval'),
-        SwitchListTile(
-          value: edited.requireApproval,
-          activeThumbColor: AppTheme.accent,
-          onChanged: (v) =>
-              setState(() => _edited = edited.copyWith(requireApproval: v)),
-          title: const Text(
-            'Require approval for new requests',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
-          ),
-          subtitle: const Text(
-            'New requests wait in a queue for an admin to approve.',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        SettingsHighlight(
+          anchorId: SettingsAnchors.requestsRequireApproval,
+          highlightId: widget.highlightId,
+          child: SwitchListTile(
+            value: edited.requireApproval,
+            activeThumbColor: AppTheme.accent,
+            onChanged: (v) =>
+                setState(() => _edited = edited.copyWith(requireApproval: v)),
+            title: const Text(
+              'Require approval for new requests',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+            ),
+            subtitle: const Text(
+              'New requests wait in a queue for an admin to approve.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
           ),
         ),
         const _SectionLabel('Seasons'),
-        SwitchListTile(
-          value: edited.allowSeasonChoice,
-          activeThumbColor: AppTheme.accent,
-          onChanged: (v) =>
-              setState(() => _edited = edited.copyWith(allowSeasonChoice: v)),
-          title: const Text(
-            'Let users choose seasons',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
-          ),
-          subtitle: const Text(
-            'Allow users to pick which seasons to request for a show.',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        SettingsHighlight(
+          anchorId: SettingsAnchors.requestsSeasonChoice,
+          highlightId: widget.highlightId,
+          child: SwitchListTile(
+            value: edited.allowSeasonChoice,
+            activeThumbColor: AppTheme.accent,
+            onChanged: (v) =>
+                setState(() => _edited = edited.copyWith(allowSeasonChoice: v)),
+            title: const Text(
+              'Let users choose seasons',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+            ),
+            subtitle: const Text(
+              'Allow users to pick which seasons to request for a show.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
           ),
         ),
-        ListTile(
-          title: const Text(
-            'Default season scope',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
-          ),
-          trailing: DropdownButton<String>(
-            value: edited.defaultSeasonScope,
-            dropdownColor: AppTheme.surface,
-            underline: const SizedBox.shrink(),
-            style: const TextStyle(color: AppTheme.textPrimary, fontSize: 14),
-            items: [
-              for (final c in SeasonScope.choices)
-                DropdownMenuItem<String>(
-                  value: c.value,
-                  child: Text(c.label),
-                ),
-            ],
-            onChanged: (v) {
-              if (v == null) return;
-              setState(() => _edited = edited.copyWith(defaultSeasonScope: v));
-            },
+        SettingsHighlight(
+          anchorId: SettingsAnchors.requestsSeasonScope,
+          highlightId: widget.highlightId,
+          child: ListTile(
+            title: const Text(
+              'Default season scope',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+            ),
+            trailing: DropdownButton<String>(
+              value: edited.defaultSeasonScope,
+              dropdownColor: AppTheme.surface,
+              underline: const SizedBox.shrink(),
+              style: const TextStyle(color: AppTheme.textPrimary, fontSize: 14),
+              items: [
+                for (final c in SeasonScope.choices)
+                  DropdownMenuItem<String>(
+                    value: c.value,
+                    child: Text(c.label),
+                  ),
+              ],
+              onChanged: (v) {
+                if (v == null) return;
+                setState(
+                    () => _edited = edited.copyWith(defaultSeasonScope: v));
+              },
+            ),
           ),
         ),
         const _SectionLabel('Quality'),
-        SwitchListTile(
-          value: edited.allowQualityChoice,
-          activeThumbColor: AppTheme.accent,
-          onChanged: (v) =>
-              setState(() => _edited = edited.copyWith(allowQualityChoice: v)),
-          title: const Text(
-            'Let users choose quality',
-            style: TextStyle(
-                color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
-          ),
-          subtitle: const Text(
-            'Off by default. When off, users get the default profile below.',
-            style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+        SettingsHighlight(
+          anchorId: SettingsAnchors.requestsQualityChoice,
+          highlightId: widget.highlightId,
+          child: SwitchListTile(
+            value: edited.allowQualityChoice,
+            activeThumbColor: AppTheme.accent,
+            onChanged: (v) => setState(
+                () => _edited = edited.copyWith(allowQualityChoice: v)),
+            title: const Text(
+              'Let users choose quality',
+              style: TextStyle(
+                  color: AppTheme.textPrimary, fontWeight: FontWeight.w500),
+            ),
+            subtitle: const Text(
+              'Off by default. When off, users get the default profile below.',
+              style: TextStyle(color: AppTheme.textSecondary, fontSize: 13),
+            ),
           ),
         ),
-        _qualityTile(
-          label: 'Default Radarr quality',
-          value: edited.defaultQualityRadarr,
-          profiles: admin.radarrProfiles,
-          onChanged: (v) => setState(
-              () => _edited = edited.copyWith(defaultQualityRadarr: v)),
+        SettingsHighlight(
+          anchorId: SettingsAnchors.requestsQualityRadarr,
+          highlightId: widget.highlightId,
+          child: _qualityTile(
+            label: 'Default Radarr quality',
+            value: edited.defaultQualityRadarr,
+            profiles: admin.radarrProfiles,
+            onChanged: (v) => setState(
+                () => _edited = edited.copyWith(defaultQualityRadarr: v)),
+          ),
         ),
-        _qualityTile(
-          label: 'Default Sonarr quality',
-          value: edited.defaultQualitySonarr,
-          profiles: admin.sonarrProfiles,
-          onChanged: (v) => setState(
-              () => _edited = edited.copyWith(defaultQualitySonarr: v)),
+        SettingsHighlight(
+          anchorId: SettingsAnchors.requestsQualitySonarr,
+          highlightId: widget.highlightId,
+          child: _qualityTile(
+            label: 'Default Sonarr quality',
+            value: edited.defaultQualitySonarr,
+            profiles: admin.sonarrProfiles,
+            onChanged: (v) => setState(
+                () => _edited = edited.copyWith(defaultQualitySonarr: v)),
+          ),
         ),
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -10,17 +10,22 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/app_panel.dart';
 import '../../../core/widgets/app_sheet.dart';
 import '../../../core/widgets/attention_menu_visibility_switch.dart';
+import '../../../core/widgets/settings_highlight.dart';
 import '../../ai_assistant/data/ai_settings_service.dart';
 import '../../auth/logic/auth_provider.dart';
 import '../data/setup_status_service.dart';
 import '../logic/app_version_provider.dart';
 import '../logic/setup_status_provider.dart';
 import '../logic/update_status_provider.dart';
+import '../settings_anchors.dart';
 import 'about_sheet.dart';
 
 /// Simplified settings screen for backend-connected architecture.
 class SettingsScreen extends ConsumerStatefulWidget {
-  const SettingsScreen({super.key});
+  /// Settings-search anchor to scroll to and flash on arrival.
+  final String? highlightId;
+
+  const SettingsScreen({super.key, this.highlightId});
 
   @override
   ConsumerState<SettingsScreen> createState() => _SettingsScreenState();
@@ -57,6 +62,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       appBar: AppBar(title: const Text('Settings')),
       body: CenteredContent(
           child: ListView(
+        // Build every child while a settings-search highlight needs to find
+        // its anchor (see SettingsHighlight).
+        cacheExtent: SettingsHighlight.cacheExtentFor(widget.highlightId),
         padding: const EdgeInsets.symmetric(vertical: 8),
         children: [
           AppPanel(
@@ -139,17 +147,21 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             title: connection?.serverName ?? 'Cantinarr',
             subtitle: connection?.serverUrl ?? 'Not connected',
           ),
-          _SettingsTile(
-            icon: Icons.check_circle_outline,
-            title: 'Status',
-            subtitle:
-                auth?.isAuthenticated == true ? 'Connected' : 'Disconnected',
-            trailing: Icon(
-              Icons.circle,
-              size: 12,
-              color: auth?.isAuthenticated == true
-                  ? AppTheme.available
-                  : AppTheme.error,
+          SettingsHighlight(
+            anchorId: SettingsAnchors.rootStatus,
+            highlightId: widget.highlightId,
+            child: _SettingsTile(
+              icon: Icons.check_circle_outline,
+              title: 'Status',
+              subtitle:
+                  auth?.isAuthenticated == true ? 'Connected' : 'Disconnected',
+              trailing: Icon(
+                Icons.circle,
+                size: 12,
+                color: auth?.isAuthenticated == true
+                    ? AppTheme.available
+                    : AppTheme.error,
+              ),
             ),
           ),
 
@@ -219,14 +231,18 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               subtitle: 'Problems you reported and how they ended',
               onTap: () => context.push('/issues'),
             ),
-          _SettingsTile(
-            icon: Icons.smart_toy_outlined,
-            title: 'AI Assistant',
-            subtitle: aiAvailable ? 'Available' : 'Not configured',
-            trailing: Icon(
-              Icons.circle,
-              size: 12,
-              color: aiAvailable ? AppTheme.available : AppTheme.unavailable,
+          SettingsHighlight(
+            anchorId: SettingsAnchors.rootAiAssistant,
+            highlightId: widget.highlightId,
+            child: _SettingsTile(
+              icon: Icons.smart_toy_outlined,
+              title: 'AI Assistant',
+              subtitle: aiAvailable ? 'Available' : 'Not configured',
+              trailing: Icon(
+                Icons.circle,
+                size: 12,
+                color: aiAvailable ? AppTheme.available : AppTheme.unavailable,
+              ),
             ),
           ),
           if (user?.isAdmin == true)
@@ -347,17 +363,33 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           if (user?.isAdmin == true) ...[
             const SizedBox(height: 16),
             const _SectionHeader(title: 'Needs attention menu'),
-            const AttentionMenuVisibilitySwitch(
-              item: AttentionMenuItem.approvals,
+            SettingsHighlight(
+              anchorId: SettingsAnchors.rootAttentionApprovals,
+              highlightId: widget.highlightId,
+              child: const AttentionMenuVisibilitySwitch(
+                item: AttentionMenuItem.approvals,
+              ),
             ),
-            const AttentionMenuVisibilitySwitch(
-              item: AttentionMenuItem.issues,
+            SettingsHighlight(
+              anchorId: SettingsAnchors.rootAttentionIssues,
+              highlightId: widget.highlightId,
+              child: const AttentionMenuVisibilitySwitch(
+                item: AttentionMenuItem.issues,
+              ),
             ),
-            const AttentionMenuVisibilitySwitch(
-              item: AttentionMenuItem.agentFixes,
+            SettingsHighlight(
+              anchorId: SettingsAnchors.rootAttentionAgentFixes,
+              highlightId: widget.highlightId,
+              child: const AttentionMenuVisibilitySwitch(
+                item: AttentionMenuItem.agentFixes,
+              ),
             ),
-            const AttentionMenuVisibilitySwitch(
-              item: AttentionMenuItem.profileApprovals,
+            SettingsHighlight(
+              anchorId: SettingsAnchors.rootAttentionProfileApprovals,
+              highlightId: widget.highlightId,
+              child: const AttentionMenuVisibilitySwitch(
+                item: AttentionMenuItem.profileApprovals,
+              ),
             ),
           ],
 
@@ -371,19 +403,25 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             subtitle: 'Choose which push notifications you receive',
             onTap: () => context.push('/settings/notifications'),
           ),
-          SwitchListTile(
-            value: ref.watch(requestNotificationsEnabledProvider),
-            onChanged: (v) =>
-                ref.read(requestNotificationsEnabledProvider.notifier).set(v),
-            activeThumbColor: AppTheme.accent,
-            secondary: const Icon(Icons.notifications_active_outlined,
-                color: AppTheme.textSecondary),
-            title: const Text('Request updates',
-                style: TextStyle(
-                    color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
-            subtitle: const Text(
-                'Show an in-app banner when a request is approved or denied',
-                style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+          SettingsHighlight(
+            anchorId: SettingsAnchors.rootRequestUpdates,
+            highlightId: widget.highlightId,
+            child: SwitchListTile(
+              value: ref.watch(requestNotificationsEnabledProvider),
+              onChanged: (v) =>
+                  ref.read(requestNotificationsEnabledProvider.notifier).set(v),
+              activeThumbColor: AppTheme.accent,
+              secondary: const Icon(Icons.notifications_active_outlined,
+                  color: AppTheme.textSecondary),
+              title: const Text('Request updates',
+                  style: TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontWeight: FontWeight.w500)),
+              subtitle: const Text(
+                  'Show an in-app banner when a request is approved or denied',
+                  style:
+                      TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+            ),
           ),
 
           const SizedBox(height: 16),
@@ -397,19 +435,25 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
               subtitle: 'Install Plex and start watching your requests',
               onTap: () => context.push('/plex-guide'),
             ),
-          SwitchListTile(
-            value: ref.watch(plexGuideEnabledProvider),
-            onChanged: (v) =>
-                ref.read(plexGuideEnabledProvider.notifier).set(v),
-            activeThumbColor: AppTheme.accent,
-            secondary: const Icon(Icons.visibility_outlined,
-                color: AppTheme.textSecondary),
-            title: const Text('Show Plex guide',
-                style: TextStyle(
-                    color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),
-            subtitle: const Text(
-                'Show the Watch on Plex guide in the menu and here',
-                style: TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+          SettingsHighlight(
+            anchorId: SettingsAnchors.rootShowPlexGuide,
+            highlightId: widget.highlightId,
+            child: SwitchListTile(
+              value: ref.watch(plexGuideEnabledProvider),
+              onChanged: (v) =>
+                  ref.read(plexGuideEnabledProvider.notifier).set(v),
+              activeThumbColor: AppTheme.accent,
+              secondary: const Icon(Icons.visibility_outlined,
+                  color: AppTheme.textSecondary),
+              title: const Text('Show Plex guide',
+                  style: TextStyle(
+                      color: AppTheme.textPrimary,
+                      fontWeight: FontWeight.w500)),
+              subtitle: const Text(
+                  'Show the Watch on Plex guide in the menu and here',
+                  style:
+                      TextStyle(color: AppTheme.textSecondary, fontSize: 13)),
+            ),
           ),
 
           const SizedBox(height: 16),

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -464,13 +464,13 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           ),
           GoRoute(
             path: '/settings',
-            builder: (_, __) =>
-                const AppAmbientBackground(child: SettingsScreen()),
+            builder: (_, state) => AppAmbientBackground(
+                child: SettingsScreen(highlightId: _highlightParam(state))),
           ),
           GoRoute(
             path: '/settings/ai',
-            builder: (_, __) =>
-                const AppAmbientBackground(child: AiAccessScreen()),
+            builder: (_, state) => AppAmbientBackground(
+                child: AiAccessScreen(highlightId: _highlightParam(state))),
           ),
           GoRoute(
             path: '/settings/chatgpt',
@@ -487,13 +487,13 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           ),
           GoRoute(
             path: '/settings/credentials',
-            builder: (_, __) =>
-                const AppAmbientBackground(child: CredentialsScreen()),
+            builder: (_, state) => AppAmbientBackground(
+                child: CredentialsScreen(highlightId: _highlightParam(state))),
           ),
           GoRoute(
             path: '/settings/ai-tools',
-            builder: (_, __) =>
-                const AppAmbientBackground(child: AiToolsScreen()),
+            builder: (_, state) => AppAmbientBackground(
+                child: AiToolsScreen(highlightId: _highlightParam(state))),
           ),
           GoRoute(
             path: '/settings/change-history',
@@ -586,8 +586,9 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           ),
           GoRoute(
             path: '/settings/ai-remediation',
-            builder: (_, __) => const AppAmbientBackground(
-                child: AiRemediationSettingsScreen()),
+            builder: (_, state) => AppAmbientBackground(
+                child: AiRemediationSettingsScreen(
+                    highlightId: _highlightParam(state))),
           ),
           GoRoute(
             path: '/settings/agent-approval-rules',
@@ -596,13 +597,15 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           ),
           GoRoute(
             path: '/settings/request-settings',
-            builder: (_, __) =>
-                const AppAmbientBackground(child: RequestSettingsScreen()),
+            builder: (_, state) => AppAmbientBackground(
+                child: RequestSettingsScreen(
+                    highlightId: _highlightParam(state))),
           ),
           GoRoute(
             path: '/settings/discovery',
-            builder: (_, __) =>
-                const AppAmbientBackground(child: DiscoverySettingsScreen()),
+            builder: (_, state) => AppAmbientBackground(
+                child: DiscoverySettingsScreen(
+                    highlightId: _highlightParam(state))),
           ),
           GoRoute(
             path: '/settings/devices',
@@ -611,13 +614,15 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           ),
           GoRoute(
             path: '/settings/plex',
-            builder: (_, __) =>
-                const AppAmbientBackground(child: PlexSettingsScreen()),
+            builder: (_, state) => AppAmbientBackground(
+                child:
+                    PlexSettingsScreen(highlightId: _highlightParam(state))),
           ),
           GoRoute(
             path: '/settings/notifications',
-            builder: (_, __) => const AppAmbientBackground(
-                child: NotificationPreferencesScreen()),
+            builder: (_, state) => AppAmbientBackground(
+                child: NotificationPreferencesScreen(
+                    highlightId: _highlightParam(state))),
           ),
           GoRoute(
             path: '/settings/passkeys',
@@ -671,6 +676,11 @@ final appRouterProvider = Provider<GoRouter>((ref) {
     ],
   );
 });
+
+/// The settings-search anchor requested via `?highlight=<anchorId>`, passed
+/// through to screens that support scroll-to-and-flash on arrival.
+String? _highlightParam(GoRouterState state) =>
+    state.uri.queryParameters['highlight'];
 
 bool _isInternalReturnLocation(Uri uri) {
   return !uri.hasScheme &&

--- a/app/test/core/settings_highlight_test.dart
+++ b/app/test/core/settings_highlight_test.dart
@@ -1,0 +1,126 @@
+import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/core/widgets/settings_highlight.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The decoration ring the highlight paints while active. Scoped to the
+/// wrapper so ambient Material decorations can never match.
+Finder _activeRing() => find.descendant(
+      of: find.byType(SettingsHighlight),
+      matching: find.byWidgetPredicate(
+        (widget) =>
+            widget is DecoratedBox &&
+            widget.decoration is BoxDecoration &&
+            (widget.decoration as BoxDecoration).border != null,
+      ),
+    );
+
+Widget _harness({
+  required String? highlightId,
+  bool disableAnimations = false,
+  StateSetter? Function(StateSetter setState)? captureSetState,
+}) {
+  return MaterialApp(
+    theme: AppTheme.dark,
+    home: MediaQuery(
+      data: MediaQueryData(disableAnimations: disableAnimations),
+      child: Scaffold(
+        body: StatefulBuilder(
+          builder: (context, setState) {
+            captureSetState?.call(setState);
+            return ListView(
+              // Mirror the screen recipe: anchors far below the fold only
+              // mount when the list builds everything.
+              cacheExtent: SettingsHighlight.cacheExtentFor(highlightId),
+              children: [
+                for (var i = 0; i < 30; i++) SizedBox(height: 100, key: Key('filler-$i')),
+                SettingsHighlight(
+                  anchorId: 'test.target',
+                  highlightId: highlightId,
+                  child: const ListTile(title: Text('target')),
+                ),
+                for (var i = 0; i < 5; i++) const SizedBox(height: 100),
+              ],
+            );
+          },
+        ),
+      ),
+    ),
+  );
+}
+
+ScrollableState _scrollable(WidgetTester tester) =>
+    tester.state<ScrollableState>(find.byType(Scrollable).first);
+
+void main() {
+  testWidgets('scrolls to the matched anchor and flashes a fading ring',
+      (tester) async {
+    await tester.pumpWidget(_harness(highlightId: 'test.target'));
+    // The post-frame trigger started the scroll and the flash. The first
+    // pump gives their tickers a start time; the second lands the scroll,
+    // putting the target onstage with the ring still mid-fade.
+    await tester.pump();
+    await tester.pump(AppTheme.motionSlow);
+    expect(_scrollable(tester).position.pixels, greaterThan(2000));
+    expect(_activeRing(), findsOneWidget);
+    // Lands near the top of the viewport (alignment 0.1).
+    final targetTop = tester.getTopLeft(find.text('target')).dy;
+    expect(targetTop, greaterThanOrEqualTo(0));
+    expect(targetTop, lessThan(150));
+
+    // The ring decays to nothing once the fade completes.
+    await tester.pumpAndSettle();
+    expect(_activeRing(), findsNothing);
+  });
+
+  testWidgets('is pixel-inert when the highlight id does not match',
+      (tester) async {
+    await tester.pumpWidget(_harness(highlightId: 'test.other'));
+    await tester.pumpAndSettle();
+    expect(_scrollable(tester).position.pixels, 0);
+    expect(_activeRing(), findsNothing);
+  });
+
+  testWidgets('is pixel-inert when no highlight is requested', (tester) async {
+    await tester.pumpWidget(_harness(highlightId: null));
+    await tester.pumpAndSettle();
+    expect(_scrollable(tester).position.pixels, 0);
+    expect(_activeRing(), findsNothing);
+  });
+
+  testWidgets('fires once: rebuilds do not re-scroll or re-flash',
+      (tester) async {
+    StateSetter? rebuild;
+    await tester.pumpWidget(_harness(
+      highlightId: 'test.target',
+      captureSetState: (setState) => rebuild = setState,
+    ));
+    await tester.pumpAndSettle();
+    expect(_scrollable(tester).position.pixels, greaterThan(2000));
+
+    _scrollable(tester).position.jumpTo(0);
+    await tester.pump();
+    rebuild!(() {});
+    await tester.pumpAndSettle();
+
+    expect(_scrollable(tester).position.pixels, 0);
+    expect(_activeRing(), findsNothing);
+  });
+
+  testWidgets('reduced motion jumps, holds the ring, then clears it',
+      (tester) async {
+    await tester.pumpWidget(
+      _harness(highlightId: 'test.target', disableAnimations: true),
+    );
+    // The jump is synchronous in the post-frame trigger; one pump renders it.
+    await tester.pump();
+    expect(_scrollable(tester).position.pixels, greaterThan(2000));
+    expect(_activeRing(), findsOneWidget);
+
+    // The static ring clears via a plain Timer, which pumpAndSettle would
+    // never flush — advance past it explicitly.
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+    expect(_activeRing(), findsNothing);
+  });
+}

--- a/app/test/settings/credentials_screen_test.dart
+++ b/app/test/settings/credentials_screen_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:cantinarr/core/network/backend_client.dart';
 import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:cantinarr/features/settings/settings_anchors.dart';
 import 'package:cantinarr/features/settings/ui/credentials_screen.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
@@ -136,6 +137,37 @@ void main() {
     );
     // Only TMDB has a built-in fallback; the other credentials stay "Not set".
     expect(find.text('Not set'), findsWidgets);
+  });
+
+  testWidgets('a highlight deep link scrolls to the Trakt section on load',
+      (tester) async {
+    final adapter = _CredentialsAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'https://cantinarr.example'))
+      ..httpClientAdapter = adapter;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [backendClientProvider.overrideWithValue(dio)],
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: const CredentialsScreen(
+            highlightId: SettingsAnchors.credentialsTrakt,
+          ),
+        ),
+      ),
+    );
+    // The body mounts only after the async status load; the anchor's trigger
+    // fires then, so settling covers load, scroll, and the highlight fade.
+    await tester.pumpAndSettle();
+
+    expect(
+      tester
+          .state<ScrollableState>(find.byType(Scrollable).first)
+          .position
+          .pixels,
+      greaterThan(0),
+    );
+    expect(find.text('Trakt'), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
## Summary

Settings screens now accept a `?highlight=<anchorId>` query param: on arrival the matched control is scrolled into view and flashes a briefly fading accent ring. This is the mechanism half of settings search — a follow-up PR adds the search bar on `/settings` that navigates with these deep links.

- **`SettingsHighlight`** (new, `core/widgets/`): wraps an anchorable control; when its `anchorId` matches the screen's `highlightId` it fires once after its first frame — `Scrollable.ensureVisible` + a ~1.6s fading accent ring. Reduced motion jumps instead and shows the ring statically. Pixel-inert when idle (foreground-only decoration, no layout change), so wrapped tiles render identically when no highlight is active.
- **`SettingsAnchors`** (new, `features/settings/`): 55 stable kebab-case anchor ids across 9 screens (root settings, Request Defaults, Notification Preferences, AI Remediation, Plex Invites, Providers & Credentials, Discovery, AI Tools, AI Access). Ids travel in shareable URLs — add, never rename.
- **Router**: the 9 screen builders read `?highlight=` and pass it as a `highlightId` ctor param (screens stay pumpable in tests without a router).
- **Lazy-list gotcha**: `ListView(children:)` inflates lazily, so an anchor below the fold would never mount. While a highlight is active, anchored lists widen `cacheExtent` via `SettingsHighlight.cacheExtentFor` (finite — an infinite extent breaks semantics geometry).

## Testing

- New `test/core/settings_highlight_test.dart`: scrolls + lands near the viewport top, ring appears then fades, inert on mismatched/absent ids, one-shot across rebuilds, reduced-motion jump + timer-cleared static ring.
- New integration case in `credentials_screen_test.dart`: `CredentialsScreen(highlightId: SettingsAnchors.credentialsTrakt)` scrolls on load with the real async-load flow.
- `flutter analyze --no-fatal-infos` clean; full `flutter test` suite green (1018 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GExZ4KiC18Gb1vaCk74GQv