### PR TITLE
fix(server): unstrand staged agent resumes and speak admin at give-up

### DIFF
--- a/server/internal/db/db.go
+++ b/server/internal/db/db.go
@@ -504,7 +504,7 @@ CREATE TABLE IF NOT EXISTS agent_runs (
     cache_read_tokens INTEGER NOT NULL DEFAULT 0,
     active_seconds INTEGER NOT NULL DEFAULT 0,   -- wall-clock excluding paused waits
     deadline_at DATETIME,                        -- retired 2026-08 (was a never-read watchdog deadline); kept NULL for rollback compatibility
-    stop_reason TEXT,                            -- vocabulary owned by runner.go's stop* constants plus the abort reasons (server_restarted, issue_closed, media_state_changed, external_resolution, arr_recovery_in_flight, action_outcome_unknown)
+    stop_reason TEXT,                            -- vocabulary owned by runner.go's stop* constants plus the abort reasons (server_restarted, issue_closed, media_state_changed, external_resolution, arr_recovery_in_flight, action_outcome_unknown, superseded_by_later_run)
     transcript_json TEXT NOT NULL DEFAULT '',    -- UNTRUNCATED provider-neutral transcript for resume (NOT the audit ledger)
     started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     finished_at DATETIME

--- a/server/internal/mcp/import_doctor.go
+++ b/server/internal/mcp/import_doctor.go
@@ -654,6 +654,11 @@ func (s *ToolServer) getManualImportCandidates(input json.RawMessage, instanceID
 			}
 		}
 		sb.WriteString("\n\nUse execute_manual_import to import these (add force=true to import despite permanent rejections).")
+		// Chaptarr re-runs author/book identification when the import actually
+		// executes, so "no rejections listed" above is not a promise: issue 856
+		// (2026-08-11) proposed a plain import off a clean candidate list and
+		// Chaptarr refused it at import time with an author-match rejection.
+		sb.WriteString(" Note: Chaptarr re-checks identification at import time — a candidate with no rejections listed can still be rejected when the import runs; if that happens the file is not moved and the queue item will show the reason.")
 		return &ToolResult{Text: sb.String()}, nil
 
 	default:

