### PR TITLE
Drop retired Gemini 2.5 Flash-Lite from the model picker

### DIFF
--- a/server/internal/credentials/registry.go
+++ b/server/internal/credentials/registry.go
@@ -181,7 +181,6 @@ var AIProviders = []AIProviderOption{
 			{ID: "gemini-3.1-pro-preview-customtools", Label: "Gemini 3.1 Pro Preview Custom Tools", Description: "Gemini 3.1 Pro endpoint tuned for custom tool-heavy workflows"},
 			{ID: "gemini-2.5-pro", Label: "Gemini 2.5 Pro", Description: "Advanced reasoning and coding"},
 			{ID: "gemini-2.5-flash", Label: "Gemini 2.5 Flash", Description: "Low-latency reasoning"},
-			{ID: "gemini-2.5-flash-lite", Label: "Gemini 2.5 Flash-Lite", Description: "Fastest budget Gemini option"},
 		},
 	},
 	{


### PR DESCRIPTION
Google has retired `gemini-2.5-flash-lite` for newer API keys; picking it fails the save-time probe with Google's own message pointing at `gemini-3.5-flash-lite` (seen in #504). Remove the entry so the picker only offers models a key can actually save. The other Gemini entries, including 2.5 Pro and 2.5 Flash, still pass the probe.

Catalog-only change: installs that already store the model keep working, since chats use the stored ID and nothing re-validates against the catalog after save time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JvKCQU7NoSgwTGddnZKRR