### PR TITLE
Let very large libraries through the proxy sanitizer

### DIFF
--- a/server/internal/proxy/handler.go
+++ b/server/internal/proxy/handler.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"io"
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -115,10 +116,16 @@ func (h *Handler) proxyRequest(w http.ResponseWriter, r *http.Request, target *u
 			remapUpstreamRedirect(resp, target, stripPrefix)
 			return sanitizeProxyTransportResponse(resp)
 		},
-		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			// ModifyResponse errors are intentionally opaque: an upstream parse
 			// error must never reflect the response body (and any embedded secret)
-			// back to the client or into the default ReverseProxy error log.
+			// back to the client or into the default ReverseProxy error log. Known
+			// sanitizer sentinels carry no upstream content, so those (and only
+			// those) are logged — a rejection like the size cap was previously
+			// indistinguishable from any other 502 (#483).
+			if reason := sanitizeFailureReason(err); reason != "" {
+				log.Printf("instance proxy: %s %s: %s", r.Method, r.URL.Path, reason)
+			}
 			sanitizeResponseHeaders(w.Header())
 			w.Header().Set("Content-Type", "application/json")
 			enforcePrivateProxyCachePolicy(w.Header())

--- a/server/internal/proxy/sanitize.go
+++ b/server/internal/proxy/sanitize.go
@@ -16,9 +16,12 @@ import (
 
 const (
 	// Keep response sanitization memory-bounded. Arr list/history responses are
-	// normally far smaller than this; an oversized JSON response is rejected
-	// rather than passed through unsanitized.
-	maxSanitizedJSONResponseSize int64 = 32 << 20
+	// normally far smaller than this, but the unpaginated full-library
+	// endpoints (/movie, /series, /author, /book) scale with library size and
+	// exceeded the previous 32 MiB bound on large real-world instances (#483).
+	// An oversized JSON response is still rejected rather than passed through
+	// unsanitized.
+	maxSanitizedJSONResponseSize int64 = 256 << 20
 	redactedValue                      = "[REDACTED]"
 	maxJSONSniffBytes                  = 4 << 10
 )
@@ -32,6 +35,28 @@ var (
 	errJSONResponseSniffFailed = errors.New("could not classify upstream response")
 	errUnsanitizableUpgrade    = errors.New("protocol upgrade cannot be sanitized")
 )
+
+// sanitizeFailureReason returns the loggable reason when err is one of the
+// sanitizer's own sentinel errors, and "" otherwise. Only sentinel text is
+// safe to log: any other proxy error may embed upstream details (hosts,
+// response fragments), which must stay out of logs just as they stay out of
+// client responses.
+func sanitizeFailureReason(err error) string {
+	for _, sentinel := range []error{
+		errEncodedJSONResponse,
+		errJSONResponseTooLarge,
+		errInvalidJSONResponse,
+		errMalformedJSONMediaType,
+		errStreamingJSONResponse,
+		errJSONResponseSniffFailed,
+		errUnsanitizableUpgrade,
+	} {
+		if errors.Is(err, sentinel) {
+			return sentinel.Error()
+		}
+	}
+	return ""
+}
 
 // sanitizeProxyResponse removes credentials that an arr (or one of its
 // integrations) embeds in an otherwise user-readable response. In particular,

--- a/server/internal/proxy/sanitize_test.go
+++ b/server/internal/proxy/sanitize_test.go
@@ -409,3 +409,17 @@ func TestArrAPIPathSuffix(t *testing.T) {
 		}
 	}
 }
+
+func TestSanitizeFailureReasonLogsOnlySentinels(t *testing.T) {
+	if got := sanitizeFailureReason(errJSONResponseTooLarge); got != errJSONResponseTooLarge.Error() {
+		t.Errorf("sentinel reason = %q; want %q", got, errJSONResponseTooLarge.Error())
+	}
+	// A transport error can embed the upstream URL; it must never become a
+	// loggable reason.
+	if got := sanitizeFailureReason(errors.New("dial tcp radarr.internal:7878: no route to host")); got != "" {
+		t.Errorf("non-sentinel reason = %q; want empty", got)
+	}
+	if got := sanitizeFailureReason(nil); got != "" {
+		t.Errorf("nil reason = %q; want empty", got)
+	}
+}


### PR DESCRIPTION
Fixes #491. Follows up #490 with the second failure layer the reporter hit while verifying it on their instance (see their test feedback on #483).

## Problem

The instance proxy buffers and sanitizes every JSON response in memory, rejecting bodies over 32 MiB with an opaque `{"error":"unsafe upstream response"}` 502. The unpaginated full-library endpoints (`/movie`, `/series`, `/author`, `/book`) scale with library size, and the #483 reporter's Radarr payload exceeds 32 MiB, so after #490 removed the client timeout their library view failed at this second layer instead.

## Change

- **Cap raised 32 MiB → 256 MiB** (`proxy/sanitize.go`). Realistic multi-thousand-title payloads land in the tens-to-low-hundreds of MB uncompressed (the proxy forces identity encoding). The security property is unchanged: an oversized body is still rejected, never passed through unsanitized, and memory stays hard-bounded.
- **Rejections are now diagnosable** (`proxy/handler.go`): the ErrorHandler logs the sanitizer's own sentinel reasons with method + arr-side path only. Anything else stays unlogged on purpose — transport errors can embed upstream hosts and response fragments, and the never-reflect design predates this change. A new test pins that only sentinels produce a loggable reason.
- The reporter's third suggestion (fail fast on declared `Content-Length`) already exists — `sanitizeProxyResponse` checks it before the `ReadAll` — which is also why their pre-#490 logs showed 502s racing the old 15s client timeout.

## Tradeoff

Sanitization JSON-parses the whole body, so peak transient memory on a request is a small multiple of the payload; raising the cap raises the worst case correspondingly. A streaming token-level sanitizer would remove the ceiling entirely and is the natural next step if real libraries ever approach 256 MiB.

## Verification

- `go vet ./...` clean, `go test ./...` all packages pass (the oversize tests derive from the constant, so they track the new cap)
- The reporter has offered to re-test against their instance; this PR's `pr-N` preview image is the artifact for that

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UkpE2EaKa2sLToaMcnBRDa