### PR TITLE
fix(app): let admins approve the agent's book file deletions

### DIFF
--- a/app/lib/features/issues/data/agent_action_models.dart
+++ b/app/lib/features/issues/data/agent_action_models.dart
@@ -599,6 +599,7 @@ class AgentActionParams {
           'season',
           'episodes',
           'blocklist',
+          'book_id',
         },
       AgentActionKind.unknown => const <String>{},
     };
@@ -709,35 +710,48 @@ class AgentActionParams {
         // Deleting is irreversible, so every part of the target is required and
         // strictly typed here — an under-specified proposal stays readable as
         // history but must never reach an Approve button.
-        if (media == 'book') {
-          return 'Deleting library files is not supported for books.';
-        }
-        if (!_isInt('tmdb_id') || (tmdbId ?? 0) <= 0) {
-          return 'The title whose files would be deleted is missing.';
-        }
         if (_raw.containsKey('blocklist') && _raw['blocklist'] is! bool) {
           return 'The proposed deletion options are malformed.';
         }
-        if (media == 'movie') {
-          if (_raw.containsKey('season') || _raw.containsKey('episodes')) {
-            return 'The proposed movie deletion contains TV episode details.';
+        if (media == 'book') {
+          // A book delete addresses the durable Chaptarr record id; book_id
+          // and the blocklist choice are the entire target.
+          if (!_isInt('book_id') || (bookId ?? 0) <= 0) {
+            return 'The book whose files would be deleted is missing.';
+          }
+          if ((tmdbId ?? 0) != 0 ||
+              _raw.containsKey('season') ||
+              _raw.containsKey('episodes')) {
+            return 'The proposed book deletion contains invalid media details.';
           }
         } else {
-          if (!_isInt('season') || season == null) {
-            return 'The proposed TV season is invalid.';
+          if (_raw.containsKey('book_id')) {
+            return 'The proposed deletion contains book details.';
           }
-          if (!_isIntList('episodes', optional: true)) {
-            return 'The list of episodes to delete is malformed.';
+          if (!_isInt('tmdb_id') || (tmdbId ?? 0) <= 0) {
+            return 'The title whose files would be deleted is missing.';
           }
-          final numbers = episodes;
-          if (numbers.isEmpty) {
-            return 'The episodes whose files would be deleted are missing.';
-          }
-          if (numbers.any((n) => n <= 0)) {
-            return 'The proposed episode numbers are invalid.';
-          }
-          if (numbers.length > _maxDeleteEpisodes) {
-            return 'The proposed deletion covers too many episodes to review.';
+          if (media == 'movie') {
+            if (_raw.containsKey('season') || _raw.containsKey('episodes')) {
+              return 'The proposed movie deletion contains TV episode details.';
+            }
+          } else {
+            if (!_isInt('season') || season == null) {
+              return 'The proposed TV season is invalid.';
+            }
+            if (!_isIntList('episodes', optional: true)) {
+              return 'The list of episodes to delete is malformed.';
+            }
+            final numbers = episodes;
+            if (numbers.isEmpty) {
+              return 'The episodes whose files would be deleted are missing.';
+            }
+            if (numbers.any((n) => n <= 0)) {
+              return 'The proposed episode numbers are invalid.';
+            }
+            if (numbers.length > _maxDeleteEpisodes) {
+              return 'The proposed deletion covers too many episodes to review.';
+            }
           }
         }
       case AgentActionKind.unknown:

--- a/app/lib/features/issues/ui/proposed_action_card.dart
+++ b/app/lib/features/issues/ui/proposed_action_card.dart
@@ -899,7 +899,9 @@ class _ActionCopy {
   /// (files gone versus files gone *and* that release stood down), so it is
   /// never folded away.
   static String _deleteSummary(AgentActionParams p) {
-    final one = p.mediaType != 'tv' || p.episodes.length == 1;
+    // A book delete covers every file the record holds — plural, count unknown.
+    final one = p.mediaType == 'movie' ||
+        (p.mediaType == 'tv' && p.episodes.length == 1);
     final files = one ? 'file' : 'files';
     final replacements = one ? 'a replacement' : 'replacements';
     if (!p.blocklist) {
@@ -965,10 +967,13 @@ class _ActionCopy {
   static String _deleteConfirmation(AgentActionParams p) {
     final episodes = p.episodes;
     final isTv = p.mediaType == 'tv';
-    final one = !isTv || episodes.length == 1;
+    // A book delete covers every file the record holds — plural, count unknown.
+    final one = p.mediaType == 'movie' || (isTv && episodes.length == 1);
 
     final String target;
-    if (isTv && episodes.isNotEmpty) {
+    if (p.mediaType == 'book') {
+      target = 'every file this book holds in your library';
+    } else if (isTv && episodes.isNotEmpty) {
       final season = p.season;
       target = '${one ? '1 file' : '${episodes.length} files'} from your '
           'library — ${season == null ? '' : 'season $season, '}'
@@ -1119,6 +1124,7 @@ class _ActionCopy {
       case AgentActionKind.deleteMediaFiles:
         if (p.mediaType != null) rows.add(('Type', mediaLabel(), false));
         if (p.tmdbId != null) rows.add(('TMDB id', '${p.tmdbId}', false));
+        if (p.bookId != null) rows.add(('Book id', '${p.bookId}', false));
         if (p.season != null) rows.add(('Season', '${p.season}', false));
         final toDelete = p.episodes;
         if (toDelete.isNotEmpty) {

--- a/app/test/issues/agent_action_models_test.dart
+++ b/app/test/issues/agent_action_models_test.dart
@@ -451,12 +451,56 @@ void main() {
       expect(action.canTakeAction, isTrue);
     });
 
+    test('a book deletion is addressed by the record id and stays actionable',
+        () {
+      // The wrong-book repair: the server proposes {media_type, book_id,
+      // blocklist} and nothing else, and the app must let an admin approve it.
+      final action = _delete(
+        {'media_type': 'book', 'book_id': 912, 'blocklist': true},
+        issueMediaType: 'book',
+        serviceType: 'chaptarr',
+      );
+
+      expect(action.params.bookId, 912);
+      expect(action.params.blocklist, isTrue);
+      expect(action.params.validationProblem(action.kind), isNull);
+      expect(action.canTakeAction, isTrue);
+
+      // Blocklist stays optional, exactly like the video deletions.
+      final filesOnly = _delete(
+        {'media_type': 'book', 'book_id': 912},
+        issueMediaType: 'book',
+        serviceType: 'chaptarr',
+      );
+      expect(filesOnly.params.blocklist, isFalse);
+      expect(filesOnly.params.validationProblem(filesOnly.kind), isNull);
+      expect(filesOnly.canTakeAction, isTrue);
+    });
+
     test('every malformed or under-specified deletion is refused', () {
       // (params, expected message fragment). One rejection path per row; each
       // row is otherwise valid so the fragment proves which gate fired.
       final cases = <(Map<String, dynamic>, String)>[
-        // Chaptarr has no equivalent delete/mark-failed pair.
-        ({'media_type': 'book'}, 'books'),
+        // A book delete is addressed by the durable record id alone.
+        ({'media_type': 'book'}, 'book whose files'),
+        ({'media_type': 'book', 'book_id': 0}, 'book whose files'),
+        // A numeric-looking string is never coerced into an identifier.
+        ({'media_type': 'book', 'book_id': '912'}, 'book whose files'),
+        // …and takes only book_id and blocklist; video scope is a category
+        // error, exactly as the server refuses it.
+        (
+          {'media_type': 'book', 'book_id': 912, 'tmdb_id': 27205},
+          'invalid media details'
+        ),
+        (
+          {'media_type': 'book', 'book_id': 912, 'season': 1},
+          'invalid media details'
+        ),
+        // The converse: a video deletion must not carry a book id.
+        (
+          {'media_type': 'movie', 'tmdb_id': 27205, 'book_id': 912},
+          'book details'
+        ),
         // No title to resolve the library record from.
         ({'media_type': 'movie'}, 'title'),
         ({'media_type': 'movie', 'tmdb_id': 0}, 'title'),
@@ -865,7 +909,11 @@ AgentAction _delete(
       'can_decide': true,
       'issue_status': 'awaiting_approval',
       'issue_media_type': issueMediaType,
-      'instance_id': serviceType == 'radarr' ? 'radarr-main' : 'sonarr-main',
-      'instance_name': serviceType == 'radarr' ? 'Main Movies' : 'Main TV',
+      'instance_id': '$serviceType-main',
+      'instance_name': switch (serviceType) {
+        'radarr' => 'Main Movies',
+        'chaptarr' => 'Main Books',
+        _ => 'Main TV',
+      },
       'instance_service_type': serviceType,
     });

--- a/app/test/issues/proposed_action_card_test.dart
+++ b/app/test/issues/proposed_action_card_test.dart
@@ -134,6 +134,28 @@ AgentAction _deleteFiles({required bool blocklist}) => AgentAction.fromJson({
       'instance_service_type': 'sonarr',
     });
 
+/// The wrong-book repair: a deletion addressed by the durable Chaptarr record
+/// id, with no episode scope at all.
+AgentAction _deleteBookFiles() => AgentAction.fromJson({
+      'id': 17,
+      'issue_id': 7,
+      'kind': 'delete_media_files',
+      'params': {
+        'media_type': 'book',
+        'book_id': 912,
+        'blocklist': true,
+      },
+      'rationale': 'The imported file is a different book with the same title.',
+      'status': 'proposed',
+      'can_decide': true,
+      'issue_status': 'awaiting_approval',
+      'issue_title': 'The Wrong Book',
+      'issue_media_type': 'book',
+      'instance_id': 'chaptarr-main',
+      'instance_name': 'Main Books',
+      'instance_service_type': 'chaptarr',
+    });
+
 /// A fake service that returns canned decision results without any network I/O.
 class _FakeIssuesService extends IssuesService {
   _FakeIssuesService() : super(backendDio: Dio());
@@ -428,6 +450,49 @@ void main() {
       find.textContaining('If blocking those releases already sent your media '
           'service looking for replacements itself, Cantinarr leaves that to '
           'it.'),
+      findsOneWidget,
+    );
+    await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('a book deletion is approvable and names its record target',
+      (tester) async {
+    await _pump(
+      tester,
+      auth: _adminState,
+      service: _FakeIssuesService(),
+      action: _deleteBookFiles(),
+    );
+
+    // Plural on purpose: a book delete covers every file the record holds.
+    expect(
+      find.text('Delete the wrong files, block those releases from coming '
+          'back, and look for replacements'),
+      findsOneWidget,
+    );
+    expect(find.text('Book'), findsOneWidget);
+    expect(find.text('Book id'), findsOneWidget);
+    expect(find.text('912'), findsOneWidget);
+    expect(find.text('Block the release'), findsOneWidget);
+    // The whole point of the repair: an admin can actually approve it.
+    expect(find.widgetWithText(ElevatedButton, 'Approve'), findsOneWidget);
+
+    await tester.ensureVisible(find.widgetWithText(ElevatedButton, 'Approve'));
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Approve'));
+    await tester.pumpAndSettle();
+    expect(
+      find.textContaining(
+          'permanently delete every file this book holds in your library'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining(
+          'This cannot be undone: the files are removed from disk'),
+      findsOneWidget,
+    );
+    expect(
+      find.textContaining('Cantinarr then looks for a replacement.'),
       findsOneWidget,
     );
     await tester.tap(find.widgetWithText(TextButton, 'Cancel'));


### PR DESCRIPTION
## What

A book `delete_media_files` proposal from the remediation agent could never be approved from the app. The server has proposed and executed book deletes since the wrong-book repair (18e4a70), but the app's approval card still carried the older guard from the pre-air season wave (7bb9f83): `media_type: book` was rejected outright ("Deleting library files is not supported for books"), and the kind's allowed-key set omitted `book_id`, so the proposal read as unrecognized either way. The card showed an error instead of the Approve control, leaving auto-approval rules as the only path a book delete could ever take.

## How

- `agent_action_models.dart`: the delete validation gains the book arm, mirroring the server's schema exactly — a book delete is addressed by the durable Chaptarr record id (`book_id > 0` required; season/episodes/tmdb_id are a category error), and video deletions now refuse a stray `book_id` for the same reason. `book_id` joins the kind's allowed keys.
- `proposed_action_card.dart`: the summary and the irreversible-target confirmation describe the book variant — plural on purpose, since a book delete covers every file the record holds — and the detail rows show the record id. The replacement/blocklist copy already matches what `DeleteBookFilesHelper` actually does (blocklist via mark-failed, then a search unless Chaptarr's failed-download handling takes over).

## Tests

- Model: a book delete (with and without blocklist) validates and stays actionable; refusal rows for a missing/zero/string `book_id`, video scope on a book delete, and a book id on a movie delete.
- Card: a book deletion renders its record target and an Approve control, and the confirmation names the exact irreversible action.
- Full suite: `flutter analyze` clean, `flutter test` 1491 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzxDCLXC1R97yoGdx8Y1ih