### PR TITLE
Fix library loading timing out for large Radarr/Sonarr/Chaptarr libraries

### DIFF
--- a/app/lib/core/network/long_request_options.dart
+++ b/app/lib/core/network/long_request_options.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+
+/// Per-request [Options] for backend-proxied calls whose response can take a
+/// long time to START arriving: the server buffers and sanitizes the arr's
+/// entire response before the first byte reaches the app.
+///
+/// Native: `receiveTimeout` bounds time-to-headers plus body-read inactivity,
+/// so raising it alone suffices; `connectTimeout` (socket connect only) stays
+/// null to inherit the base default so an unreachable server still fails
+/// fast. Web (XHR): time-to-first-headers is bounded by `connectTimeout` — a
+/// GET with only a raised `receiveTimeout` still aborts at the base default
+/// with connectionTimeout — so it must be raised alongside. [isWeb] exists
+/// only so VM tests can exercise the web branch.
+Options longRequestOptions({
+  Duration timeout = const Duration(seconds: 120),
+  bool isWeb = kIsWeb,
+}) =>
+    Options(receiveTimeout: timeout, connectTimeout: isWeb ? timeout : null);

--- a/app/lib/features/chaptarr/data/chaptarr_api_service.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_api_service.dart
@@ -339,7 +339,7 @@ class ChaptarrApiService {
     final resp = await _dio.get(
       '$_basePath/release',
       queryParameters: {'bookId': bookId},
-      options: Options(receiveTimeout: const Duration(seconds: 120)),
+      options: longRequestOptions(),
     );
     return _releaseList(resp.data)
         .whereType<Map<String, dynamic>>()
@@ -352,7 +352,7 @@ class ChaptarrApiService {
     await _dio.post(
       '$_basePath/release',
       data: {'guid': guid, 'indexerId': indexerId},
-      options: Options(receiveTimeout: const Duration(seconds: 60)),
+      options: longRequestOptions(timeout: const Duration(seconds: 60)),
     );
   }
 
@@ -369,7 +369,7 @@ class ChaptarrApiService {
         'downloadId': downloadId,
         'filterExistingFiles': false,
       },
-      options: Options(receiveTimeout: const Duration(seconds: 60)),
+      options: longRequestOptions(timeout: const Duration(seconds: 60)),
     );
     return (resp.data as List<dynamic>)
         .map((c) =>

--- a/app/lib/features/chaptarr/data/chaptarr_api_service.dart
+++ b/app/lib/features/chaptarr/data/chaptarr_api_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
+import '../../../core/network/long_request_options.dart';
 import 'chaptarr_models.dart';
 
 /// Coerces a Dio response body into a JSON list. Chaptarr's lookup/metadata
@@ -53,8 +54,11 @@ class ChaptarrApiService {
     return ChaptarrSystemStatus.fromJson(resp.data as Map<String, dynamic>);
   }
 
+  /// Fetches the entire author library in one unpaginated response — slow for
+  /// large libraries.
   Future<List<ChaptarrAuthor>> getAuthors() async {
-    final resp = await _dio.get('$_basePath/author');
+    final resp =
+        await _dio.get('$_basePath/author', options: longRequestOptions());
     return (resp.data as List<dynamic>)
         .map((a) => ChaptarrAuthor.fromJson(a as Map<String, dynamic>))
         .toList();
@@ -74,11 +78,17 @@ class ChaptarrApiService {
   }
 
   /// Lists books, optionally narrowed to one author. Each book carries its
-  /// editions inline — drives the per-book status line.
+  /// editions inline — drives the per-book status line. A bare call returns
+  /// the entire book library in one unpaginated response — slow for large
+  /// libraries.
   Future<List<ChaptarrBook>> getBooks({int? authorId}) async {
-    final resp = await _dio.get('$_basePath/book', queryParameters: {
-      if (authorId != null) 'authorId': authorId,
-    });
+    final resp = await _dio.get(
+      '$_basePath/book',
+      queryParameters: {
+        if (authorId != null) 'authorId': authorId,
+      },
+      options: longRequestOptions(),
+    );
     return (resp.data as List<dynamic>)
         .map((b) => ChaptarrBook.fromJson(b as Map<String, dynamic>))
         .toList();

--- a/app/lib/features/radarr/data/radarr_api_service.dart
+++ b/app/lib/features/radarr/data/radarr_api_service.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import '../../../core/network/long_request_options.dart';
 import 'radarr_models.dart';
 
 /// Networking layer for Radarr, proxied through the Cantinarr backend.
@@ -18,12 +19,18 @@ class RadarrApiService {
     return RadarrSystemStatus.fromJson(resp.data as Map<String, dynamic>);
   }
 
+  /// Fetches the entire movie library in one unpaginated response — slow for
+  /// large libraries.
   Future<List<RadarrMovie>> getMovies({String? searchTerm}) async {
     final params = <String, dynamic>{};
     if (searchTerm != null && searchTerm.isNotEmpty) {
       params['searchTerm'] = searchTerm;
     }
-    final resp = await _dio.get('$_basePath/movie', queryParameters: params);
+    final resp = await _dio.get(
+      '$_basePath/movie',
+      queryParameters: params,
+      options: longRequestOptions(),
+    );
     return (resp.data as List<dynamic>)
         .map((m) => RadarrMovie.fromJson(m as Map<String, dynamic>))
         .toList();

--- a/app/lib/features/radarr/data/radarr_api_service.dart
+++ b/app/lib/features/radarr/data/radarr_api_service.dart
@@ -207,7 +207,7 @@ class RadarrApiService {
     final resp = await _dio.get(
       '$_basePath/release',
       queryParameters: {'movieId': movieId},
-      options: Options(receiveTimeout: const Duration(seconds: 120)),
+      options: longRequestOptions(),
     );
     return (resp.data as List<dynamic>)
         .map((r) => RadarrRelease.fromJson(r as Map<String, dynamic>))
@@ -226,7 +226,7 @@ class RadarrApiService {
     await _dio.post(
       '$_basePath/release',
       data: {'guid': guid, 'indexerId': indexerId},
-      options: Options(receiveTimeout: const Duration(seconds: 60)),
+      options: longRequestOptions(timeout: const Duration(seconds: 60)),
     );
   }
 
@@ -243,7 +243,7 @@ class RadarrApiService {
         'downloadId': downloadId,
         'filterExistingFiles': false,
       },
-      options: Options(receiveTimeout: const Duration(seconds: 60)),
+      options: longRequestOptions(timeout: const Duration(seconds: 60)),
     );
     return (resp.data as List<dynamic>)
         .map((c) =>

--- a/app/lib/features/sonarr/data/sonarr_api_service.dart
+++ b/app/lib/features/sonarr/data/sonarr_api_service.dart
@@ -276,7 +276,7 @@ class SonarrApiService {
     final resp = await _dio.get(
       '$_basePath/release',
       queryParameters: {'seriesId': seriesId, 'seasonNumber': seasonNumber},
-      options: Options(receiveTimeout: const Duration(seconds: 120)),
+      options: longRequestOptions(),
     );
     return (resp.data as List<dynamic>)
         .map((r) => SonarrRelease.fromJson(r as Map<String, dynamic>))
@@ -291,7 +291,7 @@ class SonarrApiService {
     await _dio.post(
       '$_basePath/release',
       data: {'guid': guid, 'indexerId': indexerId},
-      options: Options(receiveTimeout: const Duration(seconds: 60)),
+      options: longRequestOptions(timeout: const Duration(seconds: 60)),
     );
   }
 
@@ -301,7 +301,7 @@ class SonarrApiService {
     final resp = await _dio.get(
       '$_basePath/release',
       queryParameters: {'episodeId': episodeId},
-      options: Options(receiveTimeout: const Duration(seconds: 120)),
+      options: longRequestOptions(),
     );
     return (resp.data as List<dynamic>)
         .map((r) => SonarrRelease.fromJson(r as Map<String, dynamic>))
@@ -383,7 +383,7 @@ class SonarrApiService {
         'downloadId': downloadId,
         'filterExistingFiles': false,
       },
-      options: Options(receiveTimeout: const Duration(seconds: 60)),
+      options: longRequestOptions(timeout: const Duration(seconds: 60)),
     );
     return (resp.data as List<dynamic>)
         .map((c) =>

--- a/app/lib/features/sonarr/data/sonarr_api_service.dart
+++ b/app/lib/features/sonarr/data/sonarr_api_service.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import '../../../core/network/long_request_options.dart';
 import 'sonarr_models.dart';
 
 /// Networking layer for Sonarr, proxied through the Cantinarr backend.
@@ -18,8 +19,11 @@ class SonarrApiService {
     return SonarrSystemStatus.fromJson(resp.data as Map<String, dynamic>);
   }
 
+  /// Fetches the entire series library in one unpaginated response — slow for
+  /// large libraries.
   Future<List<SonarrSeries>> getSeries() async {
-    final resp = await _dio.get('$_basePath/series');
+    final resp =
+        await _dio.get('$_basePath/series', options: longRequestOptions());
     return (resp.data as List<dynamic>)
         .map((s) => SonarrSeries.fromJson(s as Map<String, dynamic>))
         .toList();

--- a/app/test/chaptarr/chaptarr_api_service_test.dart
+++ b/app/test/chaptarr/chaptarr_api_service_test.dart
@@ -110,6 +110,10 @@ void main() {
 
       expect(adapter.lastPath, '/api/instances/inst1/api/v1/release');
       expect(adapter.lastQuery['bookId'], '359');
+      // Live indexer queries take 10-60s; the long-call options keep web from
+      // aborting at the base connect timeout before the first byte arrives.
+      expect(adapter.lastRequest?.receiveTimeout, const Duration(seconds: 120));
+      expect(adapter.lastRequest?.connectTimeout, const Duration(seconds: 15));
       expect(releases, hasLength(1));
       expect(releases.first.guid,
           'https://audiobookbay.lu/abss/dark-force-rising/');

--- a/app/test/chaptarr/chaptarr_api_service_test.dart
+++ b/app/test/chaptarr/chaptarr_api_service_test.dart
@@ -14,6 +14,7 @@ class _FakeAdapter implements HttpClientAdapter {
   final dynamic responseJson;
   String? lastPath;
   Map<String, dynamic> lastQuery = {};
+  RequestOptions? lastRequest;
 
   @override
   Future<ResponseBody> fetch(
@@ -23,6 +24,7 @@ class _FakeAdapter implements HttpClientAdapter {
   ) async {
     lastPath = options.uri.path;
     lastQuery = options.uri.queryParameters;
+    lastRequest = options;
     return ResponseBody.fromString(
       jsonEncode(responseJson),
       200,
@@ -37,12 +39,43 @@ class _FakeAdapter implements HttpClientAdapter {
 }
 
 ChaptarrApiService _service(_FakeAdapter adapter) {
-  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+  final dio = Dio(BaseOptions(
+    baseUrl: 'http://localhost',
+    connectTimeout: const Duration(seconds: 15),
+    receiveTimeout: const Duration(seconds: 15),
+  ))
     ..httpClientAdapter = adapter;
   return ChaptarrApiService(backendDio: dio, instanceId: 'inst1');
 }
 
 void main() {
+  group('library fetches', () {
+    // Both endpoints return the whole library in one unpaginated response, so
+    // serve time grows with library size; the 15s default made large
+    // libraries permanently unloadable (issue #483). connectTimeout stays the
+    // base default on native: longRequestOptions passes null and
+    // Options.compose falls back to BaseOptions.
+    test('getAuthors uses the long-call receive timeout', () async {
+      final adapter = _FakeAdapter(<dynamic>[]);
+
+      await _service(adapter).getAuthors();
+
+      expect(adapter.lastPath, '/api/instances/inst1/api/v1/author');
+      expect(adapter.lastRequest?.receiveTimeout, const Duration(seconds: 120));
+      expect(adapter.lastRequest?.connectTimeout, const Duration(seconds: 15));
+    });
+
+    test('getBooks uses the long-call receive timeout', () async {
+      final adapter = _FakeAdapter(<dynamic>[]);
+
+      await _service(adapter).getBooks();
+
+      expect(adapter.lastPath, '/api/instances/inst1/api/v1/book');
+      expect(adapter.lastRequest?.receiveTimeout, const Duration(seconds: 120));
+      expect(adapter.lastRequest?.connectTimeout, const Duration(seconds: 15));
+    });
+  });
+
   group('getReleases', () {
     // The exact envelope this Chaptarr fork returns (captured from a live
     // instance): releases live under "releases", with hiddenReleases and

--- a/app/test/core/network/long_request_options_test.dart
+++ b/app/test/core/network/long_request_options_test.dart
@@ -1,0 +1,31 @@
+import 'package:cantinarr/core/network/long_request_options.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('longRequestOptions', () {
+    test('native: raises receiveTimeout only, connectTimeout inherits base',
+        () {
+      final options = longRequestOptions(isWeb: false);
+      expect(options.receiveTimeout, const Duration(seconds: 120));
+      // Null means Options.compose falls back to the base connectTimeout, so
+      // an unreachable server still fails fast on native.
+      expect(options.connectTimeout, isNull);
+    });
+
+    test('web: raises connectTimeout to match — it bounds time-to-first-'
+        'headers there', () {
+      final options = longRequestOptions(isWeb: true);
+      expect(options.receiveTimeout, const Duration(seconds: 120));
+      expect(options.connectTimeout, const Duration(seconds: 120));
+    });
+
+    test('a custom timeout flows to both web timeouts', () {
+      final options = longRequestOptions(
+        timeout: const Duration(seconds: 60),
+        isWeb: true,
+      );
+      expect(options.receiveTimeout, const Duration(seconds: 60));
+      expect(options.connectTimeout, const Duration(seconds: 60));
+    });
+  });
+}

--- a/app/test/radarr/radarr_api_service_test.dart
+++ b/app/test/radarr/radarr_api_service_test.dart
@@ -1,0 +1,66 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/features/radarr/data/radarr_api_service.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fake Dio adapter: records the composed request options and returns a
+/// canned JSON body, so tests can pin what actually goes on the wire —
+/// including per-request timeout overrides.
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(this.responseJson);
+
+  final dynamic responseJson;
+  RequestOptions? lastRequest;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastRequest = options;
+    return ResponseBody.fromString(
+      jsonEncode(responseJson),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+RadarrApiService _service(_FakeAdapter adapter) {
+  final dio = Dio(BaseOptions(
+    baseUrl: 'http://localhost',
+    connectTimeout: const Duration(seconds: 15),
+    receiveTimeout: const Duration(seconds: 15),
+  ))
+    ..httpClientAdapter = adapter;
+  return RadarrApiService(backendDio: dio, instanceId: 'inst1');
+}
+
+void main() {
+  group('getMovies', () {
+    // The whole library comes back in one unpaginated response, so serve time
+    // grows with library size; the 15s default made large libraries
+    // permanently unloadable (issue #483).
+    test('uses the long-call receive timeout, keeping the base connect timeout',
+        () async {
+      final adapter = _FakeAdapter(<dynamic>[]);
+
+      final movies = await _service(adapter).getMovies();
+
+      expect(adapter.lastRequest?.uri.path, '/api/instances/inst1/api/v3/movie');
+      expect(adapter.lastRequest?.receiveTimeout, const Duration(seconds: 120));
+      // connectTimeout stays the base default on native: longRequestOptions
+      // passes null and Options.compose falls back to BaseOptions.
+      expect(adapter.lastRequest?.connectTimeout, const Duration(seconds: 15));
+      expect(movies, isEmpty);
+    });
+  });
+}

--- a/app/test/radarr/radarr_api_service_test.dart
+++ b/app/test/radarr/radarr_api_service_test.dart
@@ -63,4 +63,20 @@ void main() {
       expect(movies, isEmpty);
     });
   });
+
+  group('getReleases', () {
+    // Live indexer queries take 10-60s; the long-call options keep web from
+    // aborting at the base connect timeout before the first byte arrives.
+    test('uses the long-call receive timeout, keeping the base connect timeout',
+        () async {
+      final adapter = _FakeAdapter(<dynamic>[]);
+
+      await _service(adapter).getReleases(1);
+
+      expect(
+          adapter.lastRequest?.uri.path, '/api/instances/inst1/api/v3/release');
+      expect(adapter.lastRequest?.receiveTimeout, const Duration(seconds: 120));
+      expect(adapter.lastRequest?.connectTimeout, const Duration(seconds: 15));
+    });
+  });
 }

--- a/app/test/sonarr/sonarr_api_service_test.dart
+++ b/app/test/sonarr/sonarr_api_service_test.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cantinarr/features/sonarr/data/sonarr_api_service.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Fake Dio adapter: records the composed request options and returns a
+/// canned JSON body, so tests can pin what actually goes on the wire —
+/// including per-request timeout overrides.
+class _FakeAdapter implements HttpClientAdapter {
+  _FakeAdapter(this.responseJson);
+
+  final dynamic responseJson;
+  RequestOptions? lastRequest;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    lastRequest = options;
+    return ResponseBody.fromString(
+      jsonEncode(responseJson),
+      200,
+      headers: {
+        'content-type': ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+SonarrApiService _service(_FakeAdapter adapter) {
+  final dio = Dio(BaseOptions(
+    baseUrl: 'http://localhost',
+    connectTimeout: const Duration(seconds: 15),
+    receiveTimeout: const Duration(seconds: 15),
+  ))
+    ..httpClientAdapter = adapter;
+  return SonarrApiService(backendDio: dio, instanceId: 'inst1');
+}
+
+void main() {
+  group('getSeries', () {
+    // The whole library comes back in one unpaginated response, so serve time
+    // grows with library size; the 15s default made large libraries
+    // permanently unloadable (issue #483).
+    test('uses the long-call receive timeout, keeping the base connect timeout',
+        () async {
+      final adapter = _FakeAdapter(<dynamic>[]);
+
+      final series = await _service(adapter).getSeries();
+
+      expect(
+          adapter.lastRequest?.uri.path, '/api/instances/inst1/api/v3/series');
+      expect(adapter.lastRequest?.receiveTimeout, const Duration(seconds: 120));
+      // connectTimeout stays the base default on native: longRequestOptions
+      // passes null and Options.compose falls back to BaseOptions.
+      expect(adapter.lastRequest?.connectTimeout, const Duration(seconds: 15));
+      expect(series, isEmpty);
+    });
+  });
+}

--- a/app/test/sonarr/sonarr_api_service_test.dart
+++ b/app/test/sonarr/sonarr_api_service_test.dart
@@ -64,4 +64,20 @@ void main() {
       expect(series, isEmpty);
     });
   });
+
+  group('getReleases', () {
+    // Live indexer queries take 10-60s; the long-call options keep web from
+    // aborting at the base connect timeout before the first byte arrives.
+    test('uses the long-call receive timeout, keeping the base connect timeout',
+        () async {
+      final adapter = _FakeAdapter(<dynamic>[]);
+
+      await _service(adapter).getReleases(seriesId: 1, seasonNumber: 1);
+
+      expect(
+          adapter.lastRequest?.uri.path, '/api/instances/inst1/api/v3/release');
+      expect(adapter.lastRequest?.receiveTimeout, const Duration(seconds: 120));
+      expect(adapter.lastRequest?.connectTimeout, const Duration(seconds: 15));
+    });
+  });
 }


### PR DESCRIPTION
Fixes #483

## Problem

The full-library fetches (Radarr `/movie`, Sonarr `/series`, Chaptarr `/author` and `/book`) inherited the app's 15s default Dio timeout. Those endpoints return the entire library in one unpaginated response, so once a library takes longer than 15s to serve, the library view can never load — every retry fails identically with `DioException [connection timeout]` while Test Connection passes.

## Why raising receiveTimeout alone wouldn't fix it

The server proxy buffers and sanitizes the arr's entire response before the first byte reaches the app (`proxy/sanitize.go` does `io.ReadAll` + re-marshal inside `ModifyResponse`), so the whole wait is time-to-first-headers. On web, dio's browser adapter polices time-to-first-headers with the **connect** timer — a GET with only a raised `receiveTimeout` still aborts at the base 15s with `connectionTimeout` (exactly the error in the issue report). On native, `receiveTimeout` bounds awaiting response headers, so it alone suffices there.

## Change

- New `longRequestOptions()` helper (`app/lib/core/network/long_request_options.dart`): raises `receiveTimeout` to 120s, and on web also raises `connectTimeout` to match. On native, `connectTimeout` stays the base 15s so an unreachable server still fails fast.
- Applied to the four full-library fetches: `getMovies`, `getSeries`, `getAuthors`, `getBooks`.
- Second commit routes the ten existing inline slow-call overrides (release search, grab, manual import) through the same helper — their receiveTimeout-only form had the same latent web failure: a 10-60s live indexer query died at the 15s base connect timeout before the first byte arrived.

120s matches the ceiling already proven end-to-end through the proxy by interactive release search. No server changes: nothing server-side bounds the proxy path below 120s.

## Tradeoff

Web only: a black-holed (firewall-dropped) server now takes up to 120s to fail on these specific calls instead of 15s. Connection-refused still errors immediately, and native keeps the 15s fast-fail everywhere.

## Adjacent limits deliberately not addressed here (follow-up issue to come)

- The server's own availability digest fetches the full library on a 30s typed client (`request/arr_library.go` → `radarr/client.go`) and fails closed for libraries this large.
- The proxy's 32 MiB sanitized-response cap (uncompressed) would still 502 truly huge libraries.

## Verification

- `flutter analyze --no-fatal-infos` — clean
- `flutter test` — 1190 tests pass, including new tests pinning the timeout overrides per service and the helper's native/web branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkpE2EaKa2sLToaMcnBRDa