### PR TITLE
fix(app): stop the attention menu flashing on every auth refresh

### DIFF
--- a/app/lib/features/issues/logic/issues_provider.dart
+++ b/app/lib/features/issues/logic/issues_provider.dart
@@ -193,13 +193,17 @@ class PendingAgentActionsNotifier extends StateNotifier<int> {
     if (!force && admin == _isAdmin) return;
     _refreshEpoch++;
     _isAdmin = admin;
-    _ref.read(pendingAgentActionsLoadedProvider.notifier).state = false;
     _sub?.cancel();
     _sub = null;
     if (!admin) {
+      _ref.read(pendingAgentActionsLoadedProvider.notifier).state = false;
       _set(0);
       return;
     }
+    // An admin-to-admin re-bind (token refresh, resume, client swap) keeps
+    // the last count authoritative while refresh() re-reads it. Resetting
+    // the loaded flag here would flash every conditional menu entry
+    // fail-open on each auth emission.
     refresh();
     _sub = _ref
         .read(realtimeEventsProvider)

--- a/app/lib/features/profile_proposals/logic/profile_proposals_provider.dart
+++ b/app/lib/features/profile_proposals/logic/profile_proposals_provider.dart
@@ -31,13 +31,17 @@ class PendingProfileProposalsNotifier extends StateNotifier<int> {
     if (!force && admin == _isAdmin) return;
     _refreshEpoch++;
     _isAdmin = admin;
-    _ref.read(pendingProfileProposalsLoadedProvider.notifier).state = false;
     _sub?.cancel();
     _sub = null;
     if (!admin) {
+      _ref.read(pendingProfileProposalsLoadedProvider.notifier).state = false;
       _set(0);
       return;
     }
+    // An admin-to-admin re-bind (token refresh, resume, client swap) keeps
+    // the last count authoritative while refresh() re-reads it. Resetting
+    // the loaded flag here would flash every conditional menu entry
+    // fail-open on each auth emission.
     refresh();
     _sub = _ref
         .read(realtimeEventsProvider)

--- a/app/lib/features/request/logic/pending_approvals_provider.dart
+++ b/app/lib/features/request/logic/pending_approvals_provider.dart
@@ -35,13 +35,17 @@ class PendingApprovalsNotifier extends StateNotifier<int> {
     if (!force && admin == _isAdmin) return;
     _refreshEpoch++;
     _isAdmin = admin;
-    _ref.read(pendingApprovalsLoadedProvider.notifier).state = false;
     _sub?.cancel();
     _sub = null;
     if (!admin) {
+      _ref.read(pendingApprovalsLoadedProvider.notifier).state = false;
       _set(0);
       return;
     }
+    // An admin-to-admin re-bind (token refresh, resume, client swap) keeps
+    // the last count authoritative while refresh() re-reads it. Resetting
+    // the loaded flag here would flash every conditional menu entry
+    // fail-open on each auth emission.
     refresh();
     _sub = _ref
         .read(realtimeEventsProvider)

--- a/app/test/request/pending_approvals_provider_test.dart
+++ b/app/test/request/pending_approvals_provider_test.dart
@@ -66,6 +66,54 @@ void main() {
     expect(container.read(pendingApprovalsProvider), 0);
     expect(container.read(pendingApprovalsLoadedProvider), isFalse);
   });
+
+  test('an admin auth refresh keeps the loaded flag while recounting',
+      () async {
+    final auth = _MutableAuthNotifier();
+    final adapter = _ImmediateApprovalsAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+      ..httpClientAdapter = adapter;
+    final container = ProviderContainer(
+      overrides: [
+        authProvider.overrideWith(() => auth),
+        backendClientProvider.overrideWithValue(dio),
+        realtimeEventsProvider.overrideWithValue(
+          const Stream<WsEvent>.empty(),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(authProvider.future);
+    final subscription = container.listen<int>(
+      pendingApprovalsProvider,
+      (_, __) {},
+      fireImmediately: true,
+    );
+    addTearDown(subscription.close);
+
+    await _waitFor(() => container.read(pendingApprovalsLoadedProvider));
+
+    // A routine re-emission of the same admin session (token refresh, app
+    // resume, client swap) re-binds the notifier. The queue's emptiness we
+    // already know must stay known during the recount — resetting it here is
+    // what made every conditional menu entry flash fail-open.
+    auth.setAuth(const AuthState(
+      connection: BackendConnection(
+        serverUrl: 'http://localhost',
+        accessToken: 'access-rotated',
+        refreshToken: 'refresh',
+      ),
+      user: UserProfile(id: 1, username: 'admin', role: 'admin'),
+    ));
+    expect(container.read(pendingApprovalsLoadedProvider), isTrue,
+        reason: 'the re-bind itself must not un-know the count');
+
+    await pumpEventQueue();
+    await _waitFor(() => adapter.calls >= 2);
+    expect(container.read(pendingApprovalsLoadedProvider), isTrue);
+    expect(container.read(pendingApprovalsProvider), 0);
+  });
 }
 
 class _MutableAuthNotifier extends AuthNotifier {
@@ -97,6 +145,29 @@ class _DeferredApprovalsAdapter implements HttpClientAdapter {
   ) {
     calls++;
     return _response.future;
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _ImmediateApprovalsAdapter implements HttpClientAdapter {
+  int calls = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    calls++;
+    return ResponseBody.fromString(
+      jsonEncode(const <Map<String, dynamic>>[]),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
   }
 
   @override


### PR DESCRIPTION
## Summary

The Needs-attention drawer entries "fail open while the queue is unknown" by design — but the approvals, agent-fixes, and profile-proposals notifiers reset their loaded flag inside `_bind(force: true)`, which runs on **every** `authProvider` emission: token refreshes, app lifecycle resume, and every Settings visit (`refreshUser()`). Each emission flipped the entries to unknown → all conditional items appeared → the refetch resolved to 0 → they vanished. On web, where focus changes and auth refreshes are frequent, the menu flickered constantly.

Fix: an admin-to-admin re-bind keeps the last count authoritative while `refresh()` recounts — the loaded flag now resets only when leaving admin. First-load fail-open (pinned by `app_shell_test` "conditional attention entries fail open when queues are unknown") and the failed-refresh fail-open are untouched. This matches the issues counter, which already carried loadedness in its state and didn't flash.

## Testing

- New regression test: an admin auth re-emission (rotated token) keeps `pendingApprovalsLoadedProvider` true through the re-bind and recount — fails on the old code at the exact flash window.
- `flutter analyze --no-fatal-infos` clean; full `flutter test` green (1048).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GExZ4KiC18Gb1vaCk74GQv