### PR TITLE
feat(server): move Trakt discovery and Discovery rows under Plex invites in the checklist

### DIFF
--- a/server/internal/api/setup_status.go
+++ b/server/internal/api/setup_status.go
@@ -119,6 +119,20 @@ func buildSetupItems(f setupFacts) []setupItem {
 			Optional:    true,
 		},
 		{
+			Key:         "trakt",
+			Title:       "Trakt discovery",
+			Description: "Adds trending, popular lists, and the release calendar to discovery.",
+			Configured:  f.Trakt,
+			Optional:    true,
+		},
+		{
+			Key:         "discovery_prefs",
+			Title:       "Discovery rows",
+			Description: discoveryDescription(f),
+			Configured:  f.DiscoveryChosen,
+			Optional:    true,
+		},
+		{
 			Key:         "download_client",
 			Title:       "Download activity",
 			Description: "See and manage the live download queue (SABnzbd, qBittorrent, NZBGet, or Transmission).",
@@ -137,20 +151,6 @@ func buildSetupItems(f setupFacts) []setupItem {
 			Title:       "Plex monitoring (Tautulli)",
 			Description: "Watch live Plex streams, history, and stats from the app.",
 			Configured:  f.HasTautulli,
-			Optional:    true,
-		},
-		{
-			Key:         "trakt",
-			Title:       "Trakt discovery",
-			Description: "Adds trending, popular lists, and the release calendar to discovery.",
-			Configured:  f.Trakt,
-			Optional:    true,
-		},
-		{
-			Key:         "discovery_prefs",
-			Title:       "Discovery rows",
-			Description: discoveryDescription(f),
-			Configured:  f.DiscoveryChosen,
 			Optional:    true,
 		},
 		{


### PR DESCRIPTION
## Summary

Reorders the setup checklist's optional section: the **Trakt discovery → Discovery rows** pair moves up to sit directly below **Plex invites** (previously they sat after Tautulli). The pair stays adjacent — the existing test pinning "Discovery rows directly after Trakt" passes unchanged, and the README's description of that adjacency stays true. Order is server-derived, so the app needs no changes.

## Testing

`go vet ./...` and `go test ./...` clean from `server/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GExZ4KiC18Gb1vaCk74GQv