### PR TITLE
fix(app): instance form shows a friendly error when the backend is down at mount

### DIFF
--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -296,8 +296,15 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
           InstanceApiService(backendDio: ref.read(backendClientProvider));
       final instancesFuture = service.listInstances();
       final usersFuture = ref.read(authProvider.notifier).listUsers();
-      final instances = await instancesFuture;
-      final users = await usersFuture;
+      // Attach listeners to both futures now: awaiting them sequentially
+      // would leave the second future's error unhandled when the first
+      // await throws, leaking it as an unhandled zone error. Future.wait
+      // (eagerError: false) waits for both, throws the first error, and
+      // drops the rest — the single catch below stays correct.
+      final results =
+          await Future.wait<Object>([instancesFuture, usersFuture]);
+      final instances = results[0] as List<ServiceInstance>;
+      final users = results[1] as List<UserSummary>;
       users.sort((a, b) =>
           a.username.toLowerCase().compareTo(b.username.toLowerCase()));
       if (!mounted) return;

--- a/app/test/settings/instance_edit_screen_test.dart
+++ b/app/test/settings/instance_edit_screen_test.dart
@@ -24,6 +24,7 @@ class _FakeAdapter implements HttpClientAdapter {
     this.grants = const [],
     this.mediaRoots = const ['/media'],
     this.arrRootFolders = const [],
+    this.instancesError,
     this.webhookError,
     this.webhookStatus,
     this.testError,
@@ -34,6 +35,10 @@ class _FakeAdapter implements HttpClientAdapter {
   final List<Map<String, dynamic>> grants;
   final List<String> mediaRoots;
   final List<String> arrRootFolders;
+
+  /// GET /api/instances answers 500 with this message when set — mimics the
+  /// backend being down at screen mount.
+  final String? instancesError;
   final String? webhookError;
 
   /// GET /webhook status body; null mimics an older server (404), which the
@@ -65,6 +70,17 @@ class _FakeAdapter implements HttpClientAdapter {
           {'id': i + 1, 'path': arrRootFolders[i]},
       ];
     } else if (options.method == 'GET' && path == '/api/instances') {
+      final error = instancesError;
+      if (error != null) {
+        // Mirrors Go's http.Error: JSON-shaped body, text/plain content type.
+        return ResponseBody.fromString(
+          '${jsonEncode({'error': error})}\n',
+          500,
+          headers: {
+            'content-type': ['text/plain; charset=utf-8'],
+          },
+        );
+      }
       response = instances;
     } else if (options.method == 'GET' && path.endsWith('/grant-users')) {
       response = grants;
@@ -140,9 +156,13 @@ class _FakeAdapter implements HttpClientAdapter {
 }
 
 class _FakeAuthNotifier extends AuthNotifier {
-  _FakeAuthNotifier(this.users);
+  _FakeAuthNotifier(this.users, {this.listUsersError});
 
   final List<UserSummary> users;
+
+  /// listUsers throws this when set — mimics the backend being down at
+  /// screen mount.
+  final Object? listUsersError;
 
   @override
   Future<AuthState> build() async => const AuthState(
@@ -155,7 +175,11 @@ class _FakeAuthNotifier extends AuthNotifier {
       );
 
   @override
-  Future<List<UserSummary>> listUsers() async => users;
+  Future<List<UserSummary>> listUsers() async {
+    final error = listUsersError;
+    if (error != null) throw error;
+    return users;
+  }
 
   @override
   Future<void> refreshConfig() async {}
@@ -196,6 +220,7 @@ Future<void> _pumpEdit(
   WidgetTester tester, {
   required _FakeAdapter adapter,
   required List<UserSummary> users,
+  Object? listUsersError,
   InstanceEditScreen screen = const InstanceEditScreen(),
   Size viewSize = const Size(800, 1800),
   double textScaleFactor = 1,
@@ -218,7 +243,8 @@ Future<void> _pumpEdit(
   await tester.pumpWidget(
     ProviderScope(
       overrides: [
-        authProvider.overrideWith(() => _FakeAuthNotifier(users)),
+        authProvider.overrideWith(
+            () => _FakeAuthNotifier(users, listUsersError: listUsersError)),
         backendClientProvider.overrideWithValue(dio),
       ],
       child: MaterialApp.router(
@@ -245,6 +271,24 @@ Future<void> _fillForm(WidgetTester tester, String name) async {
 }
 
 void main() {
+  testWidgets(
+      'backend down at mount shows a friendly error and no unhandled error '
+      'leaks', (tester) async {
+    // Both directory loads fail: the instance list 500s and the user list
+    // throws. _loadDirectory used to await the two futures sequentially, so
+    // when the first await threw, the second future's error had no listener
+    // and escaped as an unhandled zone error — failing this test pre-fix.
+    final adapter = _FakeAdapter(instancesError: 'connection refused');
+    await _pumpEdit(
+      tester,
+      adapter: adapter,
+      users: const [],
+      listUsersError: StateError('backend down'),
+    );
+
+    expect(find.text('Could not load users'), findsOneWidget);
+  });
+
   testWidgets('first instance of a type starts as the default', (tester) async {
     final adapter = _FakeAdapter();
     await _pumpEdit(tester, adapter: adapter, users: [_user(1, 'alice')]);


### PR DESCRIPTION
## Summary

- Fixes an unhandled async error in the instance add/edit form: when the backend is down at screen mount, both directory loads fail and the second future's error leaked out of the zone instead of reaching the screen's catch.
- After the fix, the friendly "Could not load users" error state (with Retry) is the only outcome.

## Bug mechanism

`InstanceEditScreen._loadDirectory()` kicks off both loads together, then awaits them **sequentially** inside one try/catch:

```dart
final instancesFuture = service.listInstances();
final usersFuture = ref.read(authProvider.notifier).listUsers();
final instances = await instancesFuture;
final users = await usersFuture;
```

When **both** futures fail, `await instancesFuture` throws and the catch runs — but `usersFuture` never gets a listener (the second `await` is never reached), so its error completes with no handler and leaks as an **unhandled zone error**. The widget's own error handling is correct; the second error simply escapes past it.

## Reproduction

Reachable in production whenever the backend is unreachable while the instance form mounts (both `GET /api/instances` and the users fetch fail). Deterministically reproduced by the added widget test, which 500s `GET /api/instances` and makes the auth notifier's `listUsers()` throw at the same time:

```
The following StateError was thrown running a test:
Bad state: backend down
#0  _FakeAuthNotifier.listUsers (test/settings/instance_edit_screen_test.dart:180:24)
#1  _InstanceEditScreenState._loadDirectory (lib/features/settings/ui/instance_edit_screen.dart:298:59)
```

Pre-fix that test fails on the leaked zone error; post-fix it passes and asserts the "Could not load users" error state is shown.

## Fix

Attach listeners to both futures immediately with `Future.wait` (default `eagerError: false`): it waits for both futures, throws the first error into the existing catch, and drops the rest — exactly the semantics the single catch already wants. Behavior is otherwise unchanged (sorting, mounted checks, `_applyAutoDefault()`, `_loadPins()`, the "Could not load users" message).

```dart
final results = await Future.wait<Object>([instancesFuture, usersFuture]);
final instances = results[0] as List<ServiceInstance>;
final users = results[1] as List<UserSummary>;
```

The record `.wait` extension is deliberately **not** used: the package's SDK constraint is `>=3.4.0 <4.0.0` (language version 3.4), and record `.wait` requires Dart 3.5.

## Test evidence

- Red then green: the new test `backend down at mount shows a friendly error and no unhandled error leaks` fails on the unfixed code with the unhandled zone error above, and passes with the fix.
- `flutter analyze --no-fatal-infos`: no issues in the touched files.
- `flutter test`: full suite green, 1249 tests passed.

No upstream issue — the reproduction above carries the report.
