### PR TITLE
demo: implement POST /api/auth/logout for the new in-app Sign out

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -49,7 +49,7 @@ Full parity with the current Cantinarr API surface:
 | `types.go` | Shared enums/constants (statuses, media/service types, WS event names), JSON helpers |
 | `state.go` | In-memory store: users, devices, tokens, instances, sessions; seeds and accessors |
 | `ws.go` | WebSocket hub: auth, broadcast/admin/user scopes, envelope, pings |
-| `auth.go` | `/api/auth/*` — status, login, refresh, connect, me, password, plex-email, passkey stubs |
+| `auth.go` | `/api/auth/*` — status, login, refresh, connect, me, logout, password, plex-email, passkey stubs |
 | `config.go` | `/api/config` (per-user visibility), `/api/admin/setup-status`, `/api/admin/update-status` |
 | `users_admin.go` | Admin users, devices, connect tokens, test-push, Plex invites, default instances, per-user request settings |
 | `plex.go` | `/api/admin/plex/*` — link PIN simulation, servers, libraries, settings |

--- a/demo/auth.go
+++ b/demo/auth.go
@@ -29,6 +29,7 @@ func registerAuth(r chi.Router) {
 		r.Group(func(r chi.Router) {
 			r.Use(requireAuth)
 			r.Get("/me", authMeHandler)
+			r.Post("/logout", authLogoutHandler)
 			r.Post("/password", authPasswordHandler)
 			r.Post("/plex-email", authPlexEmailHandler)
 			r.Get("/passkeys", authListPasskeysHandler)
@@ -123,6 +124,22 @@ func authConnectHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	d := deviceUpsert(u.ID, req.HardwareID, req.DeviceName, req.Platform)
 	writeJSON(w, http.StatusOK, issueSession(u, d))
+}
+
+// POST /api/auth/logout — self-serve sign-out: revokes the calling device's
+// own session, mirroring the real server (idempotent; an already-gone device
+// is the goal state; 401 without a device claim). requireAuth stores only the
+// user in the context, so the device id is re-read from the bearer token it
+// already validated.
+func authLogoutHandler(w http.ResponseWriter, r *http.Request) {
+	claims, err := parseAccessClaims(
+		strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+	if err != nil || claims.DeviceID == "" {
+		writeErr(w, http.StatusUnauthorized, "no device session")
+		return
+	}
+	revokeDevice(claims.DeviceID)
+	writeJSON(w, http.StatusOK, map[string]any{"status": "signed_out"})
 }
 
 // POST /api/auth/setup — the demo reports needs_setup:false, so setup always


### PR DESCRIPTION
Follow-up to #512 (and companion to #513). The app's Sign out best-effort calls `POST /api/auth/logout` before clearing locally; the demo mock answered 404, so a signed-out demo device left its refresh token alive forever.

The handler mirrors the real server: it revokes the caller's own device via the existing `revokeDevice`, answering 200 `{"status":"signed_out"}`, and 401s without a device claim. `requireAuth` only stores the user in the context, so the device id is re-read from the bearer token the middleware already validated.

Smoke-tested against a local build of the mock:

- connect with the well-known demo token → logout → **200**
- refresh with the old token → **401 "device has been revoked"**
- `/api/auth/me` with the old access token → **401** (revocation kills live access tokens immediately, same as the real server)
- logout with no Authorization header → **401**

A repeat logout answers 401 rather than 200 because the first revoke kills the access token at the middleware — the same thing the real server's `AuthMiddleware` does — and the app clears locally regardless, so nothing depends on the repeat case.

`go vet ./...` and `go build` clean in `demo/`. `demo/README.md`'s auth.go endpoint list updated. The live demo droplet needs a redeploy to pick this up after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsVr7TjzW8FrhZq89rW1DA