### PR TITLE
Stop the sidebar instance chip from wrapping module names

### DIFF
--- a/app/lib/features/shell/ui/app_shell.dart
+++ b/app/lib/features/shell/ui/app_shell.dart
@@ -1334,6 +1334,8 @@ class _DrawerItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final trailingWidget =
+        badgeCount > 0 ? _CountPill(count: badgeCount) : trailing;
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 2),
       child: AnimatedContainer(
@@ -1383,17 +1385,46 @@ class _DrawerItem extends StatelessWidget {
                   color: selected ? AppTheme.accent : AppTheme.textSecondary,
                 ),
               ),
-              title: Text(
-                title,
-                style: TextStyle(
-                  color:
-                      selected ? AppTheme.textPrimary : AppTheme.textSecondary,
-                  fontWeight: selected ? FontWeight.w700 : FontWeight.w500,
-                  letterSpacing: selected ? 0.05 : 0,
-                ),
+              // The trailing widget rides inside the title row rather than in
+              // ListTile's own trailing slot. ListTile measures trailing first
+              // and hands the title whatever is left, so a 128px instance chip
+              // left "Chaptarr" 31px of the sidebar's 167px title slot and it
+              // wrapped mid-word to "Chapta / rr". Splitting the slot by flex
+              // instead guarantees the module name enough room for the longest
+              // label that can carry a chip, and makes the user-supplied
+              // instance name the side that ellipsizes. Both children are
+              // flexible, so no width can overflow this row.
+              title: Row(
+                children: [
+                  Flexible(
+                    flex: 3,
+                    child: Text(
+                      title,
+                      maxLines: 1,
+                      softWrap: false,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        color: selected
+                            ? AppTheme.textPrimary
+                            : AppTheme.textSecondary,
+                        fontWeight:
+                            selected ? FontWeight.w700 : FontWeight.w500,
+                        letterSpacing: selected ? 0.05 : 0,
+                      ),
+                    ),
+                  ),
+                  if (trailingWidget != null) ...[
+                    const SizedBox(width: 8),
+                    Expanded(
+                      flex: 2,
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: trailingWidget,
+                      ),
+                    ),
+                  ],
+                ],
               ),
-              trailing:
-                  badgeCount > 0 ? _CountPill(count: badgeCount) : trailing,
               selected: selected,
               selectedTileColor: Colors.transparent,
               shape: RoundedRectangleBorder(

--- a/app/test/shell/app_shell_test.dart
+++ b/app/test/shell/app_shell_test.dart
@@ -530,6 +530,76 @@ void main() {
     expect(find.text('Radarr library'), findsOneWidget);
   });
 
+  // A long instance name once squeezed the module label until "Chaptarr"
+  // wrapped mid-word to "Chapta / rr" in the desktop sidebar. The chip is the
+  // side that gives way now, so the module name stays whole on one line.
+  testWidgets('a long instance name never truncates the module label',
+      (tester) async {
+    tester.view.physicalSize = const Size(1400, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final container = ProviderContainer(
+      overrides: [
+        authProvider.overrideWith(
+          () => _FakeAuthNotifier(_longInstanceNameState()),
+        ),
+        backendClientProvider.overrideWithValue(_fakeDio()),
+        realtimeEventsProvider.overrideWithValue(const Stream<WsEvent>.empty()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final router = GoRouter(
+      initialLocation: '/dashboard/movies',
+      routes: [
+        ShellRoute(
+          builder: (context, state, child) =>
+              AppShell(currentPath: state.uri.path, child: child),
+          routes: [
+            GoRoute(
+              path: '/dashboard/movies',
+              builder: (_, __) => const Scaffold(body: Text('Dashboard home')),
+            ),
+          ],
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // "Settings" carries no instance chip, so its height is the one-line
+    // reference. The original defect made this label twice as tall.
+    expect(
+      tester.getSize(find.text('Radarr')).height,
+      tester.getSize(find.text('Settings')).height,
+      reason: 'the module name must stay on a single line',
+    );
+
+    // Absolute widths are not assertable here: the test font is a fixed-width
+    // placeholder that renders every label far wider than Roboto does. What
+    // must hold in any font is the priority -- the module name is the
+    // navigation target and outranks a user-supplied instance name, so it is
+    // the chip that gives way when the 280px sidebar runs out of room.
+    final labelWidth = tester.getSize(find.text('Radarr')).width;
+    final chipWidth =
+        tester.getSize(find.byTooltip('Choose Radarr instance')).width;
+    expect(
+      labelWidth,
+      greaterThan(chipWidth),
+      reason: 'the instance chip must not out-size the module name',
+    );
+  });
+
   testWidgets('admin drawer keeps all attention entries visible by default',
       (tester) async {
     await _pumpAdminDrawer(tester);
@@ -777,6 +847,32 @@ AuthState _multiRadarrState({required bool isAdmin}) {
       username: isAdmin ? 'admin' : 'viewer',
       role: isAdmin ? 'admin' : 'user',
     ),
+  );
+}
+
+/// Two instances (so the selector chip renders) where the active one carries a
+/// name long enough to compete with the module label for the sidebar's width.
+AuthState _longInstanceNameState() {
+  return const AuthState(
+    connection: BackendConnection(
+      serverUrl: 'http://localhost',
+      accessToken: 'access',
+      refreshToken: 'refresh',
+      instances: [
+        ServiceInstance(
+          id: 'radarr-main',
+          serviceType: 'radarr',
+          name: 'A Very Long Radarr Library Name',
+          isDefault: true,
+        ),
+        ServiceInstance(
+          id: 'radarr-4k',
+          serviceType: 'radarr',
+          name: '4K Radarr',
+        ),
+      ],
+    ),
+    user: UserProfile(id: 1, username: 'admin', role: 'admin'),
   );
 }
 


### PR DESCRIPTION
`Chaptarr` rendered as `Chapta / rr` in the desktop sidebar whenever its instance chip carried a long name. Spotted while shooting screenshots for the Unraid listing.

## Cause

`ListTile` measures its trailing slot first and gives the title whatever is left. Measured in a widget test, the sidebar's title slot is **167px**, and `_InstanceSelector` is capped at **128px** — so the module label was left **31px** and wrapped mid-word.

Radarr and Sonarr escaped it only because a chip renders solely when a module has more than one instance (`selectorInstances.length > 1`), so those rows had the full slot to themselves.

## Fix

The trailing widget now rides inside the title `Row`, which splits the slot 3:2 between label and chip. That gives the module name room for the longest label that can carry a chip, and makes the user-supplied instance name the side that ellipsizes. The module name is the navigation target and its vocabulary is fixed and short; an instance name is arbitrary, so it is the part that should give way.

Both children are flexible, so no instance name can overflow the row at any width. `spaceBetween`-style right alignment is preserved via the `Expanded` + `Align`, matching where `ListTile`'s trailing slot used to put it.

## About the test

It asserts the *priority*, not absolute widths. `flutter test` renders a fixed-width placeholder font where `Radarr` measures 96px against roughly 55px in Roboto, so any "does it fit" assertion would encode the test font rather than the real one. What is font-independent is that the label outranks the chip, plus the label staying on one line — measured against a chipless row's height, which is the defect itself.

## Verification

- `flutter analyze --no-fatal-infos` — no issues found
- `flutter test` — 1103 passed (1102 before, plus the new regression test)
- The existing shell-chrome golden is unchanged: its scenario has no instance chip, so the layout is identical.

Not yet visible on a running server — this ships with the next `latest` image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF