### PR TITLE
fix(arr): download queue reads see every row, including unmatched downloads

### DIFF
--- a/server/internal/chaptarr/client.go
+++ b/server/internal/chaptarr/client.go
@@ -1088,20 +1088,12 @@ func (c *Client) SetBookMonitored(bookIDs []int, monitored bool) error {
 	return nil
 }
 
+// GetQueue returns the same complete bounded snapshot as GetQueueDetailed.
+// It used to issue an unpaged read, which Chaptarr answers with its default
+// page of 10 rows — a silently truncated queue for any instance downloading
+// more than that.
 func (c *Client) GetQueue() ([]QueueItem, error) {
-	resp, err := c.doRequest("GET", "/api/v1/queue?includeAuthor=true&includeBook=true")
-	if err != nil {
-		return nil, fmt.Errorf("chaptarr queue: %w", err)
-	}
-	defer resp.Body.Close()
-
-	var queueResp struct {
-		Records []QueueItem `json:"records"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&queueResp); err != nil {
-		return nil, fmt.Errorf("decode queue: %w", err)
-	}
-	return queueResp.Records, nil
+	return c.GetQueueDetailed()
 }
 
 // queueMaxRecords is a safety cap on the queue records a detailed snapshot may
@@ -1118,7 +1110,10 @@ func (c *Client) GetQueueDetailed() ([]DetailedQueueItem, error) {
 		TotalRecords int                 `json:"totalRecords"`
 		Records      []DetailedQueueItem `json:"records"`
 	}
-	path := fmt.Sprintf("/api/v1/queue?page=1&pageSize=%d&includeAuthor=true&includeBook=true&sortKey=id&sortDirection=ascending", queueMaxRecords)
+	// includeUnknownAuthorItems: without it Chaptarr silently drops queue rows
+	// it could not match to a library author — exactly the rows most likely to
+	// be stuck — before the completeness checks below ever see them.
+	path := fmt.Sprintf("/api/v1/queue?page=1&pageSize=%d&includeAuthor=true&includeBook=true&includeUnknownAuthorItems=true&sortKey=id&sortDirection=ascending", queueMaxRecords)
 	if err := c.do("GET", path, nil, &resp); err != nil {
 		return nil, fmt.Errorf("chaptarr queue: %w", err)
 	}

--- a/server/internal/chaptarr/client_test.go
+++ b/server/internal/chaptarr/client_test.go
@@ -248,8 +248,10 @@ func TestGetAllBooks(t *testing.T) {
 	}
 }
 
-// TestGetQueue asserts GetQueue hits the queue endpoint with includeAuthor=true
-// and decodes the records array.
+// TestGetQueue asserts GetQueue reads the queue as one complete bounded page —
+// explicit pageSize (the server's default page is 10 rows, a silent
+// truncation) — with author context and the unknown-author rows Chaptarr
+// would otherwise drop before the page is even assembled.
 func TestGetQueue(t *testing.T) {
 	var gotPath string
 	var gotQuery url.Values
@@ -258,7 +260,7 @@ func TestGetQueue(t *testing.T) {
 		gotPath = r.URL.Path
 		gotQuery = r.URL.Query()
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"records":[{"id":1,"bookId":42,"title":"Some Book"}]}`)
+		_, _ = io.WriteString(w, `{"totalRecords":2,"records":[{"id":1,"bookId":42,"title":"Some Book"},{"id":2,"bookId":0,"title":"Unmatched.Release.epub"}]}`)
 	}))
 	defer srv.Close()
 
