### PR TITLE
feat(app): put album release dates on the calendar

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -246,7 +246,7 @@ One authenticated shell hosts both module pages and secondary work screens over 
 | `/radarr` | Library · Queue · History · Wanted · Calendar | admin |
 | `/sonarr` | Library · Queue · History · Wanted · Calendar | admin |
 | `/chaptarr` | Library · Queue · History · Wanted | admin |
-| `/lidarr` | Library · Queue · History · Wanted | admin |
+| `/lidarr` | Library · Queue · History · Wanted · Calendar | admin |
 | `/downloads` | Queue · History | admin |
 | `/tautulli` | Activity · History · Stats | admin |
 

--- a/app/lib/core/models/app_module.dart
+++ b/app/lib/core/models/app_module.dart
@@ -208,6 +208,12 @@ List<ModulePage> modulePagesFor(ModuleType type,
           activeIcon: Icons.warning_amber,
           route: '/lidarr/wanted',
         ),
+        ModulePage(
+          label: 'Calendar',
+          icon: Icons.calendar_month_outlined,
+          activeIcon: Icons.calendar_month,
+          route: '/lidarr/calendar',
+        ),
       ];
     case ModuleType.downloads:
       return const [

--- a/app/lib/features/dashboard/data/release_event.dart
+++ b/app/lib/features/dashboard/data/release_event.dart
@@ -1,9 +1,10 @@
+import '../../lidarr/data/lidarr_models.dart';
 import '../../radarr/data/radarr_models.dart';
 import '../../sonarr/data/sonarr_models.dart';
 
-/// Whether a [ReleaseEvent] represents a movie (Radarr) or a TV episode
-/// (Sonarr).
-enum ReleaseMediaType { movie, tv }
+/// Whether a [ReleaseEvent] represents a movie (Radarr), a TV episode
+/// (Sonarr), or an album (Lidarr).
+enum ReleaseMediaType { movie, tv, music }
 
 /// A single dated entry on the dashboard "Releases" timeline — either a movie
 /// becoming available (Radarr calendar) or a TV episode airing (Sonarr
@@ -21,8 +22,14 @@ class ReleaseEvent {
   final String? posterUrl;
   final ReleaseMediaType mediaType;
 
-  /// TMDB id used to open the media detail screen, when known.
+  /// TMDB id used to open the media detail screen, when known (movie/tv).
   final int? tmdbId;
+
+  /// Album identity for the music detail screen: the MusicBrainz
+  /// release-group id plus the Lidarr instance it was read from. Null for
+  /// movie/tv events.
+  final String? foreignId;
+  final String? instanceId;
 
   /// Whether the file already exists in the library.
   final bool hasFile;
@@ -34,6 +41,8 @@ class ReleaseEvent {
     this.subtitle,
     this.posterUrl,
     this.tmdbId,
+    this.foreignId,
+    this.instanceId,
     this.hasFile = false,
   });
 
@@ -119,6 +128,45 @@ ReleaseEvent? releaseEventFromSonarr(
     mediaType: ReleaseMediaType.tv,
     tmdbId: series?.tmdbId,
     hasFile: json['hasFile'] as bool? ?? false,
+  );
+}
+
+/// Builds an album [ReleaseEvent] from a Lidarr calendar entry, or null when
+/// the album carries no release date or no addressable MusicBrainz id.
+///
+/// Album release dates are calendar dates — read the components directly, the
+/// movie convention, so a midnight date never shifts a day. The poster is the
+/// external metadata-provider cover only: an arr-relative path must never be
+/// handed to this widget tree, which loads plain public URLs.
+ReleaseEvent? releaseEventFromLidarr(
+  LidarrAlbum album, {
+  required String instanceId,
+}) {
+  final release = album.releaseDate;
+  final foreignId = album.foreignAlbumId;
+  if (release == null || foreignId == null || foreignId.isEmpty) return null;
+
+  String? externalCover;
+  for (final image in album.images) {
+    final remote = image.remoteUrl;
+    if (remote != null && remote.startsWith('http')) {
+      externalCover = remote;
+      break;
+    }
+  }
+  externalCover ??= (album.remoteCover?.startsWith('http') ?? false)
+      ? album.remoteCover
+      : null;
+
+  return ReleaseEvent(
+    date: DateTime(release.year, release.month, release.day),
+    title: album.title,
+    subtitle: album.artistName.isEmpty ? 'Album' : album.artistName,
+    posterUrl: externalCover,
+    mediaType: ReleaseMediaType.music,
+    foreignId: foreignId,
+    instanceId: instanceId,
+    hasFile: album.hasFiles,
   );
 }
 

