### PR TITLE
The push relay moves to push.cantinarr.com; the old name is still accepted

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # `.env` is gitignored — never commit real secrets.
 
 # Push is ENABLED by the gateway URL in docker-compose.yml (defaults to
-# https://push.julian.codes). You normally set NOTHING here: with no API key the
+# https://push.cantinarr.com). You normally set NOTHING here: with no API key the
 # server auto-enrolls on first start and persists its own per-instance key in the
 # DB. These are optional overrides:
 
@@ -15,7 +15,7 @@ CANTINARR_PUSH_API_KEY=
 CANTINARR_PUSH_ENROLL_TOKEN=
 
 # Only if you self-host your own gateway elsewhere (overrides the compose default).
-# CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
+# CANTINARR_PUSH_GATEWAY_URL=https://push.cantinarr.com
 
 # Optional completed-media downloads. Uncomment a matching read-only volume in
 # docker-compose.yml and allowlist its Cantinarr-visible parent here. Then map

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ services:
       - ./config:/config
     # Optional: enables push notifications (see Configuration)
     # environment:
-    #   - CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
+    #   - CANTINARR_PUSH_GATEWAY_URL=https://push.cantinarr.com
     restart: unless-stopped
 ```
 
@@ -248,7 +248,7 @@ Optional server env vars for deployment tuning:
 | `CANTINARR_CODEX_BIN` | auto-discovered | Optional path to `codex-app-server` or the full `codex` CLI; container images bundle the tested 0.144.3 app-server at `/usr/local/bin/codex-app-server` |
 | `CANTINARR_CODEX_RUNTIME_DIR` | `/dev/shm/cantinarr-codex` | Absolute Linux tmpfs/ramfs directory used for server-owned, ephemeral per-session Codex state; if it already exists, it must be owned by the server user with mode `0700` |
 | `CANTINARR_MEDIA_ROOTS` | unset | Comma-separated absolute paths forming the outer filesystem allowlist for completed-media downloads. Empty disables file downloads. Mount libraries read-only inside these Cantinarr-visible roots, then map each arr-reported prefix to a path beneath them in that instance's settings; `/` is refused |
-| `CANTINARR_PUSH_GATEWAY_URL` | unset | Push gateway origin -- setting it enables push notifications (auto-enrolls on first start) |
+| `CANTINARR_PUSH_GATEWAY_URL` | unset | Push gateway origin -- setting it enables push notifications (auto-enrolls on first start). The community relay is `https://push.cantinarr.com`; its former name `https://push.julian.codes` is still accepted and rewritten to the new one at start (same gateway, same enrollment) |
 | `CANTINARR_PUSH_API_KEY` | unset | Optional pinned gateway key (blank = auto-enroll) |
 | `CANTINARR_PUSH_ENROLL_TOKEN` | unset | Only for gateways with gated enrollment |
 | `CANTINARR_APPLE_APP_IDS` | unset | `TeamID.BundleID` values for native Apple passkeys (`/.well-known/apple-app-site-association`) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,13 +15,13 @@ services:
       # arr and Cantinarr paths may differ. Example:
       # - /mnt/nas/media:/media:ro
     environment:
-      # Self-hosted push gateway (https://push.julian.codes). Setting the URL
+      # Self-hosted push gateway (https://push.cantinarr.com). Setting the URL
       # ENABLES push: with no API key, the server auto-enrolls on first start and
       # persists its own key in the DB (./config volume) — zero manual setup.
       # Set CANTINARR_PUSH_API_KEY (in a gitignored .env) only to override; set
       # CANTINARR_PUSH_ENROLL_TOKEN only if the gateway uses gated enrollment.
       # Blank the URL to disable push entirely.
-      - CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
+      - CANTINARR_PUSH_GATEWAY_URL=https://push.cantinarr.com
       - CANTINARR_PUSH_API_KEY=${CANTINARR_PUSH_API_KEY:-}
       - CANTINARR_PUSH_ENROLL_TOKEN=${CANTINARR_PUSH_ENROLL_TOKEN:-}
       # Comma-separated absolute container paths forming the outer media

--- a/server/.env.example
+++ b/server/.env.example
@@ -12,7 +12,7 @@ CANTINARR_JWT_SECRET=
 # issued key (encrypted, in the DB) — zero manual key handling. Set it only to
 # override with a specific key. CANTINARR_PUSH_ENROLL_TOKEN is needed only if the
 # gateway uses gated enrollment. Blank the URL to disable push entirely.
-CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
+CANTINARR_PUSH_GATEWAY_URL=https://push.cantinarr.com
 CANTINARR_PUSH_API_KEY=
 CANTINARR_PUSH_ENROLL_TOKEN=
 

--- a/server/README.md
+++ b/server/README.md
@@ -56,7 +56,7 @@ services:
       - ./config:/config
     environment:
       # Optional: enables push notifications (see Configuration)
