### PR TITLE
Point the README at the iPhone TestFlight beta and the Android tester email

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Your media server just learned to run itself.**
 
-**[cantinarr.com](https://cantinarr.com)** · **[Live demo](https://demo.cantinarr.com)** · **[Request a feature](https://cantinarr.com/roadmap/)**
+**[cantinarr.com](https://cantinarr.com)** · **[Live demo](https://demo.cantinarr.com)** · **[iPhone beta](https://testflight.apple.com/join/bCPDwCsD)** · **[Request a feature](https://cantinarr.com/roadmap/)**
 
 Discover and request movies, TV shows, and books. Get push notifications. Manage Radarr, Sonarr, Chaptarr, and your download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step. You set the agent's operating boundaries. Your household gets the simple experience; you keep control of access, approvals, and quality.
 
@@ -96,6 +96,21 @@ Published images stamp the web bundle with a build number that **Settings > Abou
 reports. Building the image yourself, pass your own with
 `docker build --build-arg APP_BUILD_NUMBER=<n> .`; leave it out and About falls back
 to `pubspec.yaml`'s placeholder.
+
+## Get the app
+
+The mobile apps are in beta ahead of their public store launch. Every one of these
+talks only to your own server, so stand one up first (above) -- or open the
+[live demo](https://demo.cantinarr.com) in a browser to look around.
+
+- **iPhone and iPad** -- join the public beta on
+  [TestFlight](https://testflight.apple.com/join/bCPDwCsD). No invite needed.
+- **Android** -- closed testing on Google Play, so testers are added by hand.
+  Email **windoze95@proton.me** with the address associated with your Play Store
+  (Google) account -- that exact address is what Google needs to let you in -- and
+  you'll get the opt-in link back.
+- **Any browser** -- your server already serves the full app at
+  `http://your-server:8585`. Nothing to install.
 
 ## Repository Structure
 


### PR DESCRIPTION
## What

The README never told anyone the apps exist or how to get one. A **Get the app** section now names all three routes in — the public TestFlight link for iPhone/iPad (verified live), the email to request an Android tester slot (Play testing is closed, so slots are granted by hand against the address on the tester's Google account), and the browser the server already serves the app to. The header link row gains the TestFlight link so it is reachable without scrolling.

Nothing claims a public store listing, because neither listing is live yet.

Companion change on the marketing site: windoze95/cantinarr-site#14 (App Store badge → TestFlight, Google Play badge → Android invite dialog).

## Verification

Docs-only change; no server or app code touched, so `go test`/`flutter analyze` have nothing new to prove (CI runs them anyway). The TestFlight join link was fetched and returns the live "Join the Cantinarr beta" page.

## Docs

- [x] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF