### PR TITLE
Make every published image multi-arch, latest included

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,11 +17,6 @@ on:
       - "Dockerfile"
       - ".github/workflows/docker.yml"
   workflow_dispatch:
-    inputs:
-      multi-arch:
-        description: "Build for arm64 in addition to amd64"
-        type: boolean
-        default: false
 
 # Keyed on the ref rather than the SHA for pushes: back-to-back merges must not
 # race to publish `latest`, and cancelling the older run is what keeps the
@@ -83,8 +78,13 @@ jobs:
         run: |
           echo "version=$(git describe --tags --always --match 'v[0-9]*')" >> "$GITHUB_OUTPUT"
 
+      # Every published channel — `latest` on main pushes as much as version
+      # tags — is multi-arch, so arm64 deployments track the same updates as
+      # amd64 ones. Only pr-N preview images stay amd64-only: they exist to be
+      # poked at during review, and the emulated arm64 build would slow every
+      # PR for an image nobody pulls on ARM.
       - name: Set up QEMU
-        if: startsWith(github.ref, 'refs/tags/v') || inputs.multi-arch
+        if: github.event_name != 'pull_request'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -152,7 +152,7 @@ jobs:
           grep -q '"build_number":"${{ steps.app_build.outputs.number }}"' /tmp/version.json
 
       - name: Build arm64 published image for smoke test
-        if: startsWith(github.ref, 'refs/tags/v') || inputs.multi-arch
+        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -167,7 +167,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=published
 
       - name: Verify arm64 Codex runtime and notices
-        if: startsWith(github.ref, 'refs/tags/v') || inputs.multi-arch
+        if: github.event_name != 'pull_request'
         run: |
           docker run --rm --platform linux/arm64 cantinarr-root-arm64-smoke:${{ github.sha }} sh -ec '
             test -x /usr/local/bin/codex-app-server
@@ -209,7 +209,7 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
             APP_BUILD_NUMBER=${{ steps.app_build.outputs.number }}
-          platforms: ${{ (startsWith(github.ref, 'refs/tags/v') || inputs.multi-arch) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## What

`latest` was amd64-only (multi-arch existed only on version tags), so catalog entries that point at `latest` — the Unraid CA template today, the Portainer template about to — left arm64 deployments a release behind while amd64 rode every merge.

- arm64 is now built, smoke-tested (Codex runtime + notices, same as amd64), and published on every push to `main` and on tags — every channel a user can consume is multi-arch.
- pr-N preview images deliberately stay amd64-only: they exist to be poked at during review, and the emulated arm64 build would slow every PR for an image nobody pulls on ARM.
- The `workflow_dispatch` `multi-arch` input is removed as obsolete — every publishing run is multi-arch now.

Manual test catalog note: `REL-007` already expected `latest` to verify on clean arm64 hosts; this makes that true rather than aspirational. No doc claims the old amd64-only behavior, so no doc edits.

## Cost

Main-push builds pay the QEMU arm64 build (~the same work tag builds already do, sharing the same `scope=published` GHA cache). PR latency is unchanged.

## Tests

Workflow-only change. The PR's own Docker check exercises the amd64 path; the first push to `main` after merge is the real proof and will publish the first multi-arch `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3sRVfL49wxQBiUTvgbewx