-      - CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes
+      - CANTINARR_PUSH_GATEWAY_URL=https://push.cantinarr.com
     restart: unless-stopped
 ```
 
@@ -95,7 +95,7 @@ Optional env vars for deployment tuning (a `.env` file next to the binary is aut
 | `CANTINARR_CODEX_BIN` | auto-discovered | Optional path to `codex-app-server` or the full `codex` CLI; official container images bundle the tested 0.144.3 app-server at `/usr/local/bin/codex-app-server` |
 | `CANTINARR_CODEX_RUNTIME_DIR` | `/dev/shm/cantinarr-codex` | Absolute Linux tmpfs/ramfs directory used for server-owned, ephemeral per-session Codex state; if it already exists, it must be owned by the server user with mode `0700` |
 | `CANTINARR_MEDIA_ROOTS` | unset | Comma-separated absolute server/container paths forming the outer filesystem allowlist for completed-media downloads. Empty disables downloads. Mount libraries read-only beneath these roots, then map each arr-reported prefix to a path inside them from that instance's settings; `/` and aliases of `/` are refused |
-| `CANTINARR_PUSH_GATEWAY_URL` | unset | Push gateway origin; setting it **enables** push notifications |
+| `CANTINARR_PUSH_GATEWAY_URL` | unset | Push gateway origin; setting it **enables** push notifications. The community relay is `https://push.cantinarr.com`; its former name `https://push.julian.codes` is still accepted and rewritten to the new one at start (same gateway, same enrollment) |
 | `CANTINARR_PUSH_API_KEY` | unset | Optional pinned gateway key -- leave blank and the server auto-enrolls on first start, persisting its issued key encrypted in the DB |
 | `CANTINARR_PUSH_ENROLL_TOKEN` | unset | Shared enroll token, only for gateways with gated enrollment |
 | `CANTINARR_APPLE_APP_IDS` | unset | Comma-separated `TeamID.BundleID` values served in `/.well-known/apple-app-site-association` for native Apple passkeys |

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -55,6 +55,8 @@ type Config struct {
 	// on first start and persists the issued key (see ensurePushAPIKey). An
 	// explicit key always wins. PushEnrollToken is sent as X-Enroll-Token during
 	// auto-enroll, needed only when the gateway uses gated enrollment.
+	// The relay's original name, push.julian.codes, is rewritten to the
+	// current one at load; see communityPushGatewayURL.
 	PushGatewayURL  string
 	PushAPIKey      string
 	PushEnrollToken string
@@ -72,6 +74,26 @@ type Config struct {
 	// boundaries from which completed media may be served. Per-instance mappings
 	// may target these roots or their descendants; empty disables media delivery.
 	MediaDownloadRoots []string
+}
+
+const (
+	// communityPushGatewayURL is the shared relay's current address.
+	communityPushGatewayURL = "https://push.cantinarr.com"
+	// legacyPushGatewayHost is the relay's original hostname. It still
+	// answers, but a deployment configured with it is moved to
+	// communityPushGatewayURL at load so the old name can eventually be
+	// retired. Same key, same tenant: nothing is stored per host.
+	legacyPushGatewayHost = "push.julian.codes"
+)
+
+// isLegacyPushGatewayHost reports whether raw names the relay's original
+// hostname, whatever its scheme, port, or letter case.
+func isLegacyPushGatewayHost(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(u.Hostname(), legacyPushGatewayHost)
 }
 
 func Load() (*Config, error) {
@@ -110,6 +132,15 @@ func Load() (*Config, error) {
 		CodexBin:           strings.TrimSpace(os.Getenv("CANTINARR_CODEX_BIN")),
 		CodexRuntimeDir:    strings.TrimSpace(os.Getenv("CANTINARR_CODEX_RUNTIME_DIR")),
 		MediaDownloadRoots: splitEnvList(os.Getenv("CANTINARR_MEDIA_ROOTS")),
+	}
+
+	// The community relay moved from push.julian.codes to push.cantinarr.com
+	// in September 2026. The old name still answers, so this is not what keeps
+	// pushes flowing; it moves every never-edited compose file onto the new
+	// name at its next start, so the old one can be measured down and retired.
+	if isLegacyPushGatewayHost(cfg.PushGatewayURL) {
+		log.Printf("CANTINARR_PUSH_GATEWAY_URL=%s is the push relay's old name; using %s (same gateway, same enrollment)", cfg.PushGatewayURL, communityPushGatewayURL)
+		cfg.PushGatewayURL = communityPushGatewayURL
 	}
 
 	cfg.DisableUpdateCheck = envBool(os.Getenv("CANTINARR_DISABLE_UPDATE_CHECK"))

--- a/server/internal/config/config_test.go
+++ b/server/internal/config/config_test.go
@@ -77,6 +77,30 @@ func TestLoadValidatesArrCallbackURL(t *testing.T) {
 	}
 }
 
+// TestLoadRewritesLegacyPushGatewayHost pins the relay's rename: a deployment
+// still configured with push.julian.codes is moved to push.cantinarr.com at
+// load, whatever the scheme, case, or trailing slash, while any other value
+// is left exactly as given and an unset one stays unset (push disabled).
+func TestLoadRewritesLegacyPushGatewayHost(t *testing.T) {
+	for _, tc := range []struct{ raw, want string }{
+		{"https://push.julian.codes", "https://push.cantinarr.com"},
+		{"https://push.julian.codes/", "https://push.cantinarr.com"},
+		{"http://PUSH.julian.codes", "https://push.cantinarr.com"},
+		{"https://push.cantinarr.com", "https://push.cantinarr.com"},
+		{"https://push.example.org/", "https://push.example.org"},
+		{"", ""},
+	} {
+		t.Setenv("CANTINARR_PUSH_GATEWAY_URL", tc.raw)
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load() with %q: %v", tc.raw, err)
+		}
+		if cfg.PushGatewayURL != tc.want {
+			t.Fatalf("PushGatewayURL for %q = %q, want %q", tc.raw, cfg.PushGatewayURL, tc.want)
+		}
+	}
+}
+
 // TestLoadAcceptsDeprecatedPublicURL pins the compat promise: every existing
 // deployment sets CANTINARR_PUBLIC_URL and must keep working untouched, and
 // an invalid legacy value must fail naming the variable the admin actually


### PR DESCRIPTION
> **Merge order satisfied (2026-09-04):** windoze95/push-gateway#10 is merged and deployed; `https://push.cantinarr.com` serves with a Let's Encrypt certificate alongside `push.julian.codes`. The end-to-end check below passed on this PR's preview image, so this is safe to merge.

The community push relay's canonical address becomes `https://push.cantinarr.com`. The old `push.julian.codes` keeps serving the **same** gateway (the gateway PR puts both names on one Caddy site block), so nothing here is needed to keep pushes flowing; it is what moves the fleet onto the new name so the old one can later be measured down and retired.

## Server

`config.Load` rewrites a `CANTINARR_PUSH_GATEWAY_URL` whose host is `push.julian.codes` (any scheme, case, or trailing slash) to `https://push.cantinarr.com` and logs one line naming both, in the spirit of the `CANTINARR_PUBLIC_URL` alias: the old name stays accepted for as long as it exists. Unset stays unset (push disabled); any other gateway is untouched.

This is safe because nothing is stored per host: the server persists only `push_api_key`, never the gateway URL or tenant id, so on restart the same key reaches the same tenant and every stored device token is re-registered under the new name (idempotent). No re-enrolment, no device re-registration by users, and no app release: the app never sees the gateway URL (pinned by the `/api/config` secret-shape test).

Why not a redirect at the old name: the push client is built with `CheckRedirect: http.ErrUseLastResponse`, so a 3xx is returned as an error and every send would fail; that behaviour is pinned by `TestClientDoesNotFollowRedirects`.

## Docs and examples

`docker-compose.yml`, `.env.example`, `README.md`, `server/README.md`, `server/.env.example` point at the new address; both env-var table rows say the former name is still accepted and rewritten.

## Follow-ups in other repos (after the gateway is live)

- `windoze95/cantinarr-unraid`: the `Push gateway URL` default in the template.
- The marketing site's compose snippet (`public/index.html`).
- Catalog entries: Umbrel, TrueNAS (`questions.yaml` default), Portainer (`sources/local/media_templates.json`, regenerate `templates.json`), BigBear (`app.json` + compose), CasaOS compose. Repos we don't own; PRs there once this and the gateway are live, with no comment posted without approved text.

## Verification

- `TestLoadRewritesLegacyPushGatewayHost` covers the old URL with and without a trailing slash, an `http://` upper-case form, the new URL, an unrelated gateway, and unset. The log line as emitted during the test run:

```
CANTINARR_PUSH_GATEWAY_URL=https://push.julian.codes is the push relay's old name; using https://push.cantinarr.com (same gateway, same enrollment)
```

- `go vet ./...` and `go test ./...` green locally; CI on this PR.
- End-to-end same-tenant check, done: a throwaway server on `latest` enrolled against the old name (tenant `t-a904216f1cc7`), then restarted on `pr-571` with the old URL still set. It logged the rewrite, `Push notifications enabled via https://push.cantinarr.com`, `push: gateway client ready gateway=https://push.cantinarr.com`, and the token reconciliation, with zero enrol calls; the gateway's admin list showed that single tenant, which was then deleted (204).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZPMFuN27JfifMu9tePa16