--- a/app/lib/features/dashboard/ui/dashboard_releases_tab.dart
+++ b/app/lib/features/dashboard/ui/dashboard_releases_tab.dart
@@ -8,12 +8,14 @@ import '../../../core/network/backend_client.dart';
 import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/day_sections.dart';
 import '../../auth/logic/auth_provider.dart';
+import '../../lidarr/data/lidarr_api_service.dart';
 import '../../radarr/data/radarr_api_service.dart';
 import '../../sonarr/data/sonarr_api_service.dart';
 import '../data/release_event.dart';
 
 /// Dashboard "Releases" tab — a unified view of what drops when, aggregating
-/// the default Radarr (movie) and Sonarr (episode) calendars.
+/// the default Radarr (movie) and Sonarr (episode) calendars, plus the
+/// granted Lidarr (album) calendar for users with Music access.
 ///
 /// Defaults to a date-separated list of upcoming releases, with a toggleable
 /// month-calendar view whose selected day filters the scrollable list below.
@@ -49,7 +51,8 @@ class _DashboardReleasesTabState extends ConsumerState<DashboardReleasesTab> {
   String _instanceSignature(AuthState? auth) {
     final conn = auth?.connection;
     return '${conn?.defaultRadarrInstance?.id ?? ''}'
-        '|${conn?.defaultSonarrInstance?.id ?? ''}';
+        '|${conn?.defaultSonarrInstance?.id ?? ''}'
+        '|${conn?.defaultLidarrInstance?.id ?? ''}';
   }
 
   Future<void> _load() async {
@@ -57,8 +60,13 @@ class _DashboardReleasesTabState extends ConsumerState<DashboardReleasesTab> {
     final conn = ref.read(authProvider).valueOrNull?.connection;
     final radarr = conn?.defaultRadarrInstance;
     final sonarr = conn?.defaultSonarrInstance;
+    // Lidarr is grant-only: services.lidarr is the grant bit, and the
+    // connection's instance list already contains only what this user may
+    // read, so the effective instance is theirs, never a sibling library's.
+    final lidarr =
+        (conn?.services.lidarr ?? false) ? conn?.defaultLidarrInstance : null;
 
-    if (radarr == null && sonarr == null) {
+    if (radarr == null && sonarr == null && lidarr == null) {
       if (mounted && token == _loadToken) {
         setState(() {
           _events = [];
@@ -113,6 +121,20 @@ class _DashboardReleasesTabState extends ConsumerState<DashboardReleasesTab> {
       }
     }
 
+    if (lidarr != null) {
+      try {
+        final service =
+            LidarrApiService(backendDio: dio, instanceId: lidarr.id);
+        final albums = await service.getCalendar(start: start, end: end);
+        for (final album in albums) {
+          final event = releaseEventFromLidarr(album, instanceId: lidarr.id);
+          if (event != null) events.add(event);
+        }
+      } catch (_) {
+        anyError = true;
+      }
+    }
+
     if (!mounted || token != _loadToken) return;
     events.sort((a, b) => a.date.compareTo(b.date));
     setState(() {
@@ -146,7 +168,9 @@ class _DashboardReleasesTabState extends ConsumerState<DashboardReleasesTab> {
 
     final conn = ref.watch(authProvider).valueOrNull?.connection;
     final hasInstances = conn?.defaultRadarrInstance != null ||
-        conn?.defaultSonarrInstance != null;
+        conn?.defaultSonarrInstance != null ||
+        ((conn?.services.lidarr ?? false) &&
+            conn?.defaultLidarrInstance != null);
 
     if (_isLoading) {
       return const Center(
@@ -158,8 +182,8 @@ class _DashboardReleasesTabState extends ConsumerState<DashboardReleasesTab> {
       return const _StatusMessage(
         icon: Icons.event_outlined,
         title: 'Nothing to schedule yet',
-        message: 'Connect a Radarr or Sonarr service to see when your '
-            'movies and shows drop.',
+        message: 'Connect a Radarr, Sonarr, or Lidarr service to see when '
+            'your movies, shows, and albums drop.',
       );
     }
 
@@ -371,19 +395,33 @@ class _ReleaseTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isTv = event.mediaType == ReleaseMediaType.tv;
+    final isMusic = event.mediaType == ReleaseMediaType.music;
     final tmdbId = event.tmdbId;
     final timeLabel = isTv ? DateFormat('h:mm a').format(event.date) : null;
 
-    return InkWell(
-      onTap: tmdbId != null
+    final VoidCallback? onTap;
+    if (isMusic) {
+      final foreignId = event.foreignId;
+      onTap = foreignId != null
+          ? () => context.push(
+              '/detail/album/$foreignId'
+              '?title=${Uri.encodeComponent(event.title)}'
+              '${event.instanceId != null ? '&instance_id=${event.instanceId}' : ''}')
+          : null;
+    } else {
+      onTap = tmdbId != null
           ? () => context.push('/detail/${isTv ? 'tv' : 'movie'}/$tmdbId')
-          : null,
+          : null;
+    }
+
+    return InkWell(
+      onTap: onTap,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            _poster(isTv),
+            _poster(isTv, isMusic),
             const SizedBox(width: 12),
             Expanded(
               child: Column(
@@ -404,14 +442,17 @@ class _ReleaseTile extends StatelessWidget {
                   Row(
                     children: [
                       Icon(
-                        isTv ? Icons.tv : Icons.movie_outlined,
+                        isMusic
+                            ? Icons.album_outlined
+                            : (isTv ? Icons.tv : Icons.movie_outlined),
                         size: 13,
                         color: AppTheme.textSecondary,
                       ),
                       const SizedBox(width: 5),
                       Expanded(
                         child: Text(
-                          event.subtitle ?? (isTv ? 'Episode' : 'Movie'),
+                          event.subtitle ??
+                              (isMusic ? 'Album' : (isTv ? 'Episode' : 'Movie')),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                           style: const TextStyle(
@@ -433,12 +474,14 @@ class _ReleaseTile extends StatelessWidget {
     );
   }
 
-  Widget _poster(bool isTv) {
+  Widget _poster(bool isTv, bool isMusic) {
     final placeholder = Container(
       color: AppTheme.surfaceVariant,
       child: Center(
         child: Icon(
-          isTv ? Icons.tv : Icons.movie_outlined,
+          isMusic
+              ? Icons.album_outlined
+              : (isTv ? Icons.tv : Icons.movie_outlined),
           color: AppTheme.textSecondary,
           size: 20,
         ),

--- a/app/lib/features/lidarr/data/lidarr_api_service.dart
+++ b/app/lib/features/lidarr/data/lidarr_api_service.dart
@@ -210,6 +210,25 @@ class LidarrApiService {
     return LidarrWantedPage.fromJson(resp.data as Map<String, dynamic>);
   }
 
+  /// Fetches the album calendar for a date window, with artist context so
+  /// rows can be labelled without a fan-out. Album release dates are calendar
+  /// dates (no meaningful time-of-day).
+  Future<List<LidarrAlbum>> getCalendar({
+    required String start,
+    required String end,
+  }) async {
+    final resp = await _dio.get('$_basePath/calendar', queryParameters: {
+      'start': start,
+      'end': end,
+      'unmonitored': 'false',
+      'includeArtist': 'true',
+    });
+    return _jsonList(resp.data)
+        .whereType<Map<String, dynamic>>()
+        .map(LidarrAlbum.fromJson)
+        .toList();
+  }
+
   /// Nudges Lidarr to run its completed-download import pass now (clears
   /// items stuck "waiting to import").
   Future<void> processMonitoredDownloads() async {

--- a/app/lib/features/lidarr/data/lidarr_calendar.dart
+++ b/app/lib/features/lidarr/data/lidarr_calendar.dart
@@ -1,0 +1,36 @@
+import 'lidarr_models.dart';
+
+/// One dated album release on the Lidarr calendar.
+///
+/// An album carries exactly one release date (the MusicBrainz release-group
+/// date) — a calendar date with no meaningful time-of-day, so [date] is built
+/// from the arr date's own components rather than converted between zones,
+/// which would shift a midnight date into the prior day.
+class LidarrCalendarRelease {
+  final LidarrAlbum album;
+  final DateTime date;
+
+  const LidarrCalendarRelease({required this.album, required this.date});
+}
+
+/// Maps calendar [albums] into dated rows within [start]..[end], date
+/// ascending. An album whose date misses the window (time-zone edges, clock
+/// skew) still yields its row — nothing Lidarr returned is silently dropped —
+/// and only an album with no release date at all is skipped, since it has no
+/// place on a calendar.
+List<LidarrCalendarRelease> lidarrCalendarReleases(
+  Iterable<LidarrAlbum> albums, {
+  required DateTime start,
+  required DateTime end,
+}) {
+  DateTime dateOnly(DateTime d) => DateTime(d.year, d.month, d.day);
+
+  final rows = <LidarrCalendarRelease>[];
+  for (final album in albums) {
+    final release = album.releaseDate;
+    if (release == null) continue;
+    rows.add(LidarrCalendarRelease(album: album, date: dateOnly(release)));
+  }
+  rows.sort((a, b) => a.date.compareTo(b.date));
+  return rows;
+}

--- a/app/lib/features/lidarr/ui/lidarr_calendar_screen.dart
+++ b/app/lib/features/lidarr/ui/lidarr_calendar_screen.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../../core/network/backend_client.dart';
+import '../../../core/providers/instance_provider.dart';
+import '../../../core/theme/app_theme.dart';
+import '../../../core/widgets/cached_image.dart';
+import '../../../core/widgets/day_sections.dart';
+import '../../../core/widgets/error_banner.dart';
+import '../../../navigation/ambient_page_route.dart';
+import '../data/lidarr_api_service.dart';
+import '../data/lidarr_calendar.dart';
+import '../data/lidarr_image.dart';
+import '../data/lidarr_models.dart';
+import 'lidarr_artist_screen.dart';
+
+/// Lidarr calendar: album releases grouped by day. Album release dates are
+/// calendar dates (one per album, no time-of-day), so this is the Radarr
+/// screen's shape without the per-type expansion. Tapping a row opens the
+/// artist's page, where the album and its request/search controls live.
+class LidarrCalendarScreen extends ConsumerStatefulWidget {
+  const LidarrCalendarScreen({super.key});
+
+  @override
+  ConsumerState<LidarrCalendarScreen> createState() =>
+      _LidarrCalendarScreenState();
+}
+
+class _LidarrCalendarScreenState extends ConsumerState<LidarrCalendarScreen> {
+  List<LidarrCalendarRelease> _releases = [];
+  bool _isLoading = true;
+
+  /// Bumped by every fresh load (instance switch, refresh) so in-flight
+  /// responses from a superseded fetch are dropped.
+  int _loadGeneration = 0;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadCalendar());
+  }
+
+  Future<void> _loadCalendar() async {
+    final instanceId = ref.read(instanceProvider).activeLidarrInstanceId;
+    if (instanceId == null) {
+      setState(() {
+        _isLoading = false;
+        _error = 'No Lidarr instance configured';
+      });
+      return;
+    }
+
+    final gen = ++_loadGeneration;
+    setState(() => _isLoading = true);
+    try {
+      final service = LidarrApiService(
+        backendDio: ref.read(backendClientProvider),
+        instanceId: instanceId,
+      );
+      final now = DateTime.now();
+      final start = now.subtract(const Duration(days: 7));
+      final end = now.add(const Duration(days: 30));
+      final albums = await service.getCalendar(
+        start: start.toIso8601String(),
+        end: end.toIso8601String(),
+      );
+      if (!mounted || gen != _loadGeneration) return;
+      setState(() {
+        _releases = lidarrCalendarReleases(albums, start: start, end: end);
+        _isLoading = false;
+        _error = null;
+      });
+    } catch (e) {
+      if (!mounted || gen != _loadGeneration) return;
+      setState(() {
+        _isLoading = false;
+        _error = 'Failed to load calendar: $e';
+      });
+    }
+  }
+
+  Future<void> _openArtist(LidarrAlbum album) async {
+    final instanceId = ref.read(instanceProvider).activeLidarrInstanceId;
+    if (instanceId == null) return;
+    await Navigator.of(context, rootNavigator: true).push(
+      AmbientPageRoute(
+        builder: (_) => LidarrArtistScreen(
+          instanceId: instanceId,
+          artistId: album.artistId,
+          artistName: album.artistName.isEmpty ? null : album.artistName,
+        ),
+      ),
+    );
+    // The artist page can change monitoring or trigger searches; refresh.
+    _loadCalendar();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen(instanceProvider.select((s) => s.activeLidarrInstanceId),
+        (_, __) => _loadCalendar());
+
+    if (_isLoading) {
+      return const Center(
+          child: CircularProgressIndicator(color: AppTheme.accent));
+    }
+    if (_error != null) {
+      return FullScreenError(message: _error!, onRetry: _loadCalendar);
+    }
+    if (_releases.isEmpty) {
+      return RefreshIndicator(
+        onRefresh: _loadCalendar,
+        color: AppTheme.accent,
+        child: ListView(
+          physics: const AlwaysScrollableScrollPhysics(),
+          children: const [
+            SizedBox(height: 160),
+            Icon(Icons.calendar_today_outlined,
+                size: 48, color: AppTheme.textSecondary),
+            SizedBox(height: 12),
+            Center(
+              child: Text('No upcoming releases',
+                  style: TextStyle(
+                      color: AppTheme.textSecondary, fontSize: 16)),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final groups = groupItemsByDay(_releases, (r) => r.date);
+    // Flatten day groups into a single list of headers + tiles.
+    final items = <Object>[];
+    for (final group in groups) {
+      items.add(group.key);
+      items.addAll(group.value);
+    }
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+
+    return RefreshIndicator(
+      onRefresh: _loadCalendar,
+      color: AppTheme.accent,
+      child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.only(top: 4, bottom: 24),
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final item = items[index];
+          if (item is DateTime) {
+            return DaySectionHeader(day: item, today: today);
+          }
+          final release = item as LidarrCalendarRelease;
+          return _CalendarTile(
+            release: release,
+            onTap: () => _openArtist(release.album),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CalendarTile extends ConsumerWidget {
+  final LidarrCalendarRelease release;
+  final VoidCallback? onTap;
+
+  const _CalendarTile({required this.release, this.onTap});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final album = release.album;
+    final instanceId = ref.read(instanceProvider).activeLidarrInstanceId;
+    final cover = instanceId == null
+        ? null
+        : lidarrImageSource(ref, album.coverUrl, instanceId);
+
+    return ListTile(
+      onTap: onTap,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 2),
+      leading: ClipRRect(
+        borderRadius: BorderRadius.circular(6),
+        child: SizedBox(
+          width: 48,
+          height: 48,
+          child: CachedImage(
+            url: cover?.url,
+            headers: cover?.headers,
+            fit: BoxFit.cover,
+            icon: Icons.album,
+          ),
+        ),
+      ),
+      title: Text(
+        album.year > 0 ? '${album.title} (${album.year})' : album.title,
+        style: const TextStyle(
+            color: AppTheme.textPrimary,
+            fontSize: 13.5,
+            fontWeight: FontWeight.w500),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        [
+          if (album.artistName.isNotEmpty) album.artistName,
+          if (album.albumType != null && album.albumType!.isNotEmpty)
+            album.albumType!,
+        ].join(' • '),
+        style: const TextStyle(color: AppTheme.textSecondary, fontSize: 12),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      trailing: album.hasFiles
+          ? const Icon(Icons.check_circle, size: 16, color: AppTheme.available)
+          : null,
+    );
+  }
+}

--- a/app/lib/features/lidarr/ui/lidarr_module_shell.dart
+++ b/app/lib/features/lidarr/ui/lidarr_module_shell.dart
@@ -6,11 +6,9 @@ import '../../../core/theme/app_theme.dart';
 import '../../../core/widgets/instance_dropdown.dart';
 import '../../../core/widgets/module_scaffold.dart';
 
-/// Lidarr module shell: Library | Queue | History | Wanted.
-/// Calendar is intentionally omitted this wave (album release dates are a
-/// planned follow-up). Pages render as a bottom nav on mobile and sidebar
-/// items on desktop. Shows the instance dropdown in the header when 2+
-/// instances exist.
+/// Lidarr module shell: Library | Queue | History | Wanted | Calendar.
+/// Pages render as a bottom nav on mobile and sidebar items on desktop.
+/// Shows the instance dropdown in the header when 2+ instances exist.
 class LidarrModuleShell extends ConsumerWidget {
   final int currentIndex;
   final ValueChanged<int> onTabChanged;

--- a/app/lib/navigation/app_router.dart
+++ b/app/lib/navigation/app_router.dart
@@ -19,6 +19,7 @@ import '../features/chaptarr/ui/chaptarr_module_shell.dart';
 import '../features/chaptarr/ui/chaptarr_queue_screen.dart';
 import '../features/chaptarr/ui/chaptarr_wanted_screen.dart';
 import '../features/lidarr/data/lidarr_models.dart';
+import '../features/lidarr/ui/lidarr_calendar_screen.dart';
 import '../features/lidarr/ui/lidarr_history_screen.dart';
 import '../features/lidarr/ui/lidarr_home_screen.dart';
 import '../features/lidarr/ui/lidarr_module_shell.dart';
@@ -457,6 +458,14 @@ final appRouterProvider = Provider<GoRouter>((ref) {
                   GoRoute(
                     path: '/lidarr/wanted',
                     builder: (_, __) => const LidarrWantedScreen(),
+                  ),
+                ],
+              ),
+              StatefulShellBranch(
+                routes: [
+                  GoRoute(
+                    path: '/lidarr/calendar',
+                    builder: (_, __) => const LidarrCalendarScreen(),
                   ),
                 ],
               ),

--- a/app/test/dashboard/dashboard_releases_tab_test.dart
+++ b/app/test/dashboard/dashboard_releases_tab_test.dart
@@ -1,7 +1,12 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:cantinarr/core/models/backend_connection.dart';
 import 'package:cantinarr/core/models/user_profile.dart';
+import 'package:cantinarr/core/network/backend_client.dart';
 import 'package:cantinarr/features/auth/logic/auth_provider.dart';
 import 'package:cantinarr/features/dashboard/ui/dashboard_releases_tab.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -31,7 +36,97 @@ void main() {
 
     expect(find.text('Nothing to schedule yet'), findsOneWidget);
   });
+
+  testWidgets('a music-only grant loads the Lidarr calendar into the timeline',
+      (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    final adapter = _CalendarAdapter();
+    final dio = Dio(BaseOptions(baseUrl: 'http://localhost'))
+      ..httpClientAdapter = adapter;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          authProvider.overrideWith(() => _FakeAuthNotifier(_musicOnlyState)),
+          backendClientProvider.overrideWithValue(dio),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: DashboardReleasesTab()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(adapter.calendarPaths,
+        ['/api/instances/music-1/api/v1/calendar'],
+        reason: 'the granted Lidarr instance is the one read');
+    expect(find.text('Fear Inoculum'), findsOneWidget);
+    expect(find.text('Tool'), findsOneWidget);
+  });
 }
+
+/// Serves one album on the Lidarr calendar; anything else gets `{}`.
+class _CalendarAdapter implements HttpClientAdapter {
+  final calendarPaths = <String>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    Object body = const <String, dynamic>{};
+    if (options.path.endsWith('/calendar')) {
+      calendarPaths.add(options.path);
+      body = [
+        {
+          'id': 9,
+          'title': 'Fear Inoculum',
+          'artistId': 4,
+          'foreignAlbumId': '1f4a9e6b',
+          'releaseDate':
+              DateTime.now().add(const Duration(days: 3)).toIso8601String(),
+          'artist': {'id': 4, 'artistName': 'Tool'},
+          'statistics': {'trackFileCount': 0, 'trackCount': 10},
+        }
+      ];
+    }
+    return ResponseBody.fromString(
+      jsonEncode(body),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+const _musicOnlyState = AuthState(
+  connection: BackendConnection(
+    serverUrl: 'http://localhost',
+    accessToken: 'access',
+    refreshToken: 'refresh',
+    services: AvailableServices(lidarr: true),
+    instances: [
+      ServiceInstance(
+        id: 'music-1',
+        serviceType: 'lidarr',
+        name: 'Music',
+        isDefault: true,
+      ),
+    ],
+  ),
+  user: UserProfile(id: 1, username: 'tester', role: 'user'),
+);
 
 const _noInstancesState = AuthState(
   connection: BackendConnection(

--- a/app/test/lidarr/lidarr_calendar_test.dart
+++ b/app/test/lidarr/lidarr_calendar_test.dart
@@ -1,0 +1,118 @@
+import 'package:cantinarr/features/dashboard/data/release_event.dart';
+import 'package:cantinarr/features/lidarr/data/lidarr_calendar.dart';
+import 'package:cantinarr/features/lidarr/data/lidarr_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+LidarrAlbum _album({
+  int id = 9,
+  String title = 'Fear Inoculum',
+  String? foreignId = '1f4a9e6b',
+  String? releaseDate = '2026-09-05T00:00:00Z',
+  String artist = 'Tool',
+  List<Map<String, dynamic>> images = const [],
+  String? remoteCover,
+  int trackFiles = 0,
+}) =>
+    LidarrAlbum.fromJson({
+      'id': id,
+      'title': title,
+      'artistId': 4,
+      if (foreignId != null) 'foreignAlbumId': foreignId,
+      if (releaseDate != null) 'releaseDate': releaseDate,
+      'artist': {'id': 4, 'artistName': artist},
+      'images': images,
+      if (remoteCover != null) 'remoteCover': remoteCover,
+      'statistics': {'trackFileCount': trackFiles, 'trackCount': 10},
+    });
+
+void main() {
+  group('lidarrCalendarReleases', () {
+    test('dates are read by components, never zone-shifted', () {
+      // A midnight-UTC calendar date must stay on its own day even when the
+      // viewer sits west of UTC — converting zones would shift it to the 4th.
+      final rows = lidarrCalendarReleases(
+        [_album(releaseDate: '2026-09-05T00:00:00Z')],
+        start: DateTime(2026, 9, 1),
+        end: DateTime(2026, 9, 30),
+      );
+      expect(rows, hasLength(1));
+      expect(rows.first.date, DateTime(2026, 9, 5));
+    });
+
+    test('sorts ascending and skips only dateless albums', () {
+      final rows = lidarrCalendarReleases(
+        [
+          _album(id: 2, releaseDate: '2026-09-20T00:00:00Z'),
+          _album(id: 1, releaseDate: '2026-09-05T00:00:00Z'),
+          _album(id: 3, releaseDate: null),
+        ],
+        start: DateTime(2026, 9, 1),
+        end: DateTime(2026, 9, 30),
+      );
+      expect(rows.map((r) => r.album.id), [1, 2]);
+    });
+
+    test('an out-of-window date still yields its row', () {
+      // Nothing Lidarr returned is silently dropped: window edges are the
+      // arr's business, not a second filter here.
+      final rows = lidarrCalendarReleases(
+        [_album(releaseDate: '2026-10-15T00:00:00Z')],
+        start: DateTime(2026, 9, 1),
+        end: DateTime(2026, 9, 30),
+      );
+      expect(rows, hasLength(1));
+    });
+  });
+
+  group('releaseEventFromLidarr', () {
+    test('builds a calendar-date music event with the album identity', () {
+      final event =
+          releaseEventFromLidarr(_album(trackFiles: 10), instanceId: 'music-1');
+      expect(event, isNotNull);
+      expect(event!.mediaType, ReleaseMediaType.music);
+      expect(event.date, DateTime(2026, 9, 5));
+      expect(event.title, 'Fear Inoculum');
+      expect(event.subtitle, 'Tool');
+      expect(event.foreignId, '1f4a9e6b');
+      expect(event.instanceId, 'music-1');
+      expect(event.hasFile, isTrue);
+    });
+
+    test('needs a release date and an addressable MusicBrainz id', () {
+      expect(releaseEventFromLidarr(_album(releaseDate: null),
+              instanceId: 'music-1'),
+          isNull);
+      expect(
+          releaseEventFromLidarr(_album(foreignId: null), instanceId: 'music-1'),
+          isNull);
+    });
+
+    test('poster is the external cover only — arr-relative paths are dropped',
+        () {
+      final external = releaseEventFromLidarr(
+        _album(images: const [
+          {'coverType': 'cover', 'url': '/MediaCover/Albums/9/cover.jpg'},
+          {
+            'coverType': 'cover',
+            'url': '/MediaCover/Albums/9/cover.jpg',
+            'remoteUrl': 'https://covers.example.org/9.jpg',
+          },
+        ]),
+        instanceId: 'music-1',
+      );
+      expect(external!.posterUrl, 'https://covers.example.org/9.jpg');
+
+      final relativeOnly = releaseEventFromLidarr(
+        _album(
+          images: const [
+            {'coverType': 'cover', 'url': '/MediaCover/Albums/9/cover.jpg'},
+          ],
+          remoteCover: '/MediaCover/Albums/9/cover.jpg',
+        ),
+        instanceId: 'music-1',
+      );
+      expect(relativeOnly!.posterUrl, isNull,
+          reason: 'an instance-origin path must never reach the image loader');
+    });
+  });
+}


### PR DESCRIPTION
## What

The calendar wave deferred from #545, in both places it belongs:

- **Lidarr module Calendar tab** (5th tab, matching Radarr/Sonarr): album releases grouped by day — artist-labelled rows, covers via the instance proxy, an on-disk checkmark, tap-through to the artist page. The module shell's "planned follow-up" marker is gone.
- **Dashboard Releases tab**: for users with Music access, the granted Lidarr instance's albums join the movie/TV timeline and month calendar, with the album icon, artist subtitle, external-cover-only posters, and a tap opening the album detail pinned to its instance.

## How

- Album release dates are calendar dates (MusicBrainz release-group dates, no meaningful time-of-day), so both surfaces read the date's own Y/M/D components — the established movie convention — never `toLocal()`. Unlike movies there is exactly one date per album, so Radarr's three-way per-type expansion collapses to a single dated row.
- `lidarrCalendarReleases` drops nothing Lidarr returned (an out-of-window date keeps its row; only a dateless album is skipped), and `releaseEventFromLidarr` requires an addressable MusicBrainz id, carries `foreignId`+`instanceId` on the event for the detail deep-link, and takes only an external `remoteUrl` cover — an arr-relative path never reaches the Releases tab's plain image loader.
- Lidarr is grant-only, so the Releases tab resolves the instance from the user's own connection payload (which lists only what they may read) behind the `services.lidarr` gate — the proxy's non-admin read allowlist already includes `calendar`, so no server change.
- `ReleaseMediaType` gains `music` and every switch site gains its arm; the empty-state copy now names Lidarr.

## Tests

Calendar-logic pins (component-read dates never zone-shift, ascending sort, dateless-only skip, out-of-window rows kept), event-builder pins (identity requirements, external-cover-only rule), and a Releases-tab widget test proving a music-only grant reads exactly the granted instance's calendar and renders the album. `flutter analyze` clean; `flutter test` 1496 passing.

## Docs

app/README.md nav map: `/lidarr` gains Calendar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzxDCLXC1R97yoGdx8Y1ih