### PR TITLE
fix(push): episode alerts say 'New episodes available' so a season pack doesn't read as one episode

### DIFF
--- a/app/lib/features/notifications/ui/notification_preferences_screen.dart
+++ b/app/lib/features/notifications/ui/notification_preferences_screen.dart
@@ -261,8 +261,8 @@ class _NotificationPreferencesScreenState
           anchor: SettingsAnchors.notificationsNewMovie,
         ),
         _toggle(
-          title: 'New episode available',
-          subtitle: 'When a new episode is available',
+          title: 'New episodes available',
+          subtitle: 'When new episodes are available',
           value: prefs.newEpisode,
           onChanged: (v) => _save(prefs.copyWith(newEpisode: v), prefs),
           anchor: SettingsAnchors.notificationsNewEpisode,

--- a/app/lib/features/settings/data/settings_search_index.dart
+++ b/app/lib/features/settings/data/settings_search_index.dart
@@ -793,7 +793,7 @@ const List<SettingsSearchEntry> _notificationEntries = [
   ),
   SettingsSearchEntry(
     id: SettingsAnchors.notificationsNewEpisode,
-    title: 'New episode available',
+    title: 'New episodes available',
     icon: Icons.notifications_outlined,
     route: '/settings/notifications',
     screenTitle: 'Notification Preferences',

--- a/server/internal/push/notifier.go
+++ b/server/internal/push/notifier.go
@@ -492,10 +492,15 @@ func (n *Notifier) NotifyNewMovie(title string, tmdbID int) {
 	n.notifyNewContent(CategoryNewMovie, "movie", "New movie available", title+" is ready to watch", title, tmdbID)
 }
 
-// NotifyNewEpisode pushes a "new episode available" alert to every user opted
-// into the new_episode category (on by default).
+// NotifyNewEpisode pushes a "new episodes available" alert to every user opted
+// into the new_episode category (on by default). The copy is plural with no
+// count on purpose: the alert sends on the first import of a wave and
+// claimContentAlert absorbs the rest of a season pack behind it, so at send
+// time the server cannot know whether one episode or ten are landing — an
+// honest count would mean holding the push, and a singular title undersells a
+// pack. The body stays count-free so the pair reads naturally either way.
 func (n *Notifier) NotifyNewEpisode(seriesTitle string, tmdbID int) {
-	n.notifyNewContent(CategoryNewEpisode, "tv", "New episode available", "New on "+seriesTitle, seriesTitle, tmdbID)
+	n.notifyNewContent(CategoryNewEpisode, "tv", "New episodes available", "New on "+seriesTitle, seriesTitle, tmdbID)
 }
 
 // NotifyNewBook pushes a "book became available" alert for a completed

--- a/server/internal/push/notifier_test.go
+++ b/server/internal/push/notifier_test.go
@@ -787,8 +787,8 @@ func TestNotifyNewEpisodeReachesOptedInUsers(t *testing.T) {
 		t.Errorf("new_episode recipients = %v, want [\"1\"]", ids)
 	}
 	notif, _ := body["notification"].(map[string]any)
-	if notif["title"] != "New episode available" {
-		t.Errorf("title = %v, want \"New episode available\"", notif["title"])
+	if notif["title"] != "New episodes available" {
+		t.Errorf("title = %v, want \"New episodes available\"", notif["title"])
 	}
 	if notif["body"] != "New on Severance" {
 		t.Errorf("body = %v, want \"New on Severance\"", notif["body"])


### PR DESCRIPTION
## What

The rolled-up new-episode push always said "New episode available" — singular — even when a whole season pack landed behind it. The title is now always plural: **"New episodes available" / "New on \<series\>"**.

## Why plural, why no count

The push fires the instant the first file of a wave imports, and the 10-minute claim window silently absorbs the rest of the pack *after* that push already went out. So at send time the server can't know whether one episode or ten are landing — an honest count would mean holding the notification. Instead the title commits to plural and the body stays count-free, so the pair is never factually wrong for one episode or ten, and delivery timing is untouched (no notification is delayed by this change).

## Changes

- `server/internal/push/notifier.go` — title copy + a comment stating the constraint
- `server/internal/push/notifier_test.go` — pinned title updated
- `app/.../notification_preferences_screen.dart` + `app/.../settings_search_index.dart` — the settings toggle renames with it (kept verbatim-identical for the search drift test)

Deliberately untouched: the admin-only `content_upgraded` copy ("An episode of X was replaced…") — off by default, different audience, and mass sweeps hit the storm cap anyway.

## Verification

- `go vet ./...` and `go test ./...` from `server/` — pass
- `flutter analyze --no-fatal-infos` and `flutter test` from `app/` — no issues, all 1075 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVFwVD583JBGZPm3RnmGuG