### PR TITLE
Log a wedged database connection instead of going silent

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -654,6 +654,8 @@ Language IDs may vary by service and version, so they are read live from each Ra
 
 SQLite (pure Go driver) with WAL mode. **The live schema is code**: `internal/db/db.go` -- the `initSQL` create statements plus an in-code list of tolerant `ALTER TABLE` migrations with one-time backfills. There are no SQL migration files.
 
+The pool holds **exactly one connection** (SQLite is single-writer), so every query in the process takes its turn through one door, and no query sets a timeout. Code that holds the connection while waiting for something that also needs it therefore wedges the whole server -- silently: nothing crashes, nothing errors, and a blocked goroutine writes no further log line, so the container keeps reporting itself healthy while the app has stopped working. Two rules follow. **Drain and close a cursor before calling anything that touches the database** (see `reportBookImportStalls`, whose comment records the deadlock this caused). And a **stall watchdog** (`internal/db/stallwatch.go`) probes the pool from outside every 10s; two consecutive 5s failures to acquire the connection log one `db: STALLED` line with the pool counters and a goroutine dump naming the holder, a reminder every 5 minutes while it lasts, and the duration on recovery. Only the probe carries a deadline -- real queries are untouched, so this cannot fail a slow query. It reports to the log and nowhere else on purpose: system issues and admin pushes are written through the very connection that is stuck, so during this failure the log is the only channel that still works.
+
 | Area | Tables |
 |---|---|
 | Accounts & sessions | `users`, `refresh_tokens`, `connect_tokens`, `devices` (hardware-id deduped), `webauthn_credentials` |
@@ -683,6 +685,7 @@ server/
 │   ├── config/               # Env config (port, name, passkey/push/Codex settings)
 │   ├── credentials/          # External credential registry + lazy client caching
 │   ├── db/db.go              # SQLite setup, WAL, THE live schema + in-code migrations
