### PR TITLE
feat(app): lead the Discover credentials with Trakt

### DIFF
--- a/app/lib/features/settings/data/settings_search_index.dart
+++ b/app/lib/features/settings/data/settings_search_index.dart
@@ -918,17 +918,6 @@ const List<SettingsSearchEntry> _discoveryEntries = [
     anchorId: SettingsAnchors.discoveryEnglishOnly,
   ),
   SettingsSearchEntry(
-    id: SettingsAnchors.credentialsTmdb,
-    title: 'TMDB',
-    icon: Icons.explore_outlined,
-    route: '/settings/discovery',
-    screenTitle: 'Discover',
-    section: 'Credentials',
-    keywords: ['access token', 'discovery', 'built-in key', 'movie database'],
-    gate: gateAdmin,
-    anchorId: SettingsAnchors.credentialsTmdb,
-  ),
-  SettingsSearchEntry(
     id: SettingsAnchors.credentialsTrakt,
     title: 'Trakt',
     icon: Icons.explore_outlined,
@@ -938,6 +927,17 @@ const List<SettingsSearchEntry> _discoveryEntries = [
     keywords: ['client id', 'trending', 'discovery'],
     gate: gateAdmin,
     anchorId: SettingsAnchors.credentialsTrakt,
+  ),
+  SettingsSearchEntry(
+    id: SettingsAnchors.credentialsTmdb,
+    title: 'TMDB',
+    icon: Icons.explore_outlined,
+    route: '/settings/discovery',
+    screenTitle: 'Discover',
+    section: 'Credentials',
+    keywords: ['access token', 'discovery', 'built-in key', 'movie database'],
+    gate: gateAdmin,
+    anchorId: SettingsAnchors.credentialsTmdb,
   ),
 ];
 

--- a/app/lib/features/settings/ui/discovery_settings_screen.dart
+++ b/app/lib/features/settings/ui/discovery_settings_screen.dart
@@ -309,8 +309,28 @@ class _DiscoverySettingsScreenState
           ),
         ),
         const _SectionLabel('Credentials'),
+        // Trakt leads: it is the credential that unlocks a source, while
+        // TMDB is an optional override of the built-in key.
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+          child: SettingsHighlight(
+            anchorId: SettingsAnchors.credentialsTrakt,
+            highlightId: widget.highlightId,
+            child: CredentialSection(
+              title: 'Trakt',
+              description:
+                  'Enhances discovery with trending and popular lists',
+              isConfigured:
+                  _credentials?.isConfigured('trakt_client_id') ?? false,
+              controller: _traktIdController,
+              hint: 'Trakt client ID',
+              onDelete: () =>
+                  _deleteCredential('trakt_client_id', 'Trakt'),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 20, 16, 0),
           child: SettingsHighlight(
             anchorId: SettingsAnchors.credentialsTmdb,
             highlightId: widget.highlightId,
@@ -330,24 +350,6 @@ class _DiscoverySettingsScreenState
                 message: 'Your token will be removed and '
                     'Cantinarr\'s built-in key takes over.',
               ),
-            ),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 20, 16, 0),
-          child: SettingsHighlight(
-            anchorId: SettingsAnchors.credentialsTrakt,
-            highlightId: widget.highlightId,
-            child: CredentialSection(
-              title: 'Trakt',
-              description:
-                  'Enhances discovery with trending and popular lists',
-              isConfigured:
-                  _credentials?.isConfigured('trakt_client_id') ?? false,
-              controller: _traktIdController,
-              hint: 'Trakt client ID',
-              onDelete: () =>
-                  _deleteCredential('trakt_client_id', 'Trakt'),
             ),
           ),
         ),


### PR DESCRIPTION
## Summary

Swaps the two credential blocks on the Discover screen: **Trakt first, TMDB second**. Trakt is the credential that actually unlocks the recommended row source (the locked source's "add the client ID below" hint now points at the very next block), while TMDB is an optional override already badged "Built-in key". The search registry mirrors the swap so drift-scan and ranking order stay aligned. No copy, routes, gates, or anchors changed.

## Testing

`flutter analyze --no-fatal-infos` clean; full `flutter test` green (1052) — the Discover screen tests find their targets by text/key, so the reorder passes them unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GExZ4KiC18Gb1vaCk74GQv