--- a/server/internal/remediation/recover_handoffs_test.go
+++ b/server/internal/remediation/recover_handoffs_test.go
@@ -1,0 +1,116 @@
+package remediation
+
+import (
+	"testing"
+)
+
+// These tests pin recoverWork's handling of staged decision handoffs
+// (resume_pending runs) against the strand found on issue 856 (2026-08-11):
+// an approval staged a resume, a suspend/re-promote cycle let a FRESH run
+// claim the issue and give up to needs_admin, and the handoff then sat
+// resume_pending for two days — unconsumable (the resume lane only accepted
+// investigating) while its existence also blocked the fresh-run lane's
+// NOT EXISTS guard for the issue forever.
+
+func seedHandoffIssue(t *testing.T, svc *Service, status string, closed bool) int64 {
+	t.Helper()
+	closedAt := "NULL"
+	if closed {
+		closedAt = "CURRENT_TIMESTAMP"
+	}
+	res, err := svc.db.Exec(
+		`INSERT INTO issues (source, status, media_type, tmdb_id, title, detail, instance_id, closed_at)
+		 VALUES ('auto', ?, 'tv', 42, 'Handoff Fixture', 'seed', 'sonarr-test', `+closedAt+`)`,
+		status,
+	)
+	if err != nil {
+		t.Fatalf("seed issue: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func seedRun(t *testing.T, svc *Service, issueID int64, status string) int64 {
+	t.Helper()
+	res, err := svc.db.Exec(
+		`INSERT INTO agent_runs (issue_id, trigger, status, model, proc_generation)
+		 VALUES (?, 'auto', ?, 'test', 'live-proc')`,
+		issueID, status,
+	)
+	if err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func runStateOf(t *testing.T, svc *Service, runID int64) (status, stopReason string) {
+	t.Helper()
+	if err := svc.db.QueryRow(
+		"SELECT status, COALESCE(stop_reason,'') FROM agent_runs WHERE id = ?", runID,
+	).Scan(&status, &stopReason); err != nil {
+		t.Fatalf("read run %d: %v", runID, err)
+	}
+	return status, stopReason
+}
+
+func TestRecoverWorkTerminalizesStrandedHandoffs(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	if _, err := svc.SetSettings(Settings{Enabled: true, Mode: ModeSupervised}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	runner := &Runner{db: svc.db, svc: svc, procToken: "live-proc"}
+
+	// Case 1: the issue closed under the staged handoff — it can never run.
+	closedIssue := seedHandoffIssue(t, svc, IssueResolved, true)
+	closedRun := seedRun(t, svc, closedIssue, runStatusResumePending)
+
+	// Case 2: issue 856's shape — a later run reached needs_admin, so the
+	// handoff's moment is gone even though the issue stays open.
+	supersededIssue := seedHandoffIssue(t, svc, IssueNeedsAdmin, false)
+	strandedRun := seedRun(t, svc, supersededIssue, runStatusResumePending)
+	seedRun(t, svc, supersededIssue, "gave_up")
+
+	// Case 3: needs_admin with NO later run — a suspend/re-promote cycle may
+	// still return this issue to a workable state, so the handoff is kept.
+	dormantIssue := seedHandoffIssue(t, svc, IssueNeedsAdmin, false)
+	dormantRun := seedRun(t, svc, dormantIssue, runStatusResumePending)
+
+	svc.recoverWork(runner)
+
+	if status, stop := runStateOf(t, svc, closedRun); status != "aborted" || stop != "issue_closed" {
+		t.Errorf("handoff on a closed issue = %s/%s, want aborted/issue_closed", status, stop)
+	}
+	if status, stop := runStateOf(t, svc, strandedRun); status != "aborted" || stop != "superseded_by_later_run" {
+		t.Errorf("handoff superseded by a later run = %s/%s, want aborted/superseded_by_later_run", status, stop)
+	}
+	if status, _ := runStateOf(t, svc, dormantRun); status != runStatusResumePending {
+		t.Errorf("dormant needs_admin handoff = %s, want kept %s", status, runStatusResumePending)
+	}
+	_ = dormantIssue
+}
+
+func TestRecoverWorkResumesHandoffFromOpenIssue(t *testing.T) {
+	svc, _, _ := setupTestService(t)
+	if _, err := svc.SetSettings(Settings{Enabled: true, Mode: ModeSupervised}); err != nil {
+		t.Fatalf("enable: %v", err)
+	}
+	runner := &Runner{db: svc.db, svc: svc, procToken: "live-proc"}
+
+	// An approval's resume staged while the issue flapped back through
+	// tracking and re-promoted to OPEN: the resume claim handles open, so the
+	// recovery lane must hand it back to the workers instead of stranding it.
+	openIssue := seedHandoffIssue(t, svc, IssueOpen, false)
+	openRun := seedRun(t, svc, openIssue, runStatusResumePending)
+
+	svc.recoverWork(runner)
+
+	if got := drainJobs(svc); got != 1 {
+		t.Fatalf("jobs enqueued for an open issue with a staged resume = %d, want 1", got)
+	}
+	if status, _ := runStateOf(t, svc, openRun); status != runStatusResumePending {
+		t.Fatalf("staged resume consumed prematurely by the reaper itself: %s", status)
+	}
+	// And the fresh-run guard still holds: no duplicate fresh job appeared for
+	// the same issue (the single drained job was the resume).
+}

--- a/server/internal/remediation/runner.go
+++ b/server/internal/remediation/runner.go
@@ -1670,10 +1670,36 @@ func (r *Runner) giveUp(ctx context.Context, issueID, runID int64, model, stopRe
 	// The run transition, issue claim release, and human-readable message commit
 	// together. Exhaustion is not a resolution.
 	if _, err := r.svc.GiveUpIssue(ctx, issueID, runID, stopReason, message,
-		"Agent needs administrator review: "+stopReason); err != nil {
+		giveUpResolution(stopReason)); err != nil {
 		log.Printf("remediation: giveUp transition for issue %d: %v", issueID, err)
 	}
 	return nil
+}
+
+// giveUpResolution renders a give-up's issue headline in admin language
+// instead of stop-reason vocabulary: issue 856 (2026-08-12) showed an admin a
+// raw "unverified_conclusion" token while the actual story sat one tap deeper
+// in the thread. The token stays in parentheses because it is the key an
+// admin greps runs and rules by.
+func giveUpResolution(stopReason string) string {
+	var plain string
+	switch stopReason {
+	case stopUnverifiedClose:
+		plain = "The agent investigated and reported what it found in the conversation, but could not verify that a fix took effect, so this needs a human decision."
+	case stopMaxSteps:
+		plain = "The agent used its whole step budget without reaching a verified fix; its findings are in the conversation."
+	case stopTimeout:
+		plain = "The agent ran out of time before reaching a verified fix; its findings are in the conversation."
+	case stopModelError:
+		plain = "The AI provider failed during the investigation; whatever was gathered is in the conversation."
+	case stopInfrastructure:
+		plain = "The AI provider was unavailable, so the investigation could not run."
+	case stopNoDiagnosis:
+		plain = "The agent could not identify a safe fix; its reasoning is in the conversation."
+	default:
+		return "Agent needs administrator review: " + stopReason
+	}
+	return plain + " (" + stopReason + ")"
 }
 
 // parkConfirm finalizes a run whose fix executed but whose subjective verdict

--- a/server/internal/remediation/runner_test.go
+++ b/server/internal/remediation/runner_test.go
@@ -378,8 +378,11 @@ func TestConclusionRejectsFreshReadWithoutTypedResolutionProof(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetIssue: %v", err)
 	}
-	if issue.Status != IssueNeedsAdmin || issue.Resolution != "Agent needs administrator review: "+stopUnverifiedClose {
+	if issue.Status != IssueNeedsAdmin || issue.Resolution != giveUpResolution(stopUnverifiedClose) {
 		t.Fatalf("conclusion = status %q resolution %q", issue.Status, issue.Resolution)
+	}
+	if !strings.Contains(issue.Resolution, "could not verify") || !strings.Contains(issue.Resolution, "("+stopUnverifiedClose+")") {
+		t.Fatalf("give-up headline lost its plain language or its greppable token: %q", issue.Resolution)
 	}
 }
 

--- a/server/internal/remediation/worker.go
+++ b/server/internal/remediation/worker.go
@@ -128,6 +128,28 @@ func (s *Service) recoverWork(runner *Runner) {
 		   SELECT id FROM agent_runs WHERE status != ?
 		 )`, IssueNeedsAdmin, runStatusRunning,
 	)
+	// A staged decision handoff can outlive its moment: its issue closes, or a
+	// fresh promotion run reaches needs_admin first (issue 856, 2026-08-11 —
+	// the handoff sat resume_pending for two days). An unconsumable handoff is
+	// not just ledger clutter: the fresh-run lane below skips any issue that
+	// still owns a resume_pending run, so a stranded handoff also blocks every
+	// future recovery retry for that issue. Terminalize what can never run; a
+	// handoff whose issue may yet return to a workable state is kept.
+	s.db.Exec(
+		`UPDATE agent_runs SET status = 'aborted', stop_reason = 'issue_closed',
+		 finished_at = COALESCE(finished_at, CURRENT_TIMESTAMP)
+		 WHERE status = ? AND issue_id IN (SELECT id FROM issues WHERE closed_at IS NOT NULL)`,
+		runStatusResumePending,
+	)
+	s.db.Exec(
+		`UPDATE agent_runs SET status = 'aborted', stop_reason = 'superseded_by_later_run',
+		 finished_at = COALESCE(finished_at, CURRENT_TIMESTAMP)
+		 WHERE status = ?
+		   AND EXISTS (SELECT 1 FROM agent_runs later
+		               WHERE later.issue_id = agent_runs.issue_id AND later.id > agent_runs.id)
+		   AND issue_id IN (SELECT id FROM issues WHERE closed_at IS NULL AND status = ?)`,
+		runStatusResumePending, IssueNeedsAdmin,
+	)
 	if !s.Settings().Enabled {
 		return
 	}
@@ -137,16 +159,20 @@ func (s *Service) recoverWork(runner *Runner) {
 	// approval" placeholder and never repeat the external action.
 	s.recoverDecisionHandoffs()
 
+	// The resume lane accepts open as well as investigating: a suspend/
+	// re-promote cycle between an approval and its resume legitimately lands
+	// the issue back at open (the resume claim handles both), and treating
+	// that as unresumable is exactly what stranded issue 856's handoff.
 	rows, err := s.db.Query(
 		`SELECT i.id, 0 FROM issues i
 		 WHERE i.closed_at IS NULL AND i.active_run_id IS NULL AND i.status IN (?, ?)
 		   AND NOT EXISTS (SELECT 1 FROM agent_runs r WHERE r.issue_id = i.id AND r.status = ?)
 		 UNION ALL
 		 SELECT i.id, 1 FROM issues i JOIN agent_runs r ON r.issue_id = i.id
-		 WHERE i.closed_at IS NULL AND i.active_run_id IS NULL AND i.status = ?
+		 WHERE i.closed_at IS NULL AND i.active_run_id IS NULL AND i.status IN (?, ?)
 		   AND r.status = ?`,
 		IssueOpen, IssueInvestigating, runStatusResumePending,
-		IssueInvestigating, runStatusResumePending,
+		IssueOpen, IssueInvestigating, runStatusResumePending,
 	)
 	if err != nil {
 		return


### PR DESCRIPTION
Three small fixes from the issue-856 review (the Chaptarr book whose every copy fails import on an `NO_MATCH_HOLY_GRAIL` author-match rejection):

- **Stranded decision handoffs**: an approval's staged resume could be pre-empted by a fresh promotion run reaching `needs_admin`, leaving the handoff `resume_pending` forever — and, because the fresh-run recovery lane skips issues that own a `resume_pending` run, silently blocking all future recovery retries for that issue. `recoverWork` now terminalizes handoffs whose issue closed (`issue_closed`) or was superseded by a later run (`superseded_by_later_run`), and the resume lane accepts issues back at `open` (the resume claim always could — the pipeline suite proves it). Run 64 on prod will be reaped within a minute of deploy.
- **Give-up headline in admin language**: the issue top line now reads "The agent investigated … could not verify that a fix took effect, so this needs a human decision. (unverified_conclusion)" instead of the bare token. The greppable token stays in parentheses.
- **Chaptarr candidates caveat**: the manual-import candidates tool now states that a clean rejection list is not a promise — Chaptarr re-checks identification at import time, and a rejection there leaves the file unmoved with the reason on the queue item.

New `recover_handoffs_test.go` pins all four reaper cases (closed → aborted, superseded → aborted, dormant `needs_admin` → kept, `open` → resume re-enqueued). Full server suite + vet green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvrM99oTBr2KLJxjH4sXaq