### PR TITLE
fix(app): keep conditional menu entries quiet during their first load

### DIFF
--- a/app/lib/features/issues/logic/issues_provider.dart
+++ b/app/lib/features/issues/logic/issues_provider.dart
@@ -61,6 +61,7 @@ class IssueQueueCountsNotifier extends StateNotifier<IssueQueueCounts> {
     _sub?.cancel();
     _sub = null;
     if (!admin) {
+      _ref.read(issueQueueCountsStaleProvider.notifier).state = false;
       _set(const IssueQueueCounts());
       return;
     }
@@ -103,6 +104,7 @@ class IssueQueueCountsNotifier extends StateNotifier<IssueQueueCounts> {
         tracking: issues.where((issue) => issue.status.isTracking).length,
         hasLoaded: true,
       ));
+      _ref.read(issueQueueCountsStaleProvider.notifier).state = false;
     } catch (_) {
       if (!_isAdmin || epoch != _refreshEpoch) return;
       // Preserve the last badge counts, but fail open for conditional menu
@@ -111,6 +113,7 @@ class IssueQueueCountsNotifier extends StateNotifier<IssueQueueCounts> {
         needsAttention: state.needsAttention,
         tracking: state.tracking,
       ));
+      _ref.read(issueQueueCountsStaleProvider.notifier).state = true;
     }
   }
 
@@ -161,13 +164,18 @@ final activeIssuesProvider = Provider<int>(
   ),
 );
 
-/// Whether the issue counts have an authoritative snapshot. Conditional menu
-/// visibility fails open until this is true.
+/// Whether the issue counts have an authoritative snapshot.
 final issueQueueCountsLoadedProvider = Provider<bool>(
   (ref) => ref.watch(
     issueQueueCountsProvider.select((counts) => counts.hasLoaded),
   ),
 );
+
+/// Whether the issue counts are currently unknowable: the last refresh failed
+/// and nothing authoritative has arrived since. The conditional menu entry
+/// fails open on this — never on a load merely in flight, which is what made
+/// cold starts flash every conditional entry.
+final issueQueueCountsStaleProvider = StateProvider<bool>((ref) => false);
 
 /// Tracks the number of agent-proposed actions awaiting an admin decision, for
 /// admins only.
