### PR TITLE
Give Android its own link next to the iPhone beta in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Your media server just learned to run itself.**
 
-**[cantinarr.com](https://cantinarr.com)** · **[Live demo](https://demo.cantinarr.com)** · **[iPhone beta](https://testflight.apple.com/join/bCPDwCsD)** · **[Request a feature](https://cantinarr.com/roadmap/)**
+**[cantinarr.com](https://cantinarr.com)** · **[Live demo](https://demo.cantinarr.com)** · **[iPhone beta](https://testflight.apple.com/join/bCPDwCsD)** · **[Android beta](https://cantinarr.com/#android-beta)** · **[Request a feature](https://cantinarr.com/roadmap/)**
 
 Discover and request movies, TV shows, and books. Get push notifications. Manage Radarr, Sonarr, Chaptarr, and your download clients. When downloads get stuck, Cantinarr diagnoses the cause and recommends the next step. You set the agent's operating boundaries. Your household gets the simple experience; you keep control of access, approvals, and quality.
 
@@ -105,10 +105,10 @@ talks only to your own server, so stand one up first (above) -- or open the
 
 - **iPhone and iPad** -- join the public beta on
   [TestFlight](https://testflight.apple.com/join/bCPDwCsD). No invite needed.
-- **Android** -- closed testing on Google Play, so testers are added by hand.
-  Email **windoze95@proton.me** with the address associated with your Play Store
-  (Google) account -- that exact address is what Google needs to let you in -- and
-  you'll get the opt-in link back.
+- **Android** -- [ask for a tester slot](https://cantinarr.com/#android-beta). Play
+  testing is closed, so testers are added by hand: email **windoze95@proton.me**
+  with the address associated with your Play Store (Google) account -- that exact
+  address is what Google needs to let you in -- and you'll get the opt-in link back.
 - **Any browser** -- your server already serves the full app at
   `http://your-server:8585`. Nothing to install.
 


### PR DESCRIPTION
## What

Android read as the afterthought: iOS got a link, Android got a paragraph telling people to go find a button. Both now sit side by side in the header row, and the Android link lands on [`cantinarr.com/#android-beta`](https://cantinarr.com/#android-beta) — which opens the invite dialog on arrival, so the reader sees the Google Play badge and the address to write to without hunting for either. The **Get the app** bullet leads with the same link.

Site side, already merged and deployed: windoze95/cantinarr-site#15 adds the `/#android-beta` deep link (and drops the fragment on close so a reload doesn't reopen it).

## Verification

Docs-only change. The deep link was exercised on the live site after that deploy: `https://cantinarr.com/#android-beta` opens the dialog on landing, with the address readable in the link and in the copy button.

## Docs

- [x] `README.md` — pitch, feature list, configuration/env vars, quick start
- [ ] `server/README.md` — routes, MCP tools, DB tables, env vars, package tree
- [ ] `app/README.md` — screens/features, navigation, project structure
- [ ] `AGENTS.md` — workflow, verification, or convention changes
- [ ] No docs impact — explained above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF