### PR TITLE
fix(ai): tool-heavy Codex chats answer from gathered data instead of failing after 15 tool calls

### DIFF
--- a/server/internal/ai/codex_chat_budget_test.go
+++ b/server/internal/ai/codex_chat_budget_test.go
@@ -1,0 +1,262 @@
+package ai
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/cantinarr-server/internal/auth"
+	"github.com/windoze95/cantinarr-server/internal/codexapp"
+	"github.com/windoze95/cantinarr-server/internal/credentials"
+	"github.com/windoze95/cantinarr-server/internal/db"
+	"github.com/windoze95/cantinarr-server/internal/mcp"
+	"github.com/windoze95/cantinarr-server/internal/secrets"
+)
+
+// TestCodexChatBudgetHelperProcess fakes an app-server whose model keeps
+// requesting tools until Cantinarr's budget refusal arrives, then answers from
+// gathered data; with --fake-flood-forever it never stops calling tools.
+// Termination is behavior-driven on purpose: this package cannot import the
+// codexapp refusal text, and if that text is ever reworded this fake fails
+// loudly through the hard backstop instead of hanging.
+func TestCodexChatBudgetHelperProcess(t *testing.T) {
+	if !slices.Contains(os.Args, "--codex-chat-budget-fake") {
+		return
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	send := func(value any) {
+		if err := encoder.Encode(value); err != nil {
+			t.Fatalf("encode fake response: %v", err)
+		}
+	}
+	toolCall := func(n int) map[string]any {
+		return map[string]any{"id": fmt.Sprintf("flood-%d", n), "method": "item/tool/call", "params": map[string]any{
+			"callId": fmt.Sprintf("call-%d", n), "threadId": "thread-1", "turnId": "turn-1", "tool": "search_movies", "arguments": map[string]any{"query": fmt.Sprintf("query %d", n)},
+		}}
+	}
+	forever := slices.Contains(os.Args, "--fake-flood-forever")
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 64<<10), 4<<20)
+	for scanner.Scan() {
+		var message struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+			Result struct {
+				Success      bool `json:"success"`
+				ContentItems []struct {
+					Text string `json:"text"`
+				} `json:"contentItems"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &message); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		if len(message.ID) == 0 {
+			continue
+		}
+		id := json.RawMessage(append([]byte(nil), message.ID...))
+		switch message.Method {
+		case "initialize":
+			send(map[string]any{"id": id, "result": map[string]any{"codexHome": os.Getenv("CODEX_HOME")}})
+		case "thread/start":
+			send(map[string]any{"id": id, "result": map[string]any{"thread": map[string]any{"id": "thread-1"}}})
+		case "thread/inject_items":
+			send(map[string]any{"id": id, "result": map[string]any{}})
+		case "turn/start":
+			send(map[string]any{"id": id, "result": map[string]any{"turn": map[string]any{"id": "turn-1", "status": "inProgress", "items": []any{}}}})
+			send(toolCall(1))
+		case "turn/interrupt":
+			send(map[string]any{"id": id, "result": map[string]any{}})
+			send(map[string]any{"method": "turn/completed", "params": map[string]any{
+				"threadId": "thread-1", "turn": map[string]any{"id": "turn-1", "status": "interrupted", "items": []any{}},
+			}})
+		case "":
+			key := strings.Trim(string(message.ID), `"`)
+			if !strings.HasPrefix(key, "flood-") {
+				continue
+			}
+			n, err := strconv.Atoi(strings.TrimPrefix(key, "flood-"))
+			if err != nil {
+				t.Fatalf("unexpected reply id %q", key)
+			}
+			text := ""
+			if len(message.Result.ContentItems) > 0 {
+				text = message.Result.ContentItems[0].Text
+			}
+			if !forever && strings.Contains(text, "Tool call limit reached") {
+				send(map[string]any{"method": "item/agentMessage/delta", "params": map[string]any{
+					"threadId": "thread-1", "turnId": "turn-1", "itemId": "message-1", "delta": "answer from gathered data",
+				}})
+				send(map[string]any{"method": "turn/completed", "params": map[string]any{
+					"threadId": "thread-1", "turn": map[string]any{"id": "turn-1", "status": "completed", "items": []any{}},
+				}})
+				continue
+			}
+			send(toolCall(n + 1))
+		default:
+			send(map[string]any{"id": id, "result": map[string]any{}})
+		}
+	}
+}
+
+func newCodexChatBudgetHandler(t *testing.T, extraArgs ...string) (*Handler, int64) {
+	t.Helper()
+	database, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+	result, err := database.Exec(`INSERT INTO users (username, password_hash, role) VALUES ('budget-user', '', 'user')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cipher, err := secrets.NewCipher(bytes.Repeat([]byte{0x33}, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
+	registry := credentials.NewRegistry(database, cipher)
+	toolServer := mcp.NewToolServer(registry, nil, nil, nil)
+	toolServer.SetCallAuthorizer(func(context.Context, mcp.CallContext) (string, error) {
+		return auth.RoleUser, nil
+	})
+	runtimeDir := t.TempDir()
+	if err := os.Chmod(runtimeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manager := codexapp.NewManager(database, cipher, toolServer, codexapp.Options{
+		Binary:                   os.Args[0],
+		RuntimeDir:               runtimeDir,
+		Args:                     append([]string{"-test.run=TestCodexChatBudgetHelperProcess", "--", "--codex-chat-budget-fake"}, extraArgs...),
+		AllowDiskRuntimeForTests: true,
+	})
+	if !manager.Available() {
+		t.Fatalf("test Codex manager unavailable: %v", manager.AvailabilityError())
+	}
+	h := NewHandler(registry, toolServer, manager)
+	grantResolverSharedAccess(t, database, userID, true)
+	configureResolverProfile(t, registry, database, cipher, userID, aiSourceShared, credentials.AIProviderCodex, true)
+	return h, userID
+}
+
+func chatSSEFrames(t *testing.T, body string) []map[string]json.RawMessage {
+	t.Helper()
+	var frames []map[string]json.RawMessage
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, "data: ") || line == "data: [DONE]" {
+			continue
+		}
+		var frame map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &frame); err != nil {
+			t.Fatalf("bad SSE frame %q: %v", line, err)
+		}
+		frames = append(frames, frame)
+	}
+	return frames
+}
+
+func postChat(t *testing.T, h *Handler, userID int64) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/ai/chat", strings.NewReader(`{"messages":[{"role":"user","content":"find horror movies I do not have"}]}`))
+	req = req.WithContext(context.WithValue(req.Context(), auth.ClaimsKey, &auth.Claims{UserID: userID, Role: auth.RoleUser, DeviceID: "device-1"}))
+	recorder := httptest.NewRecorder()
+	h.Chat(recorder, req)
+	return recorder
+}
+
+// TestChatPersistsConversationAfterCodexSoftLanding proves the issue #492 fix
+// end to end: a turn that exhausts the tool budget still streams a final
+// answer, emits no error frame, and keeps the stored conversation.
+func TestChatPersistsConversationAfterCodexSoftLanding(t *testing.T) {
+	h, userID := newCodexChatBudgetHandler(t)
+	recorder := postChat(t, h, userID)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	convID := ""
+	text := ""
+	for _, frame := range chatSSEFrames(t, recorder.Body.String()) {
+		if raw, ok := frame["error"]; ok {
+			t.Fatalf("budget-exhausted turn emitted an error frame: %s", raw)
+		}
+		if raw, ok := frame["conversation_id"]; ok {
+			if err := json.Unmarshal(raw, &convID); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if raw, ok := frame["text"]; ok {
+			var delta string
+			if err := json.Unmarshal(raw, &delta); err != nil {
+				t.Fatal(err)
+			}
+			text += delta
+		}
+	}
+	if convID == "" {
+		t.Fatal("no conversation_id frame")
+	}
+	if text != "answer from gathered data" {
+		t.Fatalf("streamed text = %q", text)
+	}
+	binding := h.conversations.newBinding(userID, h.resolveAI(context.Background(), userID))
+	stored, ok := h.conversations.Get(convID, userID, binding)
+	if !ok {
+		t.Fatal("budget-exhausted turn did not persist the conversation")
+	}
+	last := stored[len(stored)-1]
+	if last.Role != agentRoleAssistant {
+		t.Fatalf("last stored message role = %q, want assistant", last.Role)
+	}
+	// Question + capped tool pairs + final answer. Without the per-turn record
+	// cap, trimHistory finds no valid suffix for a maximal turn and keeps only
+	// the user question, silently dropping the answer and all tool grounding.
+	if want := 2 + 2*maxStoredToolRecordsPerTurn; len(stored) != want {
+		t.Fatalf("stored transcript length = %d, want %d", len(stored), want)
+	}
+}
+
+// TestChatEmitsHonestErrorAfterCodexHardAbort pins the copy for the rare case
+// where the model ignores every budget refusal: the SSE error frame names the
+// tool limit instead of blaming the OAuth connection, and the conversation is
+// dropped like any other failed turn.
+func TestChatEmitsHonestErrorAfterCodexHardAbort(t *testing.T) {
+	h, userID := newCodexChatBudgetHandler(t, "--fake-flood-forever")
+	recorder := postChat(t, h, userID)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", recorder.Code, recorder.Body.String())
+	}
+	convID := ""
+	errorText := ""
+	for _, frame := range chatSSEFrames(t, recorder.Body.String()) {
+		if raw, ok := frame["conversation_id"]; ok {
+			if err := json.Unmarshal(raw, &convID); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if raw, ok := frame["error"]; ok {
+			if err := json.Unmarshal(raw, &errorText); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	want := "The AI needed more lookups than one question allows and had to stop. Try again, or split the question into smaller parts."
+	if errorText != want {
+		t.Fatalf("error frame = %q, want %q", errorText, want)
+	}
+	binding := h.conversations.newBinding(userID, h.resolveAI(context.Background(), userID))
+	if _, ok := h.conversations.Get(convID, userID, binding); ok {
+		t.Fatal("hard-aborted turn must not persist the conversation")
+	}
+}

--- a/server/internal/ai/codex_handler_test.go
+++ b/server/internal/ai/codex_handler_test.go
@@ -192,3 +192,28 @@ func TestPersonalCodexReconnectPreservesAndTestsSelectedModel(t *testing.T) {
 		t.Fatalf("config=%#v found=%t err=%v", config, found, err)
 	}
 }
+
+func TestCodexClientErrorMapsToolBudgetAndTimeout(t *testing.T) {
+	cases := []struct {
+		name   string
+		err    error
+		source string
+		want   string
+	}{
+		{"tool budget shared", codexapp.ErrToolBudget, aiSourceShared,
+			"The AI needed more lookups than one question allows and had to stop. Try again, or split the question into smaller parts."},
+		{"tool budget personal", codexapp.ErrToolBudget, aiSourcePersonal,
+			"The AI needed more lookups than one question allows and had to stop. Try again, or split the question into smaller parts."},
+		{"run deadline", context.DeadlineExceeded, aiSourceShared,
+			"The AI request took too long and was stopped. Try again with a smaller question."},
+		{"provider default shared", codexapp.ErrProvider, aiSourceShared,
+			"Included OpenAI OAuth is temporarily unavailable. Try again or ask an admin to check the shared connection."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := codexClientError(tc.err, tc.source); got != tc.want {
+				t.Fatalf("codexClientError = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/server/internal/ai/codex_transcript.go
+++ b/server/internal/ai/codex_transcript.go
@@ -22,6 +22,9 @@ type codexTranscriptBuilder struct {
 	// textWritten caps total stored assistant text across the whole run, not
 	// per segment, matching the pre-interleaving bound.
 	textWritten int
+	// toolRecords counts persisted pairs so one tool-heavy turn stays well
+	// under maxStoredMessages; see maxStoredToolRecordsPerTurn.
+	toolRecords int
 }
 
 func (b *codexTranscriptBuilder) Text(value string) {
@@ -42,6 +45,12 @@ func (b *codexTranscriptBuilder) ToolRecord(name string, input json.RawMessage, 
 	id := "codex_" + newConversationID()
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.toolRecords >= maxStoredToolRecordsPerTurn {
+		// Stop persisting pairs, never text: later deltas still accumulate in
+		// b.text and reach the transcript through Finish.
+		return
+	}
+	b.toolRecords++
 	assistant := transcriptMessage{Role: agentRoleAssistant}
 	if text := strings.TrimSpace(b.text.String()); text != "" {
 		assistant.Content = append(assistant.Content, transcriptBlock{Type: blockTypeText, Text: text})

--- a/server/internal/ai/conversation.go
+++ b/server/internal/ai/conversation.go
@@ -23,6 +23,14 @@ const (
 	maxStoredToolResultBytes = 32 << 10
 	maxStoredToolInputBytes  = 16 << 10
 	maxStoredIdentifierBytes = 512
+	// maxStoredToolRecordsPerTurn bounds how many tool_use/tool_result pairs
+	// one codex turn contributes to the stored transcript. Each pair is two
+	// messages, so a turn that used the whole dynamic tool budget must not be
+	// allowed to crowd out its own final answer under maxStoredMessages —
+	// trimHistory would then find no valid suffix and keep only the user
+	// question. The earliest records carry the broad library sweeps that
+	// ground follow-up turns; later refinements are the ones dropped.
+	maxStoredToolRecordsPerTurn = 24
 	// Signed provider continuation blocks cannot be truncated or redacted
 	// without invalidating their signatures. Drop the containing provider turn
 	// when its opaque state exceeds the ordinary per-block text budget.

--- a/server/internal/ai/handler.go
+++ b/server/internal/ai/handler.go
@@ -420,6 +420,10 @@ func codexClientError(err error, source string) string {
 			return "Included OpenAI OAuth is busy with another request. Try again shortly."
 		}
 		return "Your OpenAI OAuth connection is busy with another request. Try again shortly."
+	case errors.Is(err, codexapp.ErrToolBudget):
+		return "The AI needed more lookups than one question allows and had to stop. Try again, or split the question into smaller parts."
+	case errors.Is(err, context.DeadlineExceeded):
+		return "The AI request took too long and was stopped. Try again with a smaller question."
 	case errors.Is(err, context.Canceled):
 		return "The OpenAI OAuth request was canceled."
 	default:

--- a/server/internal/codexapp/manager_test.go
+++ b/server/internal/codexapp/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -2326,6 +2327,207 @@ func TestRunWithAccountSessionAuthFailingInjectStillPurgesAccount(t *testing.T) 
 	}
 	if found, err := manager.AccountExists(SharedAccount()); err != nil || found {
 		t.Fatalf("account exists=%t err=%v, want purged after auth failure", found, err)
+	}
+	assertRuntimeEmpty(t, runtimeDir)
+}
+
+// TestToolFloodCodexAppHelperProcess drives one turn that keeps requesting
+// dynamic tools. By default it stops two calls past the budget and answers,
+// proving the soft landing; with --fake-flood-forever it never stops calling
+// tools, arming the hard backstop instead.
+func TestToolFloodCodexAppHelperProcess(t *testing.T) {
+	logPath := fakeArg("--fake-log=")
+	if logPath == "" {
+		return
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	send := func(value any) {
+		if err := encoder.Encode(value); err != nil {
+			t.Fatalf("encode fake response: %v", err)
+		}
+	}
+	toolCall := func(n int) map[string]any {
+		return map[string]any{"id": fmt.Sprintf("flood-%d", n), "method": "item/tool/call", "params": map[string]any{
+			"callId": fmt.Sprintf("call-%d", n), "threadId": "thread-1", "turnId": "turn-1", "tool": "search_movies", "arguments": map[string]any{"query": fmt.Sprintf("query %d", n)},
+		}}
+	}
+	forever := slices.Contains(os.Args, "--fake-flood-forever")
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 64<<10), maxProtocolBytes)
+	for scanner.Scan() {
+		var message map[string]any
+		if err := json.Unmarshal(scanner.Bytes(), &message); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		logFake(t, logPath, "received", message)
+		method, _ := message["method"].(string)
+		id, hasID := message["id"]
+		if !hasID {
+			continue
+		}
+		switch method {
+		case "initialize":
+			send(map[string]any{"id": id, "result": map[string]any{"codexHome": os.Getenv("CODEX_HOME")}})
+		case "thread/start":
+			send(map[string]any{"id": id, "result": map[string]any{"thread": map[string]any{"id": "thread-1"}}})
+		case "turn/start":
+			send(map[string]any{"id": id, "result": map[string]any{"turn": map[string]any{"id": "turn-1", "status": "inProgress", "items": []any{}}}})
+			send(toolCall(1))
+		case "turn/interrupt":
+			send(map[string]any{"id": id, "result": map[string]any{}})
+			send(map[string]any{"method": "turn/completed", "params": map[string]any{
+				"threadId": "thread-1", "turn": map[string]any{"id": "turn-1", "status": "interrupted", "items": []any{}},
+			}})
+		case "":
+			key := fmt.Sprint(id)
+			if !strings.HasPrefix(key, "flood-") {
+				continue
+			}
+			n, err := strconv.Atoi(strings.TrimPrefix(key, "flood-"))
+			if err != nil {
+				t.Fatalf("unexpected reply id %q", key)
+			}
+			if !forever && n >= maxDynamicToolCalls+2 {
+				send(map[string]any{"method": "item/agentMessage/delta", "params": map[string]any{
+					"threadId": "thread-1", "turnId": "turn-1", "itemId": "message-1", "delta": "answer from gathered data",
+				}})
+				send(map[string]any{"method": "turn/completed", "params": map[string]any{
+					"threadId": "thread-1", "turn": map[string]any{"id": "turn-1", "status": "completed", "items": []any{}},
+				}})
+				continue
+			}
+			send(toolCall(n + 1))
+		default:
+			send(map[string]any{"id": id, "result": map[string]any{}})
+		}
+	}
+}
+
+type floodReply struct {
+	id      int
+	success bool
+	text    string
+}
+
+// floodReplies extracts Cantinarr's replies to the flood helper's tool calls
+// from the fake protocol log, in call order.
+func floodReplies(t *testing.T, logPath string) []floodReply {
+	t.Helper()
+	var replies []floodReply
+	for _, entry := range readFakeLog(t, logPath) {
+		if entry.Kind != "received" {
+			continue
+		}
+		var envelope struct {
+			ID     string `json:"id"`
+			Method string `json:"method"`
+			Result struct {
+				Success      bool `json:"success"`
+				ContentItems []struct {
+					Text string `json:"text"`
+				} `json:"contentItems"`
+			} `json:"result"`
+		}
+		if json.Unmarshal(entry.Value, &envelope) != nil {
+			continue
+		}
+		if envelope.Method != "" || !strings.HasPrefix(envelope.ID, "flood-") {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimPrefix(envelope.ID, "flood-"))
+		if err != nil {
+			continue
+		}
+		text := ""
+		if len(envelope.Result.ContentItems) > 0 {
+			text = envelope.Result.ContentItems[0].Text
+		}
+		replies = append(replies, floodReply{id: n, success: envelope.Result.Success, text: text})
+	}
+	return replies
+}
+
+func TestCodexRunSoftLandsAfterToolBudget(t *testing.T) {
+	manager, _, _, runtimeDir, logPath := fakeManager(t)
+	if err := manager.saveAccount(SharedAccount(), []byte(`{"tokens":{"access_token":"shared-secret"}}`), AccountStatus{Connected: true}); err != nil {
+		t.Fatal(err)
+	}
+	manager.args = []string{"-test.run=TestToolFloodCodexAppHelperProcess", "--", "--fake-log=" + logPath}
+	manager.toolServer.SetCallAuthorizer(func(context.Context, mcp.CallContext) (string, error) {
+		return auth.RoleUser, nil
+	})
+	var text strings.Builder
+	toolStarts := 0
+	toolRecords := 0
+	err := manager.RunWithAccountSession(context.Background(), SharedAccount(), 2, "device-2", auth.RoleUser, "", "base", "context", "prompt", nil, Callbacks{
+		OnText:       func(delta string) { text.WriteString(delta) },
+		OnToolStart:  func(string) { toolStarts++ },
+		OnToolRecord: func(string, json.RawMessage, string, bool) { toolRecords++ },
+	})
+	if err != nil {
+		t.Fatalf("soft landing returned error: %v", err)
+	}
+	if text.String() != "answer from gathered data" {
+		t.Fatalf("streamed text = %q", text.String())
+	}
+	if toolStarts != maxDynamicToolCalls || toolRecords != maxDynamicToolCalls {
+		t.Fatalf("executed calls = %d starts / %d records, want %d each; refusals must stay invisible to callbacks", toolStarts, toolRecords, maxDynamicToolCalls)
+	}
+	refusals := 0
+	for _, reply := range floodReplies(t, logPath) {
+		if reply.id <= maxDynamicToolCalls {
+			if reply.text == toolBudgetRefusal {
+				t.Fatalf("in-budget call %d received the budget refusal", reply.id)
+			}
+			continue
+		}
+		if reply.success || reply.text != toolBudgetRefusal {
+			t.Fatalf("over-budget call %d reply success=%t text=%q, want the budget refusal", reply.id, reply.success, reply.text)
+		}
+		refusals++
+	}
+	if refusals != 2 {
+		t.Fatalf("refused replies = %d, want 2", refusals)
+	}
+	for _, entry := range readFakeLog(t, logPath) {
+		if bytes.Contains(entry.Value, []byte(`"method":"turn/interrupt"`)) {
+			t.Fatal("soft landing must not interrupt the turn")
+		}
+	}
+	assertRuntimeEmpty(t, runtimeDir)
+}
+
+func TestCodexRunAbortsAfterToolBudgetGrace(t *testing.T) {
+	manager, _, _, runtimeDir, logPath := fakeManager(t)
+	if err := manager.saveAccount(SharedAccount(), []byte(`{"tokens":{"access_token":"shared-secret"}}`), AccountStatus{Connected: true}); err != nil {
+		t.Fatal(err)
+	}
+	manager.args = []string{"-test.run=TestToolFloodCodexAppHelperProcess", "--", "--fake-log=" + logPath, "--fake-flood-forever"}
+	manager.toolServer.SetCallAuthorizer(func(context.Context, mcp.CallContext) (string, error) {
+		return auth.RoleUser, nil
+	})
+	toolStarts := 0
+	err := manager.RunWithAccountSession(context.Background(), SharedAccount(), 2, "device-2", auth.RoleUser, "", "base", "context", "prompt", nil, Callbacks{
+		OnToolStart: func(string) { toolStarts++ },
+	})
+	if !errors.Is(err, ErrToolBudget) {
+		t.Fatalf("hard abort = %v, want ErrToolBudget", err)
+	}
+	if errors.Is(err, ErrProvider) {
+		t.Fatal("tool budget abort must stay distinguishable from ErrProvider")
+	}
+	if toolStarts != maxDynamicToolCalls {
+		t.Fatalf("executed calls = %d, want %d", toolStarts, maxDynamicToolCalls)
+	}
+	waitForFakeMethod(t, logPath, "turn/interrupt")
+	refused := 0
+	for _, reply := range floodReplies(t, logPath) {
+		if reply.text == toolBudgetRefusal {
+			refused++
+		}
+	}
+	if refused < dynamicToolCallGrace {
+		t.Fatalf("refused replies = %d, want at least the %d grace refusals", refused, dynamicToolCallGrace)
 	}
 	assertRuntimeEmpty(t, runtimeDir)
 }

--- a/server/internal/codexapp/rpc.go
+++ b/server/internal/codexapp/rpc.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +16,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/windoze95/cantinarr-server/internal/secrets"
 )
 
 type rpcErrorBody struct {
@@ -60,6 +63,62 @@ type serverRequestResult struct {
 	afterWrite func()
 }
 
+// tailBuffer keeps only the last capacity bytes written to it, so the
+// app-server's stderr can be quoted (redacted) when the process dies
+// unexpectedly without ever holding unbounded diagnostic output.
+type tailBuffer struct {
+	mu       sync.Mutex
+	capacity int
+	data     []byte
+}
+
+func newTailBuffer(capacity int) *tailBuffer {
+	return &tailBuffer{capacity: capacity}
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(p) >= b.capacity {
+		b.data = append(b.data[:0], p[len(p)-b.capacity:]...)
+		return len(p), nil
+	}
+	if overflow := len(b.data) + len(p) - b.capacity; overflow > 0 {
+		b.data = append(b.data[:0], b.data[overflow:]...)
+	}
+	b.data = append(b.data, p...)
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.data)
+}
+
+// boundedLogText makes already-redacted diagnostic text safe for a single
+// server log line. Redact before bounding: truncating first could split a
+// credential so its remainder no longer matches a redaction pattern.
+func boundedLogText(text string) string {
+	text = strings.TrimSpace(text)
+	if len(text) > maxLogDetailBytes {
+		text = text[:maxLogDetailBytes] + "...[truncated]"
+	}
+	return strings.ReplaceAll(text, "\n", "\\n")
+}
+
+func describeExit(err error, stderrTail string) string {
+	detail := "exit status 0"
+	if err != nil {
+		detail = err.Error()
+	}
+	tail := boundedLogText(secrets.RedactText(stderrTail))
+	if tail == "" {
+		return detail
+	}
+	return detail + "; stderr tail: " + tail
+}
+
 type appSession struct {
 	cmd      *exec.Cmd
 	stdin    io.WriteCloser
@@ -87,6 +146,10 @@ type appSession struct {
 	processDone   chan struct{}
 	exitMu        sync.Mutex
 	exitErr       error
+	stderrTail    *tailBuffer
+	stderrDone    chan struct{}
+	stopRequested atomic.Bool
+	abortLogOnce  sync.Once
 	stopOnce      sync.Once
 	cleanupOnce   sync.Once
 	releaseSlot   func()
@@ -192,19 +255,34 @@ func (m *Manager) startSession(authJSON []byte) (*appSession, error) {
 		pending:        make(map[string]chan rpcReply),
 		notifications:  make(chan rpcNotification, maxQueuedNotifications),
 		processDone:    make(chan struct{}),
+		stderrTail:     newTailBuffer(maxStderrTailBytes),
+		stderrDone:     make(chan struct{}),
 		releaseSlot:    releaseSlot,
 		serverRequests: make(chan struct{}, maxServerRequests),
 		globalRequests: m.serverRequestSlots,
 		requestContext: requestContext,
 		cancelRequests: cancelRequests,
 	}
-	go func() { _, _ = io.Copy(io.Discard, stderr) }()
+	go func() {
+		_, _ = io.Copy(s.stderrTail, stderr)
+		close(s.stderrDone)
+	}()
 	go s.readLoop(stdout)
 	go func() {
 		err := cmd.Wait()
 		s.exitMu.Lock()
 		s.exitErr = err
 		s.exitMu.Unlock()
+		if !s.stopRequested.Load() {
+			// The process ended before teardown asked it to stop. This is the
+			// only place its exit status and stderr are ever visible; without
+			// this line every crash surfaces as the same opaque ErrProvider.
+			select {
+			case <-s.stderrDone:
+			case <-time.After(250 * time.Millisecond):
+			}
+			log.Printf("codexapp: app-server exited without shutdown: %s", describeExit(err, s.stderrTail.String()))
+		}
 		close(s.processDone)
 		s.failPending()
 	}()
@@ -358,6 +436,10 @@ func classifyRPCError(rpcErr *rpcErrorBody) error {
 		strings.Contains(text, "rate_limit_reached"):
 		return ErrUsageLimit
 	default:
+		// The classified error deliberately carries no detail, so this is the
+		// only record of what the app-server actually rejected.
+		log.Printf("codexapp: app-server rpc error code=%d detail=%s", rpcErr.Code,
+			boundedLogText(secrets.RedactText(strings.TrimSpace(rpcErr.Message+" "+string(rpcErr.Data)))))
 		return ErrProvider
 	}
 }
@@ -397,7 +479,7 @@ func (s *appSession) writeContext(ctx context.Context, message any) error {
 	case s.writeSlot <- struct{}{}:
 		defer func() { <-s.writeSlot }()
 	case <-ctx.Done():
-		s.abortProvider()
+		s.abortProvider("write slot unavailable before deadline")
 		return ctx.Err()
 	}
 	written := make(chan error, 1)
@@ -415,12 +497,19 @@ func (s *appSession) writeContext(ctx context.Context, message any) error {
 		// Closing stdin and killing the child unblocks a pipe write even when a
 		// buggy app-server stopped consuming input. The write goroutine reports
 		// into a buffered channel, so it cannot leak waiting for this caller.
-		s.abortProvider()
+		s.abortProvider("stdin write did not complete before deadline")
 		return ctx.Err()
 	}
 }
 
-func (s *appSession) abortProvider() {
+func (s *appSession) abortProvider(reason string) {
+	s.abortLogOnce.Do(func() {
+		// An abort during requested teardown is routine (a late write racing
+		// stop), not a diagnostic; only pre-shutdown aborts are worth a line.
+		if !s.stopRequested.Load() {
+			log.Printf("codexapp: killing app-server: %s", reason)
+		}
+	})
 	if s.cancelRequests != nil {
 		s.cancelRequests()
 	}
@@ -447,8 +536,10 @@ func (s *appSession) readLoop(stdout io.Reader) {
 		s.dispatch(message)
 	}
 	// A malformed/oversized stream is a failed provider process. Killing it
-	// wakes every pending request without exposing scanner or process details.
-	if scanner.Err() != nil && s.cmd.Process != nil {
+	// wakes every pending request without exposing scanner or process details
+	// to callers; the log line below is the only record of what happened.
+	if err := scanner.Err(); err != nil && s.cmd.Process != nil {
+		log.Printf("codexapp: killing app-server: stdout stream failed: %v", err)
 		_ = s.cmd.Process.Kill()
 	}
 }
@@ -493,7 +584,7 @@ func (s *appSession) dispatch(message rpcEnvelope) {
 		}
 		params, ok := compactNotification(message.Method, message.Params)
 		if !ok {
-			s.abortProvider()
+			s.abortProvider("unparseable or oversized " + message.Method + " notification")
 			return
 		}
 		ctx := s.requestContext
@@ -517,7 +608,7 @@ func (s *appSession) dispatch(message rpcEnvelope) {
 		select {
 		case response <- rpcReply{result: cloneRaw(message.Result), err: message.Error}:
 		default:
-			s.abortProvider()
+			s.abortProvider("duplicate reply for request id " + boundedLogText(key))
 		}
 	}
 }
@@ -614,6 +705,9 @@ func compactTurnError(raw json.RawMessage) json.RawMessage {
 	case strings.Contains(text, "unauthorized"), strings.Contains(text, "authentication_required"):
 		return json.RawMessage(`"unauthorized"`)
 	default:
+		// The raw upstream detail is collapsed to "providerError" from here on,
+		// so log it now or lose it — turn failures are otherwise undiagnosable.
+		log.Printf("codexapp: turn failed upstream: %s", boundedLogText(secrets.RedactText(string(raw))))
 		return json.RawMessage(`"providerError"`)
 	}
 }
@@ -667,7 +761,14 @@ func (s *appSession) failPending() {
 	}
 }
 
+func (s *appSession) exitError() error {
+	s.exitMu.Lock()
+	defer s.exitMu.Unlock()
+	return s.exitErr
+}
+
 func (s *appSession) stop() {
+	s.stopRequested.Store(true)
 	s.stopOnce.Do(func() {
 		if s.cancelRequests != nil {
 			s.cancelRequests()

--- a/server/internal/codexapp/run.go
+++ b/server/internal/codexapp/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"strconv"
 	"strings"
 	"sync"
@@ -12,6 +13,11 @@ import (
 	"github.com/windoze95/cantinarr-server/internal/mcp"
 	"github.com/windoze95/cantinarr-server/internal/secrets"
 )
+
+// toolBudgetRefusal answers every dynamic tool call past the per-turn budget.
+// The turn stays alive so the model can follow the instruction; tests match
+// this text to tell budget refusals apart from ordinary tool failures.
+const toolBudgetRefusal = "Tool call limit reached for this question. Do not call more tools. Answer the user now using only the information already gathered, and say what you could not check."
 
 type callbackSink struct {
 	mu      sync.Mutex
@@ -359,8 +365,10 @@ func (m *Manager) runWithAccount(
 	toolCalls := 0
 	seenCallIDs := make(map[string]struct{})
 	turnReady := make(chan struct{})
+	runDeadline, hasRunDeadline := runCtx.Deadline()
 	limitHit := make(chan struct{})
 	var limitOnce sync.Once
+	var softLimitOnce sync.Once
 	toolCaptured := make(chan struct{})
 	var capturedOnce sync.Once
 	outputLimitHit := make(chan struct{})
@@ -394,9 +402,22 @@ func (m *Manager) runWithAccount(
 			case <-time.After(50 * time.Millisecond):
 			}
 		}
-		if count > maxDynamicToolCalls {
-			limitOnce.Do(func() { close(limitHit) })
-			return dynamicToolResponse("Tool call limit reached.", false), nil
+		if count > maxDynamicToolCalls+dynamicToolCallGrace {
+			// Every grace refusal was ignored; the turn is unrecoverable.
+			limitOnce.Do(func() {
+				log.Printf("codexapp: aborting turn after %d dynamic tool calls (budget %d, grace %d)", count, maxDynamicToolCalls, dynamicToolCallGrace)
+				close(limitHit)
+			})
+			return dynamicToolResponse(toolBudgetRefusal, false), nil
+		}
+		if count > maxDynamicToolCalls || (hasRunDeadline && time.Until(runDeadline) < toolBudgetTimeReserve) {
+			// Budget or run deadline nearly spent: refuse the call but keep the
+			// turn alive so the model answers from what it already gathered,
+			// mirroring the forced-text final iteration of the HTTP providers.
+			softLimitOnce.Do(func() {
+				log.Printf("codexapp: dynamic tool budget spent (call %d, budget %d); steering model to answer from gathered data", count, maxDynamicToolCalls)
+			})
+			return dynamicToolResponse(toolBudgetRefusal, false), nil
 		}
 		if currentThread == "" || call.ThreadID != currentThread || currentTurn == "" || call.TurnID != currentTurn || !allowed[call.Tool] {
 			return dynamicToolResponse("This tool is not available.", false), nil
@@ -671,7 +692,7 @@ func (m *Manager) runWithAccount(
 			return runCtx.Err()
 		case <-limitHit:
 			interruptTurn(session, threadStart.Thread.ID, turnStart.Turn.ID)
-			return ErrProvider
+			return ErrToolBudget
 		case <-authorizationLost:
 			return mcp.ErrToolAuthorization
 		case <-toolCaptured:
@@ -679,6 +700,7 @@ func (m *Manager) runWithAccount(
 		case <-outputLimitHit:
 			return waitForInterruptedTurn()
 		case <-session.processDone:
+			log.Printf("codexapp: app-server exited mid-turn: %v", session.exitError())
 			return ErrProvider
 		case notification := <-session.notifications:
 			completed, err := handleNotification(notification, false)
@@ -776,6 +798,7 @@ func interruptTurn(session *appSession, threadID, turnID string) {
 
 func safeTurnError(complete turnCompleteParams) error {
 	if complete.Turn.Error == nil {
+		log.Printf("codexapp: turn ended with status %q and no error detail", complete.Turn.Status)
 		return ErrProvider
 	}
 	info := string(complete.Turn.Error.CodexErrorInfo)
@@ -785,6 +808,9 @@ func safeTurnError(complete turnCompleteParams) error {
 	case strings.Contains(info, "unauthorized"):
 		return ErrNotConnected
 	default:
+		// The raw upstream detail was already logged (and collapsed) by
+		// compactTurnError; info is the compacted classification.
+		log.Printf("codexapp: turn ended with status %q error=%s", complete.Turn.Status, boundedLogText(info))
 		return ErrProvider
 	}
 }

--- a/server/internal/codexapp/types.go
+++ b/server/internal/codexapp/types.go
@@ -21,11 +21,27 @@ const (
 	maxGlobalRequests      = 16
 	maxQueuedNotifications = 64
 	maxNotificationBytes   = 256 << 10
-	maxDynamicToolCalls    = 15
-	maxRunDuration         = 5 * time.Minute
-	maxAccountOperation    = 30 * time.Second
-	maxServerWrite         = 5 * time.Second
-	accountStatusTTL       = 60 * time.Second
+	// maxDynamicToolCalls counts individual tool calls, and codex issues them
+	// strictly sequentially — unlike the HTTP providers, whose 15-iteration cap
+	// counts model round-trips that each may carry several parallel calls. The
+	// budget stays generous so multi-instance library sweeps land; exhausting it
+	// steers the model to answer from gathered data instead of failing the turn.
+	maxDynamicToolCalls = 48
+	// dynamicToolCallGrace bounds how many over-budget calls are answered with
+	// a steering refusal before the turn is aborted as unrecoverable.
+	dynamicToolCallGrace = 8
+	// toolBudgetTimeReserve starts refusing tool calls when less than this much
+	// of the run deadline remains, so a slow turn still ends in an answer.
+	toolBudgetTimeReserve = 45 * time.Second
+	maxRunDuration        = 5 * time.Minute
+	maxAccountOperation   = 30 * time.Second
+	maxServerWrite        = 5 * time.Second
+	accountStatusTTL      = 60 * time.Second
+	// maxStderrTailBytes bounds the retained app-server stderr, quoted
+	// (redacted) only when the process dies before shutdown was requested.
+	maxStderrTailBytes = 8 << 10
+	// maxLogDetailBytes bounds redacted diagnostic detail in one log line.
+	maxLogDetailBytes = 2048
 )
 
 // Options controls app-server discovery and the memory-backed directory used
@@ -156,6 +172,7 @@ const (
 	CodeInvalidInput     Code = "invalid_input"
 	CodeBusy             Code = "busy"
 	CodeHistoryInject    Code = "history_inject"
+	CodeToolBudget       Code = "tool_budget"
 )
 
 // Error is intentionally small: it never wraps process stderr, OAuth payloads,
@@ -188,6 +205,9 @@ var (
 	// than auth or usage limits. Native history replay is an enhancement, so
 	// callers retry the turn with a flattened prompt instead of surfacing it.
 	ErrHistoryInject = &Error{Code: CodeHistoryInject, message: "Codex history injection failed"}
+	// ErrToolBudget reports that the model kept requesting tools after the
+	// dynamic tool budget was exhausted and every grace call was refused.
+	ErrToolBudget = &Error{Code: CodeToolBudget, message: "Codex turn exceeded its tool call budget"}
 )
 
 // IsCode is a convenience for HTTP adapters that map safe error classes to


### PR DESCRIPTION
Fixes #492.

## What was happening

A Codex chat turn that needed more than 15 tool calls died the moment the 16th arrived: `maxDynamicToolCalls = 15` closed `limitHit`, the run loop interrupted the turn, and the deliberately opaque `ErrProvider` ("Codex app-server request failed") surfaced as **"Included OpenAI OAuth is temporarily unavailable"** — blaming a healthy connection — while the conversation, with all 15 successful tool results in it, was deleted. Retry started from zero and hit the same wall. The reporter's log shows the signature exactly: 15 successful `tool start/end` pairs, then the error in the same second (the check fires before call 16 ever logs; the 15.9s was wall time, not a timeout).

The HTTP providers don't have this cliff: their cap counts **model round-trips** (each of which can carry several parallel tool calls) and the final iteration forces `tool_choice: none` so the user always gets an answer. Codex counted **individual sequential calls** — a much smaller effective budget, easily burned by one legitimate multi-instance library question — and hard-failed instead of landing.

## The fix

**Soft landing (parity with the other providers).** The budget rises to 48, and exhausting it no longer aborts the turn: each over-budget call gets a steering refusal — *"Tool call limit reached for this question. Do not call more tools. Answer the user now using only the information already gathered…"* — and the turn runs to completion, so the model answers from the data it collected. The same refusal kicks in when under 45s remain on the 5-minute run deadline, so slow turns also end in an answer instead of a deadline error. Only a model that ignores eight consecutive grace refusals is aborted — and that now returns a distinct `ErrToolBudget` with honest client copy ("The AI needed more lookups than one question allows…") instead of blaming OAuth. `context.DeadlineExceeded` gets honest copy too.

**Stored-transcript fix the bigger budget exposed.** A 48-call turn produces more tool_use/tool_result messages than `maxStoredMessages` allows, and `trimHistory`'s only valid fallback was the bare user question — silently dropping the final answer and every tool result. The codex transcript builder now persists at most 24 tool pairs per turn (streamed text is never dropped), so a maximal turn stores the question, the earliest tool grounding, and the answer.

**Codex failures are now diagnosable.** The `codexapp` package logged nothing: every distinct failure printed the same sentinel, app-server stderr went to `io.Discard`, the stored exit error was never read, and upstream error detail was collapsed before anything could see it. Terminal failure sites now log the actual reason — RPC error code/detail, the raw upstream turn error before `compactTurnError` collapses it, the app-server's exit status plus a redacted 8 KiB stderr tail when the process dies unrequested, and the reason for every protocol abort. All detail is redacted (`secrets.RedactText`) and bounded, goes only to the admin server log, and the opaque `Error` type contract is untouched.

## Tests

- `codexapp`: a new flood fake app-server drives real turns over stdio — soft landing (48 executed, refusals carry the steering text, no interrupt, turn completes) and hard abort (`ErrToolBudget`, interrupt observed, grace refusals counted).
- `ai`: end-to-end `Chat` SSE tests — a budget-exhausted turn streams the final answer with no error frame and **persists the conversation** (the deletion was half the bug), pinning the stored shape (question + 24 pairs + answer); a hard-aborted turn emits the new honest copy and drops the conversation; plus a table test pinning `codexClientError` for `ErrToolBudget`, `DeadlineExceeded`, and the unchanged `ErrProvider` default.
- Full suite: `go vet ./...`, `go test ./...`, and `go test -race` on both touched packages, all green. No docs owe changes (no doc mentions a chat tool-call limit); no app changes (error copy is server-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A9wzVLFQ72ytyrTMEp2WHZ