@@ -197,6 +205,7 @@ class PendingAgentActionsNotifier extends StateNotifier<int> {
     _sub = null;
     if (!admin) {
       _ref.read(pendingAgentActionsLoadedProvider.notifier).state = false;
+      _ref.read(pendingAgentActionsStaleProvider.notifier).state = false;
       _set(0);
       return;
     }
@@ -225,6 +234,7 @@ class PendingAgentActionsNotifier extends StateNotifier<int> {
       _refreshEpoch++;
       _set(raw.toInt());
       _ref.read(pendingAgentActionsLoadedProvider.notifier).state = true;
+      _ref.read(pendingAgentActionsStaleProvider.notifier).state = false;
     } else {
       _refreshDebounce?.cancel();
       _refreshDebounce = Timer(const Duration(milliseconds: 300), refresh);
@@ -242,11 +252,13 @@ class PendingAgentActionsNotifier extends StateNotifier<int> {
       if (!_isAdmin || epoch != _refreshEpoch) return;
       _set(actions.where((a) => a.canTakeAction).length);
       _ref.read(pendingAgentActionsLoadedProvider.notifier).state = true;
+      _ref.read(pendingAgentActionsStaleProvider.notifier).state = false;
     } catch (_) {
       if (!_isAdmin || epoch != _refreshEpoch) return;
       // Preserve the last badge count while making a conditionally hidden row
       // visible again until an authoritative refresh succeeds.
       _ref.read(pendingAgentActionsLoadedProvider.notifier).state = false;
+      _ref.read(pendingAgentActionsStaleProvider.notifier).state = true;
     }
   }
 
@@ -256,6 +268,7 @@ class PendingAgentActionsNotifier extends StateNotifier<int> {
     _refreshEpoch++;
     _set(value);
     _ref.read(pendingAgentActionsLoadedProvider.notifier).state = true;
+    _ref.read(pendingAgentActionsStaleProvider.notifier).state = false;
   }
 
   void _set(int value) {
@@ -278,3 +291,8 @@ final pendingAgentActionsProvider =
 
 /// Whether the agent-action count has been read successfully at least once.
 final pendingAgentActionsLoadedProvider = StateProvider<bool>((ref) => false);
+
+/// Whether the agent-actions count is currently unknowable (last refresh
+/// failed, nothing authoritative since). Fail-open signal for the
+/// conditional menu entry; loading alone never sets it.
+final pendingAgentActionsStaleProvider = StateProvider<bool>((ref) => false);

--- a/app/lib/features/profile_proposals/logic/profile_proposals_provider.dart
+++ b/app/lib/features/profile_proposals/logic/profile_proposals_provider.dart
@@ -35,6 +35,7 @@ class PendingProfileProposalsNotifier extends StateNotifier<int> {
     _sub = null;
     if (!admin) {
       _ref.read(pendingProfileProposalsLoadedProvider.notifier).state = false;
+      _ref.read(pendingProfileProposalsStaleProvider.notifier).state = false;
       _set(0);
       return;
     }
@@ -59,6 +60,7 @@ class PendingProfileProposalsNotifier extends StateNotifier<int> {
       _refreshEpoch++;
       _set(raw.toInt());
       _ref.read(pendingProfileProposalsLoadedProvider.notifier).state = true;
+      _ref.read(pendingProfileProposalsStaleProvider.notifier).state = false;
     } else {
       _refreshDebounce?.cancel();
       _refreshDebounce = Timer(const Duration(milliseconds: 300), refresh);
@@ -77,11 +79,13 @@ class PendingProfileProposalsNotifier extends StateNotifier<int> {
       if (!_isAdmin || epoch != _refreshEpoch) return;
       _set(proposals.where((p) => p.isPending).length);
       _ref.read(pendingProfileProposalsLoadedProvider.notifier).state = true;
+      _ref.read(pendingProfileProposalsStaleProvider.notifier).state = false;
     } catch (_) {
       if (!_isAdmin || epoch != _refreshEpoch) return;
       // Preserve the last badge count while making a conditionally hidden row
       // visible again until an authoritative refresh succeeds.
       _ref.read(pendingProfileProposalsLoadedProvider.notifier).state = false;
+      _ref.read(pendingProfileProposalsStaleProvider.notifier).state = true;
     }
   }
 
@@ -91,6 +95,7 @@ class PendingProfileProposalsNotifier extends StateNotifier<int> {
     _refreshEpoch++;
     _set(value);
     _ref.read(pendingProfileProposalsLoadedProvider.notifier).state = true;
+    _ref.read(pendingProfileProposalsStaleProvider.notifier).state = false;
   }
 
   void _set(int value) {
@@ -113,3 +118,9 @@ final pendingProfileProposalsProvider =
 
 /// Whether the proposal count has been read successfully at least once.
 final pendingProfileProposalsLoadedProvider = StateProvider<bool>((ref) => false);
+
+/// Whether the proposals count is currently unknowable (last refresh failed,
+/// nothing authoritative since). Fail-open signal for the conditional menu
+/// entry; loading alone never sets it.
+final pendingProfileProposalsStaleProvider =
+    StateProvider<bool>((ref) => false);

--- a/app/lib/features/request/logic/pending_approvals_provider.dart
+++ b/app/lib/features/request/logic/pending_approvals_provider.dart
@@ -39,6 +39,7 @@ class PendingApprovalsNotifier extends StateNotifier<int> {
     _sub = null;
     if (!admin) {
       _ref.read(pendingApprovalsLoadedProvider.notifier).state = false;
+      _ref.read(pendingApprovalsStaleProvider.notifier).state = false;
       _set(0);
       return;
     }
@@ -64,6 +65,7 @@ class PendingApprovalsNotifier extends StateNotifier<int> {
       _set(state + 1);
     }
     _ref.read(pendingApprovalsLoadedProvider.notifier).state = true;
+    _ref.read(pendingApprovalsStaleProvider.notifier).state = false;
   }
 
   /// Re-reads the queue depth from the backend. Call after an approve/deny so
@@ -79,11 +81,13 @@ class PendingApprovalsNotifier extends StateNotifier<int> {
       if (!_isAdmin || epoch != _refreshEpoch) return;
       _set(pending.length);
       _ref.read(pendingApprovalsLoadedProvider.notifier).state = true;
+      _ref.read(pendingApprovalsStaleProvider.notifier).state = false;
     } catch (_) {
       if (!_isAdmin || epoch != _refreshEpoch) return;
       // Preserve the last badge count, but fail open for conditional menu
       // visibility because the queue's emptiness is no longer authoritative.
       _ref.read(pendingApprovalsLoadedProvider.notifier).state = false;
+      _ref.read(pendingApprovalsStaleProvider.notifier).state = true;
     }
   }
 
@@ -93,6 +97,7 @@ class PendingApprovalsNotifier extends StateNotifier<int> {
     _refreshEpoch++;
     _set(value);
     _ref.read(pendingApprovalsLoadedProvider.notifier).state = true;
+    _ref.read(pendingApprovalsStaleProvider.notifier).state = false;
   }
 
   void _set(int value) {
@@ -117,3 +122,9 @@ final pendingApprovalsProvider =
 
 /// Whether the approvals count has been read successfully at least once.
 final pendingApprovalsLoadedProvider = StateProvider<bool>((ref) => false);
+
+/// Whether the approvals count is currently unknowable: the last refresh
+/// failed and nothing authoritative has arrived since. The conditional menu
+/// entry fails open on this — never on a load that is merely in flight,
+/// which is what made cold starts flash every conditional entry.
+final pendingApprovalsStaleProvider = StateProvider<bool>((ref) => false);

--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -876,34 +876,37 @@ class _AppShellState extends ConsumerState<AppShell>
         ref.watch(authProvider).valueOrNull?.connection?.services.chaptarr ??
             false;
     final pendingApprovals = ref.watch(pendingApprovalsProvider);
-    final approvalsLoaded = ref.watch(pendingApprovalsLoadedProvider);
+    final approvalsStale = ref.watch(pendingApprovalsStaleProvider);
     final openIssues = ref.watch(openIssuesProvider);
     final activeIssues = ref.watch(activeIssuesProvider);
-    final issuesLoaded = ref.watch(issueQueueCountsLoadedProvider);
+    final issuesStale = ref.watch(issueQueueCountsStaleProvider);
     final pendingAgentActions = ref.watch(pendingAgentActionsProvider);
-    final agentActionsLoaded = ref.watch(pendingAgentActionsLoadedProvider);
+    final agentActionsStale = ref.watch(pendingAgentActionsStaleProvider);
     final plexInvitesWaiting = ref.watch(plexInvitesWaitingProvider);
     // Setup reminder: unconfigured-feature count, shown while the admin
     // hasn't muted it from the checklist screen.
     final setupRemaining = ref.watch(setupStatusProvider)?.remaining ?? 0;
     final showSetupReminder =
         setupRemaining > 0 && ref.watch(setupReminderEnabledProvider);
+    // Conditional entries assume an in-flight first load will land empty and
+    // stay hidden — flashing every entry on cold start taught nothing. They
+    // fail open only when a queue is genuinely unknowable (refresh failed).
     final showApprovals = !ref.watch(approvalsMenuOnlyWhenPendingProvider) ||
-        !approvalsLoaded ||
+        approvalsStale ||
         pendingApprovals > 0;
     final showIssues = !ref.watch(issuesMenuOnlyWhenActiveProvider) ||
-        !issuesLoaded ||
+        issuesStale ||
         activeIssues > 0;
     final showAgentFixes =
         !ref.watch(agentFixesMenuOnlyWhenAwaitingReviewProvider) ||
-            !agentActionsLoaded ||
+            agentActionsStale ||
             pendingAgentActions > 0;
     final pendingProfileProposals = ref.watch(pendingProfileProposalsProvider);
-    final profileProposalsLoaded =
-        ref.watch(pendingProfileProposalsLoadedProvider);
+    final profileProposalsStale =
+        ref.watch(pendingProfileProposalsStaleProvider);
     final showProfileApprovals =
         !ref.watch(profileApprovalsMenuOnlyWhenPendingProvider) ||
-            !profileProposalsLoaded ||
+            profileProposalsStale ||
             pendingProfileProposals > 0;
     final showNeedsAttentionSection = showApprovals ||
         showIssues ||

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -577,6 +578,28 @@ void main() {
     expect(find.text('Profile approvals'), findsOneWidget);
   });
 
+  testWidgets(
+      'conditional attention entries stay hidden while queues first load',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'approvals_menu_only_when_pending': true,
+      'issues_menu_only_when_active': true,
+      'agent_fixes_menu_only_when_awaiting_review': true,
+      'profile_approvals_menu_only_when_pending': true,
+    });
+
+    // An in-flight first load must not flash the entries fail-open: the
+    // cold-start assumption is empty-until-proven, and only a FAILED
+    // refresh makes a queue unknowable enough to show them.
+    await _pumpAdminDrawer(tester, hangAttentionQueues: true);
+
+    expect(find.text('NEEDS ATTENTION'), findsNothing);
+    expect(find.text('Approvals'), findsNothing);
+    expect(find.text('Issues'), findsNothing);
+    expect(find.text('Agent fixes'), findsNothing);
+    expect(find.text('Profile approvals'), findsNothing);
+  });
+
   testWidgets('tracking-only issue restores Issues without an attention badge',
       (tester) async {
     SharedPreferences.setMockInitialValues({
@@ -619,6 +642,7 @@ Future<void> _pumpAdminDrawer(
   WidgetTester tester, {
   List<Map<String, dynamic>> issues = const [],
   bool failAttentionQueues = false,
+  bool hangAttentionQueues = false,
 }) async {
   tester.view.physicalSize = const Size(390, 844);
   tester.view.devicePixelRatio = 1;
@@ -652,6 +676,7 @@ Future<void> _pumpAdminDrawer(
         backendClientProvider.overrideWithValue(_fakeDio(
           issues: issues,
           failAttentionQueues: failAttentionQueues,
+          hangAttentionQueues: hangAttentionQueues,
         )),
         realtimeEventsProvider.overrideWithValue(const Stream<WsEvent>.empty()),
       ],
@@ -778,11 +803,13 @@ class _FakeAiChatNotifier extends AiChatNotifier {
 Dio _fakeDio({
   List<Map<String, dynamic>> issues = const [],
   bool failAttentionQueues = false,
+  bool hangAttentionQueues = false,
 }) {
   final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
   dio.httpClientAdapter = _JsonAdapter(
     issues: issues,
     failAttentionQueues: failAttentionQueues,
+    hangAttentionQueues: hangAttentionQueues,
   );
   return dio;
 }
@@ -791,10 +818,18 @@ class _JsonAdapter implements HttpClientAdapter {
   const _JsonAdapter({
     this.issues = const [],
     this.failAttentionQueues = false,
+    this.hangAttentionQueues = false,
   });
 
   final List<Map<String, dynamic>> issues;
   final bool failAttentionQueues;
+  final bool hangAttentionQueues;
+
+  static bool _isAttentionQueue(String path) =>
+      path == '/api/admin/requests' ||
+      path == '/api/admin/issues' ||
+      path == '/api/admin/agent-actions' ||
+      path == '/api/admin/profile-change-proposals';
 
   @override
   Future<ResponseBody> fetch(
@@ -803,11 +838,11 @@ class _JsonAdapter implements HttpClientAdapter {
     Future<void>? cancelFuture,
   ) async {
     final path = options.path;
-    if (failAttentionQueues &&
-        (path == '/api/admin/requests' ||
-            path == '/api/admin/issues' ||
-            path == '/api/admin/agent-actions' ||
-            path == '/api/admin/profile-change-proposals')) {
+    if (hangAttentionQueues && _isAttentionQueue(path)) {
+      // A first load still in flight: the response simply never arrives.
+      return Completer<ResponseBody>().future;
+    }
+    if (failAttentionQueues && _isAttentionQueue(path)) {
       return ResponseBody.fromString(
         '{"error":"temporarily unavailable"}',
         503,


### PR DESCRIPTION
## Summary

Follow-up to #430, which stopped the perpetual re-flashing: one flash remained on cold start, because counts begin life "not loaded" and the drawer failed open on that state until the first fetch resolved. This narrows fail-open to its real purpose:

- **In-flight first load → assume empty, stay hidden.** The answer arrives sub-second; showing everything for that beat taught nothing and shifted the whole menu.
- **Failed refresh → fail open.** New additive `...StaleProvider` flags (approvals, issues, agent fixes, profile proposals) are set only in the refresh catch paths and cleared by any authoritative signal (REST success, WS count, screen `setCount`). The drawer's conditional entries now key on stale-or-count, never on not-yet-loaded.
- The existing `...LoadedProvider` flags are untouched in meaning and remain for their other consumers (tests use them as ready-signals).

The pinned fail-open test (`failAttentionQueues`, 503s) passes unchanged — failure still shows everything. A new test pins the new quiet path: with all four conditional switches on and the queue fetches hanging forever, the section stays hidden.

## Testing

`flutter analyze --no-fatal-infos` clean; full `flutter test` green (1049).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GExZ4KiC18Gb1vaCk74GQv