+│   ├── db/stallwatch.go      # watches the single connection; logs a wedged pool + its holder
 │   ├── discover/             # TMDB/Trakt discovery + media detail proxy handlers
 │   ├── downloads/            # Unified download-client queue API across all four clients
 │   ├── instance/             # Instance registry, defaults invariant, per-user pins, safe webhook rotation

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -213,6 +213,12 @@ func main() {
 	requestService.SetBookImportStallSink(remediationService)
 	requestService.StartBookParkMaintenance(ctx)
 
+	// Watches the one database connection from outside and logs when nothing
+	// can get through. Deliberately not wired to the issue store above: a
+	// wedged pool is precisely the failure that cannot be written to the
+	// database, so the log is the only channel that still works.
+	db.NewStallWatchdog(database).Start(ctx)
+
 	// Proxy handler
 	proxyHandler := proxy.NewHandler(instanceStore)
 

--- a/server/internal/db/stallwatch.go
+++ b/server/internal/db/stallwatch.go
@@ -1,0 +1,185 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"runtime"
+	"time"
+)
+
+// The pool holds exactly one connection (SQLite is single-writer), so every
+// query in the process takes its turn through a single door. Code that holds
+// that connection while waiting on something which also needs it never gives it
+// back, and nothing in this codebase sets a query timeout — so the wait is
+// forever. The process does not crash, does not error, and writes no further
+// log line, because a goroutine blocked on a connection is not doing anything
+// worth logging. Users see an app that has stopped working; the operator sees a
+// container that insists it is healthy. A restart clears it and teaches nobody
+// anything. That is exactly how the PR #352 deadlock stayed unexplained.
+//
+// This watchdog does not fix that. It ends the silence: it notices from the
+// outside that nothing can get through, and prints who is holding the door.
+//
+// It must not run through the database. Every other health signal this server
+// has — system issues, admin pushes — is written to or read from the very
+// connection that is stuck, so during this failure they are the one thing that
+// cannot report it. The log is the only channel left, which is why this reports
+// there and nowhere else.
+const (
+	// stallProbeInterval is how often the door is tried. Cheap: a healthy probe
+	// holds the connection for microseconds.
+	stallProbeInterval = 10 * time.Second
+	// stallProbeTimeout is how long a probe waits for the connection before
+	// giving up. Only the probe carries this deadline; real queries are left
+	// exactly as they were, so this can neither fail a slow query nor change
+	// any behavior a user can see.
+	stallProbeTimeout = 5 * time.Second
+	// stallStrikes is how many consecutive failed probes declare a stall. One
+	// is not enough: a single slow moment under load is not a wedged pool, and
+	// a watchdog that cries wolf gets ignored precisely when it is right.
+	stallStrikes = 2
+	// stallReminderEvery re-states an ongoing stall, so an operator reading the
+	// log later sees how long it went on instead of one old line.
+	stallReminderEvery = 5 * time.Minute
+	// stallDumpLimit caps the goroutine dump. Enough to name the holder without
+	// filling a log volume during an outage.
+	stallDumpLimit = 64 << 10
+)
+
+// StallWatchdog reports, to the log only, that the single database connection
+// has been unavailable long enough that the server is effectively wedged.
+type StallWatchdog struct {
+	db            *sql.DB
+	interval      time.Duration
+	probeTimeout  time.Duration
+	strikes       int
+	reminderEvery time.Duration
+
+	// logf and dump are injected so the behavior can be tested without timers
+	// or a real stack dump.
+	logf func(format string, args ...interface{})
+	dump func() string
+
+	consecutiveFailures int
+	stalledSince        time.Time
+	lastReminder        time.Time
+}
+
+// NewStallWatchdog builds a watchdog with production settings.
+func NewStallWatchdog(database *sql.DB) *StallWatchdog {
+	return &StallWatchdog{
+		db:            database,
+		interval:      stallProbeInterval,
+		probeTimeout:  stallProbeTimeout,
+		strikes:       stallStrikes,
+		reminderEvery: stallReminderEvery,
+		logf:          log.Printf,
+		dump:          goroutineDump,
+	}
+}
+
+// Start runs the watchdog until ctx is cancelled.
+func (w *StallWatchdog) Start(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(w.interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case now := <-ticker.C:
+				w.check(ctx, now)
+			}
+		}
+	}()
+}
+
+// check performs one probe and reports any transition. Exported behavior lives
+// here rather than in the ticker loop so tests can drive it directly.
+func (w *StallWatchdog) check(ctx context.Context, now time.Time) {
+	probeCtx, cancel := context.WithTimeout(ctx, w.probeTimeout)
+	defer cancel()
+
+	// Acquiring the connection is the whole test; SELECT 1 is just the cheapest
+	// way to ask for it. database/sql applies the context while WAITING for a
+	// connection, so a held pool fails here without ever reaching SQLite.
+	var one int
+	err := w.db.QueryRowContext(probeCtx, "SELECT 1").Scan(&one)
+	if err == nil {
+		w.recovered(now)
+		return
+	}
+	// A cancelled parent means the server is shutting down, not stalling.
+	if ctx.Err() != nil {
+		return
+	}
+	// Any other error (a real query failure) is somebody else's problem: it is
+	// visible to whoever ran it. Only "could not get the connection at all"
+	// means the door is stuck.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
+
+	w.consecutiveFailures++
+	if w.consecutiveFailures < w.strikes {
+		return
+	}
+	if w.stalledSince.IsZero() {
+		w.stalledSince = now
+		w.lastReminder = now
+		w.logf(
+			"db: STALLED — no query could obtain the single connection for %s. "+
+				"The server is running but effectively wedged; requests will hang until it clears. %s\n%s",
+			w.probeTimeout*time.Duration(w.strikes), w.stats(), w.dump(),
+		)
+		return
+	}
+	if now.Sub(w.lastReminder) >= w.reminderEvery {
+		w.lastReminder = now
+		w.logf("db: still stalled after %s. %s", now.Sub(w.stalledSince).Round(time.Second), w.stats())
+	}
+}
+
+// recovered clears a stall, reporting how long it lasted. A stall that ends by
+// itself still has to be named: it is the only trace that the outage happened
+// at all, and the next one is easier to place with a duration to match against.
+func (w *StallWatchdog) recovered(now time.Time) {
+	w.consecutiveFailures = 0
+	if w.stalledSince.IsZero() {
+		return
+	}
+	w.logf("db: recovered after %s stalled.", now.Sub(w.stalledSince).Round(time.Second))
+	w.stalledSince = time.Time{}
+	w.lastReminder = time.Time{}
+}
+
+// stats renders the pool counters that corroborate the diagnosis. in_use=1 with
+// idle=0 is the connection being held; the cumulative wait counters show how
+// much of the process has already queued behind it. (database/sql exposes no
+// "currently waiting" gauge, so those two are totals since start — read them as
+// a rate between reminders, not as a queue depth.)
+func (w *StallWatchdog) stats() string {
+	s := w.db.Stats()
+	return fmt.Sprintf(
+		"pool: in_use=%d idle=%d open=%d max_open=%d waits_since_start=%d wait_time_since_start=%s",
+		s.InUse, s.Idle, s.OpenConnections, s.MaxOpenConnections,
+		s.WaitCount, s.WaitDuration.Round(time.Millisecond),
+	)
+}
+
+// goroutineDump names the holder. Without it the log says only that the server
+// is stuck, which an operator already knows from the app being down; with it
+// the stuck call site is in the log, which is the difference between an
+// afternoon of bisecting and a fix. Stopping the world briefly to collect it is
+// free here — nothing was making progress anyway.
+func goroutineDump() string {
+	buf := make([]byte, stallDumpLimit)
+	n := runtime.Stack(buf, true)
+	if n == stallDumpLimit {
+		return string(buf[:n]) + "\n… goroutine dump truncated"
+	}
+	return string(buf[:n])
+}

--- a/server/internal/db/stallwatch_test.go
+++ b/server/internal/db/stallwatch_test.go
@@ -1,0 +1,167 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newStallTestWatchdog builds a watchdog against a real database with short
+// timings, and captures what it would have logged.
+func newStallTestWatchdog(t *testing.T) (*StallWatchdog, *[]string) {
+	t.Helper()
+	database, err := Open(filepath.Join(t.TempDir(), "stall.db"))
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	t.Cleanup(func() { database.Close() })
+
+	var lines []string
+	w := NewStallWatchdog(database)
+	w.probeTimeout = 50 * time.Millisecond
+	w.reminderEvery = time.Minute
+	w.logf = func(format string, args ...interface{}) {
+		lines = append(lines, fmt.Sprintf(format, args...))
+	}
+	w.dump = func() string { return "goroutine 1 [running]:\nfake.Holder(...)" }
+	return w, &lines
+}
+
+func joined(lines []string) string { return strings.Join(lines, "\n") }
+
+// TestStallWatchdogNamesAWedgedPool drives the real failure: something takes
+// the single connection and does not give it back. Before this existed the
+// server went silent here — no crash, no error, no further log line — and an
+// operator saw only an app that had stopped working and a container claiming to
+// be healthy.
+func TestStallWatchdogNamesAWedgedPool(t *testing.T) {
+	w, lines := newStallTestWatchdog(t)
+	ctx := context.Background()
+	start := time.Now()
+
+	// Healthy: the probe gets the connection and nothing is said. A watchdog
+	// that chatters while things are fine is one nobody reads.
+	w.check(ctx, start)
+	if len(*lines) != 0 {
+		t.Fatalf("healthy probe logged %v, want silence", *lines)
+	}
+
+	// Take the only connection and hold it, exactly as a caller blocked while
+	// holding an open cursor does.
+	tx, err := w.db.Begin()
+	if err != nil {
+		t.Fatalf("begin holding transaction: %v", err)
+	}
+	defer tx.Rollback()
+
+	// One failure is not a stall — a single slow moment must not cry wolf.
+	w.check(ctx, start.Add(10*time.Second))
+	if len(*lines) != 0 {
+		t.Fatalf("a single failed probe logged %v, want it to wait for confirmation", *lines)
+	}
+
+	// The second consecutive failure is.
+	w.check(ctx, start.Add(20*time.Second))
+	if len(*lines) != 1 {
+		t.Fatalf("logged %d lines, want exactly one stall report: %v", len(*lines), *lines)
+	}
+	report := (*lines)[0]
+	if !strings.Contains(report, "STALLED") {
+		t.Fatalf("stall report = %q, want it to name the condition", report)
+	}
+	// The pool counters that corroborate it: the connection is held.
+	if !strings.Contains(report, "in_use=1") || !strings.Contains(report, "max_open=1") {
+		t.Fatalf("stall report = %q, want the pool evidence", report)
+	}
+	// And the holder. Without this the log only repeats what the operator
+	// already knows from the app being down.
+	if !strings.Contains(report, "fake.Holder") {
+		t.Fatalf("stall report = %q, want the goroutine dump naming the holder", report)
+	}
+
+	// An ongoing stall is not re-reported every probe...
+	w.check(ctx, start.Add(30*time.Second))
+	if len(*lines) != 1 {
+		t.Fatalf("logged %v, want an ongoing stall to stay quiet between reminders", *lines)
+	}
+	// ...but does not go silent for the whole outage either: a reader landing
+	// in the log later must see it was still stuck, not just that it once was.
+	w.check(ctx, start.Add(2*time.Minute))
+	if len(*lines) != 2 || !strings.Contains((*lines)[1], "still stalled") {
+		t.Fatalf("logged %v, want a reminder while stalled", *lines)
+	}
+
+	// Releasing the connection clears it, with the duration — the only trace
+	// that the outage happened at all once the server is working again.
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("release holding transaction: %v", err)
+	}
+	w.check(ctx, start.Add(3*time.Minute))
+	if len(*lines) != 3 {
+		t.Fatalf("logged %v, want a recovery line", *lines)
+	}
+	// Measured from when the stall was declared (start+20s), not from the first
+	// failed probe: the reported duration is the window the server was known to
+	// be wedged, which is what an operator matches against their outage.
+	if !strings.Contains((*lines)[2], "recovered after 2m40s") {
+		t.Fatalf("recovery line = %q, want the stall duration since it was declared", (*lines)[2])
+	}
+
+	// Back to healthy and silent.
+	w.check(ctx, start.Add(4*time.Minute))
+	if len(*lines) != 3 {
+		t.Fatalf("logged %v, want silence once recovered", *lines)
+	}
+}
+
+// TestStallWatchdogIgnoresShutdown keeps the watchdog from writing an alarming
+// last line on the way out: a cancelled context is the server stopping, not the
+// pool wedging.
+func TestStallWatchdogIgnoresShutdown(t *testing.T) {
+	w, lines := newStallTestWatchdog(t)
+	tx, err := w.db.Begin()
+	if err != nil {
+		t.Fatalf("begin holding transaction: %v", err)
+	}
+	defer tx.Rollback()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	for i := 0; i < w.strikes+1; i++ {
+		w.check(ctx, time.Now())
+	}
+	if len(*lines) != 0 {
+		t.Fatalf("logged %v during shutdown, want silence", *lines)
+	}
+}
+
+// TestStallWatchdogLeavesRealQueriesAlone is the promise that made this the
+// safe option over query timeouts: only the probe carries a deadline, so a slow
+// query still finishes instead of acquiring a new way to fail.
+func TestStallWatchdogLeavesRealQueriesAlone(t *testing.T) {
+	w, lines := newStallTestWatchdog(t)
+	ctx := context.Background()
+
+	// Probe while the connection is held, then release and run an ordinary
+	// query with no context of its own — it must succeed untouched.
+	tx, err := w.db.Begin()
+	if err != nil {
+		t.Fatalf("begin holding transaction: %v", err)
+	}
+	w.check(ctx, time.Now())
+	w.check(ctx, time.Now())
+	if err := tx.Rollback(); err != nil {
+		t.Fatalf("release holding transaction: %v", err)
+	}
+
+	var n int
+	if err := w.db.QueryRow("SELECT COUNT(*) FROM users").Scan(&n); err != nil {
+		t.Fatalf("ordinary query after a stall report: %v, want it unaffected", err)
+	}
+	if joined(*lines) == "" {
+		t.Fatal("expected the stall to have been reported")
+	}
+}


