### PR TITLE
MCP OAuth front door gets the same brute-force rate limit as app login

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -411,10 +411,11 @@ GET  /.well-known/oauth-protected-resource[/mcp]
 GET  /.well-known/oauth-authorization-server | /.well-known/openid-configuration
 POST /oauth/register                         # dynamic client registration
 GET|POST /oauth/authorize                    # browser login (password or passkey) + consent
+POST /oauth/passkey/login/begin|finish       # WebAuthn login for the authorize page
 POST /oauth/token                            # code/refresh grants, PKCE, rotating refresh
 GET  /passkeys/setup | /passkeys/create      # passkey pages for MCP/browser setup links
 ```
-These endpoints are Cantinarr's **inbound** OAuth authorization server: an external MCP client signs in to access Cantinarr. They do not link a ChatGPT account. Personal and admin-shared Codex chat use separate **outbound** device flows under `/api/ai/codex/*` and `/api/admin/ai/codex/*`.
+These endpoints are Cantinarr's **inbound** OAuth authorization server: an external MCP client signs in to access Cantinarr. They do not link a ChatGPT account. The POST endpoints (register, authorize, passkey login, token) share the same 10 requests/minute/IP rate limit as the public `/api/auth` endpoints; discovery metadata and the GET authorize form are unlimited. Personal and admin-shared Codex chat use separate **outbound** device flows under `/api/ai/codex/*` and `/api/admin/ai/codex/*`.
 
 When `CANTINARR_OAUTH_ISSUER` is set, authorization-server metadata advertises RFC 9207 issuer identification and successful password/passkey authorization responses include the exact canonical `iss`; without it, Cantinarr preserves request-derived legacy metadata and does not claim stable authorization-response issuer support. The configured issuer must use HTTPS so metadata, redirects, token audience, and auth challenges share one secure canonical external origin. Dynamic client registration accepts and echoes OpenID Connect `application_type` values `native` and `web` (omitted legacy values default to `web`); explicit web registrations require HTTPS redirects. Trusted browser preflights accept the current session header plus MCP protocol-version and method/name routing headers. Supplied origins must match the configured issuer or an entry in `CANTINARR_MCP_ALLOWED_ORIGINS`; when neither is configured all browser origins are rejected before authentication, while native/server clients normally send no `Origin` and are unaffected.
 

--- a/server/internal/api/oauth_ratelimit_test.go
+++ b/server/internal/api/oauth_ratelimit_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestOAuthCredentialEndpointsAreRateLimited pins the /oauth front-door
+// posture: every unauthenticated endpoint that accepts a credential or mints
+// server-side state shares one 10/minute/IP budget, matching /api/auth. The
+// password form on POST /oauth/authorize is the load-bearing case — without a
+// limiter it is a second, uncapped login form for brute-forcing accounts.
+func TestOAuthCredentialEndpointsAreRateLimited(t *testing.T) {
+	harness := newRBACRouterHarness(t, false)
+
+	junkAuthorize := url.Values{
+		"response_type": {"code"},
+		"client_id":     {"missing-client"},
+		"username":      {"admin"},
+		"password":      {"wrong-password"},
+	}.Encode()
+
+	postForm := func(path string) int {
+		request := httptest.NewRequest(http.MethodPost, path, strings.NewReader(junkAuthorize))
+		request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		recorder := httptest.NewRecorder()
+		harness.router.ServeHTTP(recorder, request)
+		return recorder.Code
+	}
+
+	// The shared budget admits exactly 10 requests per IP per window.
+	for attempt := 1; attempt <= 10; attempt++ {
+		if status := postForm("/oauth/authorize"); status == http.StatusTooManyRequests {
+			t.Fatalf("authorize attempt %d was limited before the 10-request budget was spent", attempt)
+		}
+	}
+
+	// Once spent, every credential endpoint answers 429 from that same budget.
+	for _, path := range []string{
+		"/oauth/authorize",
+		"/oauth/register",
+		"/oauth/passkey/login/begin",
+		"/oauth/passkey/login/finish",
+		"/oauth/token",
+	} {
+		if status := postForm(path); status != http.StatusTooManyRequests {
+			t.Errorf("POST %s after spent budget = %d, want 429", path, status)
+		}
+	}
+
+	// Discovery metadata and the login form render stay unlimited: MCP client
+	// discovery must keep working from an IP that just exhausted the budget.
+	for _, path := range []string{
+		"/.well-known/oauth-authorization-server",
+		"/.well-known/oauth-protected-resource/mcp",
+		"/oauth/authorize",
+	} {
+		request := httptest.NewRequest(http.MethodGet, path, nil)
+		recorder := httptest.NewRecorder()
+		harness.router.ServeHTTP(recorder, request)
+		if recorder.Code == http.StatusTooManyRequests {
+			t.Errorf("GET %s was rate limited; discovery and the form render must stay reachable", path)
+		}
+	}
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -73,12 +73,20 @@ func NewRouter(
 	r.Get("/.well-known/openid-configuration", oauthHandler.AuthorizationServerMetadata)
 	r.Get("/.well-known/apple-app-site-association", appleAppSiteAssociationHandler(cfg))
 	r.Get("/.well-known/assetlinks.json", androidAssetLinksHandler(cfg))
-	r.Post("/oauth/register", oauthHandler.RegisterClient)
+	// Rate limiter for the unauthenticated OAuth endpoints, matching the
+	// /api/auth posture. POST /oauth/authorize accepts a password, so leaving
+	// it unlimited would hand brute-forcers a second, uncapped login form; the
+	// register/token/passkey endpoints share the budget so unauthenticated
+	// callers cannot spam client registrations or grind at grants either. The
+	// metadata endpoints above and the GET authorize form stay unlimited —
+	// they attempt no credential and MCP client discovery depends on them.
+	oauthLimiter := auth.NewRateLimiter(10, 1*time.Minute)
+	r.With(oauthLimiter.Middleware).Post("/oauth/register", oauthHandler.RegisterClient)
 	r.Get("/oauth/authorize", oauthHandler.Authorize)
-	r.Post("/oauth/authorize", oauthHandler.Authorize)
-	r.Post("/oauth/passkey/login/begin", oauthHandler.BeginOAuthPasskeyLogin)
-	r.Post("/oauth/passkey/login/finish", oauthHandler.FinishOAuthPasskeyLogin)
-	r.Post("/oauth/token", oauthHandler.Token)
+	r.With(oauthLimiter.Middleware).Post("/oauth/authorize", oauthHandler.Authorize)
+	r.With(oauthLimiter.Middleware).Post("/oauth/passkey/login/begin", oauthHandler.BeginOAuthPasskeyLogin)
+	r.With(oauthLimiter.Middleware).Post("/oauth/passkey/login/finish", oauthHandler.FinishOAuthPasskeyLogin)
+	r.With(oauthLimiter.Middleware).Post("/oauth/token", oauthHandler.Token)
 	r.Get("/passkeys/setup", oauthHandler.PasskeySetup)
 	r.Get("/passkeys/create", oauthHandler.PasskeyCreate)
 


### PR DESCRIPTION
## What

The public OAuth endpoints that serve external MCP clients — `POST /oauth/register`, `POST /oauth/authorize`, `POST /oauth/passkey/login/begin|finish`, `POST /oauth/token` — had **no rate limiter**, while their `/api/auth` siblings are capped at 10 requests/minute/IP.

`POST /oauth/authorize` accepts a username + password, so it was an uncapped second login form: an unauthenticated attacker could brute-force account passwords through the MCP front door at full speed (bcrypt-slowed, but unlimited). `POST /oauth/register` also allowed unauthenticated client-registration row creation without bound.

## Fix

- The five credential-accepting POST endpoints share one `auth.NewRateLimiter(10, 1*time.Minute)` budget, the exact posture of the public `/api/auth` endpoints.
- Discovery metadata (`/.well-known/*`) and the `GET /oauth/authorize` form render stay unlimited — they attempt no credential, and MCP client discovery must keep working.
- `TestOAuthCredentialEndpointsAreRateLimited` pins all of it: the shared 10-request budget, 429 on every credential endpoint once spent, and discovery staying reachable from an exhausted IP.
- Server README: documents the limit and adds the previously missing `/oauth/passkey/login/begin|finish` routes to the MCP & OAuth reference.

Found during a pre-launch RBAC/authentication audit of the full MCP surface (transport auth, per-tool RBAC, live per-call reauthorization, trusted-internal boundary) — this was the one gap; the audit summary is in the session notes.

## Verification

- `go vet ./...` clean
- `go test ./...` fully green from `server/` (includes the new posture test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF