### PR TITLE
feat(app): show the premiere year small after the movie title

### DIFF
--- a/app/lib/features/media_detail/ui/media_detail_screen.dart
+++ b/app/lib/features/media_detail/ui/media_detail_screen.dart
@@ -183,6 +183,7 @@ class _MediaDetailScreenState extends ConsumerState<MediaDetailScreen> {
                 pinned: true,
                 delegate: MediaHeroDelegate(
                   title: state.title,
+                  year: tmdbPremiereYear(state.movieDetail?.releaseDate),
                   posterPath: state.posterPath,
                   backdropPath: state.backdropPath,
                   expandedExtent: MediaHeroDelegate.expandedExtentFor(

--- a/app/lib/features/media_detail/ui/media_hero.dart
+++ b/app/lib/features/media_detail/ui/media_hero.dart
@@ -30,6 +30,9 @@ import '../../../core/widgets/cached_image.dart';
 /// The backdrop is never blurred — legibility comes from gradient scrims.
 class MediaHeroDelegate extends SliverPersistentHeaderDelegate {
   final String title;
+
+  /// Premiere year rendered small after the title; null hides it.
+  final int? year;
   final String? posterPath;
   final String? backdropPath;
   final double expandedExtent;
@@ -40,6 +43,7 @@ class MediaHeroDelegate extends SliverPersistentHeaderDelegate {
 
   const MediaHeroDelegate({
     required this.title,
+    this.year,
     required this.posterPath,
     required this.backdropPath,
     required this.expandedExtent,
@@ -90,6 +94,7 @@ class MediaHeroDelegate extends SliverPersistentHeaderDelegate {
     return LayoutBuilder(
       builder: (context, constraints) => _MediaHeroBody(
         title: title,
+        year: year,
         posterPath: posterPath,
         backdropPath: backdropPath,
         expandedExtent: maxExtent,
@@ -110,6 +115,7 @@ class MediaHeroDelegate extends SliverPersistentHeaderDelegate {
   @override
   bool shouldRebuild(MediaHeroDelegate oldDelegate) =>
       title != oldDelegate.title ||
+      year != oldDelegate.year ||
       posterPath != oldDelegate.posterPath ||
       backdropPath != oldDelegate.backdropPath ||
       expandedExtent != oldDelegate.expandedExtent ||
@@ -126,6 +132,7 @@ double _ramp(double t, double a, double b) =>
 /// rebuilds during a scroll.
 class _MediaHeroBody extends StatefulWidget {
   final String title;
+  final int? year;
   final String? posterPath;
   final String? backdropPath;
   final double expandedExtent;
@@ -139,6 +146,7 @@ class _MediaHeroBody extends StatefulWidget {
 
   const _MediaHeroBody({
     required this.title,
+    this.year,
     required this.posterPath,
     required this.backdropPath,
     required this.expandedExtent,
@@ -310,6 +318,7 @@ class _MediaHeroBodyState extends State<_MediaHeroBody> {
             bottom: 20,
             child: _HeroForeground(
               title: widget.title,
+              year: widget.year,
               posterPath: widget.posterPath,
               hasBackdrop: hasBackdrop,
               expandedLayout: expandedLayout,
@@ -553,6 +562,7 @@ class _BackdropPlaneState extends State<_BackdropPlane>
 /// of the collapse.
 class _HeroForeground extends StatelessWidget {
   final String title;
+  final int? year;
   final String? posterPath;
   final bool hasBackdrop;
   final bool expandedLayout;
@@ -562,6 +572,7 @@ class _HeroForeground extends StatelessWidget {
 
   const _HeroForeground({
     required this.title,
+    this.year,
     required this.posterPath,
     required this.hasBackdrop,
     required this.expandedLayout,
@@ -653,8 +664,28 @@ class _HeroForeground extends StatelessWidget {
                     label: e2eWebSemanticsEnabled ? title : null,
                     header: true,
                     excludeSemantics: e2eWebSemanticsEnabled,
-                    child: Text(
-                      title,
+                    child: Text.rich(
+                      TextSpan(
+                        text: title,
+                        children: [
+                          // The premiere year rides along at roughly half the
+                          // display size — identification, not headline.
+                          if (year != null)
+                            TextSpan(
+                              text: ' ($year)',
+                              style: TextStyle(
+                                fontSize: expandedLayout
+                                    ? 28
+                                    : mobileFontSize * 0.6,
+                                fontWeight: FontWeight.w600,
+                                letterSpacing:
+                                    expandedLayout ? -0.5 : -0.25,
+                                color: AppTheme.textPrimary
+                                    .withValues(alpha: 0.75),
+                              ),
+                            ),
+                        ],
+                      ),
                       style:
                           Theme.of(context).textTheme.displaySmall?.copyWith(
                         color: AppTheme.textPrimary,

--- a/app/test/media_detail/media_hero_test.dart
+++ b/app/test/media_detail/media_hero_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   Widget heroPage({
     required String title,
+    int? year,
     String? backdropPath,
     String? posterPath,
     ScrollController? controller,
@@ -19,6 +20,7 @@ void main() {
               pinned: true,
               delegate: MediaHeroDelegate(
                 title: title,
+                year: year,
                 posterPath: posterPath,
                 backdropPath: backdropPath,
                 expandedExtent: 480,
@@ -45,6 +47,29 @@ void main() {
     expect(find.bySemanticsIdentifier('media-detail-title'), findsOneWidget);
     expect(find.text('NOW IN FOCUS'), findsNothing);
     semantics.dispose();
+  });
+
+  testWidgets('a known premiere year rides small after the title',
+      (tester) async {
+    await tester.pumpWidget(
+      heroPage(title: 'Project Hail Mary', year: 2026),
+    );
+    await tester.pumpAndSettle();
+
+    // The year joins the display title's rich text; a missing year (every
+    // other test here) leaves the plain title untouched.
+    final richTitle = tester.widget<Text>(
+      find.byWidgetPredicate(
+        (w) =>
+            w is Text &&
+            w.textSpan?.toPlainText() == 'Project Hail Mary (2026)',
+      ),
+    );
+    final span = richTitle.textSpan! as TextSpan;
+    final yearSpan = span.children!.single as TextSpan;
+    expect(yearSpan.text, ' (2026)');
+    expect(yearSpan.style?.fontSize, lessThan(richTitle.style!.fontSize!),
+        reason: 'the year renders smaller than the title');
   });
 
   testWidgets('hero renders a finished composition without any artwork',


### PR DESCRIPTION
## Summary

Opening a movie from Discover (or anywhere) now shows its **premiere year in parentheses after the hero title**, styled at roughly half the display size with a slightly muted weight/color — identification, not headline. The year threads through `MediaHeroDelegate` as an optional `int? year` (fed from `tmdbPremiereYear(movieDetail.releaseDate)`, the existing helper); a missing/unparseable date renders the title exactly as before, and the collapsed marquee bar stays year-free. TV detail is untouched per the ask — wiring `tvDetail.firstAirDate` later is a one-line change.

## Testing

- New hero test: the year joins the title's rich text at a smaller font size than the title; the no-year path is covered by every other hero test (plain title unchanged).
- `flutter analyze --no-fatal-infos` clean; full `flutter test` green (1050).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GExZ4KiC18Gb1vaCk74GQv