### PR TITLE
Keep request availability and agent scans working for large libraries

### DIFF
--- a/server/internal/chaptarr/client.go
+++ b/server/internal/chaptarr/client.go
@@ -697,11 +697,22 @@ func (c *Client) GetBooks(authorID int) ([]Book, error) {
 	return matched, nil
 }
 
+// libraryFetchClient allows the much longer round-trips of a full-library
+// fetch, whose serve time grows with library size (matching the app's 120s
+// ceiling for the same endpoint). The normal 30s client fails closed on
+// libraries big enough to matter.
+func libraryFetchClient() *http.Client {
+	return &http.Client{
+		Timeout:       120 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
 // GetAllBooks lists every book in the Chaptarr library (all authors). Chaptarr
 // returns the same book shape as GetBooks; omitting authorId widens the scope.
 func (c *Client) GetAllBooks() ([]Book, error) {
 	var books []Book
-	if err := c.do("GET", "/api/v1/book", nil, &books); err != nil {
+	if err := c.doWith(libraryFetchClient(), "GET", "/api/v1/book", nil, &books); err != nil {
 		return nil, fmt.Errorf("chaptarr books: %w", err)
 	}
 	return books, nil

--- a/server/internal/radarr/client.go
+++ b/server/internal/radarr/client.go
@@ -844,10 +844,21 @@ func (c *Client) TriggerRssSync() error {
 	return c.triggerCommand(map[string]any{"name": "RssSync"})
 }
 
+// libraryFetchClient allows the much longer round-trips of a full-library
+// fetch, whose serve time grows with library size (matching the app's 120s
+// ceiling for the same endpoint). The normal 30s client fails closed on
+// libraries big enough to matter.
+func libraryFetchClient() *http.Client {
+	return &http.Client{
+		Timeout:       120 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
 // GetMovies lists all movies in the Radarr library.
 func (c *Client) GetMovies() ([]Movie, error) {
 	var movies []Movie
-	if err := c.do("GET", "/api/v3/movie", nil, &movies); err != nil {
+	if err := c.doWith(libraryFetchClient(), "GET", "/api/v3/movie", nil, &movies); err != nil {
 		return nil, fmt.Errorf("radarr movies: %w", err)
 	}
 	return movies, nil

--- a/server/internal/sonarr/client.go
+++ b/server/internal/sonarr/client.go
@@ -950,10 +950,21 @@ func (c *Client) TriggerRssSync() error {
 	return c.triggerCommand(map[string]any{"name": "RssSync"})
 }
 
+// libraryFetchClient allows the much longer round-trips of a full-library
+// fetch, whose serve time grows with library size (matching the app's 120s
+// ceiling for the same endpoint). The normal 30s client fails closed on
+// libraries big enough to matter.
+func libraryFetchClient() *http.Client {
+	return &http.Client{
+		Timeout:       120 * time.Second,
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse },
+	}
+}
+
 // GetAllSeries lists every series in the Sonarr library.
 func (c *Client) GetAllSeries() ([]Series, error) {
 	var series []Series
-	if err := c.do("GET", "/api/v3/series", nil, &series); err != nil {
+	if err := c.doWith(libraryFetchClient(), "GET", "/api/v3/series", nil, &series); err != nil {
 		return nil, fmt.Errorf("sonarr series list: %w", err)
 	}
 	return series, nil


### PR DESCRIPTION
Addresses the first half of #491 (the digest-timeout item). The 32 MiB sanitized-response cap remains open there for a separate design decision.

## Problem

The server's own full-library fetches ran on the arr clients' default 30s timeout:

- `radarr.GetMovies` / `sonarr.GetAllSeries` feed the request-availability digests (`request/arr_library.go`), which fail closed on error. For a library big enough to serve slowly, exactly the users #483 was about, request-availability status silently degrades, and the arr eats a wasted full-library serialization every 120s cache cycle since the failure is never cached.
- The same three methods (plus `chaptarr.GetAllBooks` behind the book digests) also back the MCP library tools and remediation agent scans, which all hit the same 30s wall.

Meanwhile the app-facing proxy path has no such bound, and #490 raised the app's own ceiling for these endpoints to 120s. This closes the asymmetry.

## Change

Route `GetMovies`, `GetAllSeries`, and `GetAllBooks` through a per-package `libraryFetchClient()` with a 120s timeout, mirroring the existing `releaseSearchClient()` precedent. Every caller keeps its fail-closed behavior for libraries that exceed even 120s. No behavior change for anything else on the default 30s client.

## Verification

- `go vet ./...` clean
- `go test ./...` all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkpE2EaKa2sLToaMcnBRDa