### PR TITLE
Add an Unraid Community Applications template

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,11 @@ Docs are part of the change, not a follow-up. A feature is not merged-complete u
 | `app/README.md` | App features/screens, navigation map, project structure, key dependencies |
 | `docs/books-setup.md` | End-to-end book automation setup: Chaptarr instance, per-user access grant (no global default), instant updates, download path mappings |
 | `docs/store-release.md` | Store release pipeline: how builds reach TestFlight/Play, signing secrets, one-time store-console setup |
+| `templates/cantinarr.xml` + `ca_profile.xml` | Unraid Community Applications listing: published port, appdata path, the deployment env vars an admin is offered, and the listing copy |
 | `AGENTS.md` | Workflows, verification, conventions (this file) |
 
 - When a change touches a documented surface (new route, tool, env var, table, screen, workflow), update the owning doc **in the same PR**. The PR template's docs checklist is there to force the question.
 - Numbers drift fastest: tool counts, route lists, env-var tables, version floors (Go, Flutter/Dart). If you add one, update the count everywhere it appears (`grep -ri` for the old number).
 - Docs describe shipped reality — never "planned", "upcoming", or aspirational behavior.
+- **The Unraid template is a deployment surface, not a doc that can lag.** A stale template hands admins a container that is wrong on first boot, and Community Applications re-reads it from `main` on its own schedule — there is no release to gate it. Changing the exposed port, the `/config` contract, or any env var an admin is expected to set means editing `templates/cantinarr.xml` in the same PR. `TemplateURL` must keep pointing at that file's own raw URL on `main`.
 - `CLAUDE.md` must remain a thin import of this file so every agent reads one playbook. If you change workflows here, check `CLAUDE.md` still just imports and points.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ checkout instead, layer the dev override:
 
 Open `http://your-server:8585` -- the setup wizard walks you through creating an admin account. Discovery and search work immediately on the built-in TMDB key. Then connect your services (Radarr, Sonarr, etc.) from **Settings > Providers & Credentials** and **Settings > Add Instance** in the admin UI. Configure an included AI provider there (fresh installs preselect OpenAI OAuth with the fast GPT-5.6 Luna model -- connecting a ChatGPT account is all it takes) and grant it per user, or let each person bring a provider under **Settings > AI Access**.
 
+### Unraid
+
+The Community Applications template ships in this repo at
+[`templates/cantinarr.xml`](templates/cantinarr.xml). Cantinarr is not in the Apps
+tab, and Unraid removed custom template repositories, so add the file to the
+user-template folder yourself:
+
+```bash
+curl -o /boot/config/plugins/dockerMan/templates-user/my-cantinarr.xml \
+  https://raw.githubusercontent.com/windoze95/cantinarr/main/templates/cantinarr.xml
+```
+
+Then **Docker > Add Container**, pick `Cantinarr` from the Template dropdown, and
+Apply. It publishes port 8585 and keeps the database and encryption key in
+`/mnt/user/appdata/cantinarr`. Two advanced fields are worth opening: **Public
+URL**, the origin your arrs POST webhooks back to, and the read-only **Media
+library** mount plus **Media roots**, which together turn on completed-media
+downloads.
+
 ### From Source
 
 ```bash
@@ -136,6 +155,8 @@ cantinarr/
 │
 ├── Dockerfile              # Multi-stage build (Flutter web + Go)
 ├── docker-compose.yml      # Full-stack deployment (push env pre-wired)
+├── templates/              # Unraid Community Applications app template
+├── ca_profile.xml          # Community Applications repository profile
 ├── AGENTS.md               # Contributor/agent operating manual (CLAUDE.md imports it)
 └── README.md               # This file
 ```

--- a/ca_profile.xml
+++ b/ca_profile.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<CommunityApplications>
+  <Profile>This is the source repository for **Cantinarr**, a self-hosted request and media-management front end for Radarr, Sonarr, and Chaptarr. It publishes one Docker application: `Cantinarr`, the single-container server that also serves the web app.
+
+The template here is maintained alongside the code, so its ports, paths, and variables track the shipping image rather than drifting behind it.
+
+Support: open an issue on the [issue tracker](https://github.com/windoze95/cantinarr/issues). Feature requests go to [cantinarr.com/roadmap](https://cantinarr.com/roadmap/), no account needed.</Profile>
+  <Icon>https://raw.githubusercontent.com/windoze95/cantinarr/main/app/web/icons/Icon-512.png</Icon>
+  <WebPage>https://cantinarr.com</WebPage>
+  <DonateLink>https://github.com/sponsors/windoze95</DonateLink>
+  <DonateText>Support Cantinarr development</DonateText>
+</CommunityApplications>

--- a/templates/cantinarr.xml
+++ b/templates/cantinarr.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>Cantinarr</Name>
+  <Repository>ghcr.io/windoze95/cantinarr:latest</Repository>
+  <Registry>https://ghcr.io/windoze95/cantinarr</Registry>
+  <Network>bridge</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Icon>https://raw.githubusercontent.com/windoze95/cantinarr/main/app/web/icons/Icon-512.png</Icon>
+  <WebUI>http://[IP]:[PORT:8585]/</WebUI>
+  <Overview>Cantinarr is a self-hosted request and media-management front end for Radarr, Sonarr, and Chaptarr. Your household browses movies, TV, and books, taps request, and Cantinarr does the rest -- nobody but you ever sees an API key, a TVDB ID, or a quality profile. You keep approvals, per-user access, and quality control.
+
+Discovery and search work the moment the container starts, on a built-in TMDB key with no signup. Availability is computed live from your arrs instead of a stored snapshot that drifts, and Cantinarr installs its own authenticated webhooks when you add an instance, so manual imports, deletes, and adds show up the moment they happen.
+
+When a download gets stuck, the Import Doctor says why in plain English -- sample file, un-extracted archive, not an upgrade, stalled torrent, remote path mapping, permissions -- and offers one-click fixes. An optional AI agent watches for problems, gives your services time to recover on their own, and then proposes a fix for your approval within boundaries you set. Bring your own Anthropic, OpenAI, Gemini, or xAI Grok key, or link a ChatGPT or SuperGrok subscription with a one-time browser code.
+
+Also included: live SABnzbd, qBittorrent, NZBGet, and Transmission queue control with a master pause; deep Radarr/Sonarr drill-down from series to season to episode; Tautulli activity and history; one-tap Plex invites; push notifications to the iOS and Android apps; passwordless and passkey login; and a Model Context Protocol endpoint so external AI clients can drive it.
+
+One container, one port, no database to run. Open the WebUI after install and a setup wizard creates your admin account -- then add your services from Settings. The same server also serves the full web app, so there is nothing to install on a browser.</Overview>
+  <Support>https://github.com/windoze95/cantinarr/issues</Support>
+  <Project>https://github.com/windoze95/cantinarr</Project>
+  <TemplateURL>https://raw.githubusercontent.com/windoze95/cantinarr/main/templates/cantinarr.xml</TemplateURL>
+  <ReadMe>https://raw.githubusercontent.com/windoze95/cantinarr/main/README.md</ReadMe>
+  <Category>MediaApp:Video MediaApp:Books Tools:Utilities</Category>
+  <ExtraSearchTerms>radarr sonarr chaptarr readarr requests request manager overseerr jellyseerr ombi petio movies tv books ebooks audiobooks plex tmdb trakt ai mcp</ExtraSearchTerms>
+  <Requires>Nothing beyond this container. Radarr, Sonarr, Chaptarr, download clients, Tautulli, and Plex are all optional and are added from the admin UI after first run.</Requires>
+  <Changes>### 2026-08-16
+- First Community Applications release.</Changes>
+  <Date>2026-08-16</Date>
+  <MinVer>6.1</MinVer>
+  <License>AGPLv3</License>
+  <DonateLink>https://github.com/sponsors/windoze95</DonateLink>
+  <DonateText>Support Cantinarr development</DonateText>
+  <Screenshot>https://raw.githubusercontent.com/windoze95/cantinarr/main/app/android/fastlane/metadata/android/en-US/images/tenInchScreenshots/01_discover.png</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/windoze95/cantinarr/main/app/android/fastlane/metadata/android/en-US/images/tenInchScreenshots/04_movie_detail.png</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/windoze95/cantinarr/main/app/android/fastlane/metadata/android/en-US/images/tenInchScreenshots/02_seasons.png</Screenshot>
+  <Screenshot>https://raw.githubusercontent.com/windoze95/cantinarr/main/app/android/fastlane/metadata/android/en-US/images/tenInchScreenshots/06_downloads.png</Screenshot>
+
+  <Config Name="WebUI" Target="8585" Default="8585" Mode="tcp" Description="Port for the Cantinarr web app and API. The container always listens on 8585; change only the host side if something else already uses it." Type="Port" Display="always" Required="true" Mask="false">8585</Config>
+  <Config Name="Appdata" Target="/config" Default="/mnt/user/appdata/cantinarr" Mode="rw" Description="Cantinarr's database and its generated encryption key. Instance API keys, download-client passwords, and AI credentials are AES-256-GCM encrypted with that key, so back up this folder and keep it out of public shares." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/cantinarr</Config>
+  <Config Name="Push gateway URL" Target="CANTINARR_PUSH_GATEWAY_URL" Default="https://push.julian.codes" Description="Enables push notifications to the iOS and Android apps. Leave it set and the server enrolls itself on first start and stores its own key in the appdata volume -- no signup, no account. Clear the field to disable push entirely, or point it at your own gateway." Type="Variable" Display="always" Required="false" Mask="false">https://push.julian.codes</Config>
+  <Config Name="Public URL" Target="CANTINARR_PUBLIC_URL" Default="" Description="Origin your Radarr, Sonarr, and Chaptarr containers POST webhooks back to, so it has to be reachable from those containers -- for example http://192.168.1.10:8585 or, on a shared Docker network, http://cantinarr:8585 . Leave blank to use whatever address you browse to. Set it explicitly behind a reverse proxy, because forwarded headers are deliberately ignored." Type="Variable" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="Media library (optional, read-only)" Target="/media" Default="" Mode="ro" Description="Only needed if you want signed-in users to download completed files (ebooks, audiobooks, movies, episodes) from your library. Map the share holding that library here, then set Media roots below to /media. Leave blank to keep file downloads off." Type="Path" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="Media roots" Target="CANTINARR_MEDIA_ROOTS" Default="" Description="Comma-separated container paths that completed-media downloads may serve from. Empty keeps downloads disabled. After mapping the read-only library above, set this to /media -- then map each arr-reported path to a folder beneath it in that instance's settings. A bare / is refused." Type="Variable" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="MCP OAuth issuer" Target="CANTINARR_OAUTH_ISSUER" Default="" Description="Only needed if you expose Cantinarr's Model Context Protocol endpoint to external AI clients through a reverse proxy. Set it to the canonical external HTTPS origin, for example https://cantinarr.example.com , and keep it stable -- changing it makes existing MCP clients reconnect." Type="Variable" Display="advanced" Required="false" Mask="false"></Config>
+</Container>


### PR DESCRIPTION
Adds the two files the [Community Apps submission flow](https://ca.unraid.net/submit) scans, in the layout Unraid's [starter repo](https://github.com/unraid/unraid-community-apps-starter) prescribes:

- `ca_profile.xml` at the root — repository profile, icon, homepage, sponsor link.
- `templates/cantinarr.xml` — the app template (`<Container version="2">`).

## What the template offers an admin

| Field | Visibility | Notes |
|---|---|---|
| WebUI port 8585 | always | Container side is fixed; the image listens on 8585 |
| `/config` → `/mnt/user/appdata/cantinarr` | always | DB + the generated encryption key, so the description says to back it up |
| `CANTINARR_PUSH_GATEWAY_URL` | always | Pre-filled with the same default `docker-compose.yml` ships, so push works out of the box — visible rather than advanced so clearing it (disabling push) is one field, not a hunt |
| `CANTINARR_PUBLIC_URL` | advanced | The origin the arrs POST webhooks back to |
| `/media` read-only mount + `CANTINARR_MEDIA_ROOTS` | advanced | The two layers that turn on completed-media downloads; both blank by default, which keeps downloads off |
| `CANTINARR_OAUTH_ISSUER` | advanced | Only needed when `/mcp` is exposed through a reverse proxy |

No PUID/PGID: the final image is a static Go binary on Alpine that reads neither, so offering them would be a lie in the UI. `<Shell>sh</Shell>` for the same reason — Alpine has no bash, and `bash` would break the console button.

## Why it lives in this repo

274 of the 4,123 templates in the current CA feed are hosted in their own project repo, so this is a well-worn path — and it is the one that does not drift. Community Applications re-reads `main` on its own schedule; there is no release to gate a stale template, and a wrong port or `/config` contract is wrong on an admin's first boot. `AGENTS.md` now names the template as a same-PR surface for exactly that reason, and the docs table gives it an owner.

## Verification

- Both files parse as XML.
- Every raw URL the template references (icon, README, four screenshots, `TemplateURL`) resolves to a path tracked in this repo, so they go live with the merge.
- `ghcr.io/windoze95/cantinarr:latest` confirmed anonymously pullable — CA requires a public image.
- No `server/` or `app/` code changed, so the Go and Flutter suites have nothing to prove here; CI runs them anyway.

Submission at ca.unraid.net/submit needs an Unraid account and is a separate manual step once this is on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF