### PR TITLE
fix(books): Chaptarr history rows show real event labels instead of raw names

### DIFF
--- a/app/lib/features/chaptarr/ui/chaptarr_book_detail_sheet.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_book_detail_sheet.dart
@@ -311,22 +311,34 @@ class _ChaptarrBookDetailSheetState
   }
 }
 
-String _historyEventLabel(ChaptarrHistoryRecord r) {
+/// Exported for the wire-vocabulary test: every event name Chaptarr's
+/// history enum can emit must map to a readable label, never the raw name.
+String chaptarrBookHistoryEventLabel(ChaptarrHistoryRecord r) {
   switch (r.eventType) {
     case 'grabbed':
       final indexer = r.indexer;
       return indexer != null && indexer.isNotEmpty
           ? 'Grabbed from $indexer'
           : 'Grabbed';
+    // Chaptarr's history enum spells whole-download imports downloadImported;
+    // the previously matched downloadFolderImported never occurs on the wire.
     case 'bookFileImported':
-    case 'downloadFolderImported':
+    case 'downloadImported':
       return 'Imported';
+    case 'bookImportIncomplete':
+      return 'Import incomplete';
     case 'downloadFailed':
       return 'Download failed';
     case 'bookFileDeleted':
       return 'File deleted';
     case 'bookFileRenamed':
       return 'File renamed';
+    case 'bookFileRetagged':
+      return 'File retagged';
+    case 'bookFileConverted':
+      return 'File converted';
+    case 'bookFileConversionFailed':
+      return 'Conversion failed';
     case 'downloadIgnored':
       return 'Download ignored';
     default:
@@ -368,7 +380,7 @@ class _HistoryTile extends StatelessWidget {
           Text(
             record.sourceTitle.isNotEmpty
                 ? record.sourceTitle
-                : _historyEventLabel(record),
+                : chaptarrBookHistoryEventLabel(record),
             style: const TextStyle(
                 color: AppTheme.textPrimary,
                 fontSize: 13,
@@ -381,7 +393,7 @@ class _HistoryTile extends StatelessWidget {
               style:
                   const TextStyle(color: AppTheme.textSecondary, fontSize: 11)),
           const SizedBox(height: 2),
-          Text(_historyEventLabel(record),
+          Text(chaptarrBookHistoryEventLabel(record),
               style: const TextStyle(color: AppTheme.requested, fontSize: 12)),
           if (format != BookFormat.unknown) ...[
             const SizedBox(height: 4),

--- a/app/lib/features/chaptarr/ui/chaptarr_history_screen.dart
+++ b/app/lib/features/chaptarr/ui/chaptarr_history_screen.dart
@@ -215,7 +215,10 @@ String _timeLabel(DateTime? date) {
   return DateFormat('h:mm a').format(local);
 }
 
-({IconData icon, Color color, String label}) _eventStyle(String eventType) {
+/// Exported for the wire-vocabulary test: every event name Chaptarr's
+/// history enum can emit must map to a styled label, never the raw fallback.
+({IconData icon, Color color, String label}) chaptarrHistoryEventStyle(
+    String eventType) {
   switch (eventType) {
     case 'grabbed':
       return (
@@ -223,13 +226,23 @@ String _timeLabel(DateTime? date) {
         color: AppTheme.downloading,
         label: 'Grabbed'
       );
-    case 'bookImported':
-    case 'downloadFolderImported':
-    case 'authorFolderImported':
+    // Import events as Chaptarr's history enum actually spells them:
+    // bookFileImported per file, downloadImported when the whole download
+    // lands. The previously matched bookImported / downloadFolderImported /
+    // authorFolderImported never occur on the wire, so every import rendered
+    // through the generic fallback.
+    case 'bookFileImported':
+    case 'downloadImported':
       return (
         icon: Icons.check_circle_outline,
         color: AppTheme.available,
         label: 'Imported'
+      );
+    case 'bookImportIncomplete':
+      return (
+        icon: Icons.warning_amber,
+        color: AppTheme.warning,
+        label: 'Import incomplete'
       );
     case 'downloadFailed':
       return (
@@ -248,6 +261,24 @@ String _timeLabel(DateTime? date) {
         icon: Icons.drive_file_rename_outline,
         color: AppTheme.accent,
         label: 'Renamed'
+      );
+    case 'bookFileRetagged':
+      return (
+        icon: Icons.sell_outlined,
+        color: AppTheme.accent,
+        label: 'Retagged'
+      );
+    case 'bookFileConverted':
+      return (
+        icon: Icons.autorenew,
+        color: AppTheme.available,
+        label: 'Converted'
+      );
+    case 'bookFileConversionFailed':
+      return (
+        icon: Icons.error_outline,
+        color: AppTheme.error,
+        label: 'Conversion failed'
       );
     case 'downloadIgnored':
       return (icon: Icons.block, color: AppTheme.unavailable, label: 'Ignored');
@@ -289,7 +320,7 @@ class _HistoryTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final style = _eventStyle(record.eventType);
+    final style = chaptarrHistoryEventStyle(record.eventType);
     final subtitleParts = [
       style.label,
       if (record.quality != null && record.quality!.isNotEmpty) record.quality!,

--- a/app/test/chaptarr/chaptarr_history_event_names_test.dart
+++ b/app/test/chaptarr/chaptarr_history_event_names_test.dart
@@ -1,0 +1,65 @@
+import 'package:cantinarr/features/chaptarr/data/chaptarr_models.dart';
+import 'package:cantinarr/features/chaptarr/ui/chaptarr_book_detail_sheet.dart';
+import 'package:cantinarr/features/chaptarr/ui/chaptarr_history_screen.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// The event names Chaptarr's history enum actually serializes on the wire
+// (EntityHistoryEventType, camelCase). The two screens used to match invented
+// names — 'bookImported', 'downloadFolderImported', 'authorFolderImported' —
+// so real events fell through to the raw fallback. This pins every wire name
+// to a mapped label so the vocabulary cannot drift again.
+const _wireEventNames = [
+  'grabbed',
+  'bookFileImported',
+  'downloadImported',
+  'bookImportIncomplete',
+  'downloadFailed',
+  'bookFileDeleted',
+  'bookFileRenamed',
+  'bookFileRetagged',
+  'downloadIgnored',
+  'bookFileConverted',
+  'bookFileConversionFailed',
+];
+
+ChaptarrHistoryRecord _record(String eventType) =>
+    ChaptarrHistoryRecord(id: 1, eventType: eventType);
+
+void main() {
+  test('history screen styles every wire event name', () {
+    for (final name in _wireEventNames) {
+      final style = chaptarrHistoryEventStyle(name);
+      expect(style.label, isNot(name),
+          reason: "'$name' fell through to the raw fallback");
+    }
+  });
+
+  test('book detail sheet labels every wire event name', () {
+    for (final name in _wireEventNames) {
+      final label = chaptarrBookHistoryEventLabel(_record(name));
+      expect(label, isNot(name),
+          reason: "'$name' fell through to the raw fallback");
+    }
+  });
+
+  test('import events read as Imported in both screens', () {
+    for (final name in ['bookFileImported', 'downloadImported']) {
+      expect(chaptarrHistoryEventStyle(name).label, 'Imported');
+      expect(chaptarrBookHistoryEventLabel(_record(name)), 'Imported');
+    }
+  });
+
+  test('the invented names stay unmapped so nobody re-adds them', () {
+    for (final name in [
+      'bookImported',
+      'downloadFolderImported',
+      'authorFolderImported',
+    ]) {
+      // Falling through to the fallback IS the assertion: these names never
+      // occur on the wire, and a case for one of them would be dead code
+      // masquerading as coverage.
+      expect(chaptarrHistoryEventStyle(name).label, name);
+      expect(chaptarrBookHistoryEventLabel(_record(name)), name);
+    }
+  });
+}


### PR DESCRIPTION
## What

Both Chaptarr history surfaces (the history screen and the book detail sheet) matched import-event names that never occur on the wire — \`bookImported\`, \`downloadFolderImported\`, \`authorFolderImported\` — so real imports rendered through the generic raw fallback, and the two screens didn't even agree with each other. Verified against Chaptarr's now-public history enum: per-file imports serialize as \`bookFileImported\`, whole-download imports as \`downloadImported\`.

Both mappers now cover every name the enum serializes, including the previously unhandled \`bookImportIncomplete\`, \`bookFileRetagged\`, and the audiobook-conversion events (\`bookFileConverted\` / \`bookFileConversionFailed\`).

## User-visible effect

History rows in the Chaptarr screens get correct labels and icons — "Imported" instead of a raw camelCase token — and conversion/retag/incomplete events stop rendering as anonymous unknowns.

## Tests

New \`chaptarr_history_event_names_test.dart\` pins the full wire vocabulary to mapped labels in both screens, and pins the three invented names staying unmapped so dead cases can't be re-added. \`flutter analyze --no-fatal-infos\` clean; \`flutter test\` green (1083 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF