### PR TITLE
docs(readme): a copy-paste compose example for Portainer and Dockhand stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ is `docker compose pull && docker compose up -d`. To build the image from your
 checkout instead, layer the dev override:
 `docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build`.
 
+Or add Cantinarr to an existing stack (Portainer, Dockhand, etc.) -- no clone
+needed; this minimal service is the whole setup:
+
+```yaml
+services:
+  cantinarr:
+    image: ghcr.io/windoze95/cantinarr:latest
+    ports:
+      - "8585:8585"
+    volumes:
+      - ./config:/config
+    # Optional: enables push notifications (see Configuration)
+    # environment:
+    #   - CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
+    restart: unless-stopped
+```
+
+Update it later with `docker compose pull && docker compose up -d`.
+
 Open `http://your-server:8585` -- the setup wizard walks you through creating an admin account. Discovery and search work immediately on the built-in TMDB key. Then connect your services (Radarr, Sonarr, etc.) from **Settings > Providers & Credentials** and **Settings > Add Instance** in the admin UI. Configure an included AI provider there (fresh installs preselect OpenAI OAuth with the fast GPT-5.6 Luna model -- connecting a ChatGPT account is all it takes) and grant it per user, or let each person bring a provider under **Settings > AI Access**.
 
 ### Unraid


### PR DESCRIPTION
## What

Adds a copy-paste compose snippet to the README Quick Start for users who run Cantinarr from Portainer, Dockhand, or another existing stack and never clone the repo. One intro sentence, the minimal service, one update-path sentence (`docker compose pull && docker compose up -d`):

```yaml
services:
  cantinarr:
    image: ghcr.io/windoze95/cantinarr:latest
    ports:
      - "8585:8585"
    volumes:
      - ./config:/config
    # Optional: enables push notifications (see Configuration)
    # environment:
    #   - CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
    restart: unless-stopped
```

Notes on shape:

- Mirrors the essentials of the repo-root `docker-compose.yml` (published image, `8585:8585`, `./config:/config`, `restart: unless-stopped`) and matches the `server/README.md` quick-start service.
- The push-gateway env is kept as a comment, including its `environment:` key: an `environment:` line with only a comment under it parses as null and fails compose validation (`services.cantinarr.environment must be a mapping`), and push stays opt-in per the env-var table.

## Verification (exact snippet, podman)

The exact YAML block above was written byte-for-byte to a fresh dir as `docker-compose.yml` and run on macOS with podman 6.1.0 (applehv machine, rootful) delegating to docker-compose v5.4.0:

- `podman compose up -d` -> image pulled, container `Up`, `0.0.0.0:8585->8585/tcp`
- `curl -fsS http://localhost:8585/` -> **HTTP 200**, `<title>Cantinarr</title>` (setup wizard); container log: `Cantinarr server starting on :8585` and `Push notifications disabled (CANTINARR_PUSH_GATEWAY_URL unset)`, confirming the commented env block is inert
- `./config` on the host received `cantinarr.db` (+WAL) and `encryption.key`, proving the bind works
- `podman compose down -v` + temp dir removed; clean

One host-specific finding, not a snippet defect: with the compose project under macOS `/tmp`, the relative `./config` bind resolves inside the podman VM's SELinux-enforcing tmpfs and SQLite gets `unable to open database file` (classic unlabeled-bind denial; a `:Z` relabel or any bind under the virtiofs-shared home directory works). That is podman-machine-on-macOS behavior — the shipped snippet targets Linux Docker/Podman hosts where `./config` binds are the norm, same as the repo-root compose file.

Fixes #476