@@ -274,8 +276,14 @@ func TestGetQueue(t *testing.T) {
 	if gotQuery.Get("includeAuthor") != "true" {
 		t.Errorf("includeAuthor = %q, want true (query %v)", gotQuery.Get("includeAuthor"), gotQuery)
 	}
-	if len(items) != 1 || items[0].BookID != 42 {
-		t.Fatalf("items = %+v, want one item with bookId 42", items)
+	if gotQuery.Get("pageSize") != "1000" {
+		t.Errorf("pageSize = %q, want 1000 — an unpaged read is the server's 10-row default page", gotQuery.Get("pageSize"))
+	}
+	if gotQuery.Get("includeUnknownAuthorItems") != "true" {
+		t.Errorf("includeUnknownAuthorItems = %q, want true (query %v)", gotQuery.Get("includeUnknownAuthorItems"), gotQuery)
+	}
+	if len(items) != 2 || items[0].BookID != 42 || items[1].BookID != 0 {
+		t.Fatalf("items = %+v, want the matched item and the unknown-author item", items)
 	}
 }
 

--- a/server/internal/radarr/client.go
+++ b/server/internal/radarr/client.go
@@ -423,18 +423,25 @@ func (c *Client) AddMovie(addReq *AddMovieRequest) error {
 	return nil
 }
 
+// GetQueue returns the lean queue view as one complete bounded page. It used
+// to issue an unpaged read, which Radarr answers with its default page of 10
+// rows — a silently truncated queue for any instance downloading more than
+// that. includeUnknownMovieItems keeps rows Radarr could not match to a
+// library movie visible; consumers must treat MovieID 0 as unmatched.
 func (c *Client) GetQueue() ([]QueueItem, error) {
-	resp, err := c.doRequest("GET", "/api/v3/queue?includeMovie=true")
-	if err != nil {
+	var queueResp struct {
+		TotalRecords int         `json:"totalRecords"`
+		Records      []QueueItem `json:"records"`
+	}
+	path := fmt.Sprintf("/api/v3/queue?page=1&pageSize=%d&includeMovie=true&includeUnknownMovieItems=true&sortKey=id&sortDirection=ascending", queueMaxRecords)
+	if err := c.do("GET", path, nil, &queueResp); err != nil {
 		return nil, fmt.Errorf("radarr queue: %w", err)
 	}
-	defer resp.Body.Close()
-
-	var queueResp struct {
-		Records []QueueItem `json:"records"`
+	if queueResp.TotalRecords < 0 || queueResp.TotalRecords > queueMaxRecords {
+		return nil, fmt.Errorf("radarr queue snapshot incomplete: invalid or oversized total %d (safety cap %d)", queueResp.TotalRecords, queueMaxRecords)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&queueResp); err != nil {
-		return nil, fmt.Errorf("decode queue: %w", err)
+	if len(queueResp.Records) != queueResp.TotalRecords {
+		return nil, fmt.Errorf("radarr queue snapshot incomplete: received %d of %d records in bounded page", len(queueResp.Records), queueResp.TotalRecords)
 	}
 	return queueResp.Records, nil
 }
@@ -496,7 +503,10 @@ func (c *Client) GetQueueDetailed() ([]DetailedQueueItem, error) {
 		TotalRecords int                 `json:"totalRecords"`
 		Records      []DetailedQueueItem `json:"records"`
 	}
-	path := fmt.Sprintf("/api/v3/queue?page=1&pageSize=%d&includeMovie=true&sortKey=id&sortDirection=ascending", queueMaxRecords)
+	// includeUnknownMovieItems: without it Radarr silently drops queue rows it
+	// could not match to a library movie — exactly the rows most likely to be
+	// stuck — before the completeness checks below ever see them.
+	path := fmt.Sprintf("/api/v3/queue?page=1&pageSize=%d&includeMovie=true&includeUnknownMovieItems=true&sortKey=id&sortDirection=ascending", queueMaxRecords)
 	if err := c.do("GET", path, nil, &resp); err != nil {
 		return nil, fmt.Errorf("radarr queue: %w", err)
 	}

--- a/server/internal/radarr/client_test.go
+++ b/server/internal/radarr/client_test.go
@@ -210,6 +210,37 @@ func mustTime(t *testing.T, value string) time.Time {
 	return parsed
 }
 
+// TestGetQueueReadsOneCompleteBoundedPage pins the lean queue read's contract:
+// explicit paging (an unpaged read is the server's silent 10-row default page),
+// unknown-movie rows included, and truncation an error rather than a shorter
+// queue.
+func TestGetQueueReadsOneCompleteBoundedPage(t *testing.T) {
+	body := `{"totalRecords":2,"records":[{"movieId":42,"title":"Heat","status":"downloading"},{"movieId":0,"title":"Unmatched.Release","status":"downloading"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("page") != "1" || q.Get("pageSize") != "1000" {
+			t.Errorf("queue was not requested in one bounded page: %s", r.URL.RawQuery)
+		}
+		if q.Get("includeUnknownMovieItems") != "true" {
+			t.Errorf("includeUnknownMovieItems = %q, want true", q.Get("includeUnknownMovieItems"))
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	items, err := NewClient(server.URL, "key").GetQueue()
+	if err != nil {
+		t.Fatalf("GetQueue: %v", err)
+	}
+	if len(items) != 2 || items[0].MovieID != 42 || items[1].MovieID != 0 {
+		t.Fatalf("items = %+v, want the matched row and the unknown-movie row", items)
+	}
+
+	body = `{"totalRecords":2,"records":[{"movieId":42}]}`
+	if _, err := NewClient(server.URL, "key").GetQueue(); err == nil {
+		t.Fatal("accepted a truncated queue as a complete page")
+	}
+}
+
 func TestGetQueueDetailedRejectsClampedSinglePage(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/request/service_movie_test.go
+++ b/server/internal/request/service_movie_test.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -56,7 +57,11 @@ func (f *fakeRadarr) handler(t *testing.T) http.Handler {
 			if records == "" {
 				records = "[]"
 			}
-			_, _ = w.Write([]byte(`{"records":` + records + `}`))
+			// The client's bounded-page read fails closed unless totalRecords
+			// matches the page, mirroring the live paged envelope.
+			var rows []json.RawMessage
+			_ = json.Unmarshal([]byte(records), &rows)
+			_, _ = fmt.Fprintf(w, `{"totalRecords":%d,"records":%s}`, len(rows), records)
 		default:
 			t.Errorf("unexpected radarr request %s %s", r.Method, r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -500,18 +500,25 @@ func (c *Client) SetEpisodesMonitored(episodeIDs []int, monitored bool) error {
 	return nil
 }
 
+// GetQueue returns the lean queue view as one complete bounded page. It used
+// to issue an unpaged read, which Sonarr answers with its default page of 10
+// rows — a silently truncated queue for any instance downloading more than
+// that. includeUnknownSeriesItems keeps rows Sonarr could not match to a
+// library series visible; consumers must treat SeriesID 0 as unmatched.
 func (c *Client) GetQueue() ([]QueueItem, error) {
-	resp, err := c.doRequest("GET", "/api/v3/queue?includeSeries=true")
-	if err != nil {
+	var queueResp struct {
+		TotalRecords int         `json:"totalRecords"`
+		Records      []QueueItem `json:"records"`
+	}
+	path := fmt.Sprintf("/api/v3/queue?page=1&pageSize=%d&includeSeries=true&includeUnknownSeriesItems=true&sortKey=id&sortDirection=ascending", queueMaxRecords)
+	if err := c.do("GET", path, nil, &queueResp); err != nil {
 		return nil, fmt.Errorf("sonarr queue: %w", err)
 	}
-	defer resp.Body.Close()
-
-	var queueResp struct {
-		Records []QueueItem `json:"records"`
+	if queueResp.TotalRecords < 0 || queueResp.TotalRecords > queueMaxRecords {
+		return nil, fmt.Errorf("sonarr queue snapshot incomplete: invalid or oversized total %d (safety cap %d)", queueResp.TotalRecords, queueMaxRecords)
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&queueResp); err != nil {
-		return nil, fmt.Errorf("decode queue: %w", err)
+	if len(queueResp.Records) != queueResp.TotalRecords {
+		return nil, fmt.Errorf("sonarr queue snapshot incomplete: received %d of %d records in bounded page", len(queueResp.Records), queueResp.TotalRecords)
 	}
 	return queueResp.Records, nil
 }
@@ -593,7 +600,10 @@ func (c *Client) GetQueueDetailed() ([]DetailedQueueItem, error) {
 		TotalRecords int                 `json:"totalRecords"`
 		Records      []DetailedQueueItem `json:"records"`
 	}
-	path := fmt.Sprintf("/api/v3/queue?page=1&pageSize=%d&includeSeries=true&includeEpisode=true&sortKey=id&sortDirection=ascending", queueMaxRecords)
+	// includeUnknownSeriesItems: without it Sonarr silently drops queue rows it
+	// could not match to a library series — exactly the rows most likely to be
+	// stuck — before the completeness checks below ever see them.
+	path := fmt.Sprintf("/api/v3/queue?page=1&pageSize=%d&includeSeries=true&includeEpisode=true&includeUnknownSeriesItems=true&sortKey=id&sortDirection=ascending", queueMaxRecords)
 	if err := c.do("GET", path, nil, &resp); err != nil {
 		return nil, fmt.Errorf("sonarr queue: %w", err)
 	}

--- a/server/internal/sonarr/client_test.go
+++ b/server/internal/sonarr/client_test.go
@@ -394,6 +394,37 @@ func TestGetImportHistoryRejectsTruncatedResult(t *testing.T) {
 	}
 }
 
+// TestGetQueueReadsOneCompleteBoundedPage pins the lean queue read's contract:
+// explicit paging (an unpaged read is the server's silent 10-row default page),
+// unknown-series rows included, and truncation an error rather than a shorter
+// queue.
+func TestGetQueueReadsOneCompleteBoundedPage(t *testing.T) {
+	body := `{"totalRecords":2,"records":[{"seriesId":42,"title":"Andor","status":"downloading"},{"seriesId":0,"title":"Unmatched.Release","status":"downloading"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("page") != "1" || q.Get("pageSize") != "1000" {
+			t.Errorf("queue was not requested in one bounded page: %s", r.URL.RawQuery)
+		}
+		if q.Get("includeUnknownSeriesItems") != "true" {
+			t.Errorf("includeUnknownSeriesItems = %q, want true", q.Get("includeUnknownSeriesItems"))
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	items, err := NewClient(server.URL, "key").GetQueue()
+	if err != nil {
+		t.Fatalf("GetQueue: %v", err)
+	}
+	if len(items) != 2 || items[0].SeriesID != 42 || items[1].SeriesID != 0 {
+		t.Fatalf("items = %+v, want the matched row and the unknown-series row", items)
+	}
+
+	body = `{"totalRecords":2,"records":[{"seriesId":42}]}`
+	if _, err := NewClient(server.URL, "key").GetQueue(); err == nil {
+		t.Fatal("accepted a truncated queue as a complete page")
+	}
+}
+
 func TestGetQueueDetailedRejectsClampedSinglePage(t *testing.T) {
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/websocket/catchup_test.go
+++ b/server/internal/websocket/catchup_test.go
@@ -41,7 +41,7 @@ func (b *videoBackend) handler() http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == b.apiPrefix+"/queue":
-			fmt.Fprintf(w, `{"records":%s}`, b.queue)
+			fmt.Fprint(w, queueEnvelope(b.queue))
 		case r.URL.Path == b.apiPrefix+"/history":
 			b.historyHits++
 			records := b.history

--- a/server/internal/websocket/chaptarr_witness_test.go
+++ b/server/internal/websocket/chaptarr_witness_test.go
@@ -110,7 +110,7 @@ func (b *chaptarrBackend) handler() http.HandlerFunc {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/api/v1/queue":
-			fmt.Fprintf(w, `{"records":%s}`, b.queue)
+			fmt.Fprint(w, queueEnvelope(b.queue))
 		case r.URL.Path == "/api/v1/history":
 			records := b.history
 			if r.URL.Query().Get("eventType") == "5" {

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -1294,8 +1294,14 @@ func (h *Hub) pollRadarrInstance(instanceID string, client *radarr.Client) {
 		if item.Size > 0 {
 			progress = (item.Size - item.Sizeleft) / item.Size
 		}
-		currentQueue[item.MovieID] = progress
 		tuples = append(tuples, fmt.Sprintf("%d|%s|%.0f", item.MovieID, item.Status, item.Sizeleft))
+		if item.MovieID <= 0 {
+			// A queue row Radarr could not match to a library movie has no id
+			// to witness or announce; it still counts toward the composition
+			// tuple above so its arrival/departure invalidates queue views.
+			continue
+		}
+		currentQueue[item.MovieID] = progress
 
 		// Look up TMDB ID for this movie
 		movie, err := client.GetMovie(item.MovieID)
@@ -1320,9 +1326,10 @@ func (h *Hub) pollRadarrInstance(instanceID string, client *radarr.Client) {
 	var departed []int
 	if prevQueue := h.prevRadarrQueue[instanceID]; prevQueue != nil {
 		for movieID := range prevQueue {
-			if _, stillInQueue := currentQueue[movieID]; !stillInQueue {
-				departed = append(departed, movieID)
+			if _, stillInQueue := currentQueue[movieID]; stillInQueue || movieID <= 0 {
+				continue
 			}
+			departed = append(departed, movieID)
 		}
 		sort.Ints(departed)
 	}
@@ -1399,8 +1406,14 @@ func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
 		if item.Size > 0 {
 			progress = (item.Size - item.Sizeleft) / item.Size
 		}
-		currentQueue[item.SeriesID] = progress
 		tuples = append(tuples, fmt.Sprintf("%d|%s|%.0f", item.SeriesID, item.Status, item.Sizeleft))
+		if item.SeriesID <= 0 {
+			// A queue row Sonarr could not match to a library series has no id
+			// to witness or announce; it still counts toward the composition
+			// tuple above so its arrival/departure invalidates queue views.
+			continue
+		}
+		currentQueue[item.SeriesID] = progress
 
 		series, err := client.GetSeries(item.SeriesID)
 		if err != nil {
@@ -1424,9 +1437,10 @@ func (h *Hub) pollSonarrInstance(instanceID string, client *sonarr.Client) {
 	var departed []int
 	if prevQueue := h.prevSonarrQueue[instanceID]; prevQueue != nil {
 		for seriesID := range prevQueue {
-			if _, stillInQueue := currentQueue[seriesID]; !stillInQueue {
-				departed = append(departed, seriesID)
+			if _, stillInQueue := currentQueue[seriesID]; stillInQueue || seriesID <= 0 {
+				continue
 			}
+			departed = append(departed, seriesID)
 		}
 		sort.Ints(departed)
 	}
@@ -1520,8 +1534,14 @@ func (h *Hub) pollChaptarrInstance(instanceID string, client *chaptarr.Client) {
 	currentQueue := make(map[int]struct{}, len(queue))
 	tuples := make([]string, 0, len(queue))
 	for _, item := range queue {
-		currentQueue[item.BookID] = struct{}{}
 		tuples = append(tuples, fmt.Sprintf("%d|%s|%.0f", item.BookID, item.Status, item.Sizeleft))
+		if item.BookID <= 0 {
+			// A queue row Chaptarr could not match to a library book has no id
+			// to witness or announce; it still counts toward the composition
+			// tuple above so its arrival/departure invalidates queue views.
+			continue
+		}
+		currentQueue[item.BookID] = struct{}{}
 	}
 
 	// A book record that left the queue and now has a file finished importing.

--- a/server/internal/websocket/queue_witness_test.go
+++ b/server/internal/websocket/queue_witness_test.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,18 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/db"
 	"github.com/windoze95/cantinarr-server/internal/radarr"
 )
+
+// queueEnvelope wraps a records array in the paged envelope the arr queue
+// endpoint serves; the client's bounded-page read fails closed unless
+// totalRecords matches the page.
+func queueEnvelope(records string) string {
+	if records == "" {
+		records = "[]"
+	}
+	var rows []json.RawMessage
+	_ = json.Unmarshal([]byte(records), &rows)
+	return fmt.Sprintf(`{"totalRecords":%d,"records":%s}`, len(rows), records)
+}
 
 // witnessDB opens a file-backed database with the full schema. File-backed
 // rather than :memory: so two hubs can share it the way two processes share the
@@ -122,7 +135,7 @@ func TestQueueWitnessResumesRadarrDepartureAcrossRestart(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
 		case r.URL.Path == "/api/v3/queue":
-			fmt.Fprintf(w, `{"records":%s}`, queue)
+			fmt.Fprint(w, queueEnvelope(queue))
 		case r.URL.Path == "/api/v3/movie/42":
 			fmt.Fprint(w, `{"id":42,"title":"The Matrix","tmdbId":603,"hasFile":true,"monitored":true}`)
 		default:
@@ -144,6 +157,44 @@ func TestQueueWitnessResumesRadarrDepartureAcrossRestart(t *testing.T) {
 
 	if got := after.movieCalls(); len(got) != 1 || got[0] != "The Matrix|603" {
 		t.Fatalf("resumed movie witness = %v, want exactly The Matrix|603", got)
+	}
+}
+
+// TestPollSkipsUnknownMediaRows pins the unknown-item contract: a queue row
+// the arr could not match to a library record (media id 0) is visible to the
+// poller — the read no longer drops it — but it has no identity to look up,
+// witness, or announce, so its departure must alert on the matched row only
+// and must never fetch /movie/0.
+func TestPollSkipsUnknownMediaRows(t *testing.T) {
+	database := witnessDB(t)
+	var queue string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/api/v3/queue":
+			fmt.Fprint(w, queueEnvelope(queue))
+		case r.URL.Path == "/api/v3/movie/42":
+			fmt.Fprint(w, `{"id":42,"title":"The Matrix","tmdbId":603,"hasFile":true,"monitored":true}`)
+		case r.URL.Path == "/api/v3/movie/0":
+			t.Error("poller looked up movie id 0 for an unknown-media queue row")
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+		default:
+			http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	client := radarr.NewClient(srv.URL, "test-key")
+
+	queue = `[{"id":1,"movieId":42,"status":"downloading","size":100,"sizeleft":50},` +
+		`{"id":2,"movieId":0,"title":"Unmatched.Release","status":"downloading","size":100,"sizeleft":80}]`
+	content := &recordingContent{}
+	hub := NewHub(nil, nil, nil, database, content, nil)
+	hub.pollRadarrInstance("movies-a", client)
+
+	queue = `[]`
+	hub.pollRadarrInstance("movies-a", client)
+	if got := content.movieCalls(); len(got) != 1 || got[0] != "The Matrix|603" {
+		t.Fatalf("departure alerts = %v, want exactly the matched movie", got)
 	}
 }
 

--- a/server/internal/websocket/serve_ws_test.go
+++ b/server/internal/websocket/serve_ws_test.go
@@ -471,7 +471,7 @@ func TestPollResultReachesSubscribedClients(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/api/v3/queue":
-			_, _ = w.Write([]byte(`{"records":[{"movieId":7,"title":"Heat","status":"downloading","size":1000,"sizeleft":250}]}`))
+			_, _ = w.Write([]byte(`{"totalRecords":1,"records":[{"movieId":7,"title":"Heat","status":"downloading","size":1000,"sizeleft":250}]}`))
 		case "/api/v3/movie/7":
 			_, _ = w.Write([]byte(`{"id":7,"title":"Heat","tmdbId":949,"hasFile":false}`))
 		default:


### PR DESCRIPTION
## What

The lean \`GetQueue\` in the Chaptarr/Radarr/Sonarr clients issued an **unpaged** queue read. The Servarr lineage answers that with its default page of **10 rows** (verified against Chaptarr's now-public source), so any instance downloading more than 10 items had a silently truncated queue: the websocket completion witness could miss finished imports, and \"new book/movie/episode arrived\" alerts could be lost during busy stretches. GetQueue now reads one complete bounded page and fails closed on truncation, exactly like \`GetQueueDetailed\`.

Every queue read (lean and detailed, all three services) now also passes the include-unknown flag (\`includeUnknownAuthorItems\` / \`includeUnknownMovieItems\` / \`includeUnknownSeriesItems\`). Without it the arr silently drops queue rows it could not match to a library record — exactly the downloads most likely to be stuck — before Cantinarr ever sees them. Remediation observation was already designed for these rows (the download-id scope fallback existed for \"incomplete queue payloads\") and every consumer nil-guards the embedded media context; the rows just never arrived.

The websocket pollers treat media id 0 as unmatched: such rows count toward queue-composition invalidation but are never looked up, witnessed, or announced.

## User-visible effect

- Book/movie/episode arrival notifications no longer miss completions when more than 10 downloads are running on one instance.
- The remediation agent and Import Doctor can now observe stuck downloads the arr failed to match to a library record.

## Tests

- \`TestGetQueue\` (chaptarr) and new \`TestGetQueueReadsOneCompleteBoundedPage\` (radarr, sonarr) pin the paging + include-unknown query and the truncation fail-closed.
- New \`TestPollSkipsUnknownMediaRows\` pins that an unknown-media queue row is visible but never fetched as \`/movie/0\` nor announced on departure.
- \`go vet ./...\` and \`go test ./...\` green from \`server/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF