### PR TITLE
fix(admin): unconfigured shared AI is named as absent, and its wait counter stops inflating

### DIFF
--- a/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
+++ b/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
@@ -405,83 +405,117 @@ class _AiRemediationSettingsScreenState
           ),
         ),
         const _SectionLabel('Shared AI'),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
-          child: Text(
-            'Uses the shared ${_providerOption(_credentials!)?.label ?? _credentials!.ai.provider} '
-            'provider and credential from Admin > Providers & Credentials. '
-            'The assistant model there is ${_credentials!.ai.model}. You can '
-            'choose a different model below for remediation only.',
-            style: const TextStyle(
-              color: AppTheme.textSecondary,
-              fontSize: 13,
-              height: 1.35,
+        // The server synthesizes a default provider and model even when
+        // nothing is set up, so only the live configured flag may claim a
+        // provider exists.
+        if (!_credentials!.ai.sharedConfigured) ...[
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 4, 16, 8),
+            child: Text(
+              'No shared AI provider is set up yet. Remediation always runs '
+              'on the shared provider, so detected problems will wait instead '
+              'of being investigated until one is configured.',
+              style: TextStyle(
+                color: AppTheme.warning,
+                fontSize: 13,
+                height: 1.35,
+              ),
             ),
           ),
-        ),
-        _anchor(
-          SettingsAnchors.remediationModel,
+          _anchor(
+            SettingsAnchors.remediationModel,
+            ListTile(
+              leading: const Icon(Icons.vpn_key_outlined,
+                  color: AppTheme.accent),
+              title: const Text('Set up the shared provider',
+                  style: TextStyle(color: AppTheme.textPrimary)),
+              subtitle: const Text('Admin > Providers & Credentials',
+                  style:
+                      TextStyle(color: AppTheme.textSecondary, fontSize: 12)),
+              trailing: const Icon(Icons.chevron_right,
+                  color: AppTheme.textSecondary, size: 18),
+              onTap: () => context.push('/settings/credentials'),
+            ),
+          ),
+        ] else ...[
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
-            child: DropdownButtonFormField<String>(
-              key: ValueKey(
-                'remediation-model-${_credentials!.ai.provider}-$_modelSelection',
+            child: Text(
+              'Uses the shared ${_providerOption(_credentials!)?.label ?? _credentials!.ai.provider} '
+              'provider and credential from Admin > Providers & Credentials. '
+              'The assistant model there is ${_credentials!.ai.model}. You can '
+              'choose a different model below for remediation only.',
+              style: const TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 13,
+                height: 1.35,
               ),
-              initialValue: _modelSelection,
-              isExpanded: true,
-              decoration: const InputDecoration(
-                labelText: 'Remediation model',
-                isDense: true,
-              ),
-              items: [
-                DropdownMenuItem(
-                  value: _sharedModel,
-                  child: Text('Use shared model (${_credentials!.ai.model})'),
+            ),
+          ),
+          _anchor(
+            SettingsAnchors.remediationModel,
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+              child: DropdownButtonFormField<String>(
+                key: ValueKey(
+                  'remediation-model-${_credentials!.ai.provider}-$_modelSelection',
                 ),
-                ...?_providerOption(_credentials!)?.models.map(
-                      (model) => DropdownMenuItem(
-                        value: model.id,
-                        child: Text(model.label),
+                initialValue: _modelSelection,
+                isExpanded: true,
+                decoration: const InputDecoration(
+                  labelText: 'Remediation model',
+                  isDense: true,
+                ),
+                items: [
+                  DropdownMenuItem(
+                    value: _sharedModel,
+                    child: Text('Use shared model (${_credentials!.ai.model})'),
+                  ),
+                  ...?_providerOption(_credentials!)?.models.map(
+                        (model) => DropdownMenuItem(
+                          value: model.id,
+                          child: Text(model.label),
+                        ),
                       ),
-                    ),
-                const DropdownMenuItem(
-                  value: _customModel,
-                  child: Text('Custom model ID'),
-                ),
-              ],
-              onChanged: (value) {
-                if (value != null) {
-                  setState(() => _modelSelection = value);
-                }
-              },
-            ),
-          ),
-        ),
-        if (_modelSelection == _customModel)
-          Padding(
-            padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
-            child: TextField(
-              controller: _customModelController,
-              decoration: const InputDecoration(
-                labelText: 'Custom model ID',
-                helperText:
-                    'Saving runs a small response test before activation.',
-                isDense: true,
+                  const DropdownMenuItem(
+                    value: _customModel,
+                    child: Text('Custom model ID'),
+                  ),
+                ],
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() => _modelSelection = value);
+                  }
+                },
               ),
             ),
           ),
-        const Padding(
-          padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
-          child: Text(
-            'If the shared provider changes later, Cantinarr falls back to its '
-            'shared model until a remediation override is tested for the new provider.',
-            style: TextStyle(
-              color: AppTheme.textSecondary,
-              fontSize: 12,
-              height: 1.35,
+          if (_modelSelection == _customModel)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+              child: TextField(
+                controller: _customModelController,
+                decoration: const InputDecoration(
+                  labelText: 'Custom model ID',
+                  helperText:
+                      'Saving runs a small response test before activation.',
+                  isDense: true,
+                ),
+              ),
+            ),
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 0, 16, 8),
+            child: Text(
+              'If the shared provider changes later, Cantinarr falls back to its '
+              'shared model until a remediation override is tested for the new provider.',
+              style: TextStyle(
+                color: AppTheme.textSecondary,
+                fontSize: 12,
+                height: 1.35,
+              ),
             ),
           ),
-        ),
+        ],
         const _SectionLabel('Limits'),
         _anchor(
           SettingsAnchors.remediationMaxSteps,

--- a/app/lib/features/settings/data/credentials_service.dart
+++ b/app/lib/features/settings/data/credentials_service.dart
@@ -50,6 +50,12 @@ class AiCredentialConfig {
   final String provider;
   final String model;
   final List<AiProviderOption> providers;
+
+  /// Whether the shared provider is actually ready (credential stored, or the
+  /// Codex account connected). [provider] and [model] alone can't answer this:
+  /// the server synthesizes defaults for them even when nothing is set up.
+  /// Older servers never send the field; assume configured rather than nag.
+  final bool sharedConfigured;
   final bool healthCheckEnabled;
   final int healthCheckIntervalHours;
   final DateTime? healthLastCheckedAt;
@@ -58,6 +64,7 @@ class AiCredentialConfig {
     required this.provider,
     required this.model,
     required this.providers,
+    this.sharedConfigured = true,
     required this.healthCheckEnabled,
     required this.healthCheckIntervalHours,
     required this.healthLastCheckedAt,
@@ -65,6 +72,7 @@ class AiCredentialConfig {
 
   factory AiCredentialConfig.fromJson(Map<String, dynamic> json) {
     final config = json['config'] as Map<String, dynamic>? ?? const {};
+    final shared = json['shared'] as Map<String, dynamic>? ?? const {};
     final health = json['health_check'] as Map<String, dynamic>? ?? const {};
     final providersJson = json['providers'] as List? ?? const [];
     final providers = providersJson
@@ -88,6 +96,7 @@ class AiCredentialConfig {
               ? selected!.models.first.id
               : 'claude-opus-4-8'),
       providers: providers,
+      sharedConfigured: shared['configured'] as bool? ?? true,
       healthCheckEnabled: health['enabled'] as bool? ?? true,
       healthCheckIntervalHours:
           (health['interval_hours'] as num?)?.toInt() ?? 24,

--- a/app/lib/features/settings/ui/users_screen.dart
+++ b/app/lib/features/settings/ui/users_screen.dart
@@ -28,6 +28,7 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
   bool _isLoading = true;
   String? _error;
   String _sharedAiProvider = '';
+  bool _sharedAiConfigured = true;
 
   @override
   void initState() {
@@ -47,6 +48,7 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
           backendDio: ref.read(backendClientProvider),
         ).getStatus();
         _sharedAiProvider = credentials.ai.provider;
+        _sharedAiConfigured = credentials.ai.sharedConfigured;
       } catch (_) {
         // User management remains usable if provider status is temporarily
         // unavailable. The confirmation falls back to a generic quota warning.
@@ -337,13 +339,18 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
       // refresh deliberately becomes "unknown" so the stronger combined
       // warning is shown instead of trusting a stale API-key snapshot.
       var currentProvider = '';
+      var currentConfigured = true;
       try {
         final credentials = await CredentialsService(
           backendDio: ref.read(backendClientProvider),
         ).getStatus();
         currentProvider = credentials.ai.provider;
+        currentConfigured = credentials.ai.sharedConfigured;
         if (mounted) {
-          setState(() => _sharedAiProvider = currentProvider);
+          setState(() {
+            _sharedAiProvider = currentProvider;
+            _sharedAiConfigured = currentConfigured;
+          });
         }
       } catch (_) {
         if (mounted) {
@@ -351,14 +358,22 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
         }
       }
       if (!mounted) return;
-      final codex = currentProvider == 'codex';
       final providerUnknown = currentProvider.isEmpty;
+      // The server defaults the provider name even with nothing set up, so
+      // the provider-specific warnings only apply when one actually exists.
+      final unconfigured = !currentConfigured && !providerUnknown;
+      final codex = currentProvider == 'codex' && !unconfigured;
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (dialogContext) => AlertDialog(
           title: Text('Include AI access for ${user.username}?'),
           content: Text(
-            codex
+            unconfigured
+                ? 'No shared AI provider is set up yet, so this only stages '
+                    'access. Once an admin configures one under Providers & '
+                    'Credentials, this user\'s prompts will run through it '
+                    'and count against its quota or allowance.'
+                : codex
                 ? 'Prompts and tool context will use the shared OpenAI OAuth '
                     'account. All enabled users consume the same Codex '
                     'allowance, and activity is attributable to that account. '
@@ -506,6 +521,7 @@ class _UsersScreenState extends ConsumerState<UsersScreen> {
             ),
             onSetSharedAiAccess: (enabled) => _setSharedAiAccess(user, enabled),
             sharedAiProvider: _sharedAiProvider,
+            sharedAiConfigured: _sharedAiConfigured,
           );
         },
       ),
@@ -528,6 +544,7 @@ class _UserTile extends StatelessWidget {
     required this.onRequestSettings,
     required this.onSetSharedAiAccess,
     required this.sharedAiProvider,
+    required this.sharedAiConfigured,
   });
 
   final UserSummary user;
@@ -544,6 +561,7 @@ class _UserTile extends StatelessWidget {
   final VoidCallback onRequestSettings;
   final ValueChanged<bool> onSetSharedAiAccess;
   final String sharedAiProvider;
+  final bool sharedAiConfigured;
 
   /// A user who has never connected a device is stuck in "invited limbo":
   /// either their invite is still pending or the link was lost/expired.
@@ -682,11 +700,16 @@ class _UserTile extends StatelessWidget {
             leading: const Icon(Icons.auto_awesome_outlined),
             title: const Text('Included AI access'),
             subtitle: Text(
-              sharedAiProvider == 'codex'
-                  ? 'Shared OpenAI OAuth allowance'
-                  : sharedAiProvider.isEmpty
-                      ? 'Provider status unavailable'
-                      : 'Server provider quota',
+              // An unknown provider (failed fetch) is not the same as a known
+              // absence — and the server-defaulted provider name may not
+              // claim an allowance that doesn't exist yet.
+              !sharedAiConfigured && sharedAiProvider.isNotEmpty
+                  ? 'No shared provider configured yet'
+                  : sharedAiProvider == 'codex'
+                      ? 'Shared OpenAI OAuth allowance'
+                      : sharedAiProvider.isEmpty
+                          ? 'Provider status unavailable'
+                          : 'Server provider quota',
             ),
             trailing: IgnorePointer(
               child: Switch(

--- a/app/test/issues/ai_remediation_settings_screen_test.dart
+++ b/app/test/issues/ai_remediation_settings_screen_test.dart
@@ -47,6 +47,36 @@ void main() {
     expect(find.text('Remediation model'), findsOneWidget);
   });
 
+  testWidgets('an unconfigured shared provider is named as absent, not defaulted',
+      (tester) async {
+    final adapter = _RemediationSettingsAdapter(sharedConfigured: false);
+    final dio = Dio(BaseOptions(baseUrl: 'https://cantinarr.example'))
+      ..httpClientAdapter = adapter;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [backendClientProvider.overrideWithValue(dio)],
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: const AiRemediationSettingsScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await _scrollUntilBuilt(tester, find.text('SHARED AI'));
+    await _scrollUntilBuilt(tester, find.text('Set up the shared provider'));
+    expect(
+      find.textContaining('No shared AI provider is set up yet'),
+      findsOneWidget,
+    );
+    expect(find.text('Set up the shared provider'), findsOneWidget);
+    // The server-synthesized defaults must not leak through as a provider.
+    expect(find.textContaining('Uses the shared'), findsNothing);
+    expect(find.text('Remediation model'), findsNothing);
+    expect(find.textContaining('Use shared model'), findsNothing);
+  });
+
   testWidgets('clears legacy provider and model fields when settings are saved',
       (tester) async {
     final adapter = _RemediationSettingsAdapter(
@@ -123,10 +153,17 @@ Future<void> _scrollUntilBuilt(WidgetTester tester, Finder finder) async {
 }
 
 class _RemediationSettingsAdapter implements HttpClientAdapter {
-  _RemediationSettingsAdapter({this.provider = '', this.model = ''});
+  _RemediationSettingsAdapter({
+    this.provider = '',
+    this.model = '',
+    this.sharedConfigured,
+  });
 
   final String provider;
   final String model;
+
+  /// null omits the `shared` block, exercising the older-server default.
+  final bool? sharedConfigured;
   Map<String, dynamic>? saved;
 
   Map<String, dynamic> get _settings => {
@@ -191,6 +228,8 @@ class _RemediationSettingsAdapter implements HttpClientAdapter {
             },
           ],
           'health_check': {'enabled': true, 'interval_hours': 24},
+          if (sharedConfigured != null)
+            'shared': {'configured': sharedConfigured},
         },
       };
 }

--- a/app/test/settings/users_screen_test.dart
+++ b/app/test/settings/users_screen_test.dart
@@ -101,6 +101,53 @@ void main() {
     expect(auth.aiAccessUpdates, isEmpty);
   });
 
+  testWidgets('an unconfigured shared provider stages access without OAuth claims',
+      (tester) async {
+    await tester.binding.setSurfaceSize(const Size(1000, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final auth = _FakeAuthNotifier();
+    // The server defaults the provider name to codex even when nothing is
+    // configured — the flag, not the name, decides what the admin is told.
+    final dio = Dio(BaseOptions(baseUrl: 'https://cantinarr.example'))
+      ..httpClientAdapter =
+          _CredentialsAdapter(provider: 'codex', configured: false);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith(() => auth),
+          backendClientProvider.overrideWithValue(dio),
+          plexInviteConfiguredProvider.overrideWith((_) async => false),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.dark,
+          home: const UsersScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byIcon(Icons.more_vert));
+    await tester.pumpAndSettle();
+    expect(find.text('No shared provider configured yet'), findsOneWidget);
+    await tester.tap(find.text('Included AI access'));
+    await tester.pumpAndSettle();
+
+    expect(auth.aiAccessUpdates, isEmpty);
+    expect(
+      find.textContaining('No shared AI provider is set up yet'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('Codex'), findsNothing);
+    expect(find.textContaining('OAuth'), findsNothing);
+
+    // The grant itself still saves — it simply waits for a provider.
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Include AI access'));
+    await tester.pumpAndSettle();
+    expect(auth.aiAccessUpdates, [(7, true)]);
+  });
+
   testWidgets('enable confirmation refreshes a provider changed elsewhere',
       (tester) async {
     await tester.binding.setSurfaceSize(const Size(1000, 800));
@@ -247,11 +294,15 @@ class _CredentialsAdapter implements HttpClientAdapter {
     required this.provider,
     this.nextProvider,
     this.fail = false,
+    this.configured,
   });
 
   final String provider;
   final String? nextProvider;
   final bool fail;
+
+  /// null omits the `shared` block, exercising the older-server default.
+  final bool? configured;
   int requests = 0;
 
   @override
@@ -277,6 +328,7 @@ class _CredentialsAdapter implements HttpClientAdapter {
         'ai': {
           'config': {'provider': responseProvider, 'model': 'default'},
           'providers': const [],
+          if (configured != null) 'shared': {'configured': configured},
         },
       }),
       200,

--- a/server/internal/remediation/provider_health.go
+++ b/server/internal/remediation/provider_health.go
@@ -19,10 +19,10 @@ const (
 // circuit breaker: the agent did not fail — it was never given a provider.
 //
 // Same transactional shape as RecordSharedAIHealth: find-or-open under one tx,
-// refresh occurrences on repeats, resolve-with-note on recovery. The two sinks
-// stay separate because they answer different questions — the daily health turn
-// says "the configured model stopped answering"; this says "remediation has
-// nothing configured to ask".
+// refresh occurrences on repeats (at most hourly), resolve-with-note on
+// recovery. The two sinks stay separate because they answer different
+// questions — the daily health turn says "the configured model stopped
+// answering"; this says "remediation has nothing configured to ask".
 func (s *Service) RecordRemediationProviderHealth(available bool) error {
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -31,9 +31,11 @@ func (s *Service) RecordRemediationProviderHealth(available bool) error {
 	defer tx.Rollback()
 
 	var issueID int64
+	var recentlyRefreshed bool
 	err = tx.QueryRow(`
-		SELECT id FROM issues
-		WHERE dedupe_key = ? AND closed_at IS NULL`, remediationProviderDedupeKey).Scan(&issueID)
+		SELECT id, COALESCE(datetime(updated_at) >= datetime('now', '-1 hour'), 0)
+		FROM issues
+		WHERE dedupe_key = ? AND closed_at IS NULL`, remediationProviderDedupeKey).Scan(&issueID, &recentlyRefreshed)
 	if available {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil
@@ -87,6 +89,13 @@ func (s *Service) RecordRemediationProviderHealth(available bool) error {
 	} else if err != nil {
 		return fmt.Errorf("find remediation provider issue: %w", err)
 	} else {
+		// recoverWork re-runs every waiting issue once a minute, and each pass
+		// lands here while the provider is missing. Refreshing at most hourly
+		// keeps occurrences a readable "hours in this state" instead of a
+		// per-minute counter, and spares a write transaction per issue per tick.
+		if recentlyRefreshed {
+			return nil
+		}
 		if _, err := tx.Exec(`
 			UPDATE issues SET status = ?, occurrences = occurrences + 1, updated_at = CURRENT_TIMESTAMP
 			WHERE id = ? AND closed_at IS NULL`,

--- a/server/internal/remediation/provider_health_test.go
+++ b/server/internal/remediation/provider_health_test.go
@@ -67,6 +67,48 @@ func TestRunWithoutProviderLeavesIssueWaiting(t *testing.T) {
 	}
 }
 
+// TestProviderUnavailableRefreshThrottledHourly: recoverWork retries every
+// waiting issue once a minute, so the standing system issue must not absorb a
+// write (and an occurrences bump) per tick — repeats inside an hour are
+// no-ops, and the first repeat past the hour refreshes exactly once.
+func TestProviderUnavailableRefreshThrottledHourly(t *testing.T) {
+	service, _, _ := setupTestService(t)
+	for i := 0; i < 3; i++ {
+		if err := service.RecordRemediationProviderHealth(false); err != nil {
+			t.Fatalf("record unavailable %d: %v", i, err)
+		}
+	}
+	var occurrences int
+	if err := service.db.QueryRow(
+		"SELECT occurrences FROM issues WHERE dedupe_key = ?",
+		remediationProviderDedupeKey,
+	).Scan(&occurrences); err != nil {
+		t.Fatalf("read provider issue: %v", err)
+	}
+	if occurrences != 1 {
+		t.Fatalf("occurrences = %d after minutely repeats, want 1 (throttled)", occurrences)
+	}
+
+	if _, err := service.db.Exec(
+		"UPDATE issues SET updated_at = datetime('now', '-61 minutes') WHERE dedupe_key = ?",
+		remediationProviderDedupeKey,
+	); err != nil {
+		t.Fatalf("backdate provider issue: %v", err)
+	}
+	if err := service.RecordRemediationProviderHealth(false); err != nil {
+		t.Fatalf("record unavailable after an hour: %v", err)
+	}
+	if err := service.db.QueryRow(
+		"SELECT occurrences FROM issues WHERE dedupe_key = ?",
+		remediationProviderDedupeKey,
+	).Scan(&occurrences); err != nil {
+		t.Fatalf("re-read provider issue: %v", err)
+	}
+	if occurrences != 2 {
+		t.Fatalf("occurrences = %d after backdated repeat, want 2", occurrences)
+	}
+}
+
 // TestProviderRestoredResolvesSystemIssue: the first successful resolve closes
 // the standing system issue with its own resolution kind.
 func TestProviderRestoredResolvesSystemIssue(t *testing.T) {


### PR DESCRIPTION
## What

Two admin surfaces affirmatively claimed a shared AI provider that was never set up, and the standing "no provider" system issue burned a write per waiting issue per minute.

The server synthesizes a default provider and model (`codex` / `gpt-5.6-luna`) even on an untouched install, so the provider *name* can never prove a provider exists. Both screens now read the live `ai.shared.configured` flag from `/api/admin/credentials` instead:

- **AI Remediation screen**: when unconfigured, the Shared AI section stops describing "the shared OpenAI (OAuth) provider" and its model dropdown, and instead says no provider is set up yet (detected problems wait instead of being investigated), with a tile linking to Providers & Credentials. The `remediation.model` settings-search anchor stays mounted on that tile.
- **Users screen**: the "Included AI access" menu subtitle and confirmation dialog stop promising a "Shared OpenAI OAuth allowance"; with no provider they explain the grant is staged and starts counting against the provider's quota once one exists. The grant itself still saves.
- Older servers never send the flag; the app assumes configured rather than nag (`shared.configured` absent → `true`).

- **Server**: `RecordRemediationProviderHealth` refreshed the standing `system:remediation-provider` issue on every `recoverWork` pass — one SQLite write transaction per waiting issue per minute, inflating `occurrences` to ~1440/day of noise. Repeats now refresh at most hourly, so the counter reads as hours in this state. Creation, recovery-resolve, and dedupe behavior are unchanged.

## Tests

- Go: new `TestProviderUnavailableRefreshThrottledHourly` (minutely repeats don't bump; a repeat past the hour bumps exactly once). Full `go vet ./...` + `go test ./...` green.
- Flutter: new widget tests pin the unconfigured branches of both screens (and that adapters omitting `shared` exercise the older-server default). Full `flutter analyze` + `flutter test` (1079) green, including the settings-search drift test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF