### PR TITLE
Keep the Coming Soon row to movies not yet released

### DIFF
--- a/server/internal/discover/handler.go
+++ b/server/internal/discover/handler.go
@@ -164,11 +164,25 @@ func (h *Handler) TopRatedMovies(w http.ResponseWriter, r *http.Request) {
 	h.cachedTMDBFeed(w, key, ttlTrending, "/movie/top_rated", params)
 }
 
+// UpcomingMovies backs the Coming Soon row. TMDB's /movie/upcoming matches any
+// country's theatrical window, so a title already streaming here — or a 1994
+// re-release — still counts as "upcoming" somewhere and lands in the row.
+// Discovering on the primary release date instead keeps the row to movies not
+// released anywhere yet, and the three-month cap leaves far-future titles to
+// the Most Anticipated row.
 func (h *Handler) UpcomingMovies(w http.ResponseWriter, r *http.Request) {
 	page := queryInt(r, "page", 1)
-	key := fmt.Sprintf("upcoming:%d", page)
-	params := url.Values{"page": {strconv.Itoa(page)}}
-	h.cachedTMDBFeed(w, key, ttlTrending, "/movie/upcoming", params)
+	now := time.Now()
+	from := now.Format("2006-01-02")
+	to := now.AddDate(0, 3, 0).Format("2006-01-02")
+	key := fmt.Sprintf("upcoming:%s:%d", from, page)
+	params := url.Values{
+		"page":                     {strconv.Itoa(page)},
+		"sort_by":                  {"popularity.desc"},
+		"primary_release_date.gte": {from},
+		"primary_release_date.lte": {to},
+	}
+	h.cachedTMDBFeed(w, key, ttlTrending, "/discover/movie", params)
 }
 
 func (h *Handler) NowPlayingMovies(w http.ResponseWriter, r *http.Request) {

--- a/server/internal/discover/handler_test.go
+++ b/server/internal/discover/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -172,6 +173,7 @@ func newEnv(t *testing.T, configured bool) *env {
 	router := chi.NewRouter()
 	router.Get("/discover/trending", handler.Trending)
 	router.Get("/discover/movies", handler.DiscoverMovies)
+	router.Get("/discover/movies/upcoming", handler.UpcomingMovies)
 	router.Get("/discover/tv", handler.DiscoverTV)
 	router.Get("/discover/tv/popular", handler.PopularTV)
 	router.Get("/discover/tv/featured", handler.FeaturedTV)
@@ -424,6 +426,44 @@ func TestUnconfiguredCredentialsReturn503(t *testing.T) {
 	}
 	if e.upstream.hitCount() != 0 {
 		t.Fatalf("upstream hits = %d, want 0 without credentials", e.upstream.hitCount())
+	}
+}
+
+// TestUpcomingMoviesQueriesFutureWindow pins the Coming Soon contract: the row
+// is a discover query on the primary release date from today through three
+// months out, never TMDB's /movie/upcoming — whose any-country theatrical
+// matching kept surfacing movies already out (and decades-old re-releases).
+func TestUpcomingMoviesQueriesFutureWindow(t *testing.T) {
+	e := newEnv(t, true)
+
+	// Capture the window on both sides of the request so a midnight rollover
+	// mid-test cannot flake the date assertions.
+	windowAt := func(now time.Time) [2]string {
+		return [2]string{now.Format("2006-01-02"), now.AddDate(0, 3, 0).Format("2006-01-02")}
+	}
+	before := windowAt(time.Now())
+	e.doOK(t, "/discover/movies/upcoming?page=3")
+	after := windowAt(time.Now())
+
+	hit := e.upstream.hit(t, 0)
+	if hit.path != "/3/discover/movie" {
+		t.Errorf("upstream path = %s, want /3/discover/movie", hit.path)
+	}
+	if got := hit.query.Get("page"); got != "3" {
+		t.Errorf("upstream page = %q, want 3", got)
+	}
+	if got := hit.query.Get("sort_by"); got != "popularity.desc" {
+		t.Errorf("upstream sort_by = %q, want popularity.desc", got)
+	}
+	window := [2]string{hit.query.Get("primary_release_date.gte"), hit.query.Get("primary_release_date.lte")}
+	if window != before && window != after {
+		t.Errorf("upstream release window = %v, want %v (today through three months out)", window, before)
+	}
+
+	// Repeats within the TTL are cache hits.
+	e.doOK(t, "/discover/movies/upcoming?page=3")
+	if e.upstream.hitCount() != 1 {
+		t.Errorf("upstream hits after repeat = %d, want 1 (served from cache)", e.upstream.hitCount())
 	}
 }
 


### PR DESCRIPTION
## Why

The Coming Soon row was full of movies already out and available — the live feed even included The Shawshank Redemption (1994) and Harry Potter and the Philosopher's Stone (2001).

The row proxied TMDB's `/movie/upcoming`, which matches **any country's** theatrical release window (release types 2|3). A movie streaming here for months still counts as "upcoming" if any country has a theatrical date in the next ~3 weeks, and re-releases of old classics qualify too. Pinning a `region` doesn't fix it either — `region=US` still returned Cars, Akira, and The Nutty Professor via re-releases.

## What

`UpcomingMovies` now queries `/discover/movie` with `primary_release_date.gte=today`, `primary_release_date.lte=today+3 months`, sorted by popularity:

- Nothing already released anywhere can appear — the primary (first-anywhere) release date must be in the future.
- The 3-month cap keeps far-future titles (Avengers: Doomsday, 2028 placeholders) in the Most Anticipated row where they belong, instead of duplicating it.
- The cache key includes the day so the window rolls at midnight.

No API surface change: same route, same TMDB page shape, so both consumers (Movies tab row, Discover screen) are fixed by the one handler. Unreleased movies mostly have zero votes, and the poster card already hides the rating badge at 0, so the row renders cleanly.

Verified live against TMDB: the new query returns Coyote vs. Acme, Insidious: Out of the Further, Fall 2: Deadpoint, Resident Evil — all genuinely unreleased — where the old one led with titles released last May/June.

## Docs

- [x] No documented surface changed — route list and response shape are untouched (`server/README.md` names the route without describing upstream mechanics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MAqNNqiVUUgAYJBjh2sVdF