### PR TITLE
feat(app): drop the AI Assistant tile from Settings

### DIFF
--- a/app/lib/features/settings/data/settings_search_index.dart
+++ b/app/lib/features/settings/data/settings_search_index.dart
@@ -170,16 +170,6 @@ const List<SettingsSearchEntry> _rootEntries = [
     gate: gateNonAdmin,
   ),
   SettingsSearchEntry(
-    id: 'screen.ai-assistant',
-    title: 'AI Assistant',
-    icon: Icons.smart_toy_outlined,
-    route: '/assistant',
-    screenTitle: 'Settings',
-    section: 'Modules',
-    keywords: ['available', 'chat', 'ask', 'configured'],
-    gate: gateEveryone,
-  ),
-  SettingsSearchEntry(
     id: 'screen.add-instance',
     title: 'Add Instance',
     icon: Icons.add,

--- a/app/lib/features/settings/settings_anchors.dart
+++ b/app/lib/features/settings/settings_anchors.dart
@@ -9,7 +9,6 @@
 /// Never rename a value: ids travel in shareable URLs. Add, don't repurpose.
 abstract final class SettingsAnchors {
   // /settings (root)
-  static const rootAiAssistant = 'root.ai-assistant';
   static const rootRequestUpdates = 'root.request-updates';
   static const rootShowPlexGuide = 'root.show-plex-guide';
   static const rootAttentionApprovals = 'root.attention-approvals';

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -72,8 +72,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final updateStatus = ref.watch(updateStatusProvider);
     final aiSettings = ref.watch(aiSettingsProvider).valueOrNull;
     final appVersion = ref.watch(appVersionProvider).valueOrNull;
-    final aiAvailable =
-        aiSettings?.effective.available ?? connection?.services.ai ?? false;
     final gates = SettingsSearchGates(
       user: user,
       chaptarrEnabled: connection?.services.chaptarr ?? false,
@@ -213,21 +211,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 subtitle: 'Problems you reported and how they ended',
                 onTap: () => context.push('/issues'),
               ),
-            SettingsHighlight(
-              anchorId: SettingsAnchors.rootAiAssistant,
-              highlightId: _activeHighlight,
-              child: _SettingsTile(
-                icon: Icons.smart_toy_outlined,
-                title: 'AI Assistant',
-                subtitle: aiAvailable ? 'Available' : 'Not configured',
-                trailing: Icon(
-                  Icons.circle,
-                  size: 12,
-                  color: aiAvailable ? AppTheme.available : AppTheme.unavailable,
-                ),
-                onTap: () => context.push('/assistant'),
-              ),
-            ),
             if (user?.isAdmin == true)
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),

--- a/app/test/settings/settings_screen_test.dart
+++ b/app/test/settings/settings_screen_test.dart
@@ -37,12 +37,6 @@ void main() {
     expect(find.byType(AttentionMenuVisibilitySwitch), findsNothing);
     expect(find.text('NEEDS ATTENTION MENU'), findsNothing);
     expect(find.text('Configuration History'), findsNothing);
-    await tester.scrollUntilVisible(
-      find.text('AI Assistant'),
-      200,
-      scrollable: find.byType(Scrollable).first,
-    );
-    expect(find.text('Available'), findsOneWidget);
   });
 
   testWidgets('marks a broken personal override instead of showing included',

--- a/app/test/settings/settings_search_index_test.dart
+++ b/app/test/settings/settings_search_index_test.dart
@@ -38,7 +38,6 @@ const _routableSettingsPaths = {
   '/setup',
   '/issues',
   '/plex-guide',
-  '/assistant',
   '/approvals',
   '/agent-actions',
 };


### PR DESCRIPTION
## Summary

Follow-up to #427: the AI Assistant row in Settings duplicated the drawer's always-present AI Assistant entry (same `/assistant` destination), and the assistant has no settings of its own to point at — per-user config is the AI Access tile, admin config is AI Tools/Credentials. The tile, its search-index entry, and its now-unused highlight anchor are removed; `/assistant` leaves the index test's route mirror.

Also trims the one root-screen test assertion that referenced the tile (its subject is the AI Access subtitle, which stays covered).

## Testing

`flutter analyze --no-fatal-infos` clean; full `flutter test` green (1047).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GExZ4KiC18Gb1vaCk74GQv