### PR TITLE
fix(proxy): scrub credentials from URLs embedded in queue and history messages

### DIFF
--- a/server/internal/proxy/sanitize.go
+++ b/server/internal/proxy/sanitize.go
@@ -475,9 +475,11 @@ func normalizeSensitiveName(name string) string {
 // values. The targeted userinfo rewrite preserves the rest of the URL spelling;
 // query redaction preserves parameter order, duplicate keys, and fragments.
 // Relative URLs are supported because arr history records occasionally contain
-// them.
+// them, and URLs embedded mid-string are covered because queue and history
+// prose quotes download-client and indexer URLs inside larger messages.
 func sanitizeURLCredentials(raw string) string {
 	raw = stripURLUserinfo(raw)
+	raw = stripEmbeddedURLUserinfo(raw)
 	return redactURLQuery(raw)
 }
 
@@ -504,17 +506,76 @@ func stripURLUserinfo(raw string) string {
 	return raw[:authorityStart] + authority[userinfoEnd+1:] + raw[authorityEnd:]
 }
 
+// stripEmbeddedURLUserinfo removes userinfo from absolute URL references that
+// appear inside prose, such as "Unable to connect to http://user:pass@host/".
+// stripURLUserinfo only recognizes a string that is itself a URL reference, so
+// without this pass a credential quoted mid-message would survive scrubbing.
+func stripEmbeddedURLUserinfo(raw string) string {
+	cursor := 0
+	for {
+		relative := strings.Index(raw[cursor:], "://")
+		if relative < 0 {
+			return raw
+		}
+		colon := cursor + relative
+		schemeStart := colon
+		for schemeStart > 0 && isURLSchemeByte(raw[schemeStart-1]) {
+			schemeStart--
+		}
+		// A scheme cannot start with a digit or punctuation, so a decorated
+		// reference such as "item2https://..." resolves at its alpha suffix.
+		for schemeStart < colon && !isASCIIAlpha(raw[schemeStart]) {
+			schemeStart++
+		}
+		// Resume just past the marker rather than past the authority: an
+		// authority scan that swallowed prose may itself contain the "://" of
+		// a following comma- or semicolon-separated reference.
+		cursor = colon + len("://")
+		if !isURLScheme(raw[schemeStart:colon]) {
+			continue
+		}
+		authorityEnd := cursor
+		for authorityEnd < len(raw) && !isEmbeddedAuthorityTerminator(raw[authorityEnd]) {
+			authorityEnd++
+		}
+		authority := raw[cursor:authorityEnd]
+		userinfoEnd := strings.LastIndexByte(authority, '@')
+		if userinfoEnd < 0 {
+			continue
+		}
+		raw = raw[:cursor] + authority[userinfoEnd+1:] + raw[authorityEnd:]
+	}
+}
+
+// isEmbeddedAuthorityTerminator ends the authority scan of a URL reference
+// found in prose. Beyond the RFC 3986 authority delimiters, characters that
+// cannot appear in a host end the scan so a later word's "@" is never treated
+// as userinfo. Comma and semicolon are deliberately not terminators: they are
+// legal inside userinfo, and a separated second URL is still reached because
+// the caller rescans from just past each "://" marker.
+func isEmbeddedAuthorityTerminator(b byte) bool {
+	switch b {
+	case '/', '?', '#', '\\', '"', '\'', '<', '>', '(', ')', '[', ']', '{', '}':
+		return true
+	default:
+		return b <= 0x20 || b == 0x7f
+	}
+}
+
 func isURLScheme(value string) bool {
 	if value == "" || !isASCIIAlpha(value[0]) {
 		return false
 	}
 	for i := 1; i < len(value); i++ {
-		b := value[i]
-		if !isASCIIAlpha(b) && (b < '0' || b > '9') && b != '+' && b != '-' && b != '.' {
+		if !isURLSchemeByte(value[i]) {
 			return false
 		}
 	}
 	return true
+}
+
+func isURLSchemeByte(b byte) bool {
+	return isASCIIAlpha(b) || b >= '0' && b <= '9' || b == '+' || b == '-' || b == '.'
 }
 
 func isASCIIAlpha(value byte) bool {

--- a/server/internal/proxy/sanitize_test.go
+++ b/server/internal/proxy/sanitize_test.go
@@ -255,6 +255,87 @@ func TestSanitizeJSONExpandedCredentialCoverage(t *testing.T) {
 	}
 }
 
+// Queue and history prose embeds download-client and indexer URLs mid-message
+// ("Unable to connect to http://user:pass@host/..."). Userinfo must be
+// stripped from an embedded reference even though the surrounding string is
+// not itself a URL reference, because requesters can read queue and history
+// records through the instance proxy.
+func TestStripEmbeddedURLUserinfo(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{
+			name:  "prose before the reference",
+			value: "Unable to connect to http://embedded-user:embedded-pass@qbit.invalid:8080/api/v2 after 3 tries",
+			want:  "Unable to connect to http://qbit.invalid:8080/api/v2 after 3 tries",
+		},
+		{
+			name:  "comma-separated references each keep their own scrub",
+			value: "tried http://a:secret-one@first.invalid,http://b:secret-two@second.invalid/path today",
+			want:  "tried http://first.invalid,http://second.invalid/path today",
+		},
+		{
+			name:  "password containing a comma is not split into prose",
+			value: "see http://user:pa,ss@host.invalid then retry",
+			want:  "see http://host.invalid then retry",
+		},
+		{
+			name:  "uppercase scheme",
+			value: "Retry HTTPS://embedded-user:embedded-pass@files.invalid now",
+			want:  "Retry HTTPS://files.invalid now",
+		},
+		{
+			name:  "scheme decorated by a leading digit",
+			value: "item2https://embedded-user:embedded-pass@download.invalid done",
+			want:  "item2https://download.invalid done",
+		},
+		{
+			name:  "IPv6 authority",
+			value: "dial http://embedded-user:embedded-pass@[::1]:7878/api failed",
+			want:  "dial http://[::1]:7878/api failed",
+		},
+		{
+			name:  "prose email and bare URL stay untouched",
+			value: "contact ops@example.invalid about http://tracker.invalid/announce",
+			want:  "contact ops@example.invalid about http://tracker.invalid/announce",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeURLCredentials(tc.value); got != tc.want {
+				t.Errorf("sanitizeURLCredentials(%q) = %q, want %q", tc.value, got, tc.want)
+			}
+		})
+	}
+}
+
+// End to end: a queue-shaped status message loses both the embedded userinfo
+// and the embedded sensitive query value while the readable prose survives.
+func TestSanitizeJSONScrubsEmbeddedProseURL(t *testing.T) {
+	const (
+		username = "embedded-user"
+		password = "embedded-pass"
+		apiKey   = "embedded-api-key"
+	)
+	body := []byte(`{"statusMessages":[{"title":"item","messages":["Download failed from https://` +
+		username + `:` + password + `@indexer.invalid/get?apikey=` + apiKey + ` after 2 attempts"]}]}`)
+
+	sanitized, err := sanitizeJSON(body)
+	if err != nil {
+		t.Fatalf("sanitizeJSON: %v", err)
+	}
+	for _, secret := range []string{username, password, apiKey} {
+		if bytes.Contains(sanitized, []byte(secret)) {
+			t.Fatalf("sanitized JSON retained %q: %s", secret, sanitized)
+		}
+	}
+	if !bytes.Contains(sanitized, []byte("indexer.invalid")) || !bytes.Contains(sanitized, []byte("Download failed")) {
+		t.Errorf("prose or host was over-redacted: %s", sanitized)
+	}
+}
+
 // INST-018: Secret-bearing response URL headers are scrubbed without losing routing.
 func TestSanitizeResponseURLHeaders(t *testing.T) {
 	const (


### PR DESCRIPTION
## Summary
- The proxy sanitizer stripped `user:pass@` only from strings that **are** URLs; queue/history prose that quotes a URL mid-message ("Unable to connect to http://user:pass@qbit:8080/…") kept its credentials, while embedded `?apikey=` query values were already redacted. Requesters can read queue and history through the instance proxy, so this closes a credential-disclosure path to non-admins.
- Adds an embedded-reference pass to `sanitizeURLCredentials`: find each `://`, walk back to a valid scheme, bound the authority at prose delimiters, strip userinfo. Comma/semicolon remain legal inside userinfo; separated URL lists are still covered by rescanning from just past each marker.
- Salvaged lean from the wave-2 security-coverage snapshot (`41ef935`) before that branch was deleted. Deliberately not taken from the snapshot: WHATWG whitespace/backslash normalization, protocol-relative prose detection, SSE sanitization, and the 1xx header wrapper — those defend against a hostile arr, which is out of threat model.

## Test plan
- [x] New `TestStripEmbeddedURLUserinfo` table (prose, comma-separated lists, comma-in-password, uppercase scheme, digit-decorated scheme, IPv6, email false-positive) — fails on `main`, passes here
- [x] New end-to-end `TestSanitizeJSONScrubsEmbeddedProseURL` (queue-shaped statusMessages)
- [x] `go vet ./...` and full `go test ./...` from `server/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF