### PR TITLE
fix: hold every requester read to the client-reachable and redacted boundaries

### DIFF
--- a/server/internal/remediation/handler.go
+++ b/server/internal/remediation/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/windoze95/cantinarr-server/internal/ai"
 	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
 )
 
 const maxRemediationRequestBytes = 64 << 10
@@ -228,6 +229,15 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
+	}
+	// The same read boundary for the thread: every reporter-visible body is
+	// already redacted at its write site, and redacting again here means a
+	// future thread writer that forgets secrets.RedactText cannot leak a
+	// credential by default.
+	if !auth.HasPermission(claims.Role, auth.PermissionRemediationManage) {
+		for i := range thread {
+			thread[i].Body = secrets.RedactText(thread[i].Body)
+		}
 	}
 	writeJSON(w, http.StatusOK, IssueDetail{Issue: *issue, Thread: thread})
 }

--- a/server/internal/remediation/read_test.go
+++ b/server/internal/remediation/read_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
@@ -219,5 +220,55 @@ func TestAdminGetMarksReadReporterDoesNot(t *testing.T) {
 	}
 	if !readFlag(t, svc, r.IssueID) {
 		t.Fatal("admin view must mark the issue read")
+	}
+}
+
+// TestGetRedactsThreadBodiesForNonAdmins pins the read-time thread boundary:
+// even if a thread writer forgets secrets.RedactText (simulated here with a
+// direct insert), a credential quoted in a message body never reaches the
+// reporter — while the admin view keeps the raw text for diagnosis.
+func TestGetRedactsThreadBodiesForNonAdmins(t *testing.T) {
+	svc, _, reporterID := setupTestService(t)
+	h := NewHandler(svc)
+	r, err := svc.CreateUserIssue(reporterID, movieReq(1))
+	if err != nil {
+		t.Fatalf("CreateUserIssue: %v", err)
+	}
+	const raw = "Retrying via http://thread-user:thread-pass@qbit.invalid:8080/api?apikey=thread-key shortly"
+	if _, err := svc.db.Exec(
+		`INSERT INTO issue_messages (issue_id, author_kind, author_id, body) VALUES (?, 'agent', NULL, ?)`,
+		r.IssueID, raw,
+	); err != nil {
+		t.Fatalf("seed unredacted message: %v", err)
+	}
+
+	reporterView := getIssueDetail(t, h, r.IssueID, &auth.Claims{UserID: reporterID, Role: auth.RoleUser})
+	var reporterBody string
+	for _, m := range reporterView.Thread {
+		if m.AuthorKind == "agent" {
+			reporterBody = m.Body
+		}
+	}
+	if reporterBody == "" {
+		t.Fatalf("agent message missing from reporter thread: %+v", reporterView.Thread)
+	}
+	for _, secret := range []string{"thread-user", "thread-pass", "thread-key"} {
+		if strings.Contains(reporterBody, secret) {
+			t.Fatalf("reporter thread leaked %q: %q", secret, reporterBody)
+		}
+	}
+	if !strings.Contains(reporterBody, "qbit.invalid") {
+		t.Fatalf("redaction destroyed the message instead of scrubbing it: %q", reporterBody)
+	}
+
+	adminView := getIssueDetail(t, h, r.IssueID, &auth.Claims{UserID: 9999, Role: auth.RoleAdmin})
+	adminSawRaw := false
+	for _, m := range adminView.Thread {
+		if m.Body == raw {
+			adminSawRaw = true
+		}
+	}
+	if !adminSawRaw {
+		t.Fatalf("admin view no longer carries the raw diagnostic body: %+v", adminView.Thread)
 	}
 }

--- a/server/internal/request/library.go
+++ b/server/internal/request/library.go
@@ -37,9 +37,11 @@ type LibraryTitle struct {
 	// format cannot be classified. The row and canonical ID remain in the digest
 	// so clients can map search identity, but must not offer a request for it.
 	StatusKnown bool `json:"status_known"`
-	// Cover is the owned record's relative cover path (e.g. /MediaCover/...),
-	// which loads with the API key — so an owned search result can show real art
-	// without the login-session-gated /MediaCoverProxy lookup cover.
+	// Cover is a client-reachable cover reference: the owned record's relative
+	// /MediaCover path (which the app resolves through the authenticated
+	// instance proxy), or the metadata CDN copy when the record carries only an
+	// absolute URL. An arr-origin absolute URL is never passed through —
+	// clients must not dereference arr-origin URLs.
 	Cover     string          `json:"cover"`
 	Ebook     FormatOwnership `json:"ebook"`
 	Audiobook FormatOwnership `json:"audiobook"`
@@ -95,7 +97,7 @@ func reduceLibrary(books []chaptarr.Book) BookLibraryDigest {
 		}
 		// Take the cover from the first record in the group that has one.
 		if g.title.Cover == "" {
-			g.title.Cover = coverOf(book)
+			g.title.Cover = clientReachableCover(book)
 		}
 		if g.title.ForeignBookID == "" {
 			g.title.ForeignBookID = book.ForeignBookID
@@ -132,22 +134,6 @@ func groupKey(book chaptarr.Book) string {
 		return book.ForeignBookID
 	}
 	return fmt.Sprintf("id:%d", book.ID)
-}
-
-// coverOf returns a book's cover image path, preferring the "cover" type, else
-// the first image with a URL.
-func coverOf(book chaptarr.Book) string {
-	for _, img := range book.Images {
-		if img.URL != "" && img.CoverType == "cover" {
-			return img.URL
-		}
-	}
-	for _, img := range book.Images {
-		if img.URL != "" {
-			return img.URL
-		}
-	}
-	return ""
 }
 
 // recordFormat resolves the single format a Chaptarr book record represents.

--- a/server/internal/request/library_test.go
+++ b/server/internal/request/library_test.go
@@ -225,3 +225,39 @@ func TestReduceLibraryPreservesMixedKnownAndUnknownCanonicalRows(t *testing.T) {
 		t.Fatalf("unknown row = %+v, want canonical ID with status_known=false", unknown)
 	}
 }
