### PR TITLE
Store listings say music

### DIFF
--- a/app/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/app/android/fastlane/metadata/android/en-US/full_description.txt
@@ -1,4 +1,4 @@
-Cantinarr is the intelligent control app for your self-hosted media server — discovery and requests for your household, control of Radarr, Sonarr, and Chaptarr for you, unified management of your download clients, plus diagnosis and admin-approved fixes when downloads get stuck.
+Cantinarr is the intelligent control app for your self-hosted media server — discovery and requests for your household, control of Radarr, Sonarr, Chaptarr, and Lidarr for you, unified management of your download clients, plus diagnosis and admin-approved fixes when downloads get stuck.
 
 You need a Cantinarr server to use this app. The server is open source and runs as a single Docker container; setup instructions are on GitHub.
 

--- a/app/ios/fastlane/metadata/en-US/description.txt
+++ b/app/ios/fastlane/metadata/en-US/description.txt
@@ -1,4 +1,4 @@
-Cantinarr is the intelligent control app for your self-hosted media server — discovery and requests for your household, control of Radarr, Sonarr, and Chaptarr for you, unified management of your download clients, plus diagnosis and admin-approved fixes when downloads get stuck.
+Cantinarr is the intelligent control app for your self-hosted media server — discovery and requests for your household, control of Radarr, Sonarr, Chaptarr, and Lidarr for you, unified management of your download clients, plus diagnosis and admin-approved fixes when downloads get stuck.
 
 You need a Cantinarr server to use this app. The server is open source and runs as a single Docker container; setup instructions are on GitHub.
 

--- a/app/ios/fastlane/metadata/en-US/keywords.txt
+++ b/app/ios/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-radarr,sonarr,plex,jellyfin,emby,media,request,server,selfhosted,homelab,library,tv,movies,mcp
+radarr,sonarr,lidarr,plex,jellyfin,emby,music,request,selfhosted,homelab,library,tv,movies,mcp

--- a/app/ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/app/ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,1 +1,1 @@
-Discover and request movies, shows, and books. Get push notifications. Manage your media stack and diagnose stuck downloads. Set the agent's operating boundaries.
+Discover and request movies, shows, books, and music. Get push notifications. Manage your media stack and diagnose stuck downloads. Set the agent's operating boundaries.


### PR DESCRIPTION
## What

The store copy still described a three-module product. Four small edits, no restructuring:

- iOS `promotional_text.txt`: "movies, shows, and books" gains music (169 of 170 characters).
- iOS `description.txt` and Android `full_description.txt`: the opening line's service list gains Lidarr.
- iOS `keywords.txt`: gains `lidarr` and `music`; to stay inside the 100-character limit it drops `media` and `server`, the two weakest terms in the set (both generic, both already implied by every other keyword). Now 94 of 100 characters.

Everything else (bullets, privacy copy, release notes) is untouched — album requests are already covered by "Request in one tap".

`storelisting.yml` syncs these to the store consoles once this merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzxDCLXC1R97yoGdx8Y1ih