### PR DESCRIPTION
The database pool holds **exactly one connection** (SQLite is single-writer), and no query in this codebase sets a timeout. Code that holds that connection while waiting on something which also needs it never gives it back, and every later query queues behind it forever.

What that looks like from outside:

- **Users:** the app stops working. Not with an error — things spin, then fail with vague connection messages.
- **Operator:** the container is still running, hasn't crashed, and reports itself healthy. The log's last line is from *before* it got stuck, because a goroutine blocked on a connection isn't doing anything worth logging. You restart, it works, and you learn nothing.

That is why the PR #352 deadlock stayed unexplained as long as it did. The specific bug was fixed in #356; the silence wasn't.

## What this does

Not a deadlock fix — a **diagnosis** fix.

A watchdog probes the pool from outside every 10s. Two consecutive 5s failures to acquire the connection produce:

```
db: STALLED — no query could obtain the single connection for 10s. The server is
running but effectively wedged; requests will hang until it clears.
pool: in_use=1 idle=0 open=1 max_open=1 waits_since_start=… wait_time_since_start=…
<goroutine dump>
```

The **goroutine dump is the point.** Without it the log only repeats what the operator already knows from the app being down. With it, the stuck call site is in the log — the difference between an afternoon of bisecting and a fix. Then a reminder every 5 minutes so a long outage isn't one old line, and on recovery the duration, which is otherwise the only trace the outage happened at all.

