### PR TITLE
Retry the GitHub Release creation past a transient API failure

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -243,8 +243,31 @@ jobs:
           # releases/latest, so the banner only ever offers stable releases.
           prerelease_flag=""
           case "$TAG" in *-*) prerelease_flag="--prerelease" ;; esac
-          gh release create "$TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --title "$TAG" \
-            --generate-notes \
-            $prerelease_flag
+          # This create is the last step of a release and the only one that needs
+          # GitHub's own API healthy at that moment — the images are already in
+          # GHCR by now. v0.2.0 burned two full runs here on a transient
+          # `HTTP 503` from POST /releases, leaving published images that no
+          # Release announced until someone re-ran the workflow by hand. Retry
+          # across that kind of blip, re-checking existence each round so a
+          # create that landed behind a failed response is recognized instead of
+          # retried into an "already exists" error.
+          for attempt in $(seq 1 6); do
+            if gh release create "$TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TAG" \
+              --generate-notes \
+              $prerelease_flag; then
+              exit 0
+            fi
+            if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+              echo "Release $TAG exists after attempt ${attempt}; treating as created."
+              exit 0
+            fi
+            if [ "$attempt" -lt 6 ]; then
+              delay=$((attempt * 30))
+              echo "Release creation failed (attempt ${attempt}/6); retrying in ${delay}s."
+              sleep "$delay"
+            fi
+          done
+          echo "::error::Could not create the GitHub Release for ${TAG} after 6 attempts."
+          exit 1


### PR DESCRIPTION
## What

Cutting `v0.2.0` today published its images on the first attempt and then lost **two whole workflow runs** to `HTTP 503: No server is currently available to service your request` from `POST /repos/.../releases`. The gate passed, the build passed, GHCR had the tagged image — only the `Create GitHub Release` step kept dying, and it took a third manual re-run 8 minutes later to get through.

That gap matters more than a red check. The server's update checker and the app's update banner both read `releases/latest`, so between the image publishing and someone noticing the failed run, a shipped release was invisible to every user it was cut for.

## Change

The create is the last step of a release and the only one that still needs GitHub's own API healthy at that moment. It now gets six attempts with a widening backoff — 30s, 60s, 90s, 120s, 150s, 7.5 minutes total, which covers the window this outage actually lasted (17:06Z failing, clear by 17:15Z).

Each round re-checks whether the release exists before retrying, so a create that landed behind a failed response is recognized as done rather than retried into an `already exists` error. The pre-existing idempotency guard at the top is unchanged, as is the `--prerelease` handling for `-`-suffixed tags.

## Verification

The `release` job only runs on `refs/tags/v*`, so this PR's own checks can't exercise it. Tested the step's script locally against a stubbed `gh` instead:

| case | result |
|---|---|
| clean create, first try | exit 0, 1 create, no sleeps |
| release already exists up front | exit 0, 0 creates (guard holds) |
| 503 twice then success (the v0.2.0 case) | exit 0, 3 creates, 2 backoffs |
| create lands behind a failed response | exit 0, recognized as created |
| hard failure, all 6 attempts | exit 1 with a clear `::error::` |
| `v0.2.0-rc.1` | `--prerelease` still passed through |

`go vet`/`go test`/`flutter analyze`/`flutter test` were not run locally — nothing under `server/` or `app/` changed — but CI runs them on this PR regardless.

## Docs

No documented surface changes. `AGENTS.md` describes the Release as automatic after a green gate, which is still true; this only makes it survive a blip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVFwVD583JBGZPm3RnmGuG