### PR TITLE
feat(app): lead Settings with the Setup Checklist, drop the overview panel

### DIFF
--- a/app/lib/features/settings/data/settings_search_index.dart
+++ b/app/lib/features/settings/data/settings_search_index.dart
@@ -111,6 +111,15 @@ class SettingsSearchEntry {
 // root's own rows and action tiles, in the root ListView's visual order.
 const List<SettingsSearchEntry> _rootEntries = [
   SettingsSearchEntry(
+    id: 'screen.setup-checklist',
+    title: 'Setup Checklist',
+    icon: Icons.checklist_outlined,
+    route: '/setup',
+    screenTitle: 'Settings',
+    keywords: ['configured', 'features', 'wizard', 'getting started', 'admin'],
+    gate: gateAdmin,
+  ),
+  SettingsSearchEntry(
     id: 'root.status',
     title: 'Status',
     icon: Icons.check_circle_outline,
@@ -199,16 +208,6 @@ const List<SettingsSearchEntry> _rootEntries = [
     section: 'Modules',
     keywords: ['sign-in', 'security', 'webauthn', 'biometric', 'face id'],
     gate: gatePasskey,
-  ),
-  SettingsSearchEntry(
-    id: 'screen.setup-checklist',
-    title: 'Setup Checklist',
-    icon: Icons.checklist_outlined,
-    route: '/setup',
-    screenTitle: 'Settings',
-    section: 'Admin',
-    keywords: ['configured', 'features', 'wizard', 'getting started'],
-    gate: gateAdmin,
   ),
   SettingsSearchEntry(
     id: 'screen.credentials',

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -7,7 +7,6 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../../core/layout/adaptive.dart';
 import '../../../core/storage/preferences.dart';
 import '../../../core/theme/app_theme.dart';
-import '../../../core/widgets/app_panel.dart';
 import '../../../core/widgets/app_sheet.dart';
 import '../../../core/widgets/attention_menu_visibility_switch.dart';
 import '../../../core/widgets/settings_highlight.dart';
@@ -92,81 +91,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         cacheExtent: SettingsHighlight.cacheExtentFor(_activeHighlight),
         padding: const EdgeInsets.symmetric(vertical: 8),
         children: [
-          AppPanel(
-            margin: const EdgeInsets.fromLTRB(16, 8, 16, 18),
-            padding: const EdgeInsets.all(18),
-            accentColor: AppTheme.signal,
-            child: Row(
-              children: [
-                Container(
-                  width: 48,
-                  height: 48,
-                  decoration: BoxDecoration(
-                    gradient: LinearGradient(
-                      begin: Alignment.topLeft,
-                      end: Alignment.bottomRight,
-                      colors: [
-                        AppTheme.signal.withValues(alpha: 0.2),
-                        AppTheme.accent.withValues(alpha: 0.11),
-                      ],
-                    ),
-                    borderRadius: BorderRadius.circular(AppTheme.radiusLarge),
-                    border: Border.all(
-                      color: AppTheme.signal.withValues(alpha: 0.22),
-                    ),
-                  ),
-                  child: const Icon(
-                    Icons.tune_rounded,
-                    color: AppTheme.signal,
-                  ),
-                ),
-                const SizedBox(width: 14),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        'Settings overview',
-                        style:
-                            Theme.of(context).textTheme.titleMedium?.copyWith(
-                                  color: AppTheme.textPrimary,
-                                  fontWeight: FontWeight.w700,
-                                ),
-                      ),
-                      const SizedBox(height: 3),
-                      Text(
-                        '${user?.username ?? 'Account'}  /  ${connection?.serverName ?? 'Cantinarr'}',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: Theme.of(context).textTheme.bodySmall,
-                      ),
-                    ],
-                  ),
-                ),
-                Container(
-                  width: 9,
-                  height: 9,
-                  decoration: BoxDecoration(
-                    color: auth?.isAuthenticated == true
-                        ? AppTheme.available
-                        : AppTheme.error,
-                    shape: BoxShape.circle,
-                    boxShadow: [
-                      BoxShadow(
-                        color: (auth?.isAuthenticated == true
-                                ? AppTheme.available
-                                : AppTheme.error)
-                            .withValues(alpha: 0.28),
-                        blurRadius: 10,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
+          // The one tile with live signal leads the screen: the checklist
+          // count is amber/red/green state, not decoration.
+          if (user?.isAdmin == true) _setupChecklistTile(context, setupStatus),
           Padding(
-            padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+            padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
             child: ListenableBuilder(
               listenable: _searchController,
               builder: (context, _) => TextField(
@@ -328,7 +257,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             if (user?.isAdmin == true) ...[
               const SizedBox(height: 16),
               const _SectionHeader(title: 'Admin'),
-              _setupChecklistTile(context, setupStatus),
               _SettingsTile(
                 icon: Icons.key_outlined,
                 title: 'Providers & Credentials',


### PR DESCRIPTION
## Summary

The "Settings overview" identity panel duplicated what the Server and Account tiles already show (username, server name, connection dot) and tapped to nothing. It's gone. The **Setup Checklist tile now leads the screen** for admins — the one row with live signal (its amber/red/green count) — sitting above the settings search field. Non-admins now start at the search field.

The checklist keeps its exact tile (colored count subtitle, /setup destination) and leaves the Admin section; its search-index entry moves to match the new visual order (registry order is both the ranking tiebreaker and the drift test's scan order).

## Testing

- `flutter analyze --no-fatal-infos` clean; full `flutter test` green (1047).
- Existing Setup Checklist tile tests and the search drift/behavior tests pass unchanged in semantics — only the registry order moved with the tile.
- Visual check in the preview harness: checklist → search → SERVER, admin persona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GExZ4KiC18Gb1vaCk74GQv