## Why this and not query timeouts

Timeouts are the stronger fix: they unwedge the server and surface a real error. They also trade a rare hang for a **new failure mode** — a legitimately slow query (big library, busy disk) starts failing where it used to finish. That's a change to behavior users can see, and it deserves its own decision rather than riding along with an observability change.

Here **only the probe carries a deadline**. Real queries are untouched. A test pins that: after a stall is reported, an ordinary query with no context of its own still runs fine.

## Why log-only, with no system issue

Every other health signal this server has — system issues, admin pushes — is written to or read from the very connection that is stuck. During this failure they are the one thing that *cannot* report it. The log is the only channel that still works, so this reports there and nowhere else. (Noted in the code and the README so nobody later "improves" it into an issue.)

## Verification

The tests drive the real failure — a held transaction taking the single connection — rather than mocking the pool:

- healthy probes stay silent (a watchdog that chatters while things are fine is one nobody reads)
- one failed probe is not a stall; the second consecutive one is
- the report carries `in_use=1 max_open=1` and the holder's stack
- an ongoing stall doesn't re-log every probe, but does remind after 5 minutes
- releasing the connection logs recovery with the duration, then returns to silence
- a cancelled context (shutdown) never reports a stall
- an ordinary query still works after a stall is reported

`go vet ./...`, `go test ./...`, `go test -race ./...` — green. No app change. `server/README.md` documents the one-connection constraint, the drain-the-cursor rule it implies, and this watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVFwVD583JBGZPm3RnmGuG