### PR TITLE
Keep shared music cache cancellation tests deterministic

### DIFF
--- a/server/internal/musicdiscovery/service_test.go
+++ b/server/internal/musicdiscovery/service_test.go
@@ -256,18 +256,27 @@ func TestCacheCombinesConcurrentRequestsAndSurvivesCanceledWaiter(t *testing.T) 
 	var m memo
 	var hits atomic.Int32
 	started, release := make(chan struct{}), make(chan struct{})
-	load := func(context.Context) ([]byte, error) {
-		hits.Add(1)
-		close(started)
-		<-release
-		return []byte("album"), nil
+	releaseLoad := sync.OnceFunc(func() { close(release) })
+	var wg sync.WaitGroup
+	t.Cleanup(func() { releaseLoad(); wg.Wait() })
+	load := func(ctx context.Context) ([]byte, error) {
+		if hits.Add(1) == 1 {
+			close(started)
+		}
+		select {
+		case <-release:
+			return []byte("album"), nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	done := make(chan error, 1)
 	go func() { _, err := m.get(ctx, "key", time.Hour, load); done <- err }()
 	<-started
-	var wg sync.WaitGroup
-	for range 12 {
+	const waiters = 12
+	for range waiters {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -277,11 +286,27 @@ func TestCacheCombinesConcurrentRequestsAndSurvivesCanceledWaiter(t *testing.T) 
 			}
 		}()
 	}
+	// Starting goroutines does not mean they have joined the shared fill.
+	// Without this barrier, cancel can abandon the only caller's work before
+	// the other readers arrive, correctly causing a new fill.
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		m.mu.Lock()
+		callers := m.pending["key"].callers
+		m.mu.Unlock()
+		if callers == waiters+1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d of %d callers joined the shared fill", callers, waiters+1)
+		}
+		time.Sleep(time.Millisecond)
+	}
 	cancel()
 	if err := <-done; !errors.Is(err, context.Canceled) {
 		t.Fatal(err)
 	}
-	close(release)
+	releaseLoad()
 	wg.Wait()
 	if hits.Load() != 1 {
 		t.Fatalf("duplicate fills %d", hits.Load())


### PR DESCRIPTION
## What

The music cache test could cancel its only registered caller before the other goroutines joined. The cache correctly abandoned that fill, and the replacement fill then panicked by closing the fixture's start channel twice. This failed the main CI release gate on `6ab0099`.

Wait for every reader to join before canceling the first caller. Make the fixture honor cancellation and clean up blocked readers, while retaining the single-fill and cache-expiry assertions. Production code is unchanged.

## Verification

- Reproduced the original panic locally with `GOMAXPROCS=1 go test -race ./internal/musicdiscovery -run '^TestCacheCombinesConcurrentRequestsAndSurvivesCanceledWaiter$' -count=100`.
- The fixed test passed 100 race runs each with `GOMAXPROCS=1` and `GOMAXPROCS=4`.
- Full `go vet ./...`, `go test ./...`, and CGO-disabled server build passed, using `-p 2` locally.
- Full music-discovery package race tests passed.
- All required PR checks are green: Go, Flutter, Test catalog, and Docker build/smoke checks.
- `git diff --check` passed. No app or documented behavior changed.

## Docs

- [x] No docs impact — this repairs test synchronization only.

The v0.10.0 tag has not been pushed. Release preparation will resume from a merged main commit after its exact-SHA CI passes.