+
+// TestReduceLibraryCoverIsClientReachable pins the digest to the same rule as
+// the recent-books feed: the cover is the relative /MediaCover path or the
+// metadata CDN remoteUrl — an arr-origin absolute URL (internal hostname,
+// possibly credential-bearing) is never handed to a non-admin client.
+func TestReduceLibraryCoverIsClientReachable(t *testing.T) {
+	books := []chaptarr.Book{
+		{
+			ID: 1, Title: "Relative", ForeignBookID: "fb-r", MediaType: "ebook",
+			Images: []chaptarr.Image{{CoverType: "cover", URL: "/MediaCover/Books/1/cover.jpg"}},
+		},
+		{
+			ID: 2, Title: "ArrOrigin", ForeignBookID: "fb-a", MediaType: "ebook",
+			Images: []chaptarr.Image{{
+				CoverType: "cover",
+				URL:       "http://library-user:library-pass@chaptarr.internal:8787/MediaCover/2/cover.jpg?apikey=library-key",
+				RemoteURL: "https://cdn.invalid/2/cover.jpg",
+			}},
+		},
+		{
+			ID: 3, Title: "ArrOnly", ForeignBookID: "fb-o", MediaType: "ebook",
+			Images: []chaptarr.Image{{CoverType: "cover", URL: "http://chaptarr.internal:8787/MediaCover/3/cover.jpg"}},
+		},
+	}
+
+	digest := reduceLibrary(books)
+	if got := findTitle(t, digest, "Relative").Cover; got != "/MediaCover/Books/1/cover.jpg" {
+		t.Errorf("relative cover = %q, want the proxied /MediaCover path", got)
+	}
+	if got := findTitle(t, digest, "ArrOrigin").Cover; got != "https://cdn.invalid/2/cover.jpg" {
+		t.Errorf("arr-origin absolute cover = %q, want the CDN remoteUrl fallback", got)
+	}
+	if got := findTitle(t, digest, "ArrOnly").Cover; got != "" {
+		t.Errorf("arr-origin-only cover = %q, want empty so the app draws its placeholder", got)
+	}
+}


### PR DESCRIPTION
## Summary
Follow-up to #460: a three-way full-surface sweep (WebSocket/downloads, requester-facing composed payloads, MCP/assistant) of arr-origin text reaching non-admins. Everything came back clean except two gaps, both fixed here:

- **Book-library digest leaked arr-origin cover URLs to requesters.** `GET /api/requests/book-library` copied `chaptarr` image URLs verbatim into a non-admin payload — an absolute arr URL (internal hostname, potentially credential-bearing query) would be handed to the client to dereference, violating the "clients must never dereference arr-origin URLs" rule. The recent-books feed already had the correct guard (`clientReachableCover`); the digest now uses it instead of its own unguarded copy.
- **Issue-thread bodies had no read-time boundary for non-admins.** Reporter-visible thread text was safe only because every current writer redacts at write. `Get` now re-redacts bodies for non-admin readers — the same by-default-safe design `applyRequesterCopy` already documents for resolutions. Admin views keep raw diagnostics.

Audited clean, no change needed: WS events (IDs/enums only), downloads endpoints (admin-gated), push bodies (no arr diagnostic prose), all MCP/assistant output (single mandatory `sanitizeToolResult` choke point), auto-issue reachability (reporter_id NULL), request/error paths (host-free by construction).

## Test plan
- [x] `TestReduceLibraryCoverIsClientReachable` — fails on unfixed code (arr URL passed through), passes here
- [x] `TestGetRedactsThreadBodiesForNonAdmins` — direct-inserts an unredacted credential-bearing message, asserts reporter view scrubs it and admin view keeps it raw; fails on unfixed code
- [x] `go vet ./...` and full `go test ./...` from `server/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF