### PR TITLE
Point Unraid install at the Apps tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ Open `http://your-server:8585` -- the setup wizard walks you through creating an
 
 ### Unraid
 
-The Community Applications template lives in
-[`windoze95/cantinarr-unraid`](https://github.com/windoze95/cantinarr-unraid).
-Cantinarr is not in the Apps tab, and Unraid removed custom template
-repositories, so add the file to the user-template folder yourself:
+Search **Cantinarr** in the **Apps** tab. The listing was approved on 2026-08-16
+and appears once the next Community Applications build publishes; its template
+lives in [`windoze95/cantinarr-unraid`](https://github.com/windoze95/cantinarr-unraid).
+
+If it is not there yet, add the file to Unraid's user-template folder yourself,
+since Unraid removed custom template repositories:
 
 ```bash
 curl -o /boot/config/plugins/dockerMan/templates-user/my-cantinarr.xml \


### PR DESCRIPTION
The Community Applications listing was submitted and auto-approved on 2026-08-16 (auto-approval applies to non-duplicated Docker apps, so it skipped the moderator queue). It appears in the Apps tab once the next CA build publishes.

Reworded so the section is true both before and after that build lands: search the Apps tab first, with the manual user-template path as the fallback rather than the only route.

No `server/` or `app/` code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF