### PR TITLE
An "on" switch now shows its thumb instead of a solid amber pill

### DIFF
--- a/app/lib/core/widgets/attention_menu_visibility_switch.dart
+++ b/app/lib/core/widgets/attention_menu_visibility_switch.dart
@@ -59,7 +59,6 @@ class AttentionMenuVisibilitySwitch extends ConsumerWidget {
         key: ValueKey('${item.name}-conditional-menu-visibility'),
         value: value,
         onChanged: (next) => _set(ref, next),
-        activeThumbColor: AppTheme.accent,
       ),
       onTap: opensQueue ? () => context.push(_route) : null,
     );

--- a/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
+++ b/app/lib/features/issues/ui/ai_remediation_settings_screen.dart
@@ -254,7 +254,6 @@ class _AiRemediationSettingsScreenState
           SettingsAnchors.remediationEnabled,
           SwitchListTile(
             value: s.enabled,
-            activeThumbColor: AppTheme.accent,
             onChanged: (v) => setState(() => _edited = s.copyWith(enabled: v)),
             title: const Text(
               'Enabled',
@@ -271,7 +270,6 @@ class _AiRemediationSettingsScreenState
           SettingsAnchors.remediationAutoDispatch,
           SwitchListTile(
             value: s.autoDispatch,
-            activeThumbColor: AppTheme.accent,
             onChanged: (v) =>
                 setState(() => _edited = s.copyWith(autoDispatch: v)),
             title: const Text(
@@ -290,7 +288,6 @@ class _AiRemediationSettingsScreenState
           SettingsAnchors.remediationAllowReporting,
           SwitchListTile(
             value: s.allowReporting,
-            activeThumbColor: AppTheme.accent,
             onChanged: (v) =>
                 setState(() => _edited = s.copyWith(allowReporting: v)),
             title: const Text(
@@ -308,7 +305,6 @@ class _AiRemediationSettingsScreenState
           SettingsAnchors.remediationMarkResolvedRead,
           SwitchListTile(
             value: s.markResolvedAsRead,
-            activeThumbColor: AppTheme.accent,
             onChanged: (v) =>
                 setState(() => _edited = s.copyWith(markResolvedAsRead: v)),
             title: const Text(

--- a/app/lib/features/notifications/ui/notification_preferences_screen.dart
+++ b/app/lib/features/notifications/ui/notification_preferences_screen.dart
@@ -405,7 +405,6 @@ class _NotificationPreferencesScreenState
     final tile = SwitchListTile(
       value: value,
       onChanged: onChanged,
-      activeThumbColor: AppTheme.accent,
       title: Text(title,
           style: const TextStyle(
               color: AppTheme.textPrimary, fontWeight: FontWeight.w500)),

--- a/app/lib/features/settings/ui/ai_tools_screen.dart
+++ b/app/lib/features/settings/ui/ai_tools_screen.dart
@@ -232,7 +232,6 @@ class _DebugLoggingTile extends StatelessWidget {
             SwitchListTile(
               value: status.enabled,
               onChanged: pending ? null : onToggle,
-              activeThumbColor: AppTheme.accent,
               title: const Text(
                 'AI Debug Logging',
                 style: TextStyle(
@@ -292,7 +291,6 @@ class _ToolTile extends StatelessWidget {
     return SwitchListTile(
       value: tool.enabled,
       onChanged: pending ? null : onChanged,
-      activeThumbColor: AppTheme.accent,
       title: Row(
         children: [
           Flexible(

--- a/app/lib/features/settings/ui/discovery_settings_screen.dart
+++ b/app/lib/features/settings/ui/discovery_settings_screen.dart
@@ -293,7 +293,6 @@ class _DiscoverySettingsScreenState
           highlightId: widget.highlightId,
           child: SwitchListTile(
             value: edited.englishOnly,
-            activeThumbColor: AppTheme.accent,
             onChanged: (v) =>
                 setState(() => _edited = edited.copyWith(englishOnly: v)),
             title: const Text(

--- a/app/lib/features/settings/ui/instance_edit_screen.dart
+++ b/app/lib/features/settings/ui/instance_edit_screen.dart
@@ -1681,7 +1681,6 @@ class _InstanceEditScreenState extends ConsumerState<InstanceEditScreen> {
         _plexAutoApprove = value;
         _mediaServerConfigDirty = true;
       }),
-      activeThumbColor: AppTheme.accent,
       contentPadding: EdgeInsets.zero,
     );
   }

--- a/app/lib/features/settings/ui/request_settings_screen.dart
+++ b/app/lib/features/settings/ui/request_settings_screen.dart
@@ -141,7 +141,6 @@ class _RequestSettingsScreenState extends ConsumerState<RequestSettingsScreen> {
           highlightId: widget.highlightId,
           child: SwitchListTile(
             value: edited.requireApproval,
-            activeThumbColor: AppTheme.accent,
             onChanged: (v) =>
                 setState(() => _edited = edited.copyWith(requireApproval: v)),
             title: const Text(
@@ -161,7 +160,6 @@ class _RequestSettingsScreenState extends ConsumerState<RequestSettingsScreen> {
           highlightId: widget.highlightId,
           child: SwitchListTile(
             value: edited.allowSeasonChoice,
-            activeThumbColor: AppTheme.accent,
             onChanged: (v) =>
                 setState(() => _edited = edited.copyWith(allowSeasonChoice: v)),
             title: const Text(
@@ -210,7 +208,6 @@ class _RequestSettingsScreenState extends ConsumerState<RequestSettingsScreen> {
           highlightId: widget.highlightId,
           child: SwitchListTile(
             value: edited.allowQualityChoice,
-            activeThumbColor: AppTheme.accent,
             onChanged: (v) => setState(
                 () => _edited = edited.copyWith(allowQualityChoice: v)),
             title: const Text(

--- a/app/lib/features/settings/ui/settings_screen.dart
+++ b/app/lib/features/settings/ui/settings_screen.dart
@@ -388,7 +388,6 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 value: ref.watch(requestNotificationsEnabledProvider),
                 onChanged: (v) =>
                     ref.read(requestNotificationsEnabledProvider.notifier).set(v),
-                activeThumbColor: AppTheme.accent,
                 secondary: const Icon(Icons.notifications_active_outlined,
                     color: AppTheme.textSecondary),
                 title: const Text('Request updates',

--- a/app/lib/features/settings/ui/users_screen.dart
+++ b/app/lib/features/settings/ui/users_screen.dart
@@ -1051,7 +1051,6 @@ class _UserTile extends StatelessWidget {
               child: Switch(
                 value: user.sharedAiEnabled,
                 onChanged: (_) {},
-                activeThumbColor: AppTheme.accent,
               ),
             ),
             contentPadding: EdgeInsets.zero,

--- a/app/lib/features/setup_wizard/ui/setup_wizard_screen.dart
+++ b/app/lib/features/setup_wizard/ui/setup_wizard_screen.dart
@@ -213,7 +213,6 @@ class _SetupWizardScreenState extends ConsumerState<SetupWizardScreen> {
           value: ref.watch(setupReminderEnabledProvider),
           onChanged: (v) =>
               ref.read(setupReminderEnabledProvider.notifier).set(v),
-          activeThumbColor: AppTheme.accent,
           secondary: const Icon(Icons.notifications_outlined,
               color: AppTheme.textSecondary),
           title: const Text('Remind me in the menu',

--- a/app/test/core/theme/switch_thumb_contrast_test.dart
+++ b/app/test/core/theme/switch_thumb_contrast_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:cantinarr/core/theme/app_theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The switch thumb must never be painted the same colour as the active
+/// track.
+///
+/// `SwitchThemeData` already resolves a selected switch to an [AppTheme.accent]
+/// track with an [AppTheme.onAccent] thumb. Sixteen call sites across eleven
+/// files had each passed `activeThumbColor: AppTheme.accent`, repainting the
+/// thumb the *same amber as the track underneath it* — so every "on" switch in
+/// the app rendered as a solid amber pill with no thumb visible at all, and
+/// read as a filled blob rather than a control with a position. The overrides
+/// are gone; these tests keep them gone, because the failure is invisible to
+/// the type system and spread by copy-paste.
+void main() {
+  test('the selected switch thumb contrasts with its track', () {
+    final switchTheme = AppTheme.dark.switchTheme;
+    const selected = <WidgetState>{WidgetState.selected};
+
+    final thumb = switchTheme.thumbColor?.resolve(selected);
+    final track = switchTheme.trackColor?.resolve(selected);
+
+    expect(thumb, AppTheme.onAccent);
+    expect(track, AppTheme.accent);
+    // The assertion that actually describes the defect: whatever the two
+    // colours are, a thumb the same colour as its track is not visible.
+    expect(thumb, isNot(track));
+  });
+
+  test('no call site repaints the active thumb with the track colour', () {
+    final offenders = <String>[];
+    for (final entity in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final lines = entity.readAsLinesSync();
+      for (var i = 0; i < lines.length; i++) {
+        if (lines[i].contains('activeThumbColor: AppTheme.accent')) {
+          offenders.add('${entity.path}:${i + 1}');
+        }
+      }
+    }
+    expect(
+      offenders,
+      isEmpty,
+      reason: 'Setting activeThumbColor to AppTheme.accent paints the thumb '
+          'the same amber as the active track, so the switch renders as a '
+          'solid pill. Drop the override and let SwitchThemeData resolve it.',
+    );
+  });
+}


### PR DESCRIPTION
Every switch in the app rendered as a solid amber pill when on, with no thumb visible at all — reading as a filled blob rather than a control with a position.

## Cause

`SwitchThemeData` in `app_theme.dart` already resolved a selected switch correctly: an `accent` track with an `onAccent` thumb. But sixteen call sites across eleven files each passed `activeThumbColor: AppTheme.accent`, repainting the thumb the **same amber as the track underneath it**. The thumb was always being drawn — it was camouflaged.

`edit_series_screen.dart` is the tell: it sets `activeTrackColor` and leaves the thumb alone, and its switches are the only ones in the app that always looked right.

## Fix

Drop the override at all sixteen sites and let the theme resolve it. No colour constants change; no other switch property moves; `activeTrackColor` users are untouched.

## Guard

`app/test/core/theme/switch_thumb_contrast_test.dart` pins both halves:

- the theme's resolved selected thumb differs from its resolved selected track, and
- no `lib/` source sets `activeThumbColor: AppTheme.accent`.

The grep half is deliberate. This defect is invisible to the type system, produces no analyzer warning, and spread by copy-paste to sixteen sites — a test that only checked the theme would have passed the whole time the app was broken. Verified the guard fails on a reintroduced override, naming the offending file and line.

## Verification

- `flutter analyze --no-fatal-infos` — unchanged baseline (11 pre-existing `deprecated_member_use` infos, none in touched files)
- `flutter test` — 1406 pass
- Visually confirmed in a release web build against a live server: Settings → Discover, the "Only show English-language titles" toggle now renders as an amber track with a dark thumb.

## Docs

No owned doc describes switch styling, so none is stale. No route, env var, tool, table, or screen changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)