### PR TITLE
Run the container as PUID/PGID so /config is not root-owned

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -147,9 +147,40 @@ jobs:
             sleep 1
           done
           [ -n "$served" ] || docker logs cantinarr-version-smoke
+          # PID 1 is the server itself (the entrypoint exec's it) and, with no
+          # PUID set, still root: the default must never move under an
+          # existing deployment.
+          uid=$(docker exec cantinarr-version-smoke awk '/^Uid:/{print $2}' /proc/1/status)
           docker rm -f cantinarr-version-smoke
+          [ "$uid" = 0 ]
           cat /tmp/version.json
           grep -q '"build_number":"${{ steps.app_build.outputs.number }}"' /tmp/version.json
+
+      - name: Verify PUID/PGID runs the server as that user and hands it /config
+        # Issue #508: with PUID/PGID set, the entrypoint must take ownership
+        # of /config and exec the server as that uid/gid, so the database and
+        # the encryption key it creates land on the host owned by that user.
+        run: |
+          confdir="$RUNNER_TEMP/puid-config"
+          mkdir -p "$confdir"
+          docker run --rm -d --name cantinarr-puid-smoke \
+            -e PUID=1234 -e PGID=4321 -v "$confdir:/config" \
+            cantinarr-root-smoke:${{ github.sha }}
+          healthy=""
+          for _ in $(seq 1 60); do
+            docker exec cantinarr-puid-smoke wget -q -O /dev/null http://localhost:8585/api/health \
+              && { healthy=1; break; }
+            sleep 1
+          done
+          [ -n "$healthy" ] || docker logs cantinarr-puid-smoke
+          ids=$(docker exec cantinarr-puid-smoke awk '/^Uid:/{u=$2} /^Gid:/{g=$2} END{print u ":" g}' /proc/1/status)
+          docker rm -f cantinarr-puid-smoke
+          echo "pid 1 ran as $ids"
+          [ "$ids" = "1234:4321" ]
+          ls -ln "$confdir"
+          for path in "$confdir" "$confdir/cantinarr.db" "$confdir/encryption.key"; do
+            [ "$(stat -c '%u:%g' "$path")" = "1234:4321" ]
+          done
 
       - name: Build arm64 published image for smoke test
         if: github.event_name != 'pull_request'
@@ -198,6 +229,10 @@ jobs:
             test -s /usr/share/licenses/codex-app-server/NOTICE
             /usr/local/bin/codex-app-server --help | grep -q -- --listen
           '
+          # The entrypoint is wired into this image too: PUID/PGID select the
+          # uid/gid the command runs as.
+          test "$(docker run --rm -e PUID=1234 -e PGID=4321 cantinarr-server-smoke:${{ github.sha }} id -u)" = 1234
+          test "$(docker run --rm -e PUID=1234 -e PGID=4321 cantinarr-server-smoke:${{ github.sha }} id -g)" = 4321
 
       # Fork PRs run with a read-only GITHUB_TOKEN, so pushing their pr-N tag
       # from this job is denied. Instead the already-cached amd64 build is

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,10 +58,15 @@ RUN CGO_ENABLED=0 go build -ldflags "-X github.com/windoze95/cantinarr-server/in
 
 # Stage 3: Final image
 FROM alpine:3.19
-RUN apk add --no-cache ca-certificates
+# su-exec is what the entrypoint drops privileges with when PUID/PGID are set.
+RUN apk add --no-cache ca-certificates su-exec
 COPY --from=go-builder /build/cantinarr /usr/local/bin/
 COPY --from=codex-downloader /codex-app-server /usr/local/bin/
 COPY --from=codex-downloader /codex-license/ /usr/share/licenses/codex-app-server/
+# Shared with server/Dockerfile: honours PUID/PGID (own /config, run as that
+# user), otherwise exec's the command untouched, root as before.
+COPY --chmod=0755 server/docker/entrypoint.sh /entrypoint.sh
 EXPOSE 8585
 VOLUME /config
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["cantinarr"]

--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ services:
     restart: unless-stopped
 ```
 
-Update it later with `docker compose pull && docker compose up -d`.
+Update it later with `docker compose pull && docker compose up -d`. The container
+runs as root unless you set `PUID`/`PGID` in its environment (see Configuration
+below), which also makes `./config` belong to that user on start -- the convention
+Synology, Unraid, and other linuxserver-style stacks expect.
 
 Open `http://your-server:8585` -- the setup wizard walks you through creating an admin account. Discovery and search work immediately on the built-in TMDB key. Then connect your services (Radarr, Sonarr, etc.) from **Settings > Providers & Credentials** and **Settings > Add Instance** in the admin UI. Configure an included AI provider there (fresh installs preselect OpenAI OAuth with the fast GPT-5.6 Luna model -- connecting a ChatGPT account is all it takes) and grant it per user, or let each person bring a provider under **Settings > AI Access**.
 
@@ -256,6 +259,8 @@ Optional server env vars for deployment tuning:
 | `CANTINARR_ANDROID_CERT_SHA256_FINGERPRINTS` | unset | Android signing cert fingerprints for `/.well-known/assetlinks.json` |
 | `CANTINARR_WEBAUTHN_EXTRA_ORIGINS` | unset | Additional WebAuthn origins to trust |
 | `CANTINARR_DISABLE_UPDATE_CHECK` | unset | Set to `1` to disable the periodic GitHub release check behind the admin update-status endpoint |
+| `PUID` | unset (runs as root) | Container image only. Run the server as this user id: on every start the image takes ownership of `/config` for it, so the database and encryption key it writes are owned by that user on the host (the linuxserver-style convention Synology and Unraid stacks expect). Ignored when the container is already started as a non-root user (compose `user:`, TrueNAS) |
+| `PGID` | same as `PUID` | Group id to pair with `PUID`; ignored without it |
 
 Source image builds also accept the Docker build argument
 `CANTINARR_E2E_WEB_SEMANTICS` (default `false`). It exists only for the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,4 +27,9 @@ services:
       # Comma-separated absolute container paths forming the outer media
       # allowlist. Empty keeps completed-media downloads disabled.
       - CANTINARR_MEDIA_ROOTS=${CANTINARR_MEDIA_ROOTS:-}
+      # Run as a specific user instead of root (Synology, Unraid, and other
+      # linuxserver-style stacks): the image makes ./config belong to that
+      # user on start. Leave both unset to keep running as root.
+      # - PUID=1000
+      # - PGID=1000
     restart: unless-stopped

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -36,10 +36,15 @@ RUN set -eux; \
     install -m 0644 /tmp/CODEX-NOTICE /codex-license/NOTICE
 
 FROM alpine:3.19
-RUN apk add --no-cache ca-certificates
+# su-exec is what the entrypoint drops privileges with when PUID/PGID are set.
+RUN apk add --no-cache ca-certificates su-exec
 COPY --from=builder /build/cantinarr /usr/local/bin/
 COPY --from=codex-downloader /codex-app-server /usr/local/bin/
 COPY --from=codex-downloader /codex-license/ /usr/share/licenses/codex-app-server/
+# Shared with the root Dockerfile: honours PUID/PGID (own /config, run as that
+# user), otherwise exec's the command untouched, root as before.
+COPY --chmod=0755 docker/entrypoint.sh /entrypoint.sh
 EXPOSE 8585
 VOLUME /config
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["cantinarr"]

--- a/server/README.md
+++ b/server/README.md
@@ -103,6 +103,8 @@ Optional env vars for deployment tuning (a `.env` file next to the binary is aut
 | `CANTINARR_ANDROID_CERT_SHA256_FINGERPRINTS` | unset | Comma-separated Android signing cert SHA-256 fingerprints for `/.well-known/assetlinks.json` and Android WebAuthn origins |
 | `CANTINARR_WEBAUTHN_EXTRA_ORIGINS` | unset | Additional WebAuthn origins to trust (e.g. non-standard HTTPS ports) |
 | `CANTINARR_DISABLE_UPDATE_CHECK` | unset | Set to `1` to disable the periodic GitHub release check behind the admin update-status endpoint |
+| `PUID` | unset (runs as root) | Container image only. Run the server as this user id: on every start the image takes ownership of `/config` for it, so the database and encryption key it writes are owned by that user on the host (the linuxserver-style convention Synology and Unraid stacks expect). Ignored when the container is already started as a non-root user (compose `user:`, TrueNAS) |
+| `PGID` | same as `PUID` | Group id to pair with `PUID`; ignored without it |
 
 OpenAI OAuth source deployments use Codex app-server and are supported only on Linux; non-Linux hosts report this provider unavailable even when a Codex binary is installed. The runtime directory's parent must exist, and the directory must be on tmpfs or ramfs—not persistent storage. Give each concurrently running Cantinarr process its own runtime directory; startup removes stale `session-*` entries from that dedicated root. The official container uses its private Docker `/dev/shm` tmpfs. Use the tested Codex 0.144.3 release or a protocol-compatible build.
 

--- a/server/docker/entrypoint.sh
+++ b/server/docker/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Container entrypoint: optionally run Cantinarr as a non-root user.
+#
+# Set PUID (and PGID, which defaults to PUID) to run the server as that user,
+# the convention linuxserver-style images use and what Synology and Unraid
+# stacks expect. On every start the entrypoint takes ownership of /config for
+# that user, so the database and the encryption key the server writes there
+# belong to the same uid/gid on the host, then drops privileges with su-exec
+# before exec'ing the command.
+#
+# With PUID unset the container behaves exactly as it always has and runs as
+# root. A container already started as a non-root user (compose `user:`,
+# TrueNAS, a Kubernetes securityContext) is left alone: nothing to chown,
+# nothing to drop. su-exec takes numeric ids, so no passwd or group entry is
+# ever created and an id that already exists in the image (Unraid's PGID=100
+# is Alpine's `users`) needs no special casing.
+set -eu
+
+log() { echo "cantinarr entrypoint: $*" >&2; }
+
+is_uint() {
+    case "$1" in
+        '' | *[!0-9]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+if [ "$(id -u)" -ne 0 ]; then
+    exec "$@"
+fi
+
+if [ -z "${PUID:-}" ]; then
+    if [ -n "${PGID:-}" ]; then
+        log "PGID is set but PUID is not; running as root (set PUID to run as another user)"
+    fi
+    exec "$@"
+fi
+
+PGID="${PGID:-$PUID}"
+if ! is_uint "$PUID" || ! is_uint "$PGID"; then
+    log "PUID and PGID must be non-negative integers (got PUID=$PUID PGID=$PGID)"
+    exit 1
+fi
+
+if [ "$PUID" -eq 0 ]; then
+    exec "$@"
+fi
+
+if ! chown -R "$PUID:$PGID" /config; then
+    log "could not take ownership of /config for $PUID:$PGID; continuing"
+fi
+log "running as $PUID:$PGID"
+# su-exec resets HOME to / for a uid with no passwd entry, so HOME is set
+# after the drop; env exec's the command, so the server is still PID 1.
+exec su-exec "$PUID:$PGID" env HOME=/config "$@"


### PR DESCRIPTION
Closes #508.

The container ran everything as root, so the database, its WAL, and the encryption key under `/config` were `root:root` on the host. Both images now carry a small entrypoint (`server/docker/entrypoint.sh`) that honours the `PUID`/`PGID` convention Synology, Unraid, and linuxserver-style stacks expect.

## Behaviour

| Condition | Result |
|---|---|
| `PUID` unset or `0` | Unchanged: runs as root, nothing is chowned. `PGID` alone is ignored with a warning line. |
| `PUID` set, container started as root | `/config` is chowned to `PUID:PGID` on every start (`PGID` defaults to `PUID`), then the server is exec'd as that uid/gid via `su-exec`. It stays PID 1. |
| Container already started as a non-root user (compose `user:`, TrueNAS, k8s `securityContext`) | Exec'd untouched. TrueNAS installs already run this way, so this path is load-bearing. |
| `PUID`/`PGID` not a non-negative integer | Clear error, exit 1. Asking for non-root must never silently yield root. |

Numeric ids only: no passwd or group entry is created, so an id that already exists in Alpine (Unraid's `PGID=100` is the `users` group) needs no special casing. su-exec resets `HOME` for an id without a passwd entry, so `HOME=/config` is set after the drop.

## Verification

- Every mode above exercised against the script in a stock `alpine:3.19` container, and the server-only image built locally and run with `PUID=1234 PGID=4321` on a named volume: PID 1 runs as `1234:4321`, `/api/health` answers, `/config`, `cantinarr.db`, and `encryption.key` are owned `1234:4321`, and `/dev/shm/cantinarr-codex` is created owned by the dropped user. Default run still reports uid 0.
- New CI proof in `docker.yml`: the existing version smoke asserts PID 1 is root by default; a new step runs the published image with `PUID`/`PGID` and a host bind mount, waits on `/api/health`, and asserts both the process ids and the host-side ownership of the directory, database, and key; the server-only smoke asserts `id -u`/`id -g` under `PUID`/`PGID`.
- `shellcheck -s sh` clean. No Go or Flutter code changed, so `go test` / `flutter test` were not run locally; CI runs them.

## Docs

`README.md` and `server/README.md` env tables gain `PUID`/`PGID` rows and the quick start says the container runs as root unless they are set; `docker-compose.yml` shows them commented out.

## Other catalogs

- **Unraid** (`windoze95/cantinarr-unraid`): windoze95/cantinarr-unraid#3 adds `PUID`=99 / `PGID`=100 fields to the template. It must land only after this PR merges and `latest` republishes, otherwise new Unraid installs would believe they run as 99 while still running as root.
- CasaOS, Portainer, Umbrel, BigBear, TrueNAS keep working unchanged (the default is still root, and TrueNAS's `user:` path is the passthrough case). Offering `PUID`/`PGID` there is optional and not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZPMFuN27JfifMu